### PR TITLE
Test helper geography + video-mode docs: one forge signer, shared fixture slug, charter

### DIFF
--- a/apps/os/e2e/AGENTS.md
+++ b/apps/os/e2e/AGENTS.md
@@ -30,8 +30,8 @@ in [docs/testing.md](../../../docs/testing.md).
   `node` project runs the engine suites in `e2e/vitest/` (agents, admin-project, preview
   smoke) and the cross-runtime example matrix in `e2e/examples/`; the `browser` project runs
   that matrix in a real browser. `pnpm e2e --project node` skips the browser lane.
-- Egress + secret substitution coverage lives in itx suite
-  (`e2e/vitest/itx.e2e.test.ts`).
+- Egress + secret substitution coverage lives in `e2e/vitest/itx-egress.e2e.test.ts`
+  (the old `itx.e2e.test.ts` monolith was split across the `itx-*.e2e.test.ts` files).
 - Preview smoke: `pnpm e2e -t "OS preview smoke"` (`preview-smoke.e2e.test.ts`) exercises a
   deployed preview, including its project MCP route (it derives its project slug from
   `GITHUB_SHA` when set).

--- a/apps/os/e2e/test-support/create-test-project.ts
+++ b/apps/os/e2e/test-support/create-test-project.ts
@@ -1,6 +1,7 @@
 import type { RpcStub } from "capnweb";
+import { uniqueFixtureSlug } from "@iterate-com/shared/test-support/fixture-slug";
 import type { Agent, Project as ProjectRpcTarget } from "../../src/itx-api.generated.ts";
-import { createAdminOsItx, requireBaseUrl, uniqueSuffix } from "./os-client.ts";
+import { createAdminOsItx, requireBaseUrl } from "./os-client.ts";
 import { connectItx } from "~/itx-client.ts";
 
 /**
@@ -15,9 +16,8 @@ import { connectItx } from "~/itx-client.ts";
  */
 export async function createTestProject(opts: { slugPrefix: string }) {
   const baseUrl = requireBaseUrl();
-  const slugPrefix = opts.slugPrefix;
-  // you get invalid DNS name errors if the slug is too long
-  const slug = `${slugPrefix.slice(0, 20)}-${uniqueSuffix()}`.replace("--", "-");
+  // Trimmed: you get invalid DNS name errors if the slug is too long.
+  const slug = uniqueFixtureSlug(opts.slugPrefix, { maxPrefixLength: 20 });
 
   using session = createAdminOsItx({ baseUrl });
   using created = session.projects.create({ slug });

--- a/apps/os/e2e/test-support/os-client.ts
+++ b/apps/os/e2e/test-support/os-client.ts
@@ -48,7 +48,3 @@ export function createAdminOsItx(input?: { baseUrl?: string; context?: string })
     ? connectItx({ auth, baseUrl, projectId: input.context })
     : connectItx({ auth, baseUrl });
 }
