### PR TITLE
fix: allow ~ in StreamPath (unbreak project shell)

### DIFF
--- a/apps/os/src/components/stream-switcher-dialog.tsx
+++ b/apps/os/src/components/stream-switcher-dialog.tsx
@@ -17,8 +17,9 @@ import { formatTimeAgo } from "~/lib/format-relative-time.ts";
 import { useLiveState } from "~/itx/itx-react.tsx";
 
 // A full canonical StreamPath of at least one segment: leading slash, lowercase
-// segments separated by single slashes, no trailing slash.
-const STREAM_PATH_PATTERN = /^(?:\/[a-z0-9_-]+)+$/;
+// segments separated by single slashes, no trailing slash. `~` is legal — GitHub
+// agent paths use g~<hex> (must stay aligned with StreamPath in stream-links).
+const STREAM_PATH_PATTERN = /^(?:\/[a-z0-9_~-]+)+$/;
 
 // The "what's happening right now" window for the default ⌘K list.
 const RECENT_WINDOW_MS = 5 * 60_000;

--- a/apps/os/src/lib/stream-links.test.ts
+++ b/apps/os/src/lib/stream-links.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  StreamPath,
+  streamPathAncestors,
+  streamPathFromSplat,
+  streamPathParent,
+  streamPathToSplat,
+} from "./stream-links.ts";
+
+describe("StreamPath", () => {
+  it("accepts the empty root and ordinary kebab segments", () => {
+    expect(StreamPath.parse("/")).toBe("/");
+    expect(StreamPath.parse("/agents")).toBe("/agents");
+    expect(StreamPath.parse("/agents/slack/main/c123/ts-111-222")).toBe(
+      "/agents/slack/main/c123/ts-111-222",
+    );
+  });
+
+  it("accepts GitHub agent paths that encode the link fingerprint with g~", () => {
+    // Production agent streams for pull requests live at
+    // /agents/repos/g~<sha256hex>/pull-requests/<n> — the tilde is part of the
+    // durable identity (see github-agent-utils). The agent roster on the
+    // project shell links every status row through StreamPath.parse; rejecting
+    // ~ crashes /projects/<slug> for any project with a linked GitHub repo.
+    const raw =
+      "/agents/repos/g~e8fa7f072e4aa206b600dd33a5eed6c49199f677f3826282a56515a8bef2aeb8/pull-requests/1998";
+    const path = StreamPath.parse(raw);
+    expect(path).toBe(raw);
+    expect(streamPathParent(path)).toBe(
+      "/agents/repos/g~e8fa7f072e4aa206b600dd33a5eed6c49199f677f3826282a56515a8bef2aeb8/pull-requests",
+    );
+    expect(streamPathAncestors(path).at(-1)).toBe(path);
+    expect(streamPathFromSplat(path.slice(1))).toBe(path);
+    expect(streamPathToSplat(path)).toBe(path.slice(1));
+  });
+
+  it("rejects segments with characters outside the path alphabet", () => {
+    expect(() => StreamPath.parse("/agents/with space")).toThrow();
+    expect(() => StreamPath.parse("/agents/Upper")).toThrow();
+    expect(() => StreamPath.parse("/agents/has.dot")).toThrow();
+  });
+});

--- a/apps/os/src/lib/stream-links.ts
+++ b/apps/os/src/lib/stream-links.ts
@@ -1,12 +1,17 @@
 import { z } from "zod";
 
-// Canonical stream path (leading slash, lowercase kebab segments), formerly
+// Canonical stream path (leading slash, lowercase path segments), formerly
 // the shared streams package's StreamPath. This module owns stream-path URL
 // plumbing, so the schema lives here; other UI modules import it from here.
+//
+// Segment alphabet is `[a-z0-9_-~]`: the tilde is required for GitHub agent
+// paths (`/agents/repos/g~<sha256hex>/pull-requests/<n>`). Without `~`, the
+// project shell's agent roster (which runs StreamPath.parse on every status
+// row) throws and the entire /projects/<slug> page hard-errors.
 const CanonicalStreamPath = z
   .string()
   .max(1023)
