### PR TITLE
Stop rebinding retired app-config secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,32 @@
 
 Monorepo for Iterate's Cloudflare Workers platform. **`apps/os`** is the main app — the product dashboard at `os.iterate.com`.
 
+## Irrevocable engineering principle: no deviant system behaviour
+
+We do not accept unexplained, unbounded, or silently tolerated system
+behaviour. An error is either an explicitly modelled and correctly classified
+expected outcome, or it is a product defect. The same rule applies to retry
+storms, stuck work, silent data loss, unexplained latency, state drift, and
+resource leaks.
+
+- Never normalize an error counter merely because it is noisy or longstanding.
+  Classify every contributing outcome, remove expected outcomes from error
+  telemetry, and fix the rest.
+- Never swallow, endlessly retry, or hide failures behind fallbacks or
+  compatibility shims. Recovery must be bounded, observable, and preserve a
+  durable explanation of what happened.
+- A healthy request is not enough if it leaves corrupt, stalled, or divergent
+  state behind. Verify the resulting state and the relevant production-shaped
+  telemetry.
+- Green tests are necessary but not sufficient. For operational changes, the
+  acceptance proof includes a preview deployment and evidence that its traces,
+  logs, metrics, and state transitions are coherent, correctly classified, and
+  free of new unexplained errors.
+
+Treat any unexplained error volume as a release blocker until evidence proves
+that each outcome is expected and correctly represented outside the error
+signal. "Unavoidable error spam" is not a category.
+
 ## Environments
 
 - The root `envs.ts` is the typed map of every deployed environment

--- a/apps/os/scripts/generate-wrangler-config.test.ts
+++ b/apps/os/scripts/generate-wrangler-config.test.ts
@@ -6,10 +6,17 @@ import {
   config,
   localAuthServiceBinding,
   OPTIONAL_SECRETS,
+  REQUIRED_SECRETS,
 } from "./generate-wrangler-config.ts";
 