-
-export function uniqueSuffix() {
-  return `${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
-}

--- a/apps/os/vitest.config.ts
+++ b/apps/os/vitest.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
       },
     },
     // Route `/api2/test` is implemented as `api2.test.ts` — not a Vitest file.
-    exclude: [...defaultExclude, "e2e/**", "**/src/routes/**/*.test.ts", "**/*.workerd.test.ts"],
+    exclude: [...defaultExclude, "e2e/**", "**/src/routes/**/*.test.ts"],
     fileParallelism: false,
     pool: "forks",
     hookTimeout: 60_000,

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -111,17 +111,17 @@ deployment under test — tests never invent parallel names for them. The two
 knobs. Nothing else exists (the root Playwright config additionally honors
 the Playwright-conventional `CI` and `VIDEO_MODE`).
 
-| Variable                         | Set by                                                  | Controls                                                                                                      | Default                         |
-| -------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| `APP_CONFIG_BASE_URL`            | Doppler (deployed configs); unset in local configs      | THE deployment under test, for every lane                                                                     | Local dev-server discovery file |
-| `APP_CONFIG_ADMIN_API_SECRET`    | Doppler                                                 | Admin credential for the itx surface (project seeding, admin lanes)                                           | None — lanes that need it throw |
-| `APP_CONFIG_INTEGRATIONS__SLACK` | Doppler                                                 | Gates the slack-agent e2e suite (provides the Slack signing secret)                                           | Unset → suite skips             |
-| `E2E_RETRY_TELEMETRY_FILE`       | The preview lane (`scripts/preview/preview.ts`), or you | Where the vitest `RetryTelemetryReporter` writes its JSON (see [Retries and timeouts](#retries-and-timeouts)) | Unset → log line only, no file  |
-| `OS_E2E_TUI_PROJECT_ID`          | `e2e/tui-test/run.ts` (internal; passed to the spec)    | The disposable project the TUI spec chats against                                                             | Unset → TUI spec skips          |
-| `OS_E2E_TUI_SNAPSHOT`            | You                                                     | `"1"` opts into the manual aesthetic TUI snapshot test                                                        | Skipped                         |
-| `GITHUB_SHA`                     | GitHub Actions (ambient)                                | Labels the preview-smoke seed project slug in CI                                                              | `"manual"`                      |
-| `CI`                             | GitHub Actions                                          | Playwright: `forbidOnly`, one retry, trace on first retry, never reuse an existing dev server                 | Unset locally                   |
-| `VIDEO_MODE`                     | You                                                     | `"1"` makes Playwright record video with relaxed timeouts                                                     | Video only retained on failure  |
+| Variable                         | Set by                                                  | Controls                                                                                                         | Default                         |
+| -------------------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `APP_CONFIG_BASE_URL`            | Doppler (deployed configs); unset in local configs      | THE deployment under test, for every lane                                                                        | Local dev-server discovery file |
+| `APP_CONFIG_ADMIN_API_SECRET`    | Doppler                                                 | Admin credential for the itx surface (project seeding, admin lanes)                                              | None — lanes that need it throw |
+| `APP_CONFIG_INTEGRATIONS__SLACK` | Doppler                                                 | Gates the slack-agent e2e suite (provides the Slack signing secret)                                              | Unset → suite skips             |
+| `E2E_RETRY_TELEMETRY_FILE`       | The preview lane (`scripts/preview/preview.ts`), or you | Where the vitest `RetryTelemetryReporter` writes its JSON (see [Retries and timeouts](#retries-and-timeouts))    | Unset → log line only, no file  |
+| `OS_E2E_TUI_PROJECT_ID`          | `e2e/tui-test/run.ts` (internal; passed to the spec)    | The disposable project the TUI spec chats against                                                                | Unset → TUI spec skips          |
+| `OS_E2E_TUI_SNAPSHOT`            | You                                                     | `"1"` opts into the manual aesthetic TUI snapshot test                                                           | Skipped                         |
+| `GITHUB_SHA`                     | GitHub Actions (ambient)                                | Labels the preview-smoke seed project slug in CI                                                                 | `"manual"`                      |
+| `CI`                             | GitHub Actions                                          | Playwright: `forbidOnly`, one retry, trace on first retry, never reuse an existing dev server                    | Unset locally                   |
+| `VIDEO_MODE`                     | You                                                     | `"1"` records spec demo videos with relaxed timeouts — see [Video mode](#video-mode-recorded-spec-demos-for-prs) | Video only retained on failure  |
 
 ## Artifacts
 
@@ -136,6 +136,75 @@ the Playwright-conventional `CI` and `VIDEO_MODE`).
   `test-results/` directory, then uploads that one workspace-relative directory
   as a CI artifact. The collection paths live in
   `scripts/preview/collect-test-artifacts.sh`.
+
+## Where test helpers live
+
+Four layers. A helper lives at the **lowest layer all its consumers share**,
+and imports point **down** only. When both lanes need a helper, it moves down
+a layer — never sideways into a copy.
+
+| Layer                     | Home                                                                                | Charter                                                                                                                                                                                                                                     |
+| ------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| L0 policy & infra         | `packages/shared/src/test-support/`                                                 | Runner-agnostic: the [e2e-policy budgets and retry telemetry](#retries-and-timeouts) (`e2e-policy/`), vitest run-artifact plumbing (`vitest-e2e/`), the fixture slug convention (`fixture-slug.ts`).                                        |
+| L1 environment & identity | `apps/os/scripts/` and `scripts/auth/`                                              | The deployment under test and who you are against it: dev-server lifecycle (`dev.ts`, `lib/dev-server-info.ts`), Doppler plumbing, the auth forge (`scripts/auth/forge-token.ts` behind `pnpm auth:mint`). Consumed by both lanes' configs. |
+| L2 surface clients        | `apps/os/e2e/test-support/` (itx surface) · `specs/test-support/` (browser surface) | Lane-specific clients and fixtures: admin itx handles and disposable projects on the itx side; forged browser sessions and page plugins on the Playwright side.                                                                             |
+| L3 domain harnesses       | `apps/os/src/domains/*/test-helpers.ts`, colocated with the domain                  | Unit-lane fakes implementing real interfaces (stream processor harnesses etc.); never imported by L2 or above.                                                                                                                              |
+
+Anti-goal: one mega test-support package. That would drag itx clients and
+forge machinery into a package that production workers import; the layers keep
+the credentialed, lane-specific pieces at the edges that need them. The
+"lowest shared layer" rule is also deliberately lazy — e.g.
+`apps/os/e2e/test-support/wait-for-condition.ts` stays L2 until a Playwright
+spec actually needs it: "needed by both lanes" is proven by a consumer, not
+predicted.
+
+## Video mode: recorded spec demos for PRs
+
+Any Playwright spec re-runs as a watchable demo — pointer highlights on every
+action, dead air compressed, the blank startup lead-in trimmed. Design and
+plugin by Misha: [middlewright](https://github.com/iterate/middlewright)'s
+`videoMode`, wired in `specs/test-support/test.ts`; the auto start-trim
+shipped in iterate/middlewright#3 / PR #1788.
+
+```bash
+# local dev, one flow (the config auto-starts the dev server; specs read
+# os secrets from the apps/os Doppler scope themselves)
+VIDEO_MODE=1 pnpm spec -g "dashboard"
+
+# against a deployed slot — note --project os: the repo root scopes to
+# _shared, which lacks the os APP_CONFIG_* values the specs need
+doppler run --project os --config preview_3 -- env VIDEO_MODE=1 pnpm spec -g "dashboard"
+```
+
+`VIDEO_MODE=1` flips two things:
+
+- **Config** (`playwright.config.ts`): `video: "on"` plus relaxed budgets
+  (10s `actionTimeout`, 300s test timeout) so highlight pauses don't trip the
+  deliberately-tight normal budgets.
+- **Plugin** (`videoMode` in `specs/test-support/test.ts`): records each
+  action's bounding box during the run, then post-renders with ffmpeg (must
+  be installed): pointer highlights, dead-air spans >300ms sped up, a 1s
+  final hold, and the blank `about:blank`-to-first-paint lead-in trimmed
+  automatically (`trimStart: "auto"`, pixel-based; an explicit
+  `page.videoMode.setStartTime()` in a spec still wins).
+
+Output lands under `test-results/playwright-output/<test-title-dir>/`:
+`video-rendered.webm` (the demo), `video-raw.webm`, and a `video-mode.html`
+frame-stepper, all also attached to the HTML report.
+
+**Getting the video into a PR description is manual** — the "automatic" part
+is only the recording/trimming. GitHub renders an inline video player only
+for `user-attachments` URLs, and only its web editors mint those (`<video>`
+tags pointing at any other host are sanitised — which is why older PRs fell
+back to release-asset GIFs, e.g. PR #1764):
+
+1. Convert for the widest GitHub support:
+   `ffmpeg -i video-rendered.webm demo.mp4`.
+2. Drag (or paste) `demo.mp4` into the PR-description editor on github.com.
+   GitHub uploads it and inserts a `https://github.com/user-attachments/assets/…`
+   URL — leave it on its own line and it renders as an inline player. There
+   is no API or `gh` route for this upload. PR #1788's before/after clip is
+   the working example.
 
 ## Retries and timeouts
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,6 +6,55 @@ policy](#retries-and-timeouts) every lane follows. For unit-test style (fake
 timers, inline snapshots, `test.for` tables), see
 [Vitest patterns](vitest-patterns.md).
 
+## Philosophy
+
+Six principles carry this system. They are conscious design — most trace
+to specific people and incidents — and should be argued with, not drifted
+away from.
+
+1. **Prove the behavior users actually get.** The default test is e2e from
+   very far away: through the itx surface or a real browser, against a
+   live deployment, with no test-only seams. Local dev already runs the
+   real worker inside vite's workerd, so a live target is always one
+   command away.
+
+2. **Fail fast; fix the product, not the timeout.** (Misha Kaletsky's
+   design — the [middlewright](https://github.com/iterate/middlewright)
+   plugin family, extracted from this repo's test infra.) Playwright
+   actions get a brutal 750ms budget that extends — up to ~30s — only
+   while the app visibly reports progress (`data-spinner`). A slow flow
+   that makes a test flaky is a product bug: add the loading state users
+   wanted anyway. In his words: "it makes your test pass fast, fail fast,
+   and it incentivises agents to improve the product when tests fail,
+   instead of bumping timeouts which makes tests worse and lets your
+   product get away with bad UX." Any explicit timeout override carries a
+   `// comment` saying why.
+
+3. **Every test owns its state.** Each e2e test and spec provisions its
+   own project (unique slug; `projects.create` resolves only after the
+   bootstrap saga commits). No shared fixtures, no ordering, no cleanup
+   coupling — this is what makes parallel workers and rule 4 sound.
+
+4. **One retry, watchdogs above, telemetry always.** Retries live in
+   exactly one layer (the individual test, CI only); everything above is
+   a fail-never-retry watchdog sized to ~2× healthy p99; every absorbed
+   retry surfaces in the PR table. Budgets are evidence, not vibes — see
+   [Retries and timeouts](#retries-and-timeouts) and the marathon audit.
+
+5. **Harnesses must be honest about fidelity.** Where we do unit-test,
+   fakes implement the real interfaces (`MemoryStream` honors idempotency
+   keys and offset gaps; eviction is an operator: `h.crash()`), every
+   vendor-touching processor suite has a refold test, and a harness that
+   structurally cannot catch a bug class says so in its file header (the
+   `stream-subscribers.teardown.test.ts` pattern).
+
+6. **No workerd test runtime.** There is deliberately no
+   `@cloudflare/vitest-pool-workers` lane: unit tests run in plain node
+   with a thin `cloudflare:workers` shim (plus capnweb's real workers
+   build), and real-runtime coverage comes from the e2e lanes against
+   live deployments — production-shaped by construction. Adding a third
+   runtime needs a proven coverage gap, not a preference.
+
 ## Lanes
 
 | Lane             | Command (from `apps/os` unless noted) | Lives in                                | Proves                                                                                                                                                                                                                                                                                                                                                                                                                    |
@@ -15,17 +64,34 @@ timers, inline snapshots, `test.for` tables), see
 | TUI              | `pnpm exec tsx e2e/tui-test/run.ts`   | `apps/os/e2e/tui-test/`                 | The `iterate chat` TUI through a real PTY (Microsoft TUI Test) against a disposable project.                                                                                                                                                                                                                                                                                                                              |
 | Playwright specs | `pnpm spec` (repo root)               | `specs/` (`playwright.config.ts`)       | Browser-level product flows: signup, project create, dashboard, REPL, agent chat, reactivity.                                                                                                                                                                                                                                                                                                                             |
 
-## Don't over-test
+## What earns a test
 
-We prefer e2e tests from very far away — through the itx surface or the
-browser, against a live deployment — because they prove behavior users
-actually get. Unit tests are for when there's a good reason: typically a
-large number of cases that would be too slow or too expensive to run e2e
-(fold/reduce logic, parsers, pure functions with wide input tables). Stream
-processors are the deliberate example — they get purpose-built node test
-harnesses (see [Writing & testing stream processors](writing-stream-processors.md))
-exactly so their many event-ordering and redelivery cases can run as fast
-unit tests.
+The default is a covering e2e. A **unit test** earns its place in exactly
+two ways:
+
+- **Wide case tables.** Fold/reduce logic, parsers, pure functions — and
+  above all stream processors: many event-ordering and redelivery cases
+  that would be too slow or expensive to run e2e. These get purpose-built
+  node harnesses (see
+  [Writing & testing stream processors](writing-stream-processors.md)) and
+  captured-journal incident repros (`stream-repros/iterate-pr-NNNN-*`).
+- **Tiny kernels.** Zero-maintenance guards for adversarial and security
+  invariants: bad-signature ⇒ 401 before routing, path-escape rejection,
+  ciphertext binding, secret redaction in `inspect()`, tenancy-collision
+  checks. Small, hostile inputs, cheap to keep — these stay even though
+  each one is thin.
+
+### Ship-with rules
+
+New work of these shapes ships WITH these tests. Absence is a review
+blocker, not a style note:
+
+| You built                                           | It ships with                                                                                                                                                                             |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A stream processor, or a new side-effect arm in one | A harness suite including a **refold test** (replay the whole journal ⇒ zero side effects, zero appends); if it holds obligations, an **eviction-recovery** test (`h.crash()` mid-flight) |
+| An itx capability or API surface                    | A catalogue example proven by the examples matrix (and thereby every runtime), plus engine e2e for its failure arms                                                                       |
+| A product flow in the dashboard                     | A Playwright spec under `specs/`, readable as a product spec                                                                                                                              |
+| An incident fix with a journal-shaped cause         | A captured-journal repro named for the PR (`stream-repros/`)                                                                                                                              |
 
 What we do NOT want:
 
@@ -39,6 +105,43 @@ What we do NOT want:
   verbatim couplings, not a guard test.
 - Unit tests for arg parsing of internal scripts, trivial glue, or anything
   a covering e2e already proves by existing.
+
+## Test dimensions (DRAFT — under discussion)
+
+Every test sits somewhere on five axes, and the rule mirrors the env-var
+doctrine: **one control per dimension, no parallel mechanisms**, and the
+vanilla `vitest` / `playwright` CLIs keep working. Dimensions are expressed
+through file names, project selection, and environment presence — never a
+bespoke runner.
+
+| Dimension    | Values                                            | Controlled by                                                                                                         | Status         |
+| ------------ | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | -------------- |
+| Surface      | in-process / itx API / browser / PTY              | which lane you invoke (`pnpm test` / `pnpm e2e` / `pnpm spec` / tui) + vitest `--project`                             | works today    |
+| Speed        | fast / slow-by-contract                           | per-test `{ timeout }` capped at `E2E_HEAVY_TEST_TIMEOUT_MS`; the slowest-first sequencer feeds on observed seconds   | works today    |
+| Determinism  | deterministic / retry-absorbed                    | `E2E_CI_RETRIES = 1` + retry telemetry — a nondeterministic test that retries is visible, never silent                | works today    |
+| Cost         | free / pays for LLM turns                         | **gap** — implicit today (the onboarding smoke and codemode proofs pay; nothing marks them)                           | proposal below |
+| Remote reach | hermetic / hits a deployment / hits a third party | **partial** — `APP_CONFIG_INTEGRATIONS__*` presence gates third-party suites; deployment-reach is implied by the lane | proposal below |
+
+Draft proposal for the two gaps, keeping vanilla CLIs:
+
+- Put the **cost** dimension in the filename, the same way lanes already
+  live there: `*.llm.e2e.test.ts` for tests that pay for model turns.
+  Filename dimensions compose with plain vitest filtering
+  (`pnpm e2e llm`), grep, and the sequencer — no runner machinery. The
+  e2e-policy guard test can then enforce the budget structurally: files
+  NOT tagged `.llm.` must not import the agent-turn helpers.
+- Keep **third-party reach** on environment presence (the doppler-native
+  control we already have); it composes with per-env secrets and skips
+  cleanly when a config lacks the integration.
+- Playwright's native tags (`@slow`, `--grep`) are the escape hatch on the
+  specs side if a spec ever needs a dimension; don't build it until one
+  does.
+
+Open questions for the next grilling round: is the filename the right home
+for cost (vs a lint-enforced import rule alone)? Should third-party reach
+be visible in filenames too, or is env-gating enough? Does "slow" deserve
+a filename marker so the sequencer stops needing hand-maintained observed
+seconds?
 
 ## Running a lane against an environment
 
@@ -235,8 +338,9 @@ only on genuine infra wedges).
    wedged platform _should_ get killed; both historical watchdog kills were
    genuine infra wedges where retrying was hopeless.
 4. **Waits are progress-based; static budgets are backstops.** The
-   Playwright `actionTimeout` is a tight 750ms; the middlewright
-   spinner-waiter (see `patches/`) extends it — up to ~30s — only while the
+   Playwright `actionTimeout` is a tight 750ms; the
+   [middlewright](https://github.com/iterate/middlewright) spinner-waiter
+   extends it — up to ~30s — only while the
    app visibly reports progress. An app that goes blank fails fast instead
    of being slept through: this exact tightness caught a real blank-render
    product bug (flake 21). Don't widen budgets to paper over a missing
@@ -256,7 +360,7 @@ only on genuine infra wedges).
 | One vitest e2e test/hook   | `testTimeout` / `hookTimeout`         | `apps/os/e2e/vitest.config.ts` ← `E2E_TEST_TIMEOUT_MS`             | 120s                                      | retry once (CI)             |
 | A container-cold-boot test | per-test `{ timeout }`                | individual tests, capped at `E2E_HEAVY_TEST_TIMEOUT_MS`            | ≤ 240s                                    | retry once (CI)             |
 | The onboarding smoke gate  | attempt loop                          | `apps/os/e2e/vitest/onboarding-smoke.ts`                           | 90s greeting wait                         | one more attempt, then fail |
-| The preview vitest lane    | `timeout N pnpm e2e`                  | `scripts/preview/preview.ts` ← `OS_PREVIEW_LANE_TIMEOUT_SECS`      | 480s                                      | **fail — never retry**      |
+| Each preview sub-lane      | `timeout N <lane command>`            | `scripts/preview/preview.ts` ← `OS_PREVIEW_LANE_TIMEOUT_SECS`      | 480s                                      | **fail — never retry**      |
 | One whole preview run      | `RUN_TIMEOUT_SECS` kill-tree watchdog | `scripts/preview/flake-hunt-loop.sh` ← `PREVIEW_RUN_WATCHDOG_SECS` | 600s                                      | **kill — never retry**      |
 | The Depot CI job           | `timeout-minutes`                     | `.depot/workflows/*.yml`                                           | 10–45 (mainline/preview) / 300 (marathon) | outer edge: re-run button   |
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -14,6 +14,7 @@
     "./apps/internal-router-contract": "./src/apps/internal-router-contract.ts",
     "./test-support/vitest-e2e": "./src/test-support/vitest-e2e/index.ts",
     "./test-support/e2e-policy": "./src/test-support/e2e-policy/index.ts",
+    "./test-support/fixture-slug": "./src/test-support/fixture-slug.ts",
     "./request-logging": "./src/request-logging.ts",
     "./slugify": "./src/slugify.ts",
     "./posthog": {

--- a/packages/shared/src/test-support/fixture-slug.ts
+++ b/packages/shared/src/test-support/fixture-slug.ts
@@ -10,9 +10,7 @@
  * yet, so disposal is a no-op and stages accumulate fixtures until reset.
  */
 export function uniqueFixtureSlug(prefix: string, opts?: { maxPrefixLength?: number }): string {
-  const trimmedPrefix =
-    opts?.maxPrefixLength === undefined ? prefix : prefix.slice(0, opts.maxPrefixLength);
-  return `${trimmedPrefix}-${Date.now().toString(36)}-${crypto.randomUUID().slice(0, 8)}`
+  return `${prefix.slice(0, opts?.maxPrefixLength)}-${Date.now().toString(36)}-${crypto.randomUUID().slice(0, 8)}`
     .toLowerCase()
     .replace(/-{2,}/g, "-");
 }

--- a/packages/shared/src/test-support/fixture-slug.ts
+++ b/packages/shared/src/test-support/fixture-slug.ts
@@ -1,0 +1,18 @@
+/**
+ * The naming convention for disposable test fixtures (projects, orgs) minted
+ * by the e2e and Playwright lanes: `<prefix>-<base36 timestamp>-<uuid slice>`.
+ *
+ * Project slugs become DNS labels (`<slug>.iterate-preview-N.app`,
+ * `<slug>.localhost`), so the result is lowercased, double dashes are
+ * collapsed, and callers that take arbitrary prefixes should pass
+ * `maxPrefixLength` to stay under label length limits. The timestamp keeps
+ * leaked fixtures attributable/sortable: there is no `projects.remove` on itx
+ * yet, so disposal is a no-op and stages accumulate fixtures until reset.
+ */
+export function uniqueFixtureSlug(prefix: string, opts?: { maxPrefixLength?: number }): string {
+  const trimmedPrefix =
+    opts?.maxPrefixLength === undefined ? prefix : prefix.slice(0, opts.maxPrefixLength);
+  return `${trimmedPrefix}-${Date.now().toString(36)}-${crypto.randomUUID().slice(0, 8)}`
+    .toLowerCase()
+    .replace(/-{2,}/g, "-");
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,6 @@ catalogs:
   cloudflare:
     '@cloudflare/unenv-preset': ^2.16.0
     '@cloudflare/vite-plugin': 1.43.0
-    '@cloudflare/vitest-pool-workers': ^0.14.9
     '@cloudflare/workers-types': ^4.20260621.1
     miniflare: 4.20260701.0
     workerd: 1.20260701.0
@@ -30,7 +29,6 @@ minimumReleaseAgeExclude:
   - '@cloudflare/workerd-windows-64'
   - '@cloudflare/unenv-preset'
   - '@cloudflare/vite-plugin'
-  - '@cloudflare/vitest-pool-workers'
   - '@cloudflare/worker-bundler'
   - '@cloudflare/workers-types'
   - '@mmkal/jsonata'

--- a/scripts/auth/forge-token.ts
+++ b/scripts/auth/forge-token.ts
@@ -43,7 +43,7 @@ async function importForgeKey(forgePrivateJwk: string) {
   const forgeJwk = JSON.parse(forgePrivateJwk) as JWK & { kid?: string; alg?: string };
   const alg = forgeJwk.alg ?? "EdDSA";
   const key = await importJWK(forgeJwk, alg);
-  return { key, protectedHeader: { alg, kid: forgeJwk.kid } as const };
+  return { key, protectedHeader: { alg, kid: forgeJwk.kid, typ: "JWT" } as const };
 }
 
 export function forgedSubjectForEmail(email: string) {

--- a/specs/create-project.spec.ts
+++ b/specs/create-project.spec.ts
@@ -1,11 +1,12 @@
 import { expect } from "@playwright/test";
 import { spinnerWaiter } from "middlewright";
+import { uniqueFixtureSlug } from "@iterate-com/shared/test-support/fixture-slug";
 import {
   signUpWithEmailOtp,
   startEmailOtpSignIn,
   uniqueSignupEmail,
 } from "./test-support/email-otp-signup.ts";
-import { test, uniqueSlug } from "./test-support/test.ts";
+import { test } from "./test-support/test.ts";
 
 // Deviation from the suite's forged-session fixture pattern: this spec uses a
 // freshly signed-up user, not a forged session. Creating a project mints new
@@ -16,13 +17,13 @@ test("a new user can create a project through the UI form", async ({ page }) => 
     !(await startEmailOtpSignIn(page)),
     "Email OTP sign-in is disabled for this deployment (APP_CONFIG_EMAIL_OTP_ENABLED on auth / APP_CONFIG_ITERATE_AUTH__EMAIL_OTP_ENABLED on OS).",
   );
-  const firstSlug = uniqueSlug("first-project");
+  const firstSlug = uniqueFixtureSlug("first-project");
   await signUpWithEmailOtp(page, {
     email: uniqueSignupEmail("create-project"),
     projectSlug: firstSlug,
   });
 
-  const slug = uniqueSlug("create-project");
+  const slug = uniqueFixtureSlug("create-project");
   // spinner-waiter is disabled through here: the /projects pending state and
   // the agent page's loading state both render two spinner-matching elements
   // at once, tripping its strict-mode isVisible.

--- a/specs/signup.spec.ts
+++ b/specs/signup.spec.ts
@@ -1,11 +1,12 @@
 import { expect } from "@playwright/test";
 import { spinnerWaiter } from "middlewright";
+import { uniqueFixtureSlug } from "@iterate-com/shared/test-support/fixture-slug";
 import {
   signUpWithEmailOtp,
   startEmailOtpSignIn,
   uniqueSignupEmail,
 } from "./test-support/email-otp-signup.ts";
-import { test, uniqueSlug } from "./test-support/test.ts";
+import { test } from "./test-support/test.ts";
 
 // Deviation from the suite's forged-session fixture pattern: this spec's whole
 // point is the REAL signup flow (goal 1 of the itx-v4 migration), so it drives
@@ -16,7 +17,7 @@ test("can sign up with an email one-time passcode", async ({ page }) => {
     "Email OTP sign-in is disabled for this deployment (APP_CONFIG_EMAIL_OTP_ENABLED on auth / APP_CONFIG_ITERATE_AUTH__EMAIL_OTP_ENABLED on OS).",
   );
 
-  const slug = uniqueSlug("signup");
+  const slug = uniqueFixtureSlug("signup");
   await signUpWithEmailOtp(page, { email: uniqueSignupEmail("signup"), projectSlug: slug });
 
   // Back on OS, signed in: onboarding created the first project's container

--- a/specs/test-support/forged-session.ts
+++ b/specs/test-support/forged-session.ts
@@ -1,37 +1,23 @@
 import type { Page } from "@playwright/test";
 import { z } from "zod/v4";
-import {
-  ITERATE_ACCESS_TOKEN_ORGANIZATIONS_CLAIM,
-  ITERATE_ACCESS_TOKEN_PROJECTS_CLAIM,
-  ITERATE_IS_ADMIN_CLAIM,
-  ITERATE_ROLE_CLAIM,
-  type IterateAuthAccessTokenOrganizationClaim,
-  type IterateAuthProjectClaim,
+import type {
+  IterateAuthAccessTokenOrganizationClaim,
+  IterateAuthProjectClaim,
 } from "@iterate-com/shared/auth-claims";
+import { uniqueFixtureSlug } from "@iterate-com/shared/test-support/fixture-slug";
 import { doppler } from "../../apps/os/scripts/dev.ts";
 import { connectItx } from "../../apps/os/src/itx-client.ts";
-
-type ForgePrivateJwk = JsonWebKey & {
-  alg?: string;
-  kid?: string;
-};
+import { mintForgedAccessToken, mintForgedIdToken } from "../../scripts/auth/forge-token.ts";
 
 type OsPlaywrightAuthConfig = {
   adminApiSecret: string;
   clientId: string;
-  forgePrivateJwk: ForgePrivateJwk;
+  /** The forge private JWK as its raw JSON string — what forge-token.ts consumes. */
+  forgePrivateJwk: string;
   issuer: string;
 };
 
 type OsPlaywrightAuthEnv = z.infer<typeof OsPlaywrightAuthEnv>;
-
-const ForgePrivateJwkSchema = z
-  .looseObject({
-    crv: z.literal("Ed25519"),
-    kid: z.string().min(1),
-    kty: z.literal("OKP"),
-  })
-  .transform((value) => value as ForgePrivateJwk);
 
 const OsPlaywrightAuthEnv = z.object({
   /** OS admin handle used to create and clean up fixture projects through /api/itx. */
@@ -44,15 +30,14 @@ const OsPlaywrightAuthEnv = z.object({
   AUTH_FORGE_PRIVATE_JWK: z
     .string()
     .min(1)
-    .transform((value, context) => {
+    .refine((value) => {
       try {
-        return JSON.parse(value);
-      } catch (error) {
-        context.addIssue({ code: "custom", message: `Invalid JSON ${value}: ${error}` });
-        return z.NEVER;
+        JSON.parse(value);
+        return true;
+      } catch {
+        return false;
       }
-    })
-    .pipe(ForgePrivateJwkSchema),
+    }, "must be the forge private JWK as a JSON string"),
 });
 
 export type MintedIterateSession = {
@@ -62,7 +47,6 @@ export type MintedIterateSession = {
 };
 
 let configPromise: Promise<OsPlaywrightAuthConfig> | undefined;
-let signingKeyPromise: Promise<CryptoKey> | undefined;
 
 export async function createProjectFixture(
   slugPrefix: string,
@@ -170,53 +154,40 @@ export async function mintIterateSession(input: {
   email: string;
   organizations: IterateAuthAccessTokenOrganizationClaim[];
   projects: IterateAuthProjectClaim[];
-}) {
+}): Promise<MintedIterateSession> {
   const config = await resolveOsPlaywrightAuthConfig();
-  const subject = `usr_forged_${input.email.replace(/[^a-z0-9]+/gi, "_").toLowerCase()}`;
-  const now = Math.floor(Date.now() / 1000);
-  const ttlSeconds = 60 * 60;
-  const expiresAtSeconds = now + ttlSeconds;
-  const sessionId = `ses_forged_${crypto.randomUUID().slice(0, 8)}`;
-
-  const accessToken = await signJwt({
+  // Signing lives in scripts/auth/forge-token.ts (the core behind
+  // `pnpm auth:mint`); this layer only picks the audience for the deployment
+  // under test and wraps the token pair in a browser cookie.
+  const accessToken = await mintForgedAccessToken({
+    forgePrivateJwk: config.forgePrivateJwk,
+    issuer: config.issuer,
     audience: authResourceForBaseUrl(input.baseUrl),
-    issuer: config.issuer,
-    payload: {
-      email: input.email,
-      scope: "openid profile email",
-      scopes: ["openid", "profile", "email"],
-      sid: sessionId,
-      [ITERATE_IS_ADMIN_CLAIM]: false,
-      [ITERATE_ROLE_CLAIM]: null,
-      [ITERATE_ACCESS_TOKEN_ORGANIZATIONS_CLAIM]: input.organizations,
-      [ITERATE_ACCESS_TOKEN_PROJECTS_CLAIM]: input.projects,
-    },
-    subject,
-    now,
-    expiresAtSeconds,
-    privateJwk: config.forgePrivateJwk,
+    email: input.email,
+    organizations: input.organizations,
+    projects: input.projects,
   });
-  const idToken = await signJwt({
-    audience: config.clientId,
+  const idToken = await mintForgedIdToken({
+    forgePrivateJwk: config.forgePrivateJwk,
     issuer: config.issuer,
-    payload: {
-      email: input.email,
-      email_verified: true,
-      name: input.email.split("@")[0] || input.email,
-      [ITERATE_IS_ADMIN_CLAIM]: false,
-      [ITERATE_ROLE_CLAIM]: null,
-    },
-    subject,
-    now,
-    expiresAtSeconds,
-    privateJwk: config.forgePrivateJwk,
+    clientId: config.clientId,
+    email: input.email,
   });
 
   return {
     accessToken,
-    expiresAtMs: expiresAtSeconds * 1000,
+    // The cookie's expiry mirrors the access token's `exp` claim exactly —
+    // the same derivation the session-from-token endpoint does server-side.
+    expiresAtMs: jwtExpirySeconds(accessToken) * 1000,
     idToken,
   };
+}
+
+function jwtExpirySeconds(token: string) {
+  const payload = JSON.parse(Buffer.from(token.split(".")[1]!, "base64url").toString("utf8")) as {
+    exp: number;
+  };
+  return payload.exp;
 }
 
 async function resolveOsPlaywrightAuthConfig(): Promise<OsPlaywrightAuthConfig> {
@@ -268,48 +239,6 @@ async function loadOsPlaywrightAuthEnv(): Promise<OsPlaywrightAuthEnv> {
   );
 }
 
-async function signJwt(input: {
-  audience: string;
-  expiresAtSeconds: number;
-  issuer: string;
-  now: number;
-  payload: Record<string, unknown>;
-  privateJwk: ForgePrivateJwk;
-  subject: string;
-}) {
-  const header = base64UrlEncode(
-    JSON.stringify({
-      alg: "EdDSA",
-      kid: input.privateJwk.kid,
-      typ: "JWT",
-    }),
-  );
-  const payload = base64UrlEncode(
-    JSON.stringify({
-      ...input.payload,
-      aud: input.audience,
-      exp: input.expiresAtSeconds,
-      iat: input.now,
-      iss: input.issuer,
-      sub: input.subject,
-    }),
-  );
-  const signingInput = `${header}.${payload}`;
-  const signature = await crypto.subtle.sign(
-    { name: "Ed25519" },
-    await signingKey(input.privateJwk),
-    new TextEncoder().encode(signingInput),
-  );
-  return `${signingInput}.${base64UrlEncode(signature)}`;
-}
-
-async function signingKey(privateJwk: ForgePrivateJwk) {
-  signingKeyPromise =
-    signingKeyPromise ||
-    crypto.subtle.importKey("jwk", privateJwk, { name: "Ed25519" }, false, ["sign"]);
-  return await signingKeyPromise;
-}
-
 function authResourceForBaseUrl(baseUrl: string) {
   const url = new URL(baseUrl);
   if (
@@ -321,13 +250,4 @@ function authResourceForBaseUrl(baseUrl: string) {
     return `http://${url.hostname}`;
   }
   return baseUrl.replace(/\/+$/, "");
-}
-
-function base64UrlEncode(value: string | ArrayBuffer) {
-  const bytes = typeof value === "string" ? new TextEncoder().encode(value) : new Uint8Array(value);
-  return Buffer.from(bytes).toString("base64url");
-}
-
-function uniqueFixtureSlug(prefix: string) {
-  return `${prefix}-${Date.now().toString(36)}-${crypto.randomUUID().slice(0, 8)}`.toLowerCase();
 }

--- a/specs/test-support/forged-session.ts
+++ b/specs/test-support/forged-session.ts
@@ -174,20 +174,17 @@ export async function mintIterateSession(input: {
     email: input.email,
   });
 
+  // The cookie's expiry mirrors the access token's `exp` claim exactly —
+  // the same derivation the session-from-token endpoint does server-side.
+  const { exp } = JSON.parse(
+    Buffer.from(accessToken.split(".")[1]!, "base64url").toString("utf8"),
+  ) as { exp: number };
+
   return {
     accessToken,
-    // The cookie's expiry mirrors the access token's `exp` claim exactly —
-    // the same derivation the session-from-token endpoint does server-side.
-    expiresAtMs: jwtExpirySeconds(accessToken) * 1000,
+    expiresAtMs: exp * 1000,
     idToken,
   };
-}
-
-function jwtExpirySeconds(token: string) {
-  const payload = JSON.parse(Buffer.from(token.split(".")[1]!, "base64url").toString("utf8")) as {
-    exp: number;
-  };
-  return payload.exp;
 }
 
 async function resolveOsPlaywrightAuthConfig(): Promise<OsPlaywrightAuthConfig> {

--- a/specs/test-support/test.ts
+++ b/specs/test-support/test.ts
@@ -73,7 +73,3 @@ export const test = base.extend<{
     }
   },
 });
-
-export function uniqueSlug(prefix: string) {
-  return `${prefix}-${Date.now().toString(36)}-${crypto.randomUUID().slice(0, 8)}`.toLowerCase();
-}

--- a/tasks/testing-strategy.md
+++ b/tasks/testing-strategy.md
@@ -216,6 +216,14 @@ they ride the next PR out of this branch.)
 
 ### Decisions wanted (each a short conversation)
 
+- [ ] **dummy-petshop unit lane has no retry wiring**: `github-app.test.ts`
+      ("deliver mode POSTs the x-hub-signature-256 header") flaked red with
+      "Error: bad port" on 2026-07-14 (port race binding its local webhook
+      receiver) and there is no `E2E_CI_RETRIES`/retry config on
+      `apps/dummy-petshop/vitest.config.ts` — one flake reds the whole Test
+      lane. Either wire the policy retry like the os configs or fix the
+      port allocation to bind port 0.
+
 - [x] **`prefer-object-property-match` on the e2e lane** — armed, all 91
       sites fixed in PR #1965 commit e9d3500a8 (3 parallel subagents on
       disjoint file sets): 81 rewritten (adjacent asserts on one receiver

--- a/tasks/testing-strategy.md
+++ b/tasks/testing-strategy.md
@@ -1,0 +1,305 @@
+---
+state: todo
+priority: high
+size: medium
+tags: [os, testing, e2e, lint, strategy]
+---
+
+# Testing strategy: decision log + change backlog
+
+Working document for the testing-strategy effort (branch `testing-strategy`,
+audit 2026-07-14). Decisions get dated entries; backlog items graduate into
+PRs and get checked off. The end state is a rewritten
+[docs/testing.md](../docs/testing.md) that names the philosophy explicitly —
+this file tracks how we get there.
+
+## Decisions
+
+- **2026-07-14 — vitest e2e and Playwright specs are sibling lanes.** Same
+  operational contract (Doppler config supplies the deployment, budgets from
+  `e2e-policy/budgets.ts`, one retry in CI, retry telemetry, artifact
+  collection); they differ only in assertion surface — itx API vs real
+  browser. Keep both runners: middlewright is Playwright-native and porting
+  it would risk the spinner-waiter for aesthetics. Any browser-driving that
+  isn't Playwright must justify itself.
+- **2026-07-14 — bring back the disarmed lint rules**, considered
+  individually (table below).
+- **2026-07-14 — verdict: arm all of them.** First PR in flight
+  (`rearm-e2e-lint-rules`): re-arms every rule per the proposed scopes,
+  fixes violations, adds the scope-liveness guard. The no-describe
+  flattening rides in its own commit so it can be dropped if the rationale
+  doesn't hold up (Jonas asked "why no describe" — answer: flat files are
+  the specs-as-specs doctrine; the wrapper restates the filename, and
+  describes are where closure state + lifecycle hooks breed, which fights
+  test-owns-its-state and the retry policy).
+- **2026-07-14 — unit-test bar: tables + tiny kernels** (grilling round 1).
+  Wide case tables (processor harnesses, incident repros) plus
+  zero-maintenance adversarial/security kernels earn unit tests; delete
+  only what actively lies (tautology, pinning, mock theater).
+- **2026-07-14 — ship gate: per-artifact hard rules.** Processor ⇒ harness
+  suite with refold + eviction; itx capability ⇒ catalogue example;
+  product flow ⇒ spec; incident fix ⇒ captured-journal repro. Absence is
+  a review blocker. Now drafted into docs/testing.md.
+- **2026-07-14 — deletions deferred** (Jonas: "discuss what to delete
+  later"). The LLM-in-e2e question got superseded by a better framing from
+  Jonas: **test dimensions** — surface (browser/node), speed, determinism,
+  cost (pays for LLM turns), remote reach — as first-class controllable
+  axes, while still using vanilla vitest/playwright CLIs "Misha style".
+  Draft proposal now lives in docs/testing.md § "Test dimensions (DRAFT)";
+  grilling round 2 queued on its open questions.
+
+## How the lint enforcement got disarmed (for the record)
+
+Two events, both collateral damage inside large refactors — nobody decided
+to turn the rules off:
+
+1. **PR #1341** (2026-05-18, "Remove legacy OS1 stack") deleted the
+   `spec/**` override block from `.oxlintrc.json`, taking
+   `iterate/spec-restricted-syntax` and the forced
+   `@playwright/test` → wrapped-`test` import redirect with it. When the new
+   root `specs/` lane was built days later (#1556), the block was never
+   re-created.
+2. **PR #1488** (2026-06-15, "Delete oRPC stack 2/2") deleted
+   `apps/os/e2e/vitest/agents.e2e.test.ts` — the single pilot file the
+   #1361 test-style rules were scoped to. `.oxlintrc.json:261` still points
+   at the ghost path today; the rules run against nothing.
+
+All seven rule implementations survive in `lint/oxlint-plugin-iterate.ts`,
+so re-arming is config-only plus violation fix-ups. Lesson encoded below as
+the scope-liveness guard.
+
+## Rule-by-rule reconsideration
+
+Violation counts measured 2026-07-14. "Verdict" column is for Jonas.
+
+| Rule (`lint/oxlint-plugin-iterate.ts`)                                               | Enforces                                                                                                                                                 | Violations today                                                                                                                                            | Proposed scope                                                                                                                                                                                                                                        | Verdict |
+| ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `prefer-test-over-it` (:971)                                                         | `test(...)` not `it(...)`                                                                                                                                | 2–3 sites, all in `e2e/examples/examples-browser.test.ts`                                                                                                   | `apps/os/e2e/**` + unit lanes (near-zero cost)                                                                                                                                                                                                        |         |
+| `no-lifecycle-hooks` (:724)                                                          | No `beforeEach`/`afterAll` etc.; disposable fixtures (`Symbol.asyncDispose`) instead                                                                     | **0** in `apps/os/e2e/**`                                                                                                                                   | `apps/os/e2e/**`, `specs/**` — free win. Unit lane has 29 uses; decide separately                                                                                                                                                                     |         |
+| `no-vi-mock` (:768)                                                                  | No `vi.mock`; DI / controllable fakes at the product boundary                                                                                            | **0** in `apps/os/e2e/**`                                                                                                                                   | `apps/os/e2e/**`, `specs/**` — free win. Unit lane has 24 uses (9 in `scripts/deploy.test.ts` = the mock-theater cluster); arming there forces per-file disables, i.e. mocking becomes a visible commented decision — separate call                   |         |
+| `no-describe` (:747)                                                                 | Flat files; the first readable unit is a test                                                                                                            | 20 calls across 19 e2e files (mostly single top-level wrappers)                                                                                             | `apps/os/e2e/**` after a mechanical flattening pass. Caveat: `describe.skipIf` env-gating (e.g. Slack suite) converts to `test.skipIf` per test or gets a commented disable. NOT for the unit lane (269 uses; `describe.for` is a documented pattern) |         |
+| `helpers-after-tests` (:913)                                                         | Helpers/fixture builders below the tests; file opens with behavior                                                                                       | unknown — needs a dry run                                                                                                                                   | `apps/os/e2e/**`, `specs/**`                                                                                                                                                                                                                          |         |
+| `prefer-object-property-match` (:944)                                                | `expect(obj).toMatchObject({p})` over `expect(obj.p).toBe(...)` — failure shows the whole object                                                         | unknown — needs a dry run                                                                                                                                   | `apps/os/e2e/**`, `specs/**`                                                                                                                                                                                                                          |         |
+| `spec-restricted-syntax` (:1111)                                                     | Playwright dialect: no awaited `expect(...)` (locators + `.waitFor()`; `expect.poll` OK), no `toBe(true/false)`, no `waitForURL`, no `baseURL` in `goto` | `specs/`: 3× `waitForURL` (signup/create-project redirect waits), 5× `toBe(true/false)`, 6× `waitForTimeout`\* all in `stream-resume-after-suspend.spec.ts` | `specs/**`. \*The suspend spec waits through windows with deliberately no UI progress — that file gets a commented disable, which is exactly the escalation rule (#1791) working                                                                      |         |
+| `no-restricted-imports` on `@playwright/test#test` (plain oxlint config, not plugin) | Specs must use the wrapped `test` (spinner-waiter, hydration, error reporter)                                                                            | 0 — 17/17 specs comply socially; only `specs/test-support/test.ts` imports raw (it IS the wrapper → exempt)                                                 | `specs/**`, message updated to point at `specs/test-support/test.ts`                                                                                                                                                                                  |         |
+
+**MERGED 2026-07-14 as `db8917f15`** — all seven rules + the
+scope-liveness guard are live on main. During babysitting, the merge from
+main brought in two repo-IDE specs whose 20s web-first waits the
+newly-armed `spec-restricted-syntax` immediately caught (kept behind
+reasoned disables — the rule working on day one); the final red check was
+a Depot provisioning failure (no logs produced), fixed by `depot ci
+rerun`. Bugbot passed; zero unresolved threads.
+
+**Outcome — PR #1965 (2026-07-14):** everything armed except
+`prefer-object-property-match` on the e2e block — the dry run found **92**
+sites, tripping the >50-sites escape valve — then Jonas called it: fixed
+and armed in a follow-up commit on the same PR (e9d3500a8; see below). `spec-restricted-syntax` was bigger
+than estimated: 30 sites, because the rule flags bare `expect()` under any
+`AwaitExpression` ancestor — including sync expects inside awaited
+`spinnerWaiter.settings.run(...)` closures; 23 rewritten to locator waits,
+7 kept via commented disables in the suspend repro. `describe.skipIf`
+gates became per-test `test.skipIf`. Collected test counts preserved
+(vitest e2e 135→135, playwright 49→49 — script-verified 1:1 mapping).
+Bonus: the scope-liveness guard exposed **10 pre-existing dead globs** in
+`.oxlintrc.json` (`startups/**`, `**/*.jsx`, `**/test-utils.ts`, …) —
+removed with zero behavior change.
+
+Related but not a rule: `toBe(true/false)` also appears **36×** in the
+vitest e2e lane (`workspace.itx` 8, `live-state` 4, `itx-egress` 4, long
+tail 1–2). If we want that ban outside Playwright specs, either extend
+`spec-restricted-syntax`'s scope or lean on `prefer-object-property-match`
+— decide during the dry run.
+
+**The scope-liveness guard (do regardless of verdicts):** a unit test in the
+same genre as `scripts/preview/e2e-policy.test.ts` asserting every
+`overrides[].files` glob in `.oxlintrc.json` matches ≥1 real file. An
+exact-filename scope survives human refactors but not AI ones; this makes a
+dead scope a red build instead of a silent no-op.
+
+## Helper geography (PR #1993 delivers this — awaiting review)
+
+**PR #1993** (branch `test-helper-geography`, not merged): charter section
+in docs/testing.md (truth fix: L1 spans TWO homes — dev-server in
+`apps/os/scripts/`, forge at repo-root `scripts/auth/`), forge-signer
+dedupe (~80-line WebCrypto fork deleted; claims field-identical; typ:JWT
+header gap closed by extending forge-token; cookie expiry now derived
+from token exp; live-proven via dashboard + REPL specs and a real
+auth:mint 302), fixture-slug L0 module (found THREE copies, not two —
+os-client `uniqueSuffix` was the third), and the video-mode docs (Part D
+below). Bonus doc'd gotcha: repo-root `doppler run --config dev -- pnpm
+spec` resolves `_shared` and its DOPPLER_PROJECT poisons the specs'
+nested os-secrets download.
+
+**Video-mode truth (Jonas asked 2026-07-14):** the automatic part is
+recording/rendering only (middlewright `videoMode`: pointer highlights,
+
+> 300ms dead-air speed-up, auto trimStart; output
+> `test-results/playwright-output/<test>/video-rendered.webm`, needs
+> ffmpeg). PR attach is MANUAL: webm→mp4, drag into the GitHub web editor
+> (mints the `user-attachments` URL — the only host GitHub's `<video>`
+> sanitiser allows; no API/gh upload route). Backlog option if we ever
+> want true automation: release-asset GIF/mp4 route like #1764.
+
+Original proposal for reference:
+
+Four layers; a helper lives at the LOWEST layer all its consumers share.
+Imports point down only. Needed by both lanes ⇒ move down, never copy
+sideways.
+
+| Layer                     | Home                                                                                  | Charter                                                                                                                       | Today                                                                               |
+| ------------------------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| L0 policy/infra           | `packages/shared/src/test-support/`                                                   | Runner-agnostic: budgets, retry telemetry, artifacts (+ proposed: fixture slug/disposal convention)                           | e2e-policy, vitest-e2e                                                              |
+| L1 environment & identity | `apps/os/scripts/`                                                                    | Dev-server lifecycle (`dev.ts`, `dev-server-info.ts`), doppler plumbing, auth forge (`scripts/auth/forge-token.ts`)           | already consumed by BOTH lanes (playwright webServer, #1987 globalSetup, auth:mint) |
+| L2 surface clients        | `apps/os/e2e/test-support/` (itx surface) and `specs/test-support/` (browser surface) | Lane-specific: os-client/create-test-project/tunnel/mock-slack vs middlewright test wrapper/forged-session fixture/OTP signup | mostly right                                                                        |
+| L3 domain harnesses       | `apps/os/src/domains/*/test-helpers.ts`, colocated                                    | Unit-lane fakes implementing real interfaces; never imported by L2+                                                           | `streams/test-helpers.ts` canonical since PR #1988                                  |
+
+Known violations / moves:
+
+1. **Forge signing duplicated** — `specs/test-support/forged-session.ts`
+   has its own `signJwt` (:271) and does NOT import
+   `scripts/auth/forge-token.ts` (which auth:mint uses). Converge on
+   forge-token as the one signer; forged-session keeps only the
+   browser/cookie/fixture layer. (specs already imports from
+   apps/os — `doppler` from scripts/dev.ts, `connectItx` — so the
+   downward dependency is established practice.)
+2. **Fixture convention split** — `create-test-project.ts` (admin-itx
+   authority) and `createProjectFixture` (forged-session authority) are
+   parallel BY DESIGN, but slug shape / DNS trimming / `await using`
+   disposal semantics should be one L0 module so they stop drifting.
+3. `wait-for-condition.ts` (L2 e2e) is generic → promote to L0 only when
+   a spec needs it.
+4. #1988 survey items (connect-flow hoisted fakes incl. github-connect
+   offset-numbering drift, MemoryKv/FakeKv) are L3 work — consolidate
+   colocated, do NOT lift into shared.
+
+Anti-goal: one mega test-support package — it would drag itx clients and
+forge machinery into a package workers import, and distance helpers from
+their lanes. Charter over centralization.
+
+## Backlog
+
+### Sibling-lane alignment (follows from decision 1)
+
+- [x] `pnpm e2e` auto-starts the local dev server mirroring `pnpm spec`'s
+      webServer semantics (no-op on deployed target / reuse live / start
+      detached / never boot in CI; no new env vars) — **PR #1987**,
+      live-proven incl. cold browser-project 26/26 (port coherence via a
+      config-eval `Symbol.for` stash shared with globalSetup — review
+      that mechanism). Awaiting Jonas review; NOT merged.
+- [x] Root `pnpm e2e` alias — same PR #1987.
+- [x] specs-at-repo-root rationale written into specs/AGENTS.md — same
+      PR #1987.
+- [ ] Decide the vitest **browser project**
+      (`e2e/examples/examples-browser.test.ts`): third browser driver,
+      local-only, preview coverage already delegated to
+      `specs/repl-examples.spec.ts`. Kill or demote to explicit manual
+      probe. (Killing it also removes the only `it(` sites in e2e.)
+
+### Quick mechanical fixes (doc/config drift from the audit)
+
+- [x] Re-point `.oxlintrc.json:261` per the verdicts above (globs, never
+      exact filenames) + add the scope-liveness guard — **PR #1965**.
+- [x] `docs/testing.md` ladder row: `OS_PREVIEW_VITEST_LANE_TIMEOUT_SECS`
+      360s → the constant is now `OS_PREVIEW_LANE_TIMEOUT_SECS` = 480s.
+- [x] `docs/testing.md` says the spinner-waiter lives in `patches/` — it's
+      the `middlewright` npm dep since #1813.
+- [x] `apps/os/e2e/AGENTS.md` still describes the pre-split
+      `itx.e2e.test.ts` monolith.
+- [x] Prune 5 dead entries from `observedFileSeconds` in
+      `apps/os/e2e/vitest.config.ts` (files renamed/deleted).
+- [x] Delete the `**/*.workerd.test.ts` exclude glob (zero matching files) —
+      the doctrine decision (catalog pins, docs) is still open below.
+
+(All five done 2026-07-14 on branch `testing-strategy`, uncommitted —
+they ride the next PR out of this branch.)
+
+### Decisions wanted (each a short conversation)
+
+- [x] **`prefer-object-property-match` on the e2e lane** — armed, all 91
+      sites fixed in PR #1965 commit e9d3500a8 (3 parallel subagents on
+      disjoint file sets): 81 rewritten (adjacent asserts on one receiver
+      merged into single `toMatchObject` calls), 10 kept behind
+      reasoned `oxlint-disable-next-line` comments where exhaustive
+      `toEqual`/frozen-state exactness is deliberate — incl. the
+      result-spill test, where printing the whole object on failure would
+      mean 10MB diffs (the rule's goal inverted). Collected count 135
+      unchanged; lint 0/0; typecheck green.
+
+- [x] **Workerd doctrine, explicitly** — drafted as Philosophy §6 in
+      docs/testing.md; the dead `@cloudflare/vitest-pool-workers` catalog
+      pin + its release-age exclude deleted (lockfile unchanged = provably
+      unconsumed). Audit CORRECTION: miniflare IS consumed
+      (`catalog:cloudflare` dep of os/auth/semaphore) and stays; workerd
+      pin left alone. Remaining: Jonas ratifies the doctrine wording.
+- [ ] **Dead lanes**: `apps/os/runtime-smoke.test.ts` (CI-skipped,
+      unwired), `apps/os/e2e/playwright/` + `apps/os/playwright.config.ts`
+      (wired into nothing). Wire, mark as manual probes, or delete — each
+      individually.
+- [ ] **Auth real-OAuth gap**: forged sessions bypass the code exchange
+      (incident class: streams.iterate.com stale registrations); auth's
+      preview "e2e" is one curl of the discovery doc. Cheapest fix: one spec
+      through the genuine OAuth flow per preview run.
+- [ ] **Prompt/template pinning policy**: budgets + referential integrity
+      YES (`agent-prompt-budgets.test.ts` is the good version); copy pinning
+      NO. Then delete: prompt `toContain` batteries
+      (`agent-processors.test.ts:56-79`), most of
+      `exec-typescript-description.test.ts` (keep the positional truncation
+      invariants), the string anchors in `config-repo-template.test.ts`
+      (keep structural asserts), constant restatements in
+      `subscriber-math.test.ts:19-27`.
+- [ ] **`scripts/deploy.test.ts` mock theater** (9× `vi.mock`): slim to the
+      security kernels (forbidden-service-token, exact-project-miss).
+- [ ] **Internal-CLI arg tests** (`cli.test.ts`, `session.test.ts`,
+      `itx.test.ts`, ~320 LOC): docs/testing.md explicitly disclaims these;
+      delete, keeping `session.ts`'s authority-mode guard.
+- [ ] **Dated-skip convention**: `test.skip` marked "KNOWN GAP" needs an
+      owner/expiry or it rots (`stream-lifecycle.e2e.test.ts:520`).
+
+### Larger refactors
+
+- [x] **Consolidate the harness copies** — **PR #1988** (awaiting review,
+      not merged): SIX duplicates found (audit's five + project-processor + scheduler-processor), and `agents/test-helpers.ts` was itself a
+      second "canonical" — now deleted; `streams/test-helpers.ts` is the
+      single home. Net **−851 LOC**; test counts byte-identical (1410).
+      Load-bearing clock divergences kept as explicit `now` pins with
+      comments (telegram refold stale-read; github `now: () => 10`);
+      `failAppendsOfType` promoted to canonical. Three latent hazards
+      flagged in the old copies (epoch createdAt staleness, stubbed
+      `getEvent`, creating-`eventsAt` corruption). Original plan text:
+      4–5 near-identical
+      `MemoryStreamNetwork`/`MemoryStream` re-implementations (~400 LOC) in
+      slack/email/telegram/github suites → import the shared harness
+      (`apps/os/src/domains/agents/test-helpers.ts`,
+      `streams/test-helpers.ts`). Protects the single best test asset from
+      fake-drift.
+- [ ] **The strategy doc itself**: rewrite docs/testing.md with a named
+      philosophy section — the spinner-waiter incentive loop (Misha; quote
+      the middlewright README), specs-as-product-specs (`specs/AGENTS.md`),
+      fresh-project-per-test isolation, the one-retry ladder, harness-
+      fidelity honesty (the `stream-subscribers.teardown` pattern), the
+      no-workerd doctrine. Fold or retire `docs/vitest-patterns.md` (it
+      recommends inline snapshots; the corpus has exactly one).
+- [ ] **`llmRecover`**: Misha's soft-fail LLM-recovery middlewright plugin
+      is dormant (not wired in `specs/test-support/test.ts`). Revive or
+      retire.
+- [ ] **Shared-helpers round 2** (from PR #1988's survey): connect-flow
+      `vi.hoisted` binding fakes (github-connect / telegram-connect /
+      google-connection) re-implement STREAM/SECRET seams with divergent
+      offset semantics — github-connect's fake numbers a 2-event batch
+      2,3 on append but 1,2 on getEvents (same drift class the
+      consolidation killed); duplicate Map-backed KV fakes (`MemoryKv`
+      vs `FakeKv`); copy-pasted `vi.mock` egress bundles across
+      integration suites.
+
+## Audit reference (compressed)
+
+~213 test files / ~46k LOC. Unit lane (vitest node, colocated) 146 files /
+33.9k LOC — top six files are the stream-processor/fold harness suites
+(~9k LOC, the deliberate docs/testing.md exception). OS e2e (vitest vs live
+deployment) 42 / 9.8k. Root Playwright specs 17 / 1.5k. Auth 7 / 807 via
+`node --test`. Genuinely low-value material ≈1.5k LOC (pinning, mock
+theater, CLI arg tests, dead lanes). Full audit report: chat session
+2026-07-14; Misha attribution evidence: middlewright README + repo,
+`specs/AGENTS.md` (100% his), PRs #1122/#1340/#1361/#1556/#1560/#1564/
+#1567/#1570/#1791.


### PR DESCRIPTION
## What

Four related pieces of test-infrastructure hygiene: a docs charter for where test helpers live, one forge signer instead of two, one fixture-slug convention instead of three, and documentation for Misha's video mode so everyone can put spec demos on their PRs.

## Part A — "Where test helpers live" (docs/testing.md)

| Layer | Home | Charter |
| --- | --- | --- |
| L0 policy & infra | `packages/shared/src/test-support/` | Runner-agnostic: e2e-policy budgets + retry telemetry, vitest run-artifact plumbing, the fixture slug convention (`fixture-slug.ts`, new) |
| L1 environment & identity | `apps/os/scripts/` and `scripts/auth/` | Dev-server lifecycle (`dev.ts`, `lib/dev-server-info.ts`), Doppler plumbing, the auth forge (`scripts/auth/forge-token.ts` behind `pnpm auth:mint`) — consumed by both lanes' configs |
| L2 surface clients | `apps/os/e2e/test-support/` (itx) · `specs/test-support/` (browser) | Lane-specific clients/fixtures |
| L3 domain harnesses | `apps/os/src/domains/*/test-helpers.ts`, colocated | Unit-lane fakes implementing real interfaces; never imported by L2+ |

Rule: a helper lives at the lowest layer all its consumers share; imports point down only; needed-by-both-lanes means move down, never copy sideways. Anti-goal: one mega test-support package (it would drag itx clients + forge machinery into a package workers import). `wait-for-condition.ts` deliberately stays L2 until a spec needs it.

Note the L1 home is truthfully **two** directories: dev-server lifecycle lives in `apps/os/scripts/`, the forge in repo-root `scripts/auth/`.

## Part B — one forge signer

`specs/test-support/forged-session.ts` had its own WebCrypto `signJwt` + JWK schema duplicating `scripts/auth/forge-token.ts` (the `pnpm auth:mint` core). It now imports `mintForgedAccessToken` / `mintForgedIdToken` and keeps only the audience/cookie/fixture layer.

Field-by-field claims diff (forged-session before → forge-token after):

| Field | Before (spec fork) | After (forge-token) | Equivalence |
| --- | --- | --- | --- |
| header `alg`/`kid` | `EdDSA` / jwk kid | `jwk.alg ?? "EdDSA"` / jwk kid | identical for the Ed25519 forge key |
| header `typ` | `"JWT"` | `"JWT"` — **added to forge-token** (was absent) | the one gap; forge-token extended minimally, `auth:mint` tokens gain a standards-correct `typ` (verifier uses jose `jwtVerify` with issuer/audience only — typ not enforced) |
| `iss` | config issuer | same | identical |
| `aud` (access) | `authResourceForBaseUrl(baseUrl)` | same value, still computed by forged-session (caller owns audience) | byte-identical |
| `aud` (id) | client id | client id | identical |
| `sub` | `usr_forged_<email normalized>` | `forgedSubjectForEmail()` — literally the same expression | identical |
| `email`, `scope`, `scopes`, `email_verified`, `name` | literals / `email.split("@")[0]` | identical literals / same derivation | identical for all real inputs |
| `iterate.com/is_admin` / `role` | `false` / `null` | `admin ?? false` → `false` / `null` | identical (fixtures never mint admin) |
| org/project claims | passed arrays | passed arrays (`organizations`/`projects` params already existed) | identical |
| `iat`/`exp` | `now` / `now + 3600` | `now` / `now + 3600` (default ttl) | identical semantics; the cookie's `expiresAtMs` is now **decoded from the token's `exp`** (same derivation the session-from-token endpoint does server-side), so cookie and token can never skew |
| `sid` | `ses_forged_` + uuid slice | `ses_forged_` + base36 rand | random either way; asserted nowhere (grepped) |

Cookie name (`iterate_session`), shape, `sameSite`, `secure`, and the loopback-origin audience rule are untouched.

## Part C — one fixture slug convention (L0)

New `packages/shared/src/test-support/fixture-slug.ts`: `<prefix>-<base36 timestamp>-<uuid slice>`, lowercased, dash runs collapsed, optional `maxPrefixLength` for DNS-label headroom. Replaces **three** copies (grep found a third): `os-client.ts` `uniqueSuffix` (e2e), forged-session's private `uniqueFixtureSlug` (specs), and `test.ts` `uniqueSlug` (specs UI-typed slugs).

- specs lane: byte-identical convention to before (plus the defensive dash-collapse; prefixes stay untrimmed — some are >20 chars).
- e2e `createTestProject`: keeps its 20-char prefix trim via `{ maxPrefixLength: 20 }`. Two deliberate cosmetics, loudly not silently: decimal `Date.now()` → base36 (5 chars shorter, same uniqueness), and first-`--`-only collapse → all dash runs. Grep found nothing asserting on slug shapes; `preview-mcp-smoke-<sha>` naming is separate and untouched, as is `examples-browser.test.ts`'s local marker suffix (markers, not fixture slugs).
- Disposal semantics untouched and still documented at the call sites: `projects.remove` doesn't exist yet, the `await using` no-op shape is deliberate.

## Part D — video mode documented (design: Misha / middlewright)

What I learned investigating the actual mechanism, now written down in docs/testing.md:

- **Automatic part**: `VIDEO_MODE=1 pnpm spec -g "<flow>"` — config flips `video: "on"` + relaxed budgets; middlewright's `videoMode` plugin post-renders pointer highlights, speeds up dead air >300ms, holds the final frame, and auto-trims the blank startup lead-in (`trimStart: "auto"`, iterate/middlewright#3 via #1788). Output: `test-results/playwright-output/<test-dir>/video-rendered.webm` (+ raw webm + `video-mode.html` frame-stepper). Needs ffmpeg.
- **Manual part (the attach)**: GitHub renders an inline player only for `user-attachments/assets/…` URLs, and only the web editor's attachment flow mints those — convert `video-rendered.webm` → mp4, drag/paste into the PR-description editor, leave the minted URL on its own line. There is **no API/gh route** for that upload; `<video>` tags pointing at any other host are sanitised, which is why older PRs (e.g. #1764) fell back to release-asset GIFs. #1788 is the working inline-video example.
- Recipe gotcha discovered while proving the doc: from the repo root, `doppler run --config dev -- pnpm spec` resolves the `_shared` Doppler project and its `DOPPLER_PROJECT` env poisons the specs' nested os-secrets download — run bare locally (specs read the `apps/os` scope themselves) or wrap with `--project os` for deployed targets. The doc recipe shows both working forms.

## Live proof

Against local dev (this branch):

- `pnpm spec -g "dashboard"` → **1 passed (8.0s)** — forged-session smoke, i.e. forge-token-signed access+id tokens created the fixture, set the cookie, and entered the dashboard.
- `pnpm spec -g "project REPL accepts a forged session"` → **1 passed (5.7s)**.
- `pnpm auth:mint --help` works; a real mint → `GET /api/iterate-auth/session-from-token` → **HTTP 302** (server-side `jwtVerify` accepts the new `typ`-bearing tokens on the `auth:mint` lane too).
- `VIDEO_MODE=1 pnpm spec -g "dashboard"` → passed; `video-rendered.webm`, `video-raw.webm`, `video-mode.html`, `video-mode.json` appeared exactly where the new doc says.
- `pnpm lint`, `pnpm typecheck`, `pnpm knip`, `pnpm format` green; `packages/shared` unit suite 38/38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation and test-harness refactors; the forge-token path affects Playwright auth fixtures and `auth:mint` headers but is low-risk with claimed live spec coverage.
> 
> **Overview**
> Consolidates test infrastructure and documents how testing is organized: a **four-layer helper charter** (L0 shared policy through L3 domain harnesses), expanded **philosophy** (e2e-first, middlewright timeouts, no workerd vitest pool), ship-with rules, draft test dimensions, and **VIDEO_MODE** recording plus manual GitHub PR attach steps.
> 
> **Code hygiene:** adds L0 `uniqueFixtureSlug` in `@iterate-com/shared/test-support/fixture-slug` and wires it through OS e2e `createTestProject`, Playwright specs, and forged-session fixtures—replacing three divergent slug helpers and removing `uniqueSuffix` from `os-client`. Playwright **forged-session** drops ~80 lines of duplicate WebCrypto JWT signing in favor of `scripts/auth/forge-token.ts` (`mintForgedAccessToken` / `mintForgedIdToken`); forge tokens gain `typ: "JWT"`, and session cookie expiry is derived from the access token `exp`.
> 
> **Config/docs cleanup:** drops unused `@cloudflare/vitest-pool-workers` from the pnpm catalog and the dead `**/*.workerd.test.ts` vitest exclude; updates `e2e/AGENTS.md` for the split `itx-*.e2e.test.ts` files. Adds `tasks/testing-strategy.md` as the decision/backlog companion to the rewritten `docs/testing.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f9dbb0626cacc6304fbd1bf662a528adcacf9b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "cleanup-failed",
      "updatedAt": "2026-07-14T15:02:23.988Z",
      "headSha": "7f9dbb0626cacc6304fbd1bf662a528adcacf9b5",
      "message": "CloudflareApiError: Cloudflare API POST /accounts/376ef7ed81b0573f93524de763666c15/d1/database/2017a0b9-ebd5-482c-b2b8-894a27733dbc/query failed (429): [{\"code\":971,\"message\":\"Please wait and consider throttling your request speed\"}]\n    at cfV4 (/home/runner/work/iterate/iterate/scripts/lib/env-context.ts:108:13)\n    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)\n    at async wipeD1Tables (/home/runner/work/iterate/iterate/scripts/lib/deploy-helpers.ts:312:5)\n    at async eraseData (/home/runner/work/iterate/iterate/apps/auth/scripts/erase-data.ts:44:3)\n    at async Command.<anonymous> (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:416:32)\n    at async Command.parseAsync (/home/runner/work/iterate/iterate/node_modules/.pnpm/commander@14.0.3/node_modules/commander/lib/command.js:1122:5)\n    at async Command.<anonymous> (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:457:21)\n    at async Command.parseAsync (/home/runner/work/iterate/iterate/node_modules/.pnpm/commander@14.0.3/node_modules/commander/lib/command.js:1122:5)\n    at async Object.run (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:527:9) {\n  method: 'POST',\n  path: '/accounts/376ef7ed81b0573f93524de763666c15/d1/database/2017a0b9-ebd5-482c-b2b8-894a27733dbc/query',\n  status: 429\n}\n\n\n> @iterate-com/auth@0.0.0-dev destroy /home/runner/work/iterate/iterate/apps/auth\n> tsx ./scripts/erase-data.ts --env preview_3\n\nErasing all data in preview_3 (auth D1 2017a0b9-ebd5-482c-b2b8-894a27733dbc)\n ELIFECYCLE  Command failed with exit code 1.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/265938980866177",
      "shortSha": "7f9dbb0",
      "cleanupDurationMs": 1498,
      "deployDurationMs": 18200,
      "testDurationMs": 655,
      "testRetries": null,
      "workerSizeKib": 4030.87,
      "workerGzipKib": 819.54,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-14T15:02:22.926Z",
      "headSha": "7f9dbb0626cacc6304fbd1bf662a528adcacf9b5",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/265938980866177",
      "shortSha": "7f9dbb0",
      "cleanupDurationMs": 433,
      "deployDurationMs": 16350,
      "testDurationMs": 21058,
      "testRetries": null,
      "workerSizeKib": 5117.13,
      "workerGzipKib": 1458.43,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-14T15:02:21.144Z",
      "headSha": "7f9dbb0626cacc6304fbd1bf662a528adcacf9b5",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/265938980866177",
      "shortSha": "7f9dbb0",
      "cleanupDurationMs": 222570,
      "deployDurationMs": 84482,
      "testDurationMs": 206395,
      "testRetries": "9 retried: agent answers after llm model is selected (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · is MITM-intercepted and routed through project egress with secret substitution (vitest x1) · delivery expressions must end in a property step, rejected before commit (vitest x1) · webhook subscriptions validate their URL before commit (vitest x1) · global streams reject webhook subscriptions before commit (vitest x1) · stream subscribe replays history, tails live appends, and unsubscribes (vitest x1) · reactivity page repaints from a stream subscription after a page action (specs x1) · reactivity page appends a batch and renders every delivered marker (specs x1)",
      "workerSizeKib": 16353.42,
      "workerGzipKib": 4410.78,
      "mainWorkerGzipKib": 4411.67
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-14T14:58:39.142Z",
      "headSha": "7f9dbb0626cacc6304fbd1bf662a528adcacf9b5",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/265938980866177",
      "shortSha": "7f9dbb0",
      "cleanupDurationMs": 564,
      "deployDurationMs": 13450,
      "testDurationMs": 6939,
      "testRetries": null,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.78,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": {
    "dopplerConfig": "preview_3",
    "slug": "preview-3"
  },
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>Slot: preview-3 | Doppler config: preview_3</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | cleanup failed | `7f9dbb0` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 819.5 KiB | 18.2s | 655ms |  | 1.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/265938980866177) | 2026-07-14T15:02:23.988Z | CloudflareApiError: Cloudflare API POST /accounts/376ef7ed81b0573f93524de763666c15/d1/database/2017a0b9-ebd5-482c-b2b8-894a27733dbc/query failed (429): [{"code":971,"message":"Ple... |
| OS | released | `7f9dbb0` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 4.31 MiB (-0.9 KiB vs main) | 84.5s | 206.4s | 9 retried: agent answers after llm model is selected (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · is MITM-intercepted and routed through project egress with secret substitution (vitest x1) · delivery expressions must end in a property step, rejected before commit (vitest x1) · webhook subscriptions validate their URL before commit (vitest x1) · global streams reject webhook subscriptions before commit (vitest x1) · stream subscribe replays history, tails live appends, and unsubscribes (vitest x1) · reactivity page repaints from a stream subscription after a page action (specs x1) · reactivity page appends a batch and renders every delivered marker (specs x1) | 222.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/265938980866177) | 2026-07-14T15:02:21.144Z | Preview app released. |
| Semaphore | released | `7f9dbb0` | [https://semaphore.iterate-preview-3.com](https://semaphore.iterate-preview-3.com) | 440.8 KiB | 13.4s | 6.9s |  | 564ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/265938980866177) | 2026-07-14T14:58:39.142Z | Preview app released. |
| Streams Example App | released | `7f9dbb0` | [https://streams.iterate-preview-3.com](https://streams.iterate-preview-3.com) | 1.42 MiB | 16.4s | 21.1s |  | 433ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/265938980866177) | 2026-07-14T15:02:22.926Z | Preview app released. |

</details>

<details>
<summary>Auth failure details</summary>

<pre>CloudflareApiError: Cloudflare API POST /accounts/376ef7ed81b0573f93524de763666c15/d1/database/2017a0b9-ebd5-482c-b2b8-894a27733dbc/query failed (429): [{"code":971,"message":"Please wait and consider throttling your request speed"}]
    at cfV4 (/home/runner/work/iterate/iterate/scripts/lib/env-context.ts:108:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async wipeD1Tables (/home/runner/work/iterate/iterate/scripts/lib/deploy-helpers.ts:312:5)
    at async eraseData (/home/runner/work/iterate/iterate/apps/auth/scripts/erase-data.ts:44:3)
    at async Command.&lt;anonymous&gt; (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:416:32)
    at async Command.parseAsync (/home/runner/work/iterate/iterate/node_modules/.pnpm/commander@14.0.3/node_modules/commander/lib/command.js:1122:5)
    at async Command.&lt;anonymous&gt; (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:457:21)
    at async Command.parseAsync (/home/runner/work/iterate/iterate/node_modules/.pnpm/commander@14.0.3/node_modules/commander/lib/command.js:1122:5)
    at async Object.run (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:527:9) {
  method: 'POST',
  path: '/accounts/376ef7ed81b0573f93524de763666c15/d1/database/2017a0b9-ebd5-482c-b2b8-894a27733dbc/query',
  status: 429
}


&gt; @iterate-com/auth@0.0.0-dev destroy /home/runner/work/iterate/iterate/apps/auth
&gt; tsx ./scripts/erase-data.ts --env preview_3

Erasing all data in preview_3 (auth D1 2017a0b9-ebd5-482c-b2b8-894a27733dbc)
 ELIFECYCLE  Command failed with exit code 1.</pre>

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +17 -1 | +6 -1 🟩⬜⬜⬜⬜ |
| Tests | +13 -15 | +12 -13 🟥⬜⬜⬜⬜ |
| CI & scripts | +1 -1 | +1 -1 🟩⬜⬜⬜⬜ |
| Config | +1 -2 | +1 -2 🟥⬜⬜⬜⬜ |
| Docs | +510 -24 | +440 -24 🟩🟩🟩🟩🟩 |
| Other | +34 -121 | +27 -113 🟥🟥⬜⬜⬜ |
| **Total** | **+576 -164** | **+487 -154** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 985e5d1 and 7f9dbb0, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->