### PR TITLE
fix: allow ~ in StreamPath segments (unbreak project shell)

### DIFF
--- a/apps/os/src/components/stream-switcher-dialog.tsx
+++ b/apps/os/src/components/stream-switcher-dialog.tsx
@@ -17,8 +17,9 @@ import { formatTimeAgo } from "~/lib/format-relative-time.ts";
 import { useLiveState } from "~/itx/itx-react.tsx";
 
 // A full canonical StreamPath of at least one segment: leading slash, lowercase
-// segments separated by single slashes, no trailing slash.
-const STREAM_PATH_PATTERN = /^(?:\/[a-z0-9_-]+)+$/;
+// segments separated by single slashes, no trailing slash. `~` is legal — GitHub
+// agent paths use g~<hex> (must stay aligned with StreamPath in stream-links).
+const STREAM_PATH_PATTERN = /^(?:\/[a-z0-9_~-]+)+$/;
 
 // The "what's happening right now" window for the default ⌘K list.
 const RECENT_WINDOW_MS = 5 * 60_000;

--- a/apps/os/src/lib/stream-links.test.ts
+++ b/apps/os/src/lib/stream-links.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  StreamPath,
+  streamPathAncestors,
+  streamPathFromSplat,
+  streamPathParent,
+  streamPathToSplat,
+} from "./stream-links.ts";
+
+describe("StreamPath", () => {
+  it("accepts the empty root and ordinary kebab segments", () => {
+    expect(StreamPath.parse("/")).toBe("/");
+    expect(StreamPath.parse("/agents")).toBe("/agents");
+    expect(StreamPath.parse("/agents/slack/main/c123/ts-111-222")).toBe(
+      "/agents/slack/main/c123/ts-111-222",
+    );
+  });
+
+  it("accepts GitHub agent paths that encode the link fingerprint with g~", () => {
+    // Production agent streams for pull requests live at
+    // /agents/repos/g~<sha256hex>/pull-requests/<n> — the tilde is part of the
+    // durable identity (see github-agent-utils). The agent roster on the
+    // project shell links every status row through StreamPath.parse; rejecting
+    // ~ crashes /projects/<slug> for any project with a linked GitHub repo.
+    const raw =
+      "/agents/repos/g~e8fa7f072e4aa206b600dd33a5eed6c49199f677f3826282a56515a8bef2aeb8/pull-requests/1998";
+    const path = StreamPath.parse(raw);
+    expect(path).toBe(raw);
+    expect(streamPathParent(path)).toBe(
+      "/agents/repos/g~e8fa7f072e4aa206b600dd33a5eed6c49199f677f3826282a56515a8bef2aeb8/pull-requests",
+    );
+    expect(streamPathAncestors(path).at(-1)).toBe(path);
+    expect(streamPathFromSplat(path.slice(1))).toBe(path);
+    expect(streamPathToSplat(path)).toBe(path.slice(1));
+  });
+
+  it("rejects segments with characters outside the path alphabet", () => {
+    expect(() => StreamPath.parse("/agents/with space")).toThrow();
+    expect(() => StreamPath.parse("/agents/Upper")).toThrow();
+    expect(() => StreamPath.parse("/agents/has.dot")).toThrow();
+  });
+});

--- a/apps/os/src/lib/stream-links.ts
+++ b/apps/os/src/lib/stream-links.ts
@@ -1,12 +1,17 @@
 import { z } from "zod";
 
-// Canonical stream path (leading slash, lowercase kebab segments), formerly
+// Canonical stream path (leading slash, lowercase path segments), formerly
 // the shared streams package's StreamPath. This module owns stream-path URL
 // plumbing, so the schema lives here; other UI modules import it from here.
+//
+// Segment alphabet is `[a-z0-9_-~]`: the tilde is required for GitHub agent
+// paths (`/agents/repos/g~<sha256hex>/pull-requests/<n>`). Without `~`, the
+// project shell's agent roster (which runs StreamPath.parse on every status
+// row) throws and the entire /projects/<slug> page hard-errors.
 const CanonicalStreamPath = z
   .string()
   .max(1023)
-  .regex(/^\/(?:[a-z0-9_-]+(?:\/[a-z0-9_-]+)*)?$/);
+  .regex(/^\/(?:[a-z0-9_~-]+(?:\/[a-z0-9_~-]+)*)?$/);
 
 export const StreamPath = z.preprocess<string, typeof CanonicalStreamPath, string>((value) => {
   if (typeof value !== "string") {


### PR DESCRIPTION
## What

Prd's `/projects/<slug>` pages hard-error with a ZodError (`invalid_format` against the canonical stream-path regex) for any project with a GitHub-linked repo. #1994 introduced agent streams at `/agents/repos/g~<sha256hex>/pull-requests/<n>` — the `~` is outside the UI's segment alphabet `[a-z0-9_-]`.

The project home renders the root stream feed; every `child-stream-created` row builds its link via `linkOptionsForStreamPath` → `StreamPath.parse`, so a single `g~` path throws during render and the whole page error-boundaries. The agent roster (#1966) parses the same way for any busy `g~` PR agent. Confirmed on prd `iterate`: the root journal has hundreds of `g~…` child paths (roster is empty there, so the feed rows are the trigger).

## Fix

Add `~` to the canonical segment alphabet in `lib/stream-links.ts` and the ⌘K switcher's aligned `STREAM_PATH_PATTERN`. No workaround, no compat shims — the alphabet simply now matches what the platform mints.

## Tests

New `stream-links.test.ts` pins the real prd `g~<hex>` path through parse/parent/ancestors/splat round-trip, plus the rejection cases (spaces, uppercase, dots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow validation widening for paths the platform already mints; no auth or data-path changes beyond fixing parse failures.
> 
> **Overview**
> **Fixes hard errors on `/projects/<slug>`** when the stream feed or agent roster hits GitHub PR agent paths like `/agents/repos/g~<sha256hex>/pull-requests/<n>` — `StreamPath.parse` was rejecting `~` because segments only allowed `[a-z0-9_-]`.
> 
> The canonical Zod regex in `stream-links.ts` and the aligned `STREAM_PATH_PATTERN` in the stream switcher dialog now include `~` in each segment. **New `stream-links.test.ts`** covers a real `g~` path (parse, parent, ancestors, splat round-trip) and keeps rejecting spaces, uppercase, and dots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 186f706038508b1d3edd71f1cc7567b3fe51e6a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +7 -2 | +1 -1 🟩⬜⬜⬜⬜ |
| UI components | +3 -2 | +1 -1 🟩⬜⬜⬜⬜ |
| Tests | +42 -0 | +34 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+52 -4** | **+36 -2** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between c80cad7 and 186f706, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->