### PR TITLE
Run all workspace and Petshop tests in CI

### DIFF
--- a/.depot/workflows/cloudflare-preview-cleanup.yml
+++ b/.depot/workflows/cloudflare-preview-cleanup.yml
@@ -45,6 +45,7 @@ on:
       - apps/os/src/domains/streams/**
       - apps/semaphore/**
       - apps/streams-example-app/**
+      - apps/dummy-petshop/**
 
 concurrency:
   group: cloudflare-previews-${{ github.event.pull_request.number || inputs.pull-request-number }}

--- a/.depot/workflows/cloudflare-previews.yml
+++ b/.depot/workflows/cloudflare-previews.yml
@@ -64,6 +64,7 @@ on:
       - apps/os/src/domains/streams/**
       - apps/semaphore/**
       - apps/streams-example-app/**
+      - apps/dummy-petshop/**
   workflow_dispatch:
     inputs:
       pull-request-number:

--- a/apps/os/e2e/vitest/integrations-github.e2e.test.ts
+++ b/apps/os/e2e/vitest/integrations-github.e2e.test.ts
@@ -21,18 +21,24 @@
 // instead — so proving one proves both.
 //
 // Requires a deployed OS (APP_CONFIG_BASE_URL) and a reachable dummy-petshop
-// (PETSHOP_BASE_URL, or derived). See petshop-support.ts.
+// (the exact PETSHOP_BASE_URL supplied by preview orchestration).
 
 import { generateKeyPairSync } from "node:crypto";
 import { expect, test } from "vitest";
 import { waitForCondition } from "../test-support/wait-for-condition.ts";
 import { adminSecret, withItxSession } from "./test-helpers.ts";
-import { petshopBaseUrl, petshopExpireTokens, petshopRegisterApp } from "./petshop-support.ts";
+import {
+  petshopBaseUrl,
+  petshopExpireTokens,
+  petshopRegisterApp,
+  shouldSkipPetshopE2e,
+} from "./petshop-support.ts";
 
 const RUN = crypto.randomUUID().slice(0, 8);
 
-// Opt-in: talks to a deployed dummy-petshop (see integrations-petshop.e2e.test).
-test.skipIf(!process.env.PETSHOP_BASE_URL)(
+// Local runs opt in explicitly; preview CI supplies its leased Petshop URL
+// and fails closed if orchestration ever drops it.
+test.skipIf(shouldSkipPetshopE2e())(
   "bring-your-own App: mint installation token in the Secret DO, act as the installation, re-mint on expiry",
   async () => {
     const petshop = petshopBaseUrl();

--- a/apps/os/e2e/vitest/integrations-petshop.e2e.test.ts
+++ b/apps/os/e2e/vitest/integrations-petshop.e2e.test.ts
@@ -13,7 +13,7 @@
 //   3. describe() never leaks material; uses land on the audit trail.
 //
 // Requires a deployed OS (APP_CONFIG_BASE_URL) and a reachable dummy-petshop
-// (PETSHOP_BASE_URL, or derived). See petshop-support.ts.
+// (the exact PETSHOP_BASE_URL supplied by preview orchestration).
 
 import { expect, test } from "vitest";
 import { waitForCondition } from "../test-support/wait-for-condition.ts";
@@ -25,16 +25,16 @@ import {
   petshopExchangeCode,
   petshopExpireTokens,
   petshopMintClient,
+  shouldSkipPetshopE2e,
 } from "./petshop-support.ts";
 
 const RUN = crypto.randomUUID().slice(0, 8);
 const REDIRECT_URI = "https://example.com/callback";
 
-// Opt-in: this suite talks to a deployed dummy-petshop, which only exists at
-// slots where it was deployed. Point PETSHOP_BASE_URL at one to run it;
-// otherwise it skips, so the shared CI e2e lane (whose preview slot has no
-// petshop) stays green.
-test.skipIf(!process.env.PETSHOP_BASE_URL)(
+// Local runs can opt in by pointing PETSHOP_BASE_URL at a fixture. Preview CI
+// always supplies the Petshop deployment from its own leased slot and fails
+// closed rather than silently skipping this coverage.
+test.skipIf(shouldSkipPetshopE2e())(
   "two OAuth clients, two connections: connect, call, forced-expiry refresh",
   async () => {
     const petshop = petshopBaseUrl();
@@ -121,7 +121,7 @@ test.skipIf(!process.env.PETSHOP_BASE_URL)(
 // APP_CONFIG_INTEGRATIONS__PETSHOP) resolved from typed AppConfig by the
 // Secret DO's trusted code. No project app secret, no platform bytes in
 // project material. Only `clientCreds` differs from the userspace lane.
-test.skipIf(!process.env.PETSHOP_BASE_URL)(
+test.skipIf(shouldSkipPetshopE2e())(
   "first-party lane: client credential resolves from platform config, same strategy",
   async () => {
     const petshop = petshopBaseUrl();

--- a/apps/os/e2e/vitest/integrations-userspace.e2e.test.ts
+++ b/apps/os/e2e/vitest/integrations-userspace.e2e.test.ts
@@ -15,7 +15,7 @@
 import { expect, test } from "vitest";
 import { waitForCondition } from "../test-support/wait-for-condition.ts";
 import { startEgressEcho } from "./itx-capability-fixtures.ts";
-import { petshopBaseUrl, petshopExpireTokens } from "./petshop-support.ts";
+import { petshopBaseUrl, petshopExpireTokens, shouldSkipPetshopE2e } from "./petshop-support.ts";
 import { adminSecret, withItxSession } from "./test-helpers.ts";
 
 const RUN_SUFFIX = crypto.randomUUID().slice(0, 8);
@@ -233,7 +233,7 @@ test("builtin waitrose: grammar, __describe, and method-miss stay loud", async (
 // use (no initial token anywhere), re-mint on 401 — and the minted session is
 // an ordinary bearer on petshop's ONE pets API. Same opt-in gate as
 // integrations-petshop.e2e.test.ts.
-test.skipIf(!process.env.PETSHOP_BASE_URL)(
+test.skipIf(shouldSkipPetshopE2e())(
   "waitrose-session strategy: username/password secret mints on first use, re-mints on 401, session works on the API",
   async () => {
     const petshop = petshopBaseUrl();

--- a/apps/os/e2e/vitest/petshop-support.ts
+++ b/apps/os/e2e/vitest/petshop-support.ts
@@ -11,17 +11,27 @@ export const PETSHOP_DEFAULT_CLIENT = {
   clientSecret: "petshop-default-secret",
 } as const;
 
-/** The petshop the OS deployment can reach. Explicit `PETSHOP_BASE_URL` wins;
- * otherwise derive it from the OS base by swapping the first hostname label
- * (`os.iterate-preview-3.com` → `dummy-petshop.iterate-preview-3.com`). */
+/**
+ * Local e2e can opt out when the fixture was not started. CI may not: the
+ * preview orchestrator must pass the deployed sibling's exact URL, and a
+ * missing value is an orchestration failure rather than permission to turn
+ * these integration tests into silent skips.
+ */
+export function shouldSkipPetshopE2e(): boolean {
+  if (process.env.PETSHOP_BASE_URL?.trim()) return false;
+  if (process.env.CI === "true") {
+    throw new Error(
+      "CI must provide PETSHOP_BASE_URL for the deployed preview Petshop; refusing to skip OS Petshop e2e.",
+    );
+  }
+  return true;
+}
+
+/** The exact deployed Petshop selected by the preview orchestrator. */
 export function petshopBaseUrl(): string {
   const explicit = process.env.PETSHOP_BASE_URL?.trim();
   if (explicit) return explicit.replace(/\/$/, "");
-  const appBase = process.env.APP_CONFIG_BASE_URL?.trim();
-  if (!appBase) throw new Error("petshop e2e needs PETSHOP_BASE_URL or APP_CONFIG_BASE_URL");
-  const url = new URL(appBase);
-  url.hostname = url.hostname.replace(/^[^.]+\./, "dummy-petshop.");
-  return url.origin;
+  throw new Error("petshop e2e needs the deployed fixture's exact PETSHOP_BASE_URL");
 }
 
 function backdoorHeaders(): Record<string, string> {

--- a/apps/os/scripts/deploy.test.ts
+++ b/apps/os/scripts/deploy.test.ts
@@ -9,9 +9,26 @@ import {
   assertDopplerSecretAbsent,
   assertWorkerSecretAbsent,
 } from "../../../scripts/lib/deploy-helpers.ts";
-import { isExactOsProjectMiss } from "./deploy.ts";
+import { assertPreviewPetshopIntegrationConfigured, isExactOsProjectMiss } from "./deploy.ts";
 
 const secretName = "APP_CONFIG_ITERATE_AUTH__SERVICE_TOKEN";
+
+describe("preview Petshop deployment invariant", () => {
+  it("requires first-party Petshop credentials in every preview OS config", () => {
+    expect(() => assertPreviewPetshopIntegrationConfigured("preview_4", {})).toThrow(
+      /preview_4 requires APP_CONFIG_INTEGRATIONS__PETSHOP/,
+    );
+    expect(() =>
+      assertPreviewPetshopIntegrationConfigured("preview_4", {
+        APP_CONFIG_INTEGRATIONS__PETSHOP: '{"oauthClientId":"petshop-default"}',
+      }),
+    ).not.toThrow();
+  });
+
+  it("does not require the test fixture in production", () => {
+    expect(() => assertPreviewPetshopIntegrationConfigured("prd", {})).not.toThrow();
+  });
+});
 
 describe("forbidden auth service-token invariants (secret-leak protection)", () => {
   it("refuses when the resolved Doppler config carries the retired secret", () => {

--- a/apps/os/scripts/deploy.ts
+++ b/apps/os/scripts/deploy.ts
@@ -55,6 +55,21 @@ import { ensureWorkerEventsQueue } from "./event-queue-resources.ts";
 import { ensureR2Bucket } from "./ensure-resources.ts";
 
 const RETIRED_AUTH_SERVICE_TOKEN = "APP_CONFIG_ITERATE_AUTH__SERVICE_TOKEN";
+const PREVIEW_PETSHOP_CONFIG = "APP_CONFIG_INTEGRATIONS__PETSHOP";
+
+/** Preview OS always runs its first-party integration proof against the
+ * sibling dummy Petshop. Keep the formerly optional deployment setting from
+ * drifting out of a slot and turning that proof into a runtime 401. */
+export function assertPreviewPetshopIntegrationConfigured(
+  envName: string,
+  secrets: Record<string, string | undefined>,
+) {
+  if (envName.startsWith("preview_") && !secrets[PREVIEW_PETSHOP_CONFIG]?.trim()) {
+    throw new Error(
+      `${envName} requires ${PREVIEW_PETSHOP_CONFIG} so OS preview e2e can exercise the deployed dummy Petshop.`,
+    );
+  }
+}
 
 function osSmokes(env: DeployedEnv) {
   return [
@@ -152,6 +167,8 @@ export default async function deploy(
       if (previewHeadSha) {
         secretValues.APP_CONFIG_ITERATE_SDK_PACKAGE_SPEC = `https://pkg.pr.new/iterate/iterate/iterate@${previewHeadSha}`;
       }
+
+      assertPreviewPetshopIntegrationConfigured(ctx.name, secretValues);
 
       // Parse the exact env the worker will see (secrets + generated vars) with
       // the worker's own schema — the strongest possible pre-flight.

--- a/apps/os/src/domains/secrets/utils.ts
+++ b/apps/os/src/domains/secrets/utils.ts
@@ -433,11 +433,11 @@ type SecretErrorCode =
  * a 4xx instead of leaking an exception. `detail` (message-only) names the
  * specifics — e.g. which URL part held a disallowed placeholder. */
 export class SecretSubstitutionError extends Error {
-  constructor(
-    readonly code: SecretErrorCode,
-    detail?: string,
-  ) {
+  readonly code: SecretErrorCode;
+
+  constructor(code: SecretErrorCode, detail?: string) {
     super(detail === undefined ? code : `${code}: ${detail}`);
+    this.code = code;
     this.name = "SecretSubstitutionError";
   }
 }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -64,6 +64,16 @@ away from.
 | TUI              | `pnpm exec tsx e2e/tui-test/run.ts`   | `apps/os/e2e/tui-test/`                 | The `iterate chat` TUI through a real PTY (Microsoft TUI Test) against a disposable project.                                                                                                                                                                                                                                                                                                                       |
 | Playwright specs | `pnpm spec` (repo root)               | `specs/` (`playwright.config.ts`)       | Browser-level product flows: signup, project create, dashboard, REPL, agent chat, reactivity.                                                                                                                                                                                                                                                                                                                      |
 
+The normal Depot **Test** workflow runs `pnpm test` from the repo root. That
+recursively runs every workspace's `test` script, including the `iterate` CLI
+and dummy-petshop's unit suite. Live tests with separate `test:e2e` scripts
+belong to preview CI instead: dummy-petshop is deployed and runs its complete
+live e2e whenever that app is selected.
+
+Two narrower lanes are deliberate. The TUI lane above is manual-only. The
+streams example app runs its `@preview`-tagged Vitest and Playwright coverage
+in preview CI; its full `pnpm test:e2e` suite remains a local/manual lane.
+
 Smoke-testing a deployment (what the deploy pipeline probes automatically,
 plus manual/agent recipes for production): [Smoke testing](smoke-testing.md).
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -68,7 +68,10 @@ The normal Depot **Test** workflow runs `pnpm test` from the repo root. That
 recursively runs every workspace's `test` script, including the `iterate` CLI
 and dummy-petshop's unit suite. Live tests with separate `test:e2e` scripts
 belong to preview CI instead: dummy-petshop is deployed and runs its complete
-live e2e whenever that app is selected.
+live e2e whenever that app is selected. Selecting OS also selects and deploys
+dummy-petshop first, then passes that same leased preview's recorded
+`PETSHOP_BASE_URL` into the OS e2e lane. The OS Petshop integration specs fail
+CI if that URL is absent; they cannot silently skip back out of preview CI.
 
 Two narrower lanes are deliberate. The TUI lane above is manual-only. The
 streams example app runs its `@preview`-tagged Vitest and Playwright coverage

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "spec": "playwright test --config playwright.config.ts",
     "e2e": "pnpm --dir apps/os e2e",
     "vitest": "pnpm --dir apps/os test",
-    "test": "pnpm -r --parallel --filter '!iterate' test",
+    "test": "pnpm -r --parallel test",
     "clean": "rm -rf ./**/node_modules",
     "super-reset": "pnpm i && pnpm -r --parallel --filter '!iterate' super-reset",
     "auth:mint": "tsx scripts/auth/mint-session.ts",

--- a/scripts/ci/depot-workflows.test.ts
+++ b/scripts/ci/depot-workflows.test.ts
@@ -136,6 +136,16 @@ describe("Depot deployment safety", () => {
 });
 
 describe("Depot validation capacity", () => {
+  it("runs every workspace test script, including the iterate CLI", () => {
+    const packageJson = JSON.parse(readFileSync(resolve(repoRoot, "package.json"), "utf8")) as {
+      scripts: { test: string };
+    };
+    const workflow = readFileSync(resolve(repoRoot, ".depot/workflows/test.yml"), "utf8");
+
+    expect(packageJson.scripts.test).toBe("pnpm -r --parallel test");
+    expect(workflow).toContain("run: doppler run -- pnpm test");
+  });
+
   it.each([
     {
       file: ".depot/workflows/test.yml",

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -41,6 +41,7 @@ const {
   orderPreviewDeployBatches,
   parseCloudflarePreviewState,
   parseEnvironmentConfigLeaseData,
+  readPreviewAppConfig,
   reconcileEnvironmentConfigLeaseResources,
   releaseLeaseDespiteTeardownFailure,
   renderCloudflarePreviewPullRequestBody,
@@ -116,7 +117,7 @@ describe("preview workflow scope", () => {
     expect(cloudflarePreviewSharedPaths).toContain("patches/**");
   });
 
-  it("runs the dummy-petshop live e2e against its deployed preview", () => {
+  it("runs the dummy-petshop live e2e against its deployed preview", async () => {
     const petshop = cloudflarePreviewApps["dummy-petshop"];
 
     expect(petshop).toMatchObject({
@@ -125,6 +126,17 @@ describe("preview workflow scope", () => {
       previewReadyUrlPath: "/",
       previewTestBaseUrlEnvVar: "PETSHOP_BASE_URL",
       previewTestCommandArgs: ["pnpm", "test:e2e"],
+    });
+    await expect(
+      readPreviewAppConfig({
+        app: petshop,
+        commandEnvironment: {},
+        dopplerConfig: "preview_3",
+        repositoryRoot: repoRoot,
+      }),
+    ).resolves.toEqual({
+      baseUrl: "https://dummy-petshop.iterate-preview-3.com",
+      projectHostnameBases: [],
     });
     for (const workflow of ["cloudflare-previews.yml", "cloudflare-preview-cleanup.yml"]) {
       expect(readFileSync(resolve(repoRoot, ".depot/workflows", workflow), "utf8")).toContain(

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -48,6 +48,7 @@ const {
   resolveAuthPreviewRootSecret,
   resolvePreviewCompareBaseSha,
   resolvePreviewReadinessUrls,
+  resolvePreviewTestBaseUrlEnvironment,
   selectPreviewAppsForPullRequest,
   selectPreviewAppsNeedingRetry,
   splitRepositoryFullName,
@@ -55,8 +56,8 @@ const {
 } = previewInternals;
 
 describe("preview app dependency expansion", () => {
-  it("expands os to include its auth dependency", () => {
-    expect(expandPreviewDependencies(["os"])).toEqual(["os", "auth"]);
+  it("expands os to include its auth and dummy-petshop dependencies", () => {
+    expect(expandPreviewDependencies(["os"])).toEqual(["os", "auth", "dummy-petshop"]);
   });
 
   it("expands semaphore to include its auth dependency", () => {
@@ -68,7 +69,11 @@ describe("preview app dependency expansion", () => {
   });
 
   it("deduplicates dependencies", () => {
-    expect(expandPreviewDependencies(["os", "os", "auth"])).toEqual(["os", "auth"]);
+    expect(expandPreviewDependencies(["os", "os", "auth"])).toEqual([
+      "os",
+      "auth",
+      "dummy-petshop",
+    ]);
   });
 });
 
@@ -81,12 +86,14 @@ describe("preview deploy ordering", () => {
     ).toEqual([["semaphore"]]);
   });
 
-  it("deploys auth before OS", () => {
+  it("deploys auth and dummy-petshop before OS", () => {
     expect(
-      orderPreviewDeployBatches([cloudflarePreviewApps.os, cloudflarePreviewApps.auth]).map(
-        (batch) => batch.map((app) => app.slug),
-      ),
-    ).toEqual([["auth"], ["os"]]);
+      orderPreviewDeployBatches([
+        cloudflarePreviewApps.os,
+        cloudflarePreviewApps.auth,
+        cloudflarePreviewApps["dummy-petshop"],
+      ]).map((batch) => batch.map((app) => app.slug)),
+    ).toEqual([["auth", "dummy-petshop"], ["os"]]);
   });
 
   it("keeps auth dependents parallel after auth is ready", () => {
@@ -95,8 +102,12 @@ describe("preview deploy ordering", () => {
         cloudflarePreviewApps.os,
         cloudflarePreviewApps.semaphore,
         cloudflarePreviewApps.auth,
+        cloudflarePreviewApps["dummy-petshop"],
       ]).map((batch) => batch.map((app) => app.slug)),
-    ).toEqual([["auth"], ["os", "semaphore"]]);
+    ).toEqual([
+      ["auth", "dummy-petshop"],
+      ["os", "semaphore"],
+    ]);
   });
 });
 
@@ -143,6 +154,57 @@ describe("preview workflow scope", () => {
         "- apps/dummy-petshop/**",
       );
     }
+  });
+
+  it("deploys OS after Petshop and passes that exact preview URL to OS e2e", () => {
+    const headSha = "abc1234";
+    const os = cloudflarePreviewApps.os;
+
+    expect(os).toMatchObject({
+      paths: expect.arrayContaining(["apps/dummy-petshop/**"]),
+      previewDependencies: ["auth", "dummy-petshop"],
+      previewTestDependencyBaseUrlEnvVars: {
+        "dummy-petshop": "PETSHOP_BASE_URL",
+      },
+    });
+    expect(
+      resolvePreviewTestBaseUrlEnvironment({
+        app: os,
+        apps: {
+          os: {
+            headSha,
+            publicUrl: "https://os.iterate-preview-7.com",
+          },
+          "dummy-petshop": {
+            headSha,
+            publicUrl: "https://dummy-petshop.iterate-preview-7.com",
+          },
+        },
+        headSha,
+      }),
+    ).toEqual([
+      "OS_BASE_URL=https://os.iterate-preview-7.com",
+      "PETSHOP_BASE_URL=https://dummy-petshop.iterate-preview-7.com",
+    ]);
+  });
+
+  it("refuses to run OS e2e against a missing or stale Petshop deployment", () => {
+    expect(() =>
+      resolvePreviewTestBaseUrlEnvironment({
+        app: cloudflarePreviewApps.os,
+        apps: {
+          os: {
+            headSha: "current-head",
+            publicUrl: "https://os.iterate-preview-7.com",
+          },
+          "dummy-petshop": {
+            headSha: "older-head",
+            publicUrl: "https://dummy-petshop.iterate-preview-7.com",
+          },
+        },
+        headSha: "current-head",
+      }),
+    ).toThrow(/PETSHOP_BASE_URL requires dummy-petshop deployed at head current/);
   });
 
   it("rejects pre-RPC branches before the preview orchestrator can deploy Auth", () => {
@@ -417,7 +479,7 @@ describe("preview retry selection", () => {
           notice: null,
         },
       }).map((app) => app.slug),
-    ).toEqual(["os", "auth"]);
+    ).toEqual(["os", "auth", "dummy-petshop"]);
   });
 
   it("retries apps whose slot claim failed", () => {
@@ -461,7 +523,7 @@ describe("preview retry selection", () => {
           notice: null,
         },
       }).map((app) => app.slug),
-    ).toEqual(["os", "auth"]);
+    ).toEqual(["os", "auth", "dummy-petshop"]);
   });
 
   it("re-runs awaiting-tests apps whatever head deployed them — their e2e never ran", () => {
@@ -487,7 +549,7 @@ describe("preview retry selection", () => {
           notice: null,
         },
       }).map((app) => app.slug),
-    ).toEqual(["os", "auth"]);
+    ).toEqual(["os", "auth", "dummy-petshop"]);
   });
 });
 
@@ -570,7 +632,12 @@ describe("preview deploy selection", () => {
       },
     });
 
-    expect(apps.map((app) => app.slug)).toEqual(["os", "auth", "streams-example-app"]);
+    expect(apps.map((app) => app.slug)).toEqual([
+      "os",
+      "auth",
+      "streams-example-app",
+      "dummy-petshop",
+    ]);
     // Only the green claims get probed — the failed app is already selected
     // for retry — and each app is probed on its own readiness path.
     expect(probedUrls).toEqual([
@@ -602,7 +669,7 @@ describe("preview deploy selection", () => {
       probeAppServing: everythingServing,
     });
 
-    expect(apps.map((app) => app.slug)).toEqual(["os", "semaphore", "auth"]);
+    expect(apps.map((app) => app.slug)).toEqual(["os", "semaphore", "auth", "dummy-petshop"]);
   });
 
   it("deploys the full fleet when the compare 404s because a force-push rewrote the deployed head away", async () => {

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -116,6 +116,23 @@ describe("preview workflow scope", () => {
     expect(cloudflarePreviewSharedPaths).toContain("patches/**");
   });
 
+  it("runs the dummy-petshop live e2e against its deployed preview", () => {
+    const petshop = cloudflarePreviewApps["dummy-petshop"];
+
+    expect(petshop).toMatchObject({
+      appPath: "apps/dummy-petshop",
+      paths: ["apps/dummy-petshop/**"],
+      previewReadyUrlPath: "/",
+      previewTestBaseUrlEnvVar: "PETSHOP_BASE_URL",
+      previewTestCommandArgs: ["pnpm", "test:e2e"],
+    });
+    for (const workflow of ["cloudflare-previews.yml", "cloudflare-preview-cleanup.yml"]) {
+      expect(readFileSync(resolve(repoRoot, ".depot/workflows", workflow), "utf8")).toContain(
+        "- apps/dummy-petshop/**",
+      );
+    }
+  });
+
   it("rejects pre-RPC branches before the preview orchestrator can deploy Auth", () => {
     const workflow = readFileSync(
       resolve(repoRoot, ".depot/workflows/cloudflare-previews.yml"),
@@ -592,7 +609,13 @@ describe("preview deploy selection", () => {
       probeAppServing: everythingServing,
     });
 
-    expect(apps.map((app) => app.slug)).toEqual(["os", "semaphore", "auth", "streams-example-app"]);
+    expect(apps.map((app) => app.slug)).toEqual([
+      "os",
+      "semaphore",
+      "auth",
+      "streams-example-app",
+      "dummy-petshop",
+    ]);
   });
 
   it("deploys the full fleet when the deployed head is no longer an ancestor of the current head", async () => {
@@ -612,7 +635,13 @@ describe("preview deploy selection", () => {
       probeAppServing: everythingServing,
     });
 
-    expect(apps.map((app) => app.slug)).toEqual(["os", "semaphore", "auth", "streams-example-app"]);
+    expect(apps.map((app) => app.slug)).toEqual([
+      "os",
+      "semaphore",
+      "auth",
+      "streams-example-app",
+      "dummy-petshop",
+    ]);
   });
 
   it("propagates non-404 compare failures instead of guessing a selection", async () => {

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -379,6 +379,38 @@ async function deployPreviewApps({
   return result;
 }
 
+function resolvePreviewTestBaseUrlEnvironment({
+  app,
+  apps,
+  headSha,
+}: {
+  app: CloudflarePreviewApp;
+  apps: Partial<
+    Record<CloudflarePreviewAppSlug, { headSha?: string | null; publicUrl?: string | null }>
+  >;
+  headSha: string;
+}): string[] {
+  const requiredUrls = new Map<CloudflarePreviewAppSlug, string>();
+  requiredUrls.set(app.slug, app.previewTestBaseUrlEnvVar);
+  for (const [dependencySlug, environmentVariable] of Object.entries(
+    app.previewTestDependencyBaseUrlEnvVars ?? {},
+  )) {
+    if (environmentVariable) {
+      requiredUrls.set(CloudflarePreviewAppSlug.parse(dependencySlug), environmentVariable);
+    }
+  }
+
+  return [...requiredUrls].map(([appSlug, environmentVariable]) => {
+    const entry = apps[appSlug];
+    if (!entry?.publicUrl || entry.headSha !== headSha) {
+      throw new Error(
+        `Cannot test ${app.slug}: ${environmentVariable} requires ${appSlug} deployed at head ${headSha.slice(0, 7)}. Re-run preview deploy.`,
+      );
+    }
+    return `${environmentVariable}=${entry.publicUrl}`;
+  });
+}
+
 async function testPreviewApps({
   context,
   runtime,
@@ -527,6 +559,12 @@ async function testPreviewApps({
       return null;
     }
 
+    const baseUrlEnvironment = resolvePreviewTestBaseUrlEnvironment({
+      app,
+      apps: recorded.apps,
+      headSha: context.pullRequestHeadSha,
+    });
+
     const startedAt = Date.now();
     logPreview(
       `test start: ${app.slug} against ${existingEntry.publicUrl} (doppler config ${environmentConfigLease.dopplerConfig})`,
@@ -543,7 +581,7 @@ async function testPreviewApps({
         environmentConfigLease.dopplerConfig,
         "--",
         "env",
-        `${app.previewTestBaseUrlEnvVar}=${existingEntry.publicUrl}`,
+        ...baseUrlEnvironment,
         ...app.previewTestCommandArgs,
       ],
       command: "doppler",
@@ -1095,6 +1133,13 @@ export type CloudflarePreviewApp = {
   };
   paths: string[];
   previewDependencies?: CloudflarePreviewAppSlug[];
+  /**
+   * Public URLs of deployed preview dependencies that the app's e2e command
+   * must receive. Values come from this PR's recorded deployment at the
+   * current head; a missing/stale dependency fails the lane instead of
+   * silently pointing at another environment.
+   */
+  previewTestDependencyBaseUrlEnvVars?: Partial<Record<CloudflarePreviewAppSlug, string>>;
   /** Readiness probe path on the app's public URL (default /api/__internal/health). */
   previewReadyUrlPath?: string;
   previewTestBaseUrlEnvVar: string;
@@ -1315,16 +1360,21 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
       "apps/os/**",
       "apps/auth/**",
       "apps/auth-contract/**",
+      "apps/dummy-petshop/**",
       "apps/os/src/domains/streams/**",
     ],
-    // OS bakes auth JWKS and binds auth's default RPC entrypoint, so auth must
+    // OS bakes auth JWKS and binds auth's default RPC entrypoint, and its
+    // integration e2e talks to the slot's deployed dummy Petshop. Both must
     // finish deploying before OS starts.
-    previewDependencies: ["auth"],
+    previewDependencies: ["auth", "dummy-petshop"],
     // Budgets sit ~25% above the observed green floor (deploy ~40s, e2e lane
     // ~60s as of 2026-07-02). Crossing them warns, never fails.
     previewDeployBudgetMs: 55_000,
     previewTestBudgetMs: 80_000,
     previewTestBaseUrlEnvVar: "OS_BASE_URL",
+    previewTestDependencyBaseUrlEnvVars: {
+      "dummy-petshop": "PETSHOP_BASE_URL",
+    },
     // The apps/os e2e Vitest suite runs its `node` project (engine + itx
     // catalogue matrix; the `browser` project is skipped here — the root
     // Playwright REPL specs cover the catalogue in-browser). It reads
@@ -4500,6 +4550,7 @@ export const previewInternals = {
   resolveAuthPreviewRootSecret,
   resolvePreviewCompareBaseSha,
   resolvePreviewReadinessUrls,
+  resolvePreviewTestBaseUrlEnvironment,
   selectPreviewAppsForPullRequest,
   selectPreviewAppsNeedingRetry,
   splitRepositoryFullName,

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -1060,7 +1060,13 @@ export async function provisionAuthPreviewConfigs(
   };
 }
 
-export const CloudflarePreviewAppSlug = z.enum(["os", "semaphore", "auth", "streams-example-app"]);
+export const CloudflarePreviewAppSlug = z.enum([
+  "os",
+  "semaphore",
+  "auth",
+  "streams-example-app",
+  "dummy-petshop",
+]);
 
 export type CloudflarePreviewAppSlug = z.infer<typeof CloudflarePreviewAppSlug>;
 type CloudflarePreviewAppSlugType = CloudflarePreviewAppSlug;
@@ -1455,6 +1461,20 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
         "pnpm playwright --grep @preview --reporter=list",
       ].join("; "),
     ],
+  },
+  "dummy-petshop": {
+    slug: "dummy-petshop",
+    displayName: "Dummy Petshop",
+    appPath: "apps/dummy-petshop",
+    deployCommandArgs: ["pnpm", "run-script", "deploy"],
+    // The fixture holds only fake data, so cleanup deliberately leaves its
+    // worker and singleton Durable Object in place.
+    destroyCommandArgs: ["pnpm", "run-script", "destroy"],
+    dopplerProject: "dummy-petshop",
+    paths: ["apps/dummy-petshop/**"],
+    previewReadyUrlPath: "/",
+    previewTestBaseUrlEnvVar: "PETSHOP_BASE_URL",
+    previewTestCommandArgs: ["pnpm", "test:e2e"],
   },
 };
 

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -9,6 +9,7 @@ import { resolve } from "node:path";
 import { Octokit } from "@octokit/rest";
 import { z } from "zod";
 import { createSemaphoreClient } from "../../apps/semaphore/src/contract.ts";
+import { dummyPetshopEnvs } from "../../envs.ts";
 import { createSemaphoreTokenProvider } from "../auth/semaphore-token.ts";
 import { markdownAnnotator } from "../../packages/shared/src/dev/markdown-annotator.ts";
 import { stripAnsi } from "../../packages/shared/src/dev/strip-ansi.ts";
@@ -1083,6 +1084,15 @@ export type CloudflarePreviewApp = {
   deployCommandArgs: readonly [string, ...string[]];
   destroyCommandArgs: readonly [string, ...string[]];
   dopplerProject: string;
+  /**
+   * Resolve non-secret public app config from the repo instead of Doppler.
+   * Most apps mirror this into APP_CONFIG_BASE_URL; apps whose envs.ts entry
+   * is the sole source of truth can opt into that source directly.
+   */
+  resolvePreviewAppConfig?: (dopplerConfig: string) => {
+    baseUrl: string;
+    projectHostnameBases?: string[];
+  };
   paths: string[];
   previewDependencies?: CloudflarePreviewAppSlug[];
   /** Readiness probe path on the app's public URL (default /api/__internal/health). */
@@ -1471,6 +1481,13 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
     // worker and singleton Durable Object in place.
     destroyCommandArgs: ["pnpm", "run-script", "destroy"],
     dopplerProject: "dummy-petshop",
+    resolvePreviewAppConfig: (dopplerConfig) => {
+      const env = dummyPetshopEnvs[dopplerConfig as keyof typeof dummyPetshopEnvs];
+      if (!env) {
+        throw new Error(`Unknown dummy-petshop environment ${JSON.stringify(dopplerConfig)}.`);
+      }
+      return { baseUrl: env.baseUrl };
+    },
     paths: ["apps/dummy-petshop/**"],
     previewReadyUrlPath: "/",
     previewTestBaseUrlEnvVar: "PETSHOP_BASE_URL",
@@ -3146,6 +3163,15 @@ async function readPreviewAppConfig(input: {
   repositoryRoot: string;
   signal?: AbortSignal;
 }) {
+  const PreviewAppConfig = z.object({
+    baseUrl: z.string().trim().url(),
+    projectHostnameBases: z.array(z.string().trim().min(1)).default([]),
+  });
+  const repoConfig = input.app.resolvePreviewAppConfig?.(input.dopplerConfig);
+  if (repoConfig) {
+    return PreviewAppConfig.parse(repoConfig);
+  }
+
   const script = [
     "function parseStringArrayEnv(value) {",
     "  if (!value?.trim()) return [];",
@@ -3186,13 +3212,7 @@ async function readPreviewAppConfig(input: {
     throw new Error(commandFailureMessage(result, "Failed to read preview app config."));
   }
 
-  const parsed = z
-    .object({
-      baseUrl: z.string().trim().url(),
-      projectHostnameBases: z.array(z.string().trim().min(1)).default([]),
-    })
-    .parse(JSON.parse(result.stdout));
-  return parsed;
+  return PreviewAppConfig.parse(JSON.parse(result.stdout));
 }
 
 async function runPreviewDeployCommand(input: {
@@ -4471,6 +4491,7 @@ export const previewInternals = {
   parseCloudflarePreviewState,
   parseEnvironmentConfigLeaseData,
   readPlaywrightRetryTelemetry,
+  readPreviewAppConfig,
   readVitestRetryTelemetry,
   reconcileEnvironmentConfigLeaseResources,
   releaseLeaseDespiteTeardownFailure,


### PR DESCRIPTION
## Summary

- Run every workspace test script from the normal root Test workflow, including `packages/iterate`.
- Deploy dummy-petshop as part of the preview fleet and run its complete standalone live e2e suite.
- Make dummy-petshop an OS preview dependency and pass the exact leased preview URL into the OS integration e2e suite; CI now fails instead of silently skipping if that URL is absent.
- Require the first-party Petshop config in every OS preview deployment, add regression guards, and document the deliberate manual-only TUI and tagged streams-example exceptions.

## Root cause

The Iterate package exclusion was migration residue. Enabling it exposed one Node strip-only TypeScript incompatibility, now fixed. Dummy Petshop had no preview e2e lane, and OS preview orchestration supplied only `OS_BASE_URL`; the Petshop-backed OS specs therefore skipped rather than hitting production or preview. Some preview slots also had DNS without a serving Petshop worker, and only slots 3/5/9 carried the first-party Petshop config.

OS now depends on the Petshop deployment recorded for the same PR head and receives that exact URL as `PETSHOP_BASE_URL`. All nine preview slots have serving Petshop workers and the OS preview configs carry the fixture credential; production is unchanged.

## Validation

- `pnpm test` (includes all 41 `packages/iterate` tests and 1,434 OS unit tests)
- `pnpm typecheck`
- `pnpm lint` (zero warnings)
- `pnpm format:check`
- Preview slot 1: dummy-petshop live e2e passed 6/6
- Preview slot 1: OS e2e passed 141 tests; `integrations-userspace` 3/3, `integrations-github` 1/1, and `integrations-petshop` 2/2
- All nine `dummy-petshop.iterate-preview-N.com` endpoints probed serving after fleet bring-up<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "deployed",
      "updatedAt": "2026-07-15T10:21:36.672Z",
      "headSha": "e04014f872099e7077dfe56507a2d3dd3403f46b",
      "message": null,
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/160074293859437",
      "shortSha": "e04014f",
      "deployDurationMs": 17471,
      "testDurationMs": 461,
      "testRetries": null,
      "workerSizeKib": 4030.87,
      "workerGzipKib": 819.72,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "deployed",
      "updatedAt": "2026-07-15T10:21:54.972Z",
      "headSha": "e04014f872099e7077dfe56507a2d3dd3403f46b",
      "message": null,
      "publicUrl": "https://streams.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/160074293859437",
      "shortSha": "e04014f",
      "deployDurationMs": 14209,
      "testDurationMs": 18761,
      "testRetries": null,
      "workerSizeKib": 5138.1,
      "workerGzipKib": 1465.54,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "deployed",
      "updatedAt": "2026-07-15T10:21:41.680Z",
      "headSha": "e04014f872099e7077dfe56507a2d3dd3403f46b",
      "message": null,
      "publicUrl": "https://dummy-petshop.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/160074293859437",
      "shortSha": "e04014f",
      "deployDurationMs": 7818,
      "testDurationMs": 5466,
      "testRetries": null,
      "workerSizeKib": 1139,
      "workerGzipKib": 201.58,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "deployed",
      "updatedAt": "2026-07-15T10:25:53.675Z",
      "headSha": "e04014f872099e7077dfe56507a2d3dd3403f46b",
      "message": null,
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/160074293859437",
      "shortSha": "e04014f",
      "deployDurationMs": 73426,
      "testDurationMs": 257458,
      "testRetries": "3 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · reactivity page appends a batch and renders every delivered marker (specs x1) · a commented tsconfig still schema-validates (comments are tolerated) (specs x1)",
      "workerSizeKib": 16398.11,
      "workerGzipKib": 4425.45,
      "mainWorkerGzipKib": 4425.32
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "deployed",
      "updatedAt": "2026-07-15T10:21:41.320Z",
      "headSha": "e04014f872099e7077dfe56507a2d3dd3403f46b",
      "message": null,
      "publicUrl": "https://semaphore.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/160074293859437",
      "shortSha": "e04014f",
      "deployDurationMs": 14857,
      "testDurationMs": 5103,
      "testRetries": null,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.77,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": {
    "dopplerConfig": "preview_1",
    "slug": "preview-1"
  },
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>Slot: preview-1 | Doppler config: preview_1</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | deployed | `e04014f` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 819.7 KiB | 17.5s | 461ms |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/160074293859437) | 2026-07-15T10:21:36.672Z |  |
| Dummy Petshop | deployed | `e04014f` | [https://dummy-petshop.iterate-preview-1.com](https://dummy-petshop.iterate-preview-1.com) | 201.6 KiB | 7.8s | 5.5s |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/160074293859437) | 2026-07-15T10:21:41.680Z |  |
| OS | deployed | `e04014f` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 4.32 MiB (+0.1 KiB vs main) | 73.4s | 257.5s | 3 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · reactivity page appends a batch and renders every delivered marker (specs x1) · a commented tsconfig still schema-validates (comments are tolerated) (specs x1) |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/160074293859437) | 2026-07-15T10:25:53.675Z |  |
| Semaphore | deployed | `e04014f` | [https://semaphore.iterate-preview-1.com](https://semaphore.iterate-preview-1.com) | 440.8 KiB | 14.9s | 5.1s |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/160074293859437) | 2026-07-15T10:21:41.320Z |  |
| Streams Example App | deployed | `e04014f` | [https://streams.iterate-preview-1.com](https://streams.iterate-preview-1.com) | 1.43 MiB | 14.2s | 18.8s |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/160074293859437) | 2026-07-15T10:21:54.972Z |  |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +4 -4 | +3 -4 🟥⬜⬜⬜⬜ |
| Tests | +189 -38 | +165 -28 🟩🟩🟩🟩🟥 |
| CI & scripts | +122 -11 | +98 -10 🟩🟩🟩⬜⬜ |
| Config | +1 -1 | +1 -1 🟩⬜⬜⬜⬜ |
| Docs | +13 -0 | +11 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+329 -54** | **+278 -43** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between f02de82 and e04014f, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes preview deploy ordering and CI failure modes for integration e2e; misconfigured preview slots or missing Petshop URLs will fail OS preview runs rather than skip silently.
> 
> **Overview**
> **CI and preview orchestration** now treat **dummy-petshop** as a first-class preview app: workflow path triggers include it, OS expands to depend on **auth** and **dummy-petshop** (deployed in parallel before OS), and OS e2e receives both `OS_BASE_URL` and the sibling slot’s exact **`PETSHOP_BASE_URL`** from the same PR head—stale or missing Petshop deployments fail the lane instead of guessing a hostname.
> 
> **OS Petshop integration e2e** no longer derives Petshop from `APP_CONFIG_BASE_URL`; they use `shouldSkipPetshopE2e()` (skip locally without `PETSHOP_BASE_URL`, **throw in CI** if it’s missing). **Preview OS deploy** must include `APP_CONFIG_INTEGRATIONS__PETSHOP` via `assertPreviewPetshopIntegrationConfigured` (production unchanged).
> 
> **Root `pnpm test`** runs every workspace’s test script (including `packages/iterate`); a depot workflow test locks that contract. **Docs** describe preview vs unit test lanes. Minor: `SecretSubstitutionError` assigns `code` explicitly for subclassing semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e04014f872099e7077dfe56507a2d3dd3403f46b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "deployed",
      "updatedAt": "2026-07-15T10:21:36.672Z",
      "headSha": "e04014f872099e7077dfe56507a2d3dd3403f46b",
      "message": null,
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/160074293859437",
      "shortSha": "e04014f",
      "deployDurationMs": 17471,
      "testDurationMs": 461,
      "testRetries": null,
      "workerSizeKib": 4030.87,
      "workerGzipKib": 819.72,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "deployed",
      "updatedAt": "2026-07-15T10:21:54.972Z",
      "headSha": "e04014f872099e7077dfe56507a2d3dd3403f46b",
      "message": null,
      "publicUrl": "https://streams.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/160074293859437",
      "shortSha": "e04014f",
      "deployDurationMs": 14209,
      "testDurationMs": 18761,
      "testRetries": null,
      "workerSizeKib": 5138.1,
      "workerGzipKib": 1465.54,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "deployed",
      "updatedAt": "2026-07-15T10:21:41.680Z",
      "headSha": "e04014f872099e7077dfe56507a2d3dd3403f46b",
      "message": null,
      "publicUrl": "https://dummy-petshop.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/160074293859437",
      "shortSha": "e04014f",
      "deployDurationMs": 7818,
      "testDurationMs": 5466,
      "testRetries": null,
      "workerSizeKib": 1139,
      "workerGzipKib": 201.58,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "deployed",
      "updatedAt": "2026-07-15T10:25:53.675Z",
      "headSha": "e04014f872099e7077dfe56507a2d3dd3403f46b",
      "message": null,
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/160074293859437",
      "shortSha": "e04014f",
      "deployDurationMs": 73426,
      "testDurationMs": 257458,
      "testRetries": "3 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · reactivity page appends a batch and renders every delivered marker (specs x1) · a commented tsconfig still schema-validates (comments are tolerated) (specs x1)",
      "workerSizeKib": 16398.11,
      "workerGzipKib": 4425.45,
      "mainWorkerGzipKib": 4425.32
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "deployed",
      "updatedAt": "2026-07-15T10:21:41.320Z",
      "headSha": "e04014f872099e7077dfe56507a2d3dd3403f46b",
      "message": null,
      "publicUrl": "https://semaphore.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/160074293859437",
      "shortSha": "e04014f",
      "deployDurationMs": 14857,
      "testDurationMs": 5103,
      "testRetries": null,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.77,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | deployed | `e04014f` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 819.7 KiB | 17.5s | 461ms |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/160074293859437) | 2026-07-15T10:21:36.672Z |  |
| Dummy Petshop | deployed | `e04014f` | [https://dummy-petshop.iterate-preview-1.com](https://dummy-petshop.iterate-preview-1.com) | 201.6 KiB | 7.8s | 5.5s |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/160074293859437) | 2026-07-15T10:21:41.680Z |  |
| OS | deployed | `e04014f` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 4.32 MiB (+0.1 KiB vs main) | 73.4s | 257.5s | 3 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · reactivity page appends a batch and renders every delivered marker (specs x1) · a commented tsconfig still schema-validates (comments are tolerated) (specs x1) |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/160074293859437) | 2026-07-15T10:25:53.675Z |  |
| Semaphore | deployed | `e04014f` | [https://semaphore.iterate-preview-1.com](https://semaphore.iterate-preview-1.com) | 440.8 KiB | 14.9s | 5.1s |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/160074293859437) | 2026-07-15T10:21:41.320Z |  |
| Streams Example App | deployed | `e04014f` | [https://streams.iterate-preview-1.com](https://streams.iterate-preview-1.com) | 1.43 MiB | 14.2s | 18.8s |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/160074293859437) | 2026-07-15T10:21:54.972Z |  |

</details>
<!-- /CLOUDFLARE_PREVIEW -->