### PR TITLE
Fix stale writer-lock name in example-app follower test

### DIFF
--- a/apps/streams-example-app/e2e/playwright/stream-browser.spec.ts
+++ b/apps/streams-example-app/e2e/playwright/stream-browser.spec.ts
@@ -1153,9 +1153,17 @@ async function holdLegacyWriterLock(page: Page, streamPath: string) {
 
 async function holdCurrentWriterLock(page: Page, streamPath: string) {
   await page.evaluate(async (path) => {
+    // Must match the lock a live mirror runtime requests, or the fresh tab below
+    // would elect itself leader and this "empty follower" test would be vacuous.
+    // Source of truth: streamMirrorWriterLockName + mirrorLockVersionVector in
+    // apps/os/.../browser/stream-leader.ts. Format:
+    //   stream-writer:<projectId>:<path>:browser-stream-mirror:<versionVector>
+    // versionVector = the canonical members' `<slug>@<schemaVersion>` sorted and
+    // joined by "|" (browser-feed@1, browser-raw-events@6). Bump here whenever a
+    // member's schemaVersion changes — that bump is exactly what this lock guards.
     await new Promise<void>((resolve) => {
       void navigator.locks.request(
-        `next-stream-writer:default:${path}:browser-raw-events:v4`,
+        `stream-writer:default:${path}:browser-stream-mirror:browser-feed@1|browser-raw-events@6`,
         async () => {
           resolve();
           await new Promise(() => {});


### PR DESCRIPTION
## Why

Tiny follow-up to #1997 (the browser stream mirror unification).

The example app's `stream-browser.spec.ts` helper `holdCurrentWriterLock` held the **old per-slug** lock name:

```
next-stream-writer:default:<path>:browser-raw-events:v4
```

That was the correct name before #1997. Since #1997, one mirror runtime per `(projectId, streamPath)` elects on a **mirror-level** lock:

```
stream-writer:<projectId>:<path>:browser-stream-mirror:<versionVector>
```

So the held lock no longer contended with the fresh tab — it elected itself **leader**, and the *"empty follower state is visible"* test became **vacuous**. In fact it **fails on `main`** today; the example-app playwright suite isn't wired into any CI lane (only the deploy workflow runs), so it went unnoticed.

## What

Update the held name to the current format. `versionVector` = the canonical members' `<slug>@<schemaVersion>`, sorted and `|`-joined — i.e. `browser-feed@1|browser-raw-events@6` (derived straight from `mirrorLockVersionVector` + `streamMirrorWriterLockName` in `stream-leader.ts`, referenced in a comment so a future schema bump updates it here — which is exactly what this lock guards).

## Verification

Ran the test locally against the auth-less local vite server (no doppler needed):
- **Corrected name → PASSES** — fresh tab is a `follower`, `Events: 0`, warning visible (8.0s).
- **Stale name → FAILS** — fresh tab wrongly elects itself leader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to a Playwright helper lock string and comments; no production runtime behavior.
> 
> **Overview**
> Updates the example app Playwright helper **`holdCurrentWriterLock`** so it holds the same **mirror-level** Web Lock the browser runtime uses after stream mirror unification (#1997), instead of the obsolete per-slug `next-stream-writer:…:browser-raw-events:v4` name.
> 
> The held lock is now `stream-writer:default:<path>:browser-stream-mirror:browser-feed@1|browser-raw-events@6`, matching `streamMirrorWriterLockName` + `mirrorLockVersionVector` in `stream-leader.ts`. A comment documents that format and that the version vector must be bumped when member `schemaVersion` changes.
> 
> This restores the **"empty follower state is visible"** test: without contention on the real lock, the fresh tab wrongly elected itself leader and the assertion was vacuous (and failing on `main`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d74035e78724ad02258272367babc94d76d3f99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +9 -1 | +1 -1 🟩🟩🟩🟥🟥 |
| **Total** | **+9 -1** | **+1 -1** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 7b106d6 and 0d74035, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-15T09:02:22.049Z",
      "headSha": "0d74035e78724ad02258272367babc94d76d3f99",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/160281898528725",
      "shortSha": "0d74035",
      "cleanupDurationMs": 429,
      "deployDurationMs": 19801,
      "testDurationMs": 16918,
      "testRetries": null,
      "workerSizeKib": 5138.1,
      "workerGzipKib": 1465.54,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Streams Example App | released | `0d74035` | [https://streams.iterate-preview-2.com](https://streams.iterate-preview-2.com) | 1.43 MiB | 19.8s | 16.9s |  | 429ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/160281898528725) | 2026-07-15T09:02:22.049Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->