-  .regex(/^\/(?:[a-z0-9_-]+(?:\/[a-z0-9_-]+)*)?$/);
+  .regex(/^\/(?:[a-z0-9_~-]+(?:\/[a-z0-9_~-]+)*)?$/);
 
 export const StreamPath = z.preprocess<string, typeof CanonicalStreamPath, string>((value) => {
   if (typeof value !== "string") {


### PR DESCRIPTION
## Summary

**Production break:** `/projects/iterate` (and any project with GitHub PR agents) hard-errors:

```
invalid_format … pattern: /^\\/(?:[a-z0-9_-]+…)$/
```

**Root cause:** `StreamPath` segment alphabet was `[a-z0-9_-]`, but GitHub agent paths are `/agents/repos/g~<sha256>/pull-requests/<n>`. After #1966 the sidebar roster runs `StreamPath.parse` on every agent path → Zod throw → shell dies.

**Fix at the root:** expand the canonical `StreamPath` regex (and the matching ⌘K switcher pattern) to allow `~`. No roster workaround, no backwards-compat shim.

## Test plan

- [x] Unit: `stream-links.test.ts` accepts `g~…` paths, rejects spaces/upper/dots
- [ ] CI green
- [ ] Prod: https://os.iterate.com/projects/iterate loads after deploy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow alphabet expansion with unit tests; no auth or data-path changes beyond fixing validation for existing production URLs.
> 
> **Overview**
> **Fixes a production hard-error on `/projects/<slug>`** when the project has GitHub PR agents: agent stream paths use `g~<sha256hex>` segments, but `StreamPath` only allowed `[a-z0-9_-]`, so `StreamPath.parse` on roster rows threw and the project shell crashed.
> 
> The canonical **`StreamPath` Zod regex** in `stream-links.ts` and the matching **`STREAM_PATH_PATTERN`** in the ⌘K stream switcher now allow `~` in segments (`[a-z0-9_~-]`), with comments tying this to GitHub agent path shape.
> 
> Adds **`stream-links.test.ts`** covering root/kebab paths, a real `g~…/pull-requests/<n>` path (plus parent/ancestors/splat helpers), and rejection of spaces, uppercase, and dots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ceb02c530da3cf401919105a57ed67798fb06e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +7 -2 | +1 -1 🟩⬜⬜⬜⬜ |
| UI components | +3 -2 | +1 -1 🟩⬜⬜⬜⬜ |
| Tests | +42 -0 | +34 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+52 -4** | **+36 -2** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between efc3015 and 5ceb02c, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

> [!CAUTION]
> All preview slots are leased — this PR is waiting in line for one (since 2026-07-14T15:45:05.229Z).
>   preview-2  leased by pr-1984 until 2026-07-15T13:31:44.325Z (21h47m left) | https://github.com/iterate/iterate/pull/1984
>   preview-3  leased by pr-1993 until 2026-07-15T14:58:38.511Z (23h14m left) | https://github.com/iterate/iterate/pull/1993
>   preview-4  leased by pr-1990 until 2026-07-15T13:53:39.946Z (22h9m left) | https://github.com/iterate/iterate/pull/1990
>   preview-5  leased by pr-1902 until 2026-07-15T15:41:51.034Z (23h57m left) | https://github.com/iterate/iterate/pull/1902
>   preview-6  leased by pr-1992 until 2026-07-15T15:41:33.277Z (23h56m left) | https://github.com/iterate/iterate/pull/1992
>   preview-7  leased by pr-1986 until 2026-07-15T14:09:29.214Z (22h24m left) | https://github.com/iterate/iterate/pull/1986
>   preview-8  leased by pr-1994 until 2026-07-15T15:10:11.977Z (23h25m left) | https://github.com/iterate/iterate/pull/1994
>   preview-9  leased by pr-1987 until 2026-07-15T14:44:59.818Z (22h60m left) | https://github.com/iterate/iterate/pull/1987
>   preview-1  leased by pr-1997 until 2026-07-15T15:33:59.500Z (23h49m left) | https://github.com/iterate/iterate/pull/1997

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": "All preview slots are leased — this PR is waiting in line for one (since 2026-07-14T15:45:05.229Z).\n  preview-2  leased by pr-1984 until 2026-07-15T13:31:44.325Z (21h47m left) | https://github.com/iterate/iterate/pull/1984\n  preview-3  leased by pr-1993 until 2026-07-15T14:58:38.511Z (23h14m left) | https://github.com/iterate/iterate/pull/1993\n  preview-4  leased by pr-1990 until 2026-07-15T13:53:39.946Z (22h9m left) | https://github.com/iterate/iterate/pull/1990\n  preview-5  leased by pr-1902 until 2026-07-15T15:41:51.034Z (23h57m left) | https://github.com/iterate/iterate/pull/1902\n  preview-6  leased by pr-1992 until 2026-07-15T15:41:33.277Z (23h56m left) | https://github.com/iterate/iterate/pull/1992\n  preview-7  leased by pr-1986 until 2026-07-15T14:09:29.214Z (22h24m left) | https://github.com/iterate/iterate/pull/1986\n  preview-8  leased by pr-1994 until 2026-07-15T15:10:11.977Z (23h25m left) | https://github.com/iterate/iterate/pull/1994\n  preview-9  leased by pr-1987 until 2026-07-15T14:44:59.818Z (22h60m left) | https://github.com/iterate/iterate/pull/1987\n  preview-1  leased by pr-1997 until 2026-07-15T15:33:59.500Z (23h49m left) | https://github.com/iterate/iterate/pull/1997"
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->