-it("does not ship the retired APP_CONFIG_LOGS secret", () => {
-  expect(OPTIONAL_SECRETS).not.toContain("APP_CONFIG_LOGS");
+it.each([
+  "APP_CONFIG_LOGS",
+  "APP_CONFIG_GEMINI_API_KEY",
+  "APP_CONFIG_SLACK_BOT_TOKEN",
+  "APP_CONFIG_X_AI_API_KEY",
+])("does not ship the retired %s override", (name) => {
+  expect(OPTIONAL_SECRETS).not.toContain(name);
+  expect(REQUIRED_SECRETS).not.toContain(name);
 });
 
 // Wrangler tags every `--env` deploy with `cf:service=<top-level name>` and

--- a/apps/os/scripts/generate-wrangler-config.ts
+++ b/apps/os/scripts/generate-wrangler-config.ts
@@ -53,7 +53,6 @@ export const REQUIRED_SECRETS = [
  */
 export const OPTIONAL_SECRETS = [
   "APP_CONFIG_CLOUDFLARE__API_TOKEN",
-  "APP_CONFIG_GEMINI_API_KEY",
   // Iterate-owned Exa/Parallel API keys (platform-secrets.ts registry
   // entries) — collectSecrets ships only names listed here, so a key absent
   // from this list never reaches a deployed worker even when Doppler has it.
@@ -69,8 +68,6 @@ export const OPTIONAL_SECRETS = [
   "APP_CONFIG_ITERATE_AUTH__EMAIL_OTP_ENABLED",
   "APP_CONFIG_ITERATE_AUTH__RESOURCE",
   "APP_CONFIG_POSTHOG",
-  "APP_CONFIG_SLACK_BOT_TOKEN",
-  "APP_CONFIG_X_AI_API_KEY",
   // R2 S3-API credentials the Sandbox SDK uses to presign workspace-backup
   // transfers (exact names the SDK reads). Optional: without them the
   // sandbox DO falls back to streaming archives through the BACKUP_BUCKET


### PR DESCRIPTION
## Outcome

OS no longer treats four retired app-config overrides as deployable secrets.
New deployments and local development therefore cannot bind dead configuration
solely because old Doppler values still exist.

This is stack layer **2** of the observability cleanup. It depends only on the
26-line engineering principle in #2016 (`agent/observability-principle-v2`).
Relative to that stack base, this PR remains **+9/-5 across two files**. It has
no dependency on tracing, PostHog, Analytics Engine, or the larger #1992 branch.

## Root cause

The Gemini and xAI runtime configuration and the obsolete top-level Slack bot
token were removed, but their old environment names remained in
`OPTIONAL_SECRETS`. `collectSecrets()` ships every listed optional value that
Doppler happens to contain, so generated deployments could continue binding
values that the strict runtime configuration does not recognize.

The preview for the first revision made this boundary useful: it emitted an
unknown-config warning for `APP_CONFIG_SLACK_BOT_TOKEN`. Current Slack recovery
credentials live under `APP_CONFIG_INTEGRATIONS__SLACK`; the old top-level key
has no schema field or consumer, so it belongs in the same retired set.

## Change

- remove `APP_CONFIG_GEMINI_API_KEY` from `OPTIONAL_SECRETS`;
- remove `APP_CONFIG_SLACK_BOT_TOKEN` from `OPTIONAL_SECRETS`;
- remove `APP_CONFIG_X_AI_API_KEY` from `OPTIONAL_SECRETS`; and
- generalize the existing retired-secret regression test so all four retired
  names are forbidden in both the optional and required allowlists.

Runtime change: **three deleted lines**. Entire PR: **+9/-5 across two files**.

## Deliberate boundary

Wrangler preserves secrets already bound to an existing Worker when they are
omitted from a later upload. This PR prevents rebinding but does not pretend to
delete existing retired bindings. Production currently carries
`APP_CONFIG_LOGS`, Gemini, and xAI; the preview slot also carried the obsolete
Slack key. Those bindings require an explicit one-time operator deletion
followed by a Cloudflare log query proving the corresponding configuration
warnings stop. There is no compatibility fallback or legacy shim.





## Prior preview signal

The previous unstacked head first hit a Cloudflare internal error while updating
a preview container application. Its retry deployed successfully and passed the
OS smoke plus all 137 Vitest e2e tests, then an unrelated reactivity Playwright
spec failed twice with a 1ms wait budget. Neither failure came from this two-file
allowlist change. That history does not waive the gate: this rebased head must
earn a fresh green preview before merge.

## Verification

- `pnpm --dir apps/os exec vitest run scripts/generate-wrangler-config.test.ts`
  — 15 tests passed
- `pnpm --dir apps/os typecheck`
- `pnpm lint`
- `pnpm exec oxfmt --check apps/os/scripts/generate-wrangler-config.ts apps/os/scripts/generate-wrangler-config.test.ts`
- `pnpm exec oxlint apps/os/scripts/generate-wrangler-config.ts apps/os/scripts/generate-wrangler-config.test.ts --deny-warnings`

No screenshot is relevant: this changes the deployment secret allowlist, not a
rendered surface. The required preview deploy and smoke test are CI gates.

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-15T12:08:12.249Z",
      "headSha": "84dbcd44de62ca3daccdf485a64151ab82f4f894",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/475349186159508",
      "shortSha": "84dbcd4",
      "cleanupDurationMs": 2051,
      "deployDurationMs": 16135,
      "testDurationMs": 226,
      "testRetries": null,
      "workerSizeKib": 4030.87,
      "workerGzipKib": 819.51,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-15T12:08:10.976Z",
      "headSha": "84dbcd44de62ca3daccdf485a64151ab82f4f894",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/475349186159508",
      "shortSha": "84dbcd4",
      "cleanupDurationMs": 776,
      "deployDurationMs": 13755,
      "testDurationMs": 15475,
      "testRetries": null,
      "workerSizeKib": 5139.6,
      "workerGzipKib": 1466.03,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-15T12:08:09.088Z",
      "headSha": "84dbcd44de62ca3daccdf485a64151ab82f4f894",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/475349186159508",
      "shortSha": "84dbcd4",
      "cleanupDurationMs": 75474,
      "deployDurationMs": 81142,
      "testDurationMs": 192500,
      "testRetries": "2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · reactivity page repaints from a stream subscription after a page action (specs x1)",
      "workerSizeKib": 16398.22,
      "workerGzipKib": 4425.89,
      "mainWorkerGzipKib": 4425.89
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-15T12:06:54.140Z",
      "headSha": "84dbcd44de62ca3daccdf485a64151ab82f4f894",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/475349186159508",
      "shortSha": "84dbcd4",
      "cleanupDurationMs": 520,
      "deployDurationMs": 13822,
      "testDurationMs": 7288,
      "testRetries": null,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.77,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-15T12:08:10.892Z",
      "headSha": "84dbcd44de62ca3daccdf485a64151ab82f4f894",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/475349186159508",
      "shortSha": "84dbcd4",
      "cleanupDurationMs": 689,
      "deployDurationMs": 5986,
      "testDurationMs": 5306,
      "testRetries": null,
      "workerSizeKib": 1139,
      "workerGzipKib": 201.58,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `84dbcd4` | [https://auth.iterate-preview-4.com](https://auth.iterate-preview-4.com) | 819.5 KiB | 16.1s | 226ms |  | 2.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/475349186159508) | 2026-07-15T12:08:12.249Z | Preview app released. |
| Dummy Petshop | released | `84dbcd4` | [https://dummy-petshop.iterate-preview-4.com](https://dummy-petshop.iterate-preview-4.com) | 201.6 KiB | 6.0s | 5.3s |  | 689ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/475349186159508) | 2026-07-15T12:08:10.892Z | Preview app released. |
| OS | released | `84dbcd4` | [https://os.iterate-preview-4.com](https://os.iterate-preview-4.com) | 4.32 MiB (±0 vs main) | 81.1s | 192.5s | 2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · reactivity page repaints from a stream subscription after a page action (specs x1) | 75.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/475349186159508) | 2026-07-15T12:08:09.088Z | Preview app released. |
| Semaphore | released | `84dbcd4` | [https://semaphore.iterate-preview-4.com](https://semaphore.iterate-preview-4.com) | 440.8 KiB | 13.8s | 7.3s |  | 520ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/475349186159508) | 2026-07-15T12:06:54.140Z | Preview app released. |
| Streams Example App | released | `84dbcd4` | [https://streams.iterate-preview-4.com](https://streams.iterate-preview-4.com) | 1.43 MiB | 13.8s | 15.5s |  | 776ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/475349186159508) | 2026-07-15T12:08:10.976Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deploy-time secret allowlist only; no runtime config schema or auth logic changes. Existing Worker bindings are unchanged until operators delete them manually.
> 
> **Overview**
> Stops **new** OS deploys and local dev from binding three retired Doppler overrides—`APP_CONFIG_GEMINI_API_KEY`, `APP_CONFIG_SLACK_BOT_TOKEN`, and `APP_CONFIG_X_AI_API_KEY`—by removing them from `OPTIONAL_SECRETS` in `generate-wrangler-config.ts`. That list is what `deploy.ts` passes as `optionalSecrets`, so anything still in Doppler but no longer in the strict app config schema would otherwise keep getting uploaded to Workers.
> 
> The regression test is generalized with `it.each` so four retired names (`APP_CONFIG_LOGS` plus those three) are asserted absent from both `OPTIONAL_SECRETS` and `REQUIRED_SECRETS`. This does **not** remove secrets already bound on existing Workers; it only prevents rebinding on the next upload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84dbcd44de62ca3daccdf485a64151ab82f4f894. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +9 -2 | +9 -2 🟩🟩🟩🟩🟥 |
| CI & scripts | +0 -3 | +0 -3 🟥⬜⬜⬜⬜ |
| **Total** | **+9 -5** | **+9 -5** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 3238644 and 84dbcd4, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->