### PR TITLE
Preview contention: fix leaked leases, and reclaim slot resources off the critical path (3h TTLs + GC sweep)

### DIFF
--- a/.depot/workflows/cloudflare-preview-cleanup.yml
+++ b/.depot/workflows/cloudflare-preview-cleanup.yml
@@ -18,8 +18,12 @@
 # Secrets (depot ci secrets --org 0p91s0lz49): DOPPLER_TOKEN,
 # ITERATE_BOT_GITHUB_TOKEN.
 #
-# Keep the `paths` list below identical to cloudflare-previews.yml's, so a
-# close runs cleanup for exactly the PRs that could have deployed a preview.
+# Deliberately NO `paths` filter: a closed PR that once held a slot must always
+# attempt cleanup, even when the final PR diff is empty (full revert) or no
+# longer matches deploy paths. Cleanup is a no-op when the semaphore leases
+# nothing to the PR, so the extra runs are cheap; skipping them leaks a slot
+# for up to 24h (observed 2026-07-15: pr-2005 closed after a full revert and
+# never released preview-1).
 
 name: Cloudflare Preview Cleanup (Depot CI)
 
@@ -27,25 +31,6 @@ on:
   pull_request:
     types:
       - closed
-    paths:
-      - .depot/workflows/cloudflare-previews.yml
-      - packages/shared/**
-      - packages/ui/**
-      - pnpm-lock.yaml
-      - pnpm-workspace.yaml
-      - patches/**
-      - scripts/preview/**
-      - envs.ts
-      - scripts/lib/**
-      - apps/iterate-com/**
-      - apps/auth-example/**
-      - apps/os/**
-      - apps/auth/**
-      - apps/auth-contract/**
-      - apps/os/src/domains/streams/**
-      - apps/semaphore/**
-      - apps/streams-example-app/**
-      - apps/dummy-petshop/**
 
 concurrency:
   group: cloudflare-previews-${{ github.event.pull_request.number || inputs.pull-request-number }}
@@ -62,7 +47,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Always run cleanup tooling from the default branch. The closed PR's
+          # head may predate critical fixes (e.g. release-despite-teardown
+          # failure in #1989). On 2026-07-14, cleanups for merged pr-1986/1987/1994
+          # checked out the PR head, hit Cloudflare 429s mid-erase, bailed before
+          # releasing, and renewed the lease for another 24h — starving the fleet.
+          ref: ${{ github.event.repository.default_branch }}
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
       - name: Setup Node

--- a/.depot/workflows/cloudflare-preview-gc.yml
+++ b/.depot/workflows/cloudflare-preview-gc.yml
@@ -1,0 +1,69 @@
+# Cloudflare Preview GC — the lazy, scheduled half of the preview resource
+# lifecycle (see docs/preview-resource-gc.md). Releasing a slot never waits on
+# teardown: PR-close cleanup (cloudflare-preview-cleanup.yml) is the fast path,
+# and this sweep reclaims whatever it did not — a lease that expired because a
+# PR went quiet for 3h, or a slot whose cleanup failed. It is idempotent and
+# safe to run as often as we like: `pnpm preview gc` only touches slots whose
+# lease has already expired, takes each under a NON-force lease (so it can never
+# steal a live tenant's slot), erases it, and releases it.
+#
+# Lease expiry is the only signal — no GitHub token needed. R2 data reaps itself
+# via lifecycle rules; this sweep's real job is the Durable Object / D1 / KV
+# wipe and the AI Search per-instance delete (which has no server-side expiry).
+#
+# Depot registers automatic triggers when this file is on the default branch —
+# branch-only changes to the `on:` block do not take effect until merged.
+#
+# Secrets (depot ci secrets --org 0p91s0lz49): DOPPLER_TOKEN.
+
+name: Cloudflare Preview GC (Depot CI)
+
+on:
+  # Hourly, offset off the top of the hour to avoid contending with deploys.
+  # The lease TTL is 3h, so an abandoned slot is reclaimed within ~1h of expiry.
+  schedule:
+    - cron: "23 * * * *"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Report what would be reclaimed without erasing anything
+        type: boolean
+        default: false
+
+concurrency:
+  # Never run two sweeps at once; a run in progress wins (the next tick catches
+  # anything it missed).
+  group: cloudflare-preview-gc
+  cancel-in-progress: false
+
+jobs:
+  gc:
+    name: Preview / gc
+    runs-on: depot-ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Run the sweep from the default branch so it always carries the
+          # latest tooling, like cleanup does.
+          ref: ${{ github.event.repository.default_branch }}
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install
+      - name: Install Doppler CLI
+        run: |-
+          for i in 1 2 3; do curl -sfLS https://cli.doppler.com/install.sh | sh -s -- --no-package-manager && break; echo "Attempt $i failed, retrying in 5s..."; sleep 5; done
+          doppler --version || { echo 'Failed to install Doppler CLI after 3 attempts'; exit 1; }
+      - name: Preview / gc
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+        run: |-
+          set -euo pipefail
+          doppler run --project _shared --config prd -- pnpm preview gc \
+            ${{ (github.event.inputs.dry-run == 'true') && '--dry-run' || '' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,7 @@ from your machine, and when you need a public callback URL. Doppler/Cloudflare/d
 ### Development
 
 - [Dev environments](docs/dev-environments.md) — local dev, minting identities/admin sessions, browsers for agents, preview-from-local
+- [Preview resource GC](docs/preview-resource-gc.md) — how preview slots reclaim their Cloudflare resources: lease-expiry sweep, 3h TTLs, why teardown is decoupled from releasing the slot
 - [Coding style](docs/coding-style.md)
 - [Depot CI](docs/depot-ci.md) — workflow editing, Depot CLI commands, monitoring/wait loops, logs, dispatch, metrics, secrets, and gotchas
 - [CLI scripts](docs/cli-scripts.md) — how to write normal TypeScript scripts and expose them as CLIs

--- a/apps/os/scripts/ensure-resources.ts
+++ b/apps/os/scripts/ensure-resources.ts
@@ -21,7 +21,10 @@ import {
   ensureD1,
   ensureProxiedDnsRecord,
   ensureR2ObjectExpiryLifecycle,
+  PREVIEW_DISPOSABLE_TTL_SECONDS,
+  PREVIEW_FILES_OBJECT_EXPIRY,
   PREVIEW_SEARCH_INDEX_OBJECT_EXPIRY,
+  SANDBOX_BACKUP_TTL_SECONDS_PRD,
 } from "../../../scripts/lib/deploy-helpers.ts";
 import { resolveEnvContext } from "../../../scripts/lib/env-context.ts";
 import { reconcileResources } from "../../../scripts/lib/wrangler-config.ts";
@@ -119,57 +122,51 @@ export default async function ensureResources(
   const kv = await ensureKv(`${env.osWorkerName}-project-directory`);
   const buildCacheKv = await ensureKv(`${env.osWorkerName}-worker-build-cache`);
 
-  // ---- R2: sandbox workspace backups --------------------------------------
-  // Sandboxes snapshot /workspace into this bucket when they idle out and
-  // restore it on the next start (container disk is ephemeral). Addressed by
-  // name (`${osWorkerName}-sandboxes`), so — unlike KV/D1 — there is no id to
-  // reconcile into envs.ts; create-if-missing is the whole story. Wiping a
-  // sandbox's data is erase-data's job, never this create-only script's.
-  const r2BucketName = `${env.osWorkerName}-sandboxes`;
-  await ensureR2Bucket(cf, r2BucketName);
-  // Project file storage (FILES_BUCKET, domains/files/project-files.ts). No
-  // lifecycle rule: files live until deleted. Also ensured by deploy.ts
-  // prepare() so existing envs pick the bucket up on their next deploy.
-  await ensureR2Bucket(cf, `${env.osWorkerName}-files`);
-  // The Sandbox SDK checks its backup ttl only at RESTORE time and never
-  // deletes expired objects from R2 — without a lifecycle rule the bucket
-  // grows forever under e2e churn (a fresh sandbox per test). Expire the
-  // SDK's `backups/` prefix at 90 days, matching SANDBOX_BACKUP_TTL_SECONDS
-  // in cloudflare-sandbox-durable-object.ts (keep the two aligned). PUT is
-  // idempotent; it replaces this bucket's lifecycle config wholesale, which
-  // is fine while this is the only rule we want.
-  await cf(`/r2/buckets/${r2BucketName}/lifecycle`, {
-    method: "PUT",
-    body: JSON.stringify({
-      rules: [
-        {
-          id: "expire-sandbox-workspace-backups",
-          enabled: true,
-          conditions: { prefix: "backups/" },
-          deleteObjectsTransition: { condition: { type: "Age", maxAge: 90 * 24 * 60 * 60 } },
-        },
-      ],
-    }),
-  });
-  console.log(`R2 bucket ${r2BucketName} lifecycle: backups/ expire at 90d`);
-
-  // ---- R2 + AI Search: the itx.search corpus ------------------------------
-  // The worker mirrors stream events / itx.files / repo snapshots /
-  // itx.search.index() documents into this bucket
-  // (domains/search/search-index.ts); itx.search creates ONE AI Search
-  // INSTANCE PER PROJECT (structural tenancy) inside the deployment's
+  // ---- R2 buckets + AI Search namespace -----------------------------------
+  // Sandboxes snapshot /workspace into the `-sandboxes` bucket when they idle
+  // out and restore it on the next start (container disk is ephemeral). The
+  // worker mirrors stream events / itx.files / repo snapshots /
+  // itx.search.index() documents into `-search-index`, and itx.search creates
+  // ONE AI Search INSTANCE PER PROJECT (structural tenancy) in the deployment's
   // namespace, each indexing only that project's `{projectId}/**` slice.
+  // `-files` is itx.files project storage. All are name-addressed, so — unlike
+  // KV/D1 — there is nothing to reconcile into envs.ts; create-if-missing is
+  // the whole story. Wiping their data is erase-data's / lifecycle's job.
+  const isPreview = ctx.name.startsWith("preview");
+  const sandboxesBucket = `${env.osWorkerName}-sandboxes`;
+  await ensureR2Bucket(cf, sandboxesBucket);
+  await ensureR2Bucket(cf, `${env.osWorkerName}-files`);
   await ensureR2Bucket(cf, `${env.osWorkerName}-search-index`);
   await ensureAiSearchNamespace(cf, { namespaceName: env.osWorkerName });
-  // Preview slots: the search-index corpus is disposable and churns to
-  // thousands of objects per lease. Expire it server-side so erase-data can
-  // skip the per-object DELETE storm (see erase-data.ts). Prd keeps its corpus
-  // — no expiry rule there.
-  if (ctx.name.startsWith("preview")) {
+
+  // R2 lifecycle: Cloudflare expires objects server-side so cleanup never has
+  // to delete them one-by-one — the 429 storm that used to leak preview leases
+  // (see erase-data.ts and docs/preview-resource-gc.md). The SDK/worker only
+  // CHECK ttls at read/restore time and never delete from R2, so these rules
+  // are the actual reaper. PUT replaces each bucket's lifecycle wholesale —
+  // fine while these are the only rules per bucket.
+  //
+  // Preview slots expire everything disposable 3h after last write (synthetic
+  // data; pure cost). Prd keeps its data — sandbox backups at 90 days, the
+  // search corpus + files with no rule at all. A preview sandbox's DO still
+  // writes its backup with the 90-day ttl, but this 3h rule deletes it first;
+  // restoring a reaped backup degrades to an empty workspace, so the sandbox
+  // simply comes back fresh after ~3h of no use.
+  await ensureR2ObjectExpiryLifecycle(ctx, sandboxesBucket, {
+    ruleId: "expire-sandbox-workspace-backups",
+    ttlSeconds: isPreview ? PREVIEW_DISPOSABLE_TTL_SECONDS : SANDBOX_BACKUP_TTL_SECONDS_PRD,
+    prefix: "backups/",
+  });
+  if (isPreview) {
     await ensureR2ObjectExpiryLifecycle(
       ctx,
       `${env.osWorkerName}-search-index`,
       PREVIEW_SEARCH_INDEX_OBJECT_EXPIRY,
+    );
+    await ensureR2ObjectExpiryLifecycle(
+      ctx,
+      `${env.osWorkerName}-files`,
+      PREVIEW_FILES_OBJECT_EXPIRY,
     );
   }
 

--- a/apps/os/scripts/ensure-resources.ts
+++ b/apps/os/scripts/ensure-resources.ts
@@ -17,7 +17,12 @@
  */
 import { createBuiltInPrompts, createCli, isAgent, yamlTableConsoleLogger } from "trpc-cli";
 import { envs } from "../../../envs.ts";
-import { ensureD1, ensureProxiedDnsRecord } from "../../../scripts/lib/deploy-helpers.ts";
+import {
+  ensureD1,
+  ensureProxiedDnsRecord,
+  ensureR2ObjectExpiryLifecycle,
+  PREVIEW_SEARCH_INDEX_OBJECT_EXPIRY,
+} from "../../../scripts/lib/deploy-helpers.ts";
 import { resolveEnvContext } from "../../../scripts/lib/env-context.ts";
 import { reconcileResources } from "../../../scripts/lib/wrangler-config.ts";
 import { emailDomainForDeployment } from "../src/domains/email/utils.ts";
@@ -156,6 +161,17 @@ export default async function ensureResources(
   // namespace, each indexing only that project's `{projectId}/**` slice.
   await ensureR2Bucket(cf, `${env.osWorkerName}-search-index`);
   await ensureAiSearchNamespace(cf, { namespaceName: env.osWorkerName });
+  // Preview slots: the search-index corpus is disposable and churns to
+  // thousands of objects per lease. Expire it server-side so erase-data can
+  // skip the per-object DELETE storm (see erase-data.ts). Prd keeps its corpus
+  // — no expiry rule there.
+  if (ctx.name.startsWith("preview")) {
+    await ensureR2ObjectExpiryLifecycle(
+      ctx,
+      `${env.osWorkerName}-search-index`,
+      PREVIEW_SEARCH_INDEX_OBJECT_EXPIRY,
+    );
+  }
 
   // ---- Queues: deployment event queue + Cloudflare Artifacts subscriptions -
   // One general-purpose queue per OS worker. Artifacts event subscriptions are

--- a/apps/os/scripts/erase-data.ts
+++ b/apps/os/scripts/erase-data.ts
@@ -34,7 +34,11 @@
 import { fileURLToPath } from "node:url";
 import { createBuiltInPrompts, createCli, isAgent, yamlTableConsoleLogger } from "trpc-cli";
 import { envs } from "../../../envs.ts";
-import { wipeD1Tables } from "../../../scripts/lib/deploy-helpers.ts";
+import {
+  ensureR2ObjectExpiryLifecycle,
+  PREVIEW_SEARCH_INDEX_OBJECT_EXPIRY,
+  wipeD1Tables,
+} from "../../../scripts/lib/deploy-helpers.ts";
 import { resetWorkerDurableObjects } from "../../../scripts/lib/do-reset.ts";
 import { resolveEnvContext } from "../../../scripts/lib/env-context.ts";
 import { COMPATIBILITY_DATE } from "./generate-wrangler-config.ts";
@@ -171,7 +175,40 @@ export default async function eraseData(options: {
   // user data under this script's contract. (The sandboxes bucket is left
   // alone deliberately — container teardown is broken upstream, see the DO
   // section, and its backups expire on a lifecycle rule.)
-  for (const bucket of [`${env.osWorkerName}-search-index`, `${env.osWorkerName}-files`]) {
+  //
+  // Preview slots take the search-index bucket off this hot path: it's pure
+  // derived state that churns to thousands of objects, and walking it with one
+  // DELETE per object is the biggest source of the cleanup 429 storm that
+  // leaked leases (2026-07-15: 1521 objects). Instead we guarantee its
+  // server-side expiry rule and let Cloudflare GC the objects — releasing the
+  // slot immediately. AI Search above has no equivalent (namespace-delete
+  // needs an empty namespace), so its per-instance sweep stays — but with R2
+  // off the path it no longer competes for the ~1200 req/5min budget. If the
+  // rule can't be ensured we fall back to walking the bucket as before.
+  const searchIndexBucket = `${env.osWorkerName}-search-index`;
+  const filesBucket = `${env.osWorkerName}-files`;
+  let searchIndexHandledByLifecycle = false;
+  if (ctx.name.startsWith("preview")) {
+    try {
+      await ensureR2ObjectExpiryLifecycle(
+        ctx,
+        searchIndexBucket,
+        PREVIEW_SEARCH_INDEX_OBJECT_EXPIRY,
+      );
+      searchIndexHandledByLifecycle = true;
+      console.log(
+        `R2 ${searchIndexBucket}: left to ${PREVIEW_SEARCH_INDEX_OBJECT_EXPIRY.ttlSeconds}s lifecycle expiry, not walked`,
+      );
+    } catch (error) {
+      console.warn(
+        `R2 ${searchIndexBucket} lifecycle ensure failed — falling back to walking it: ${String(error).slice(0, 200)}`,
+      );
+    }
+  }
+  const bucketsToWalk = searchIndexHandledByLifecycle
+    ? [filesBucket]
+    : [searchIndexBucket, filesBucket];
+  for (const bucket of bucketsToWalk) {
     // Per-bucket budget: a churn-refilled search-index must not starve the
     // files pass (Bugbot). 90s each + 90s instances stays well inside the
     // cleanup job's 10-minute ceiling alongside the DO/D1/KV work.

--- a/apps/os/scripts/erase-data.ts
+++ b/apps/os/scripts/erase-data.ts
@@ -36,6 +36,7 @@ import { createBuiltInPrompts, createCli, isAgent, yamlTableConsoleLogger } from
 import { envs } from "../../../envs.ts";
 import {
   ensureR2ObjectExpiryLifecycle,
+  PREVIEW_FILES_OBJECT_EXPIRY,
   PREVIEW_SEARCH_INDEX_OBJECT_EXPIRY,
   wipeD1Tables,
 } from "../../../scripts/lib/deploy-helpers.ts";
@@ -176,38 +177,38 @@ export default async function eraseData(options: {
   // alone deliberately — container teardown is broken upstream, see the DO
   // section, and its backups expire on a lifecycle rule.)
   //
-  // Preview slots take the search-index bucket off this hot path: it's pure
-  // derived state that churns to thousands of objects, and walking it with one
-  // DELETE per object is the biggest source of the cleanup 429 storm that
-  // leaked leases (2026-07-15: 1521 objects). Instead we guarantee its
-  // server-side expiry rule and let Cloudflare GC the objects — releasing the
-  // slot immediately. AI Search above has no equivalent (namespace-delete
-  // needs an empty namespace), so its per-instance sweep stays — but with R2
-  // off the path it no longer competes for the ~1200 req/5min budget. If the
-  // rule can't be ensured we fall back to walking the bucket as before.
+  // Preview slots take BOTH disposable buckets off this hot path. The
+  // search-index especially is pure derived state that churns to thousands of
+  // objects, and walking it with one DELETE per object is the biggest source
+  // of the cleanup 429 storm that leaked leases (2026-07-15: 1521 objects).
+  // Instead we guarantee each bucket's 3h server-side expiry rule and let
+  // Cloudflare GC the objects — releasing the slot immediately. AI Search above
+  // has no equivalent (namespace-delete needs an empty namespace), so its
+  // per-instance sweep stays — but with R2 off the path it no longer competes
+  // for the ~1200 req/5min budget. Any bucket whose rule can't be ensured falls
+  // back to being walked as before. Prd always walks (its data has no expiry).
   const searchIndexBucket = `${env.osWorkerName}-search-index`;
   const filesBucket = `${env.osWorkerName}-files`;
-  let searchIndexHandledByLifecycle = false;
+  const reapedByLifecycle = new Set<string>();
   if (ctx.name.startsWith("preview")) {
-    try {
-      await ensureR2ObjectExpiryLifecycle(
-        ctx,
-        searchIndexBucket,
-        PREVIEW_SEARCH_INDEX_OBJECT_EXPIRY,
-      );
-      searchIndexHandledByLifecycle = true;
-      console.log(
-        `R2 ${searchIndexBucket}: left to ${PREVIEW_SEARCH_INDEX_OBJECT_EXPIRY.ttlSeconds}s lifecycle expiry, not walked`,
-      );
-    } catch (error) {
-      console.warn(
-        `R2 ${searchIndexBucket} lifecycle ensure failed — falling back to walking it: ${String(error).slice(0, 200)}`,
-      );
+    for (const [bucket, expiry] of [
+      [searchIndexBucket, PREVIEW_SEARCH_INDEX_OBJECT_EXPIRY],
+      [filesBucket, PREVIEW_FILES_OBJECT_EXPIRY],
+    ] as const) {
+      try {
+        await ensureR2ObjectExpiryLifecycle(ctx, bucket, expiry);
+        reapedByLifecycle.add(bucket);
+        console.log(`R2 ${bucket}: left to ${expiry.ttlSeconds}s lifecycle expiry, not walked`);
+      } catch (error) {
+        console.warn(
+          `R2 ${bucket} lifecycle ensure failed — falling back to walking it: ${String(error).slice(0, 200)}`,
+        );
+      }
     }
   }
-  const bucketsToWalk = searchIndexHandledByLifecycle
-    ? [filesBucket]
-    : [searchIndexBucket, filesBucket];
+  const bucketsToWalk = [searchIndexBucket, filesBucket].filter(
+    (bucket) => !reapedByLifecycle.has(bucket),
+  );
   for (const bucket of bucketsToWalk) {
     // Per-bucket budget: a churn-refilled search-index must not starve the
     // files pass (Bugbot). 90s each + 90s instances stays well inside the

--- a/docs/dev-environments.md
+++ b/docs/dev-environments.md
@@ -356,12 +356,21 @@ invariants:
   maximizes the chance a lapsed PR retakes its own slot instead of finding
   someone else on it.
 - **Everything is attributable and visible.** `pnpm preview status` shows
-  each slot's holder, PR link, and expiry; the semaphore UI at
-  semaphore.iterate.com shows the same; every lease transition
+  each slot's holder, PR open/closed state, idle/orphaned verdict, open
+  preview-eligible PRs without a slot, and reclaim commands when the fleet
+  is full for a reason other than "nine open PRs". The semaphore UI at
+  semaphore.iterate.com shows the same live leases; every lease transition
   (acquired/renewed/evicted/expired/force-released) is logged as an event in
   the coordinator. Exceptional states — waiting for a slot, no slot
   available, slot taken over, slot moved — are additionally bannered as a
   caution alert at the top of the PR body's managed preview section.
+
+  ```bash
+  # Why are there no free slots? (uses GITHUB_TOKEN or `gh auth token`)
+  doppler run --project _shared --config prd -- pnpm preview status
+  # Free an orphaned/idle slot after checking no cleanup is mid-flight:
+  pnpm preview reclaim --slot preview-4 --force
+  ```
 
 CI and local machines run the **same preview commands against the same
 semaphore**. CI additionally checks the deployment epoch before invoking those

--- a/docs/dev-environments.md
+++ b/docs/dev-environments.md
@@ -327,9 +327,14 @@ a **holder** (`pr-1234` for the PR flow, `manual-<user>` for humans). The
 invariants:
 
 - **A PR keeps its slot from first deploy until the PR closes.** Every
-  `preview deploy` / `preview test` run renews the lease for 24h; closing the
-  PR tears the apps down and releases it. Lease expiry is only the safety
-  valve for abandoned PRs (no pushes for >24h).
+  `preview deploy` / `preview test` run renews the lease for 3h; closing the
+  PR tears the apps down and releases it. Lease expiry is the safety valve for
+  abandoned PRs (no pushes for >3h) — kept short because a leased slot costs us
+  for its Cloudflare resources, and a deploy/e2e cycle is only minutes so an
+  active PR never lapses mid-run. A lapsed lease is reclaimed by the scheduled
+  GC sweep — see **[Preview resource GC](preview-resource-gc.md)** for how
+  teardown is decoupled from releasing the slot (and how disposable data
+  expires 3h after last use).
 - **Draft PRs don't claim a slot unless they ask.** Drafts are the default
   for agent-opened PRs, and nine slots don't survive a busy night of them. A
   draft asks by wearing the `preview` label (durable — previews then behave
@@ -370,6 +375,9 @@ invariants:
   doppler run --project _shared --config prd -- pnpm preview status
   # Free an orphaned/idle slot after checking no cleanup is mid-flight:
   pnpm preview reclaim --slot preview-4 --force
+  # Reclaim every slot whose lease has expired (what the hourly GC cron runs;
+  # --dry-run to preview). Never touches a live lease.
+  doppler run --project _shared --config prd -- pnpm preview gc --dry-run
   ```
 
 CI and local machines run the **same preview commands against the same

--- a/docs/preview-resource-gc.md
+++ b/docs/preview-resource-gc.md
@@ -1,0 +1,139 @@
+# Preview resource garbage collection
+
+How preview environments reclaim their Cloudflare resources, and the design
+ideas behind it. For the day-to-day operator view (statuses, reclaim commands),
+see [Dev environments](dev-environments.md); this doc is the "why".
+
+## The principle: releasing a slot never waits on teardown
+
+There are nine preview **slots**. Each is a fixed shell of Cloudflare
+resources — a Worker, its hostname/DNS, a D1 database, KV namespaces, R2
+buckets, an AI Search namespace — created once by `ensure-resources` and
+**never deleted** (Workers especially: recreating a container-bearing Durable
+Object class is broken upstream). A slot is leased to one PR at a time through
+the [semaphore](../apps/semaphore); a PR's deploy and e2e renew the lease, and
+closing the PR releases it.
+
+The bug this design fixes: teardown used to be **on the critical path of
+releasing the slot**. Cleanup erased the slot's data, and only then released
+the lease. When the erase hit a Cloudflare rate limit (HTTP 429) it bailed
+before releasing — and renewed the lease for another day. The slot looked
+"leased" by a long-closed PR, the fleet filled up with these orphans, and open
+PRs couldn't get a preview. (Observed 2026-07-15: 4 of 9 slots held by
+closed/merged PRs.)
+
+So the rule is: **the lease is the load-bearing outcome, not the teardown.**
+The slot must free the instant a PR closes or its lease lapses; reclaiming the
+resources is a separate, lazy, rate-limited job.
+
+## Why no generation token: the project ID already is one
+
+You might expect we need to stamp each tenancy with an identifier so a new PR's
+data can't collide with the old PR's. We don't — the **project ID already does
+this**. Project IDs are `crypto.randomUUID()` (`apps/auth/src/server/id.ts`),
+and they're baked into every per-tenant resource key:
+
+- R2 objects are keyed `{projectId}/…` (`search-corpus.ts`).
+- AI Search instances are one-per-project, IDed by the project ID and scoped to
+  index only `{projectId}/**` (`search-index.ts`).
+
+A new tenant always mints fresh random project IDs, so its data lands under
+fresh keys and can never overlap a dead tenant's. **Correctness is free.** The
+only reason to delete a dead tenant's data at all is **cost** — so deletion can
+be lazy.
+
+## Two speeds of teardown
+
+Teardown splits by what it costs to leave running:
+
+| Concern                                                                                                                 | Reaped by                                                                    | When                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Orphaned **compute** — Durable Object scheduler alarms keep firing agent turns (real LLM spend) against erased projects | one O(1) parked-worker deploy that tombstones every DO class (`do-reset.ts`) | **promptly**, on PR-close cleanup, and as a backstop in the GC sweep |
+| **R2 storage** — search corpus + itx.files + sandbox backups                                                            | Cloudflare **lifecycle rules** (server-side, zero control-plane calls)       | continuously, 3h after last write                                    |
+| **AI Search instances** — no server-side expiry exists (namespace delete requires an empty namespace)                   | per-instance DELETE sweep                                                    | in the GC sweep (and PR-close cleanup)                               |
+| **D1 rows / KV keys**                                                                                                   | O(1) batched wipe                                                            | on cleanup / erase-on-acquire                                        |
+
+The expensive, rate-limit-prone operations were the **per-item** ones: R2
+deletes (a churned search-index held 1521 objects) and AI Search deletes (up to
+~162 per e2e run). Everything else is one or a few bounded calls. All of it
+shares one account-wide budget (~1200 requests / 5 min), so the per-item R2
+storm was _starving_ the AI Search deletes. Moving R2 to lifecycle rules frees
+the budget for the AI Search sweep.
+
+## Everything disposable expires 3 hours after last use
+
+Preview data is synthetic and previews churn, so retention is a pure cost knob.
+One TTL governs it: **3 hours** (`PREVIEW_DISPOSABLE_TTL_SECONDS` in
+`scripts/lib/deploy-helpers.ts`).
+
+- **Lease TTL** (`defaultPreviewLeaseMs`, `scripts/preview/preview.ts`): a slot
+  whose PR hasn't deployed/tested for 3h has an expired lease and is reclaimed.
+  A deploy/e2e cycle is minutes, so an active PR never lapses mid-run; a PR that
+  goes quiet stops costing us within ~3h instead of a full day.
+- **R2 lifecycle** on the preview `-search-index`, `-files`, and `-sandboxes`
+  (`backups/`) buckets: objects are deleted 3h after they're written.
+  `ensure-resources` installs these rules for preview slots only; prd keeps its
+  data (sandbox backups 90 days, corpus + files forever).
+- **Sandboxes**: containers already sleep after ~10 min idle
+  (`onActivityExpired` snapshots then destroys the container). The 3h backup
+  expiry finishes the job — a preview sandbox not used for 3h loses its backup,
+  and a later restore degrades gracefully to an empty workspace, so it simply
+  comes back fresh. (The DO still _writes_ backups with its 90-day ttl; on
+  preview the R2 rule deletes them first. This divergence is deliberate and
+  preview-only.)
+
+## The two phases
+
+### Phase 1 — every preview lease expires
+
+There is no immortal preview lease. PR leases renew to 3h and lapse when the PR
+stops renewing; manual `preview acquire` defaults to 3h; every leased slot
+carries a `leasedUntil`. Lease expiry is the single signal the GC acts on.
+
+### Phase 2 — the GC sweep reclaims expired leases
+
+A scheduled Depot workflow (`.depot/workflows/cloudflare-preview-gc.yml`, hourly)
+runs `pnpm preview gc`, which:
+
+1. Lists every slot and selects those whose lease is **leased but past its
+   expiry** (`selectExpiredLeasesForGc`). An expired lease means no live tenant,
+   so the whole slot is fair game. (Available slots are cleaned by their next
+   acquirer's erase-on-acquire, not here.)
+2. For each, takes it under a fresh lease with a **non-force** acquire. This is
+   the entire race story: a non-force acquire succeeds _only if the slot is
+   genuinely free_. If a new PR grabbed the slot between the snapshot and the
+   take, the acquire returns null and the sweep skips it — that PR's own
+   erase-on-acquire will clean it. No verdict logic, no stealing.
+3. Erases the slot (the same `erase-data` teardown), then releases it. An erase
+   failure releases the slot anyway — its next taker erases first, so a
+   half-wiped slot is self-healing and must never be parked out of the pool.
+
+It runs sequentially (naturally rate-limited) and is idempotent — safe to run
+as often as we like. `pnpm preview gc --dry-run` reports the plan without
+touching anything.
+
+The fast path (PR-close cleanup) still does the prompt DO-compute kill, so the
+GC is a **backstop** for what cleanup missed: a lease that expired because a PR
+went quiet, or a slot whose cleanup itself failed. Worst-case orphaned LLM spend
+is therefore one cron interval, and only in the failure case.
+
+## Self-healing invariants
+
+- **Erase-on-acquire**: every acquire erases the slot before handing it out
+  (`eraseAcquiredSlotOrGiveItBack`), so any teardown that's skipped, deferred,
+  or half-finished is harmless — the next tenant wipes first.
+- **Non-force GC acquire**: the sweep can never take a live tenant's slot.
+- **Lifecycle rules are the reaper**: the SDK/worker only _check_ ttls at
+  read/restore time and never delete from R2 themselves, so the rules are what
+  actually reclaims the storage.
+
+## Where things live
+
+| Thing                                          | File                                              |
+| ---------------------------------------------- | ------------------------------------------------- |
+| The 3h TTL + R2 lifecycle helpers              | `scripts/lib/deploy-helpers.ts`                   |
+| Lifecycle rules installed per slot             | `apps/os/scripts/ensure-resources.ts`             |
+| Preview R2 walk skipped in favour of lifecycle | `apps/os/scripts/erase-data.ts`                   |
+| Lease TTL, `gc`, `selectExpiredLeasesForGc`    | `scripts/preview/preview.ts`                      |
+| The scheduled sweep                            | `.depot/workflows/cloudflare-preview-gc.yml`      |
+| PR-close cleanup (the fast path)               | `.depot/workflows/cloudflare-preview-cleanup.yml` |

--- a/scripts/lib/deploy-helpers.test.ts
+++ b/scripts/lib/deploy-helpers.test.ts
@@ -3,7 +3,10 @@ import {
   assertWorkerSecretAbsent,
   buildR2ObjectExpiryLifecycleRules,
   ensureR2ObjectExpiryLifecycle,
+  PREVIEW_DISPOSABLE_TTL_SECONDS,
+  PREVIEW_FILES_OBJECT_EXPIRY,
   PREVIEW_SEARCH_INDEX_OBJECT_EXPIRY,
+  SANDBOX_BACKUP_TTL_SECONDS_PRD,
   smokeResponse,
 } from "./deploy-helpers.ts";
 import { CloudflareApiError } from "./env-context.ts";
@@ -82,7 +85,7 @@ describe("smokeResponse", () => {
 });
 
 describe("R2 object-expiry lifecycle", () => {
-  it("builds one Age rule scoped to every object in the bucket", () => {
+  it("builds one Age rule scoped to every object by default (empty prefix)", () => {
     const rules = buildR2ObjectExpiryLifecycleRules({ ruleId: "r", ttlSeconds: 3600 });
 
     expect(rules).toEqual([
@@ -96,11 +99,29 @@ describe("R2 object-expiry lifecycle", () => {
     ]);
   });
 
-  it("keeps the preview search-index expiry a stable, short (1 day) TTL", () => {
-    // Guards against an accidental bump: erase-data relies on this expiring
-    // the corpus promptly so it can skip the per-object delete on previews.
-    expect(PREVIEW_SEARCH_INDEX_OBJECT_EXPIRY.ttlSeconds).toBe(24 * 60 * 60);
+  it("scopes to a prefix when given one (e.g. the sandbox backups/ rule)", () => {
+    const rules = buildR2ObjectExpiryLifecycleRules({
+      ruleId: "expire-sandbox-workspace-backups",
+      ttlSeconds: SANDBOX_BACKUP_TTL_SECONDS_PRD,
+      prefix: "backups/",
+    });
+
+    expect(rules[0]?.conditions).toEqual({ prefix: "backups/" });
+    expect(rules[0]?.deleteObjectsTransition.condition).toEqual({
+      type: "Age",
+      maxAge: 90 * 24 * 60 * 60,
+    });
+  });
+
+  it("expires all preview disposable data 3h after write", () => {
+    // Guards against an accidental bump: erase-data relies on this expiring the
+    // corpus/files promptly so it can skip the per-object delete on previews,
+    // and the whole point is cost — abandoned data must not linger a full day.
+    expect(PREVIEW_DISPOSABLE_TTL_SECONDS).toBe(3 * 60 * 60);
+    expect(PREVIEW_SEARCH_INDEX_OBJECT_EXPIRY.ttlSeconds).toBe(PREVIEW_DISPOSABLE_TTL_SECONDS);
+    expect(PREVIEW_FILES_OBJECT_EXPIRY.ttlSeconds).toBe(PREVIEW_DISPOSABLE_TTL_SECONDS);
     expect(PREVIEW_SEARCH_INDEX_OBJECT_EXPIRY.ruleId).toBe("expire-preview-search-index");
+    expect(PREVIEW_FILES_OBJECT_EXPIRY.ruleId).toBe("expire-preview-files");
   });
 
   it("PUTs the rule to the bucket's lifecycle endpoint", async () => {

--- a/scripts/lib/deploy-helpers.test.ts
+++ b/scripts/lib/deploy-helpers.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { assertWorkerSecretAbsent, smokeResponse } from "./deploy-helpers.ts";
+import {
+  assertWorkerSecretAbsent,
+  buildR2ObjectExpiryLifecycleRules,
+  ensureR2ObjectExpiryLifecycle,
+  PREVIEW_SEARCH_INDEX_OBJECT_EXPIRY,
+  smokeResponse,
+} from "./deploy-helpers.ts";
 import { CloudflareApiError } from "./env-context.ts";
 
 afterEach(() => vi.unstubAllGlobals());
@@ -72,5 +78,46 @@ describe("smokeResponse", () => {
     ).resolves.toBeUndefined();
 
     expect(fetchMock).toHaveBeenCalledOnce();
+  });
+});
+
+describe("R2 object-expiry lifecycle", () => {
+  it("builds one Age rule scoped to every object in the bucket", () => {
+    const rules = buildR2ObjectExpiryLifecycleRules({ ruleId: "r", ttlSeconds: 3600 });
+
+    expect(rules).toEqual([
+      {
+        id: "r",
+        enabled: true,
+        // Empty prefix = all objects; deleting after an Age in seconds.
+        conditions: { prefix: "" },
+        deleteObjectsTransition: { condition: { type: "Age", maxAge: 3600 } },
+      },
+    ]);
+  });
+
+  it("keeps the preview search-index expiry a stable, short (1 day) TTL", () => {
+    // Guards against an accidental bump: erase-data relies on this expiring
+    // the corpus promptly so it can skip the per-object delete on previews.
+    expect(PREVIEW_SEARCH_INDEX_OBJECT_EXPIRY.ttlSeconds).toBe(24 * 60 * 60);
+    expect(PREVIEW_SEARCH_INDEX_OBJECT_EXPIRY.ruleId).toBe("expire-preview-search-index");
+  });
+
+  it("PUTs the rule to the bucket's lifecycle endpoint", async () => {
+    const cf = vi.fn(async () => ({}));
+
+    await ensureR2ObjectExpiryLifecycle(
+      { cf, cfV4: vi.fn() } as never,
+      "os-preview-7-search-index",
+      PREVIEW_SEARCH_INDEX_OBJECT_EXPIRY,
+    );
+
+    expect(cf).toHaveBeenCalledOnce();
+    const [path, init] = cf.mock.calls[0] as unknown as [string, RequestInit];
+    expect(path).toBe("/r2/buckets/os-preview-7-search-index/lifecycle");
+    expect(init.method).toBe("PUT");
+    expect(JSON.parse(init.body as string)).toEqual({
+      rules: buildR2ObjectExpiryLifecycleRules(PREVIEW_SEARCH_INDEX_OBJECT_EXPIRY),
+    });
   });
 });

--- a/scripts/lib/deploy-helpers.ts
+++ b/scripts/lib/deploy-helpers.ts
@@ -253,6 +253,19 @@ export async function ensureD1(
 }
 
 /**
+ * One TTL to rule the preview fleet: a preview slot's disposable data (search
+ * corpus, project files, sandbox backups) is expired 3 hours after it was last
+ * written. Short because previews are synthetic and churn constantly, and the
+ * whole point is cost — abandoned data should not linger. Prd keeps its own,
+ * much longer retention (see `SANDBOX_BACKUP_TTL_SECONDS_PRD`); this constant
+ * is never applied there. See docs/preview-resource-gc.md.
+ */
+export const PREVIEW_DISPOSABLE_TTL_SECONDS = 3 * 60 * 60;
+
+/** Prd sandbox workspace backups: 90 days, matching the DO's SANDBOX_BACKUP_TTL_SECONDS. */
+export const SANDBOX_BACKUP_TTL_SECONDS_PRD = 90 * 24 * 60 * 60;
+
+/**
  * The disposable per-slot R2 corpus (the itx.search `-search-index` bucket):
  * pure derived state the worker re-mirrors, which on a churned preview slot
  * grows to thousands of objects. Erasing it object-by-object is the single
@@ -263,44 +276,54 @@ export async function ensureD1(
  */
 export const PREVIEW_SEARCH_INDEX_OBJECT_EXPIRY = {
   ruleId: "expire-preview-search-index",
-  ttlSeconds: 24 * 60 * 60,
+  ttlSeconds: PREVIEW_DISPOSABLE_TTL_SECONDS,
+} as const;
+
+/** Preview project-file storage (itx.files): same disposable 3h expiry as the corpus. */
+export const PREVIEW_FILES_OBJECT_EXPIRY = {
+  ruleId: "expire-preview-files",
+  ttlSeconds: PREVIEW_DISPOSABLE_TTL_SECONDS,
 } as const;
 
 /**
- * Pure builder for a "delete every object `ttlSeconds` after it was written"
- * R2 lifecycle policy. An empty prefix scopes the rule to all objects/uploads
- * (per the R2 lifecycle API), and the Age transition takes seconds — matching
- * the sandbox-backups rule ensure-resources already puts on its own bucket.
+ * Pure builder for a "delete every matching object `ttlSeconds` after it was
+ * written" R2 lifecycle policy. `prefix` scopes the rule; an empty prefix (the
+ * default) covers all objects/uploads, per the R2 lifecycle API. The Age
+ * transition takes seconds.
  */
-export function buildR2ObjectExpiryLifecycleRules(input: { ruleId: string; ttlSeconds: number }) {
+export function buildR2ObjectExpiryLifecycleRules(input: {
+  ruleId: string;
+  ttlSeconds: number;
+  prefix?: string;
+}) {
   return [
     {
       id: input.ruleId,
       enabled: true,
-      conditions: { prefix: "" },
+      conditions: { prefix: input.prefix ?? "" },
       deleteObjectsTransition: { condition: { type: "Age", maxAge: input.ttlSeconds } },
     },
   ];
 }
 
 /**
- * Put a single "expire every object after `ttlSeconds`" lifecycle rule on an
- * R2 bucket, so Cloudflare garbage-collects the objects server-side instead of
- * erase-data walking the bucket with one rate-limited DELETE per object. PUT
+ * Put a single "expire matching objects after `ttlSeconds`" lifecycle rule on
+ * an R2 bucket, so Cloudflare garbage-collects the objects server-side instead
+ * of erase-data walking the bucket with one rate-limited DELETE per object. PUT
  * replaces the bucket's lifecycle config wholesale — fine while this is the
  * only rule the target buckets carry.
  */
 export async function ensureR2ObjectExpiryLifecycle(
   ctx: CfContext,
   bucketName: string,
-  input: { ruleId: string; ttlSeconds: number },
+  input: { ruleId: string; ttlSeconds: number; prefix?: string },
 ): Promise<void> {
   await ctx.cf(`/r2/buckets/${bucketName}/lifecycle`, {
     method: "PUT",
     body: JSON.stringify({ rules: buildR2ObjectExpiryLifecycleRules(input) }),
   });
   console.log(
-    `R2 bucket ${bucketName} lifecycle: all objects expire ${input.ttlSeconds}s after write (${input.ruleId})`,
+    `R2 bucket ${bucketName} lifecycle: objects under "${input.prefix ?? ""}" expire ${input.ttlSeconds}s after write (${input.ruleId})`,
   );
 }
 

--- a/scripts/lib/deploy-helpers.ts
+++ b/scripts/lib/deploy-helpers.ts
@@ -253,6 +253,58 @@ export async function ensureD1(
 }
 
 /**
+ * The disposable per-slot R2 corpus (the itx.search `-search-index` bucket):
+ * pure derived state the worker re-mirrors, which on a churned preview slot
+ * grows to thousands of objects. Erasing it object-by-object is the single
+ * biggest source of the cleanup 429 storm that used to leak preview leases
+ * (2026-07-15: 1521 objects, rate-limited mid-delete). Preview slots let R2
+ * lifecycle expire it server-side — zero control-plane calls — and skip the
+ * object walk in erase-data. NOT applied to prd, whose corpus must persist.
+ */
+export const PREVIEW_SEARCH_INDEX_OBJECT_EXPIRY = {
+  ruleId: "expire-preview-search-index",
+  ttlSeconds: 24 * 60 * 60,
+} as const;
+
+/**
+ * Pure builder for a "delete every object `ttlSeconds` after it was written"
+ * R2 lifecycle policy. An empty prefix scopes the rule to all objects/uploads
+ * (per the R2 lifecycle API), and the Age transition takes seconds — matching
+ * the sandbox-backups rule ensure-resources already puts on its own bucket.
+ */
+export function buildR2ObjectExpiryLifecycleRules(input: { ruleId: string; ttlSeconds: number }) {
+  return [
+    {
+      id: input.ruleId,
+      enabled: true,
+      conditions: { prefix: "" },
+      deleteObjectsTransition: { condition: { type: "Age", maxAge: input.ttlSeconds } },
+    },
+  ];
+}
+
+/**
+ * Put a single "expire every object after `ttlSeconds`" lifecycle rule on an
+ * R2 bucket, so Cloudflare garbage-collects the objects server-side instead of
+ * erase-data walking the bucket with one rate-limited DELETE per object. PUT
+ * replaces the bucket's lifecycle config wholesale — fine while this is the
+ * only rule the target buckets carry.
+ */
+export async function ensureR2ObjectExpiryLifecycle(
+  ctx: CfContext,
+  bucketName: string,
+  input: { ruleId: string; ttlSeconds: number },
+): Promise<void> {
+  await ctx.cf(`/r2/buckets/${bucketName}/lifecycle`, {
+    method: "PUT",
+    body: JSON.stringify({ rules: buildR2ObjectExpiryLifecycleRules(input) }),
+  });
+  console.log(
+    `R2 bucket ${bucketName} lifecycle: all objects expire ${input.ttlSeconds}s after write (${input.ruleId})`,
+  );
+}
+
+/**
  * Create-only DNS ensure for a Worker-routed hostname: worker zone routes
  * only fire when a proxied DNS record answers the hostname, so create a
  * proxied originless AAAA (100::) when nothing exists. Any existing record

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -49,6 +49,7 @@ const {
   resolvePreviewCompareBaseSha,
   resolvePreviewReadinessUrls,
   resolvePreviewTestBaseUrlEnvironment,
+  selectExpiredLeasesForGc,
   selectPreviewAppsForPullRequest,
   selectPreviewAppsNeedingRetry,
   splitRepositoryFullName,
@@ -150,11 +151,12 @@ describe("preview workflow scope", () => {
       baseUrl: "https://dummy-petshop.iterate-preview-3.com",
       projectHostnameBases: [],
     });
-    for (const workflow of ["cloudflare-previews.yml", "cloudflare-preview-cleanup.yml"]) {
-      expect(readFileSync(resolve(repoRoot, ".depot/workflows", workflow), "utf8")).toContain(
-        "- apps/dummy-petshop/**",
-      );
-    }
+    // Only the deploy workflow is path-filtered; cleanup deliberately has no
+    // paths list (it must run for every closed PR — see the cleanup-trigger
+    // test below), so it is not asserted here.
+    expect(
+      readFileSync(resolve(repoRoot, ".depot/workflows/cloudflare-previews.yml"), "utf8"),
+    ).toContain("- apps/dummy-petshop/**");
   });
 
   it("deploys OS after Petshop and passes that exact preview URL to OS e2e", () => {
@@ -270,6 +272,24 @@ describe("preview workflow scope", () => {
     // cleanup tooling must come from the default branch.
     expect(cleanupWorkflowText).toContain("github.event.repository.default_branch");
     expect(cleanupWorkflowText).not.toContain("github.event.pull_request.head.sha");
+  });
+
+  it("sweeps expired leases on a schedule from default-branch tooling", () => {
+    const gcWorkflowText = readFileSync(
+      resolve(repoRoot, ".depot/workflows/cloudflare-preview-gc.yml"),
+      "utf8",
+    );
+    const gcWorkflow = parseYaml(gcWorkflowText) as {
+      on?: { schedule?: { cron: string }[] };
+    };
+
+    // The GC is scheduled (the lazy half of the lifecycle), not triggered by a
+    // PR event.
+    expect(gcWorkflow.on?.schedule?.length).toBeGreaterThan(0);
+    expect(gcWorkflowText).toContain("pnpm preview gc");
+    // Runs current tooling, and needs no GitHub token — lease expiry is the
+    // only signal.
+    expect(gcWorkflowText).toContain("github.event.repository.default_branch");
   });
 });
 
@@ -1781,6 +1801,61 @@ describe("preview fleet capacity diagnosis", () => {
     expect(diagnosis.reasons.some((reason) => reason.includes("#2008"))).toBe(true);
     expect(diagnosis.reasons.some((reason) => reason.includes("#1983"))).toBe(true);
     expect(diagnosis.summary).toContain("orphaned");
+  });
+});
+
+describe("gc expired-lease selection", () => {
+  const now = 1_000_000_000_000;
+  const base = { data: {}, lastReleasedAt: null, lastAcquiredAt: null };
+
+  it("selects only leased slots whose lease is at or past expiry", () => {
+    const selected = selectExpiredLeasesForGc(
+      [
+        // Live lease — a PR is still using it, skip.
+        {
+          ...base,
+          slug: "preview-1",
+          leaseState: "leased",
+          leasedUntil: now + 60_000,
+          holder: "pr-1",
+        },
+        // Expired lease — reclaim.
+        {
+          ...base,
+          slug: "preview-2",
+          leaseState: "leased",
+          leasedUntil: now - 60_000,
+          holder: "pr-2",
+        },
+        // Exactly at expiry — reclaim (<=).
+        { ...base, slug: "preview-3", leaseState: "leased", leasedUntil: now, holder: "pr-3" },
+        // Available slots are cleaned by their next acquirer, never by gc.
+        { ...base, slug: "preview-4", leaseState: "available", leasedUntil: null, holder: null },
+      ],
+      now,
+    );
+
+    expect(selected.map((slot) => slot.slug)).toEqual(["preview-2", "preview-3"]);
+  });
+
+  it("resolves the doppler config from lease data, else derives it from the slug", () => {
+    const selected = selectExpiredLeasesForGc(
+      [
+        {
+          ...base,
+          slug: "preview-5",
+          leaseState: "leased",
+          leasedUntil: now - 1,
+          holder: "pr-5",
+          data: { dopplerConfig: "preview_5" },
+        },
+        // No payload yet → slug-derived (preview-6 → preview_6).
+        { ...base, slug: "preview-6", leaseState: "leased", leasedUntil: now - 1, holder: null },
+      ],
+      now,
+    );
+
+    expect(selected.map((slot) => slot.dopplerConfig)).toEqual(["preview_5", "preview_6"]);
   });
 });
 

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -116,9 +116,10 @@ describe("preview workflow scope", () => {
     expect(cloudflarePreviewSharedPaths).toContain("scripts/preview/**");
     expect(cloudflarePreviewSharedPaths).toContain("packages/ui/**");
     expect(cloudflarePreviewAdditionalTriggerPaths).toContain("apps/iterate-com/**");
-    // The preview deploy + e2e lifecycle is one Depot CI workflow (cleanup
-    // has its own, with mirrored paths); a change to it triggers a full-fleet
-    // preview and must be mirrored in that file's own paths list.
+    // The preview deploy + e2e lifecycle is one Depot CI workflow; a change to
+    // it triggers a full-fleet preview. Cleanup is a separate closed-event
+    // workflow with no paths filter (it must run for every closed PR that
+    // might hold a lease, including full reverts).
     expect(cloudflarePreviewSharedPaths).toContain(".depot/workflows/cloudflare-previews.yml");
     // Dependency manifests can change every app's build output; a diff that
     // touches only them must select the full fleet, not "no apps affected"
@@ -250,6 +251,25 @@ describe("preview workflow scope", () => {
     });
     expect(deployWorkflowText).not.toContain("cloudflare-preview-fleet-auth-rpc-cutover");
     expect(cleanupWorkflowText).not.toContain("cloudflare-preview-fleet-auth-rpc-cutover");
+  });
+
+  it("always runs cleanup on close with default-branch tooling (no paths filter)", () => {
+    const cleanupWorkflowText = readFileSync(
+      resolve(repoRoot, ".depot/workflows/cloudflare-preview-cleanup.yml"),
+      "utf8",
+    );
+    const cleanupWorkflow = parseYaml(cleanupWorkflowText) as {
+      on?: { pull_request?: { types?: string[]; paths?: string[] } };
+    };
+
+    expect(cleanupWorkflow.on?.pull_request?.types).toEqual(["closed"]);
+    // A paths filter skips cleanup when the final PR diff is empty (full
+    // revert) or no longer matches deploy paths — which leaks the lease.
+    expect(cleanupWorkflow.on?.pull_request?.paths).toBeUndefined();
+    // PR-head checkout reintroduces old bugs (e.g. bail-before-release);
+    // cleanup tooling must come from the default branch.
+    expect(cleanupWorkflowText).toContain("github.event.repository.default_branch");
+    expect(cleanupWorkflowText).not.toContain("github.event.pull_request.head.sha");
   });
 });
 
@@ -1700,6 +1720,67 @@ describe("lease reclaim verdicts", () => {
         now,
       }),
     ).toBe("active");
+  });
+});
+
+describe("preview fleet capacity diagnosis", () => {
+  const { diagnosePreviewFleetCapacity, pullRequestWouldClaimPreviewSlot } = previewInternals;
+
+  it("treats ready PRs and preview-labeled drafts as slot-eligible", () => {
+    expect(pullRequestWouldClaimPreviewSlot({ isDraft: false, labels: [] })).toBe(true);
+    expect(pullRequestWouldClaimPreviewSlot({ isDraft: true, labels: ["preview"] })).toBe(true);
+    expect(pullRequestWouldClaimPreviewSlot({ isDraft: true, labels: [] })).toBe(false);
+  });
+
+  it("explains a full fleet held mostly by closed PRs despite few open ones", () => {
+    const diagnosis = diagnosePreviewFleetCapacity({
+      openPullRequests: [
+        {
+          number: 2008,
+          title: "ready pr without a slot",
+          url: "https://github.com/iterate/iterate/pull/2008",
+          isDraft: false,
+          labels: [],
+        },
+        {
+          number: 1983,
+          title: "draft without opt-in",
+          url: "https://github.com/iterate/iterate/pull/1983",
+          isDraft: true,
+          labels: [],
+        },
+      ],
+      slots: [
+        {
+          slug: "preview-1",
+          verdict: "orphaned",
+          holder: "pr-1990",
+          pullRequestUrl: "https://github.com/iterate/iterate/pull/1990",
+          pullRequestState: "closed",
+          leasedUntil: "2026-07-15T13:53:39.946Z",
+          lastUsedAgo: "19h ago",
+        },
+        {
+          slug: "preview-2",
+          verdict: "active",
+          holder: "pr-2006",
+          pullRequestUrl: "https://github.com/iterate/iterate/pull/2006",
+          pullRequestState: "open",
+          leasedUntil: "2026-07-16T09:20:18.639Z",
+          lastUsedAgo: "2m ago",
+        },
+      ],
+    });
+
+    expect(diagnosis.availableCount).toBe(0);
+    expect(diagnosis.leasedCount).toBe(2);
+    expect(diagnosis.orphanedCount).toBe(1);
+    expect(diagnosis.previewEligibleWithoutSlotCount).toBe(1);
+    expect(diagnosis.reclaimCommands).toEqual(["pnpm preview reclaim --slot preview-1 --force"]);
+    expect(diagnosis.reasons.some((reason) => reason.includes("closed/merged"))).toBe(true);
+    expect(diagnosis.reasons.some((reason) => reason.includes("#2008"))).toBe(true);
+    expect(diagnosis.reasons.some((reason) => reason.includes("#1983"))).toBe(true);
+    expect(diagnosis.summary).toContain("orphaned");
   });
 });
 

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -1752,6 +1752,35 @@ describe("preview fleet capacity diagnosis", () => {
     expect(pullRequestWouldClaimPreviewSlot({ isDraft: true, labels: [] })).toBe(false);
   });
 
+  it("does not call a label-less draft slot-less when it actually holds one (--allow-draft)", () => {
+    const diagnosis = diagnosePreviewFleetCapacity({
+      openPullRequests: [
+        {
+          number: 4242,
+          title: "draft dispatched with --allow-draft",
+          url: "https://github.com/iterate/iterate/pull/4242",
+          isDraft: true,
+          labels: [],
+        },
+      ],
+      slots: [
+        {
+          slug: "preview-1",
+          verdict: "active",
+          holder: "pr-4242",
+          pullRequestUrl: "https://github.com/iterate/iterate/pull/4242",
+          pullRequestState: "open",
+          leasedUntil: "2026-07-16T09:20:18.639Z",
+          lastUsedAgo: "2m ago",
+        },
+      ],
+    });
+
+    // It holds a slot, so it must not be reported as "correctly claims no slot".
+    expect(diagnosis.holdersWithOpenPrs).toContain(4242);
+    expect(diagnosis.reasons.some((reason) => reason.includes("claim no slot"))).toBe(false);
+  });
+
   it("explains a full fleet held mostly by closed PRs despite few open ones", () => {
     const diagnosis = diagnosePreviewFleetCapacity({
       openPullRequests: [

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -1076,6 +1076,142 @@ export async function reclaim(options: ReclaimOptions = {}) {
   };
 }
 
+/** A slot whose lease has passed its expiry — a GC sweep candidate. */
+type ExpiredLeaseForGc = {
+  slug: string;
+  holder: string | null;
+  dopplerConfig: string;
+  leasedUntil: number;
+};
+
+/**
+ * Pure selection for {@link gc}: the slots whose lease is leased but past its
+ * expiry. Lease expiry is the sole GC signal — an expired lease means no live
+ * tenant, so the whole slot is fair game (available slots are cleaned by their
+ * next acquirer, not here). See docs/preview-resource-gc.md.
+ */
+function selectExpiredLeasesForGc(
+  resources: ReadonlyArray<{
+    data: Record<string, unknown>;
+    holder?: string | null;
+    leaseState: "available" | "leased";
+    leasedUntil: number | null;
+    slug: string;
+  }>,
+  now: number,
+): ExpiredLeaseForGc[] {
+  const expired: ExpiredLeaseForGc[] = [];
+  for (const resource of resources) {
+    if (resource.leaseState !== "leased" || resource.leasedUntil === null) continue;
+    if (resource.leasedUntil > now) continue;
+    expired.push({
+      slug: resource.slug,
+      holder: resource.holder ?? null,
+      // Same fallback classifyEnvironmentConfigLeases uses: the slug-derived
+      // config (preview-3 → preview_3) for a slot with no data payload yet.
+      dopplerConfig:
+        typeof resource.data.dopplerConfig === "string" && resource.data.dopplerConfig.trim()
+          ? resource.data.dopplerConfig.trim()
+          : resource.slug.replaceAll("-", "_"),
+      leasedUntil: resource.leasedUntil,
+    });
+  }
+  return expired;
+}
+
+/** Report what would be reclaimed without touching anything, or hold length. */
+type GcOptions = {
+  /** Print the plan without acquiring, erasing, or releasing anything. */
+  dryRun?: boolean;
+  /** Minutes to hold each slot while erasing it (default 30). */
+  holdMinutes?: number;
+};
+
+/**
+ * Garbage-collect preview slots whose lease has expired: for each, take it
+ * under a fresh lease, erase its data, and release it — unattended and
+ * rate-limited (runs sequentially). This is the lazy half of the model in
+ * docs/preview-resource-gc.md: releasing a slot never waits on teardown, and
+ * this scheduled sweep (the Cloudflare Preview GC Depot cron) reclaims whatever
+ * the fast path — PR-close cleanup — did not.
+ *
+ * Lease expiry is the ONLY signal; the take is a NON-force acquire, which
+ * succeeds only while the slot is genuinely free. So if a PR re-leased the slot
+ * between our snapshot and the take, the acquire returns null and we skip it
+ * (that PR's own erase-on-acquire cleans it) — no race, no verdict logic. An
+ * erase failure still releases the slot: its next taker erases first, so a
+ * half-wiped slot is self-healing and must not be parked out of the pool.
+ */
+export async function gc(options: GcOptions = {}) {
+  const runtime = createPreviewRuntime();
+  const semaphore = runtime.createPreviewSemaphoreResourceClient();
+  const now = Date.now();
+  const resources = await semaphore.list({ type: ENVIRONMENT_CONFIG_LEASE_RESOURCE_TYPE });
+  const expired = selectExpiredLeasesForGc(resources, now);
+  const holdMs = (options.holdMinutes ?? 30) * 60_000;
+  const eraseSlotData = makePreviewSlotDataEraser(runtime);
+
+  const outcomes: Array<{
+    slug: string;
+    action: "reclaimed" | "skipped" | "erase-failed" | "would-reclaim";
+    holder: string | null;
+    error?: string;
+  }> = [];
+  for (const slot of expired) {
+    if (options.dryRun) {
+      outcomes.push({ slug: slot.slug, action: "would-reclaim", holder: slot.holder });
+      continue;
+    }
+    const taken = await semaphore.acquireSpecific({
+      type: ENVIRONMENT_CONFIG_LEASE_RESOURCE_TYPE,
+      slug: slot.slug,
+      leaseMs: holdMs,
+      holder: "gc",
+    });
+    if (!taken) {
+      logPreview(`gc: ${slot.slug} was re-leased since the snapshot — leaving it to its tenant`);
+      outcomes.push({ slug: slot.slug, action: "skipped", holder: slot.holder });
+      continue;
+    }
+    try {
+      logPreview(
+        `gc: reclaiming ${slot.slug} — lease from ${slot.holder ?? "unknown"} expired ${formatDurationMs(now - slot.leasedUntil)} ago; erasing`,
+      );
+      await eraseSlotData({ dopplerConfig: slot.dopplerConfig, slug: slot.slug });
+      outcomes.push({ slug: slot.slug, action: "reclaimed", holder: slot.holder });
+    } catch (error) {
+      logPreview(
+        `gc: erase failed for ${slot.slug}; releasing it for its next taker to re-erase: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      outcomes.push({
+        slug: slot.slug,
+        action: "erase-failed",
+        holder: slot.holder,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      await semaphore.release({
+        slug: slot.slug,
+        type: ENVIRONMENT_CONFIG_LEASE_RESOURCE_TYPE,
+        leaseId: taken.leaseId,
+      });
+    }
+  }
+
+  const reclaimedCount = outcomes.filter((outcome) => outcome.action === "reclaimed").length;
+  logPreview(
+    `gc: ${expired.length} slot(s) past lease expiry, ${reclaimedCount} reclaimed${options.dryRun ? " (dry-run — nothing erased)" : ""}`,
+  );
+  return {
+    checkedAt: new Date(now).toISOString(),
+    leaseTtlHours: defaultPreviewLeaseMs / 3_600_000,
+    dryRun: options.dryRun ?? false,
+    expiredCount: expired.length,
+    reclaimedCount,
+    outcomes,
+  };
+}
+
 /**
  * Check live Semaphore environment config leases against Doppler configs and Cloudflare preview domain zones.
  */
@@ -1563,9 +1699,12 @@ const defaultRepositoryFullName = "iterate/iterate";
 // A preview slot belongs to its PR for the PR's whole life: every `preview
 // deploy` and `preview test` run renews the lease for this long, and closing
 // the PR releases it. Expiry is only the safety valve for abandoned PRs — a
-// PR that pushes nothing for this long may lose its slot to another PR.
-// While a lease is live, nothing takes the slot without a human --force.
-const defaultPreviewLeaseMs = 24 * 60 * 60 * 1000;
+// PR that pushes nothing for this long loses its slot (the GC sweep reclaims
+// it; see docs/preview-resource-gc.md). While a lease is live, nothing takes
+// the slot without a human --force. 3h keeps idle slots (and the Cloudflare
+// resources behind them) from costing us for a full day after a PR goes quiet;
+// a deploy/e2e cycle is minutes, so an active PR never lapses mid-run.
+const defaultPreviewLeaseMs = 3 * 60 * 60 * 1000;
 // Routed previews can be healthy before Cloudflare has finished issuing edge
 // certificates for newly-created hostnames. Some apps record a separate
 // project-subdomain URL; wait on that URL only when it is expected to be
@@ -3432,8 +3571,10 @@ function resolveSlotWaitTotalMs(env: NodeJS.ProcessEnv) {
 
 // A hold with no deploy/test renewal for this long counts as idle in
 // `preview reclaim` verdicts. Renewals happen on every deploy/test run, so
-// idle means "that PR/person hasn't touched the slot in this window".
-const defaultReclaimMinIdleHours = 6;
+// idle means "that PR/person hasn't touched the slot in this window". Matches
+// the lease TTL (defaultPreviewLeaseMs, 3h): a slot idle this long has a lease
+// at or past expiry, and the GC sweep will reclaim it.
+const defaultReclaimMinIdleHours = 3;
 
 /** `unknown` = the check itself failed; distinct from "not checked" (null downstream). */
 type PullRequestStateFetcher = (
@@ -4737,6 +4878,7 @@ export const previewInternals = {
   requireExplicitReclaimForce,
   retakeRecordedSlotIfFree,
   resolveSlotWaitTotalMs,
+  selectExpiredLeasesForGc,
   expandPreviewDependencies,
   orderPreviewDeployBatches,
   parseCloudflarePreviewState,

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -786,52 +786,70 @@ export async function assign(options: AssignOptions = {}) {
 }
 
 /**
- * Show environment config lease inventory and active leases for PR previews.
+ * Show environment config lease inventory, cross-check holders against GitHub
+ * PR state, and explain why the fleet can look full even when only a handful
+ * of PRs are open (orphaned closed-PR leases, idle holds, draft opt-ins, …).
+ *
+ *   doppler run --project _shared --config prd -- pnpm preview status
  */
-export async function status() {
+type StatusOptions = {
+  /** GitHub token. Defaults to GITHUB_TOKEN or `gh auth token`. */
+  githubToken?: string;
+  /** Hours without a deploy/test renewal before a hold counts as idle. */
+  minIdleHours?: number;
+};
+
+export async function status(options: StatusOptions = {}) {
   const runtime = createPreviewRuntime();
   const semaphore = runtime.createPreviewSemaphoreResourceClient();
-  const now = Date.now();
-  const resources = await semaphore.list({
-    type: ENVIRONMENT_CONFIG_LEASE_RESOURCE_TYPE,
+  const { githubToken, repositoryFullName, fetchPullRequestState } = resolvePreviewGithubContext(
+    runtime,
+    options,
+  );
+  if (!fetchPullRequestState) {
+    logPreview(
+      "no GITHUB_TOKEN / gh auth — cannot check whether pr-* holders are closed or list open PRs; lease table is still live from the semaphore",
+    );
+  }
+
+  const minIdleHours = options.minIdleHours ?? defaultReclaimMinIdleHours;
+  const slots = await classifyEnvironmentConfigLeases({
+    fetchPullRequestState,
+    minIdleMs: minIdleHours * 3_600_000,
+    semaphore,
   });
-  const available = resources
-    .filter((resource) => resource.leaseState === "available")
-    .map((resource) => ({
-      data: resource.data,
-      slug: resource.slug,
-      lastReleasedAt:
-        resource.lastReleasedAt === null ? null : new Date(resource.lastReleasedAt).toISOString(),
-    }));
-  const leased = resources
-    .filter((resource) => resource.leaseState === "leased")
-    .map((resource) => ({
-      data: resource.data,
-      slug: resource.slug,
-      holder: resource.holder ?? null,
-      pullRequestUrl: holderPullRequestUrl(resource.holder),
-      leasedUntil:
-        resource.leasedUntil === null ? null : new Date(resource.leasedUntil).toISOString(),
-      expiresInMs: resource.leasedUntil === null ? null : resource.leasedUntil - now,
-      lastAcquiredAt:
-        resource.lastAcquiredAt === null ? null : new Date(resource.lastAcquiredAt).toISOString(),
-    }))
-    .sort((left, right) => {
-      if (left.leasedUntil === null) return 1;
-      if (right.leasedUntil === null) return -1;
-      return left.leasedUntil.localeCompare(right.leasedUntil);
-    });
+  const openPullRequests = githubToken
+    ? await listOpenPullRequestsForPreviewDiagnosis(githubToken, repositoryFullName)
+    : [];
+  const diagnosis = diagnosePreviewFleetCapacity({ openPullRequests, slots });
 
   return {
-    checkedAt: new Date(now).toISOString(),
+    checkedAt: new Date().toISOString(),
     semaphoreBaseUrl: defaultSemaphoreBaseUrl,
     type: ENVIRONMENT_CONFIG_LEASE_RESOURCE_TYPE,
-    total: resources.length,
-    availableCount: available.length,
-    leasedCount: leased.length,
-    nextLeaseExpiryAt: leased[0]?.leasedUntil ?? null,
-    available,
-    leased,
+    total: slots.length,
+    availableCount: diagnosis.availableCount,
+    leasedCount: diagnosis.leasedCount,
+    minIdleHours,
+    nextLeaseExpiryAt: diagnosis.nextLeaseExpiryAt,
+    slots,
+    openPullRequests: openPullRequests.map((pullRequest) => ({
+      number: pullRequest.number,
+      title: pullRequest.title,
+      url: pullRequest.url,
+      isDraft: pullRequest.isDraft,
+      labels: pullRequest.labels,
+      previewEligible: pullRequestWouldClaimPreviewSlot(pullRequest),
+      holdsSlot: diagnosis.holdersWithOpenPrs.includes(pullRequest.number),
+    })),
+    diagnosis,
+    // Surface reclaim commands at the top level too, matching `reclaim`'s own
+    // output shape. Must be a fresh array: the trpc-cli renderer prints any
+    // value it has already seen elsewhere in the tree (here, the same array
+    // under `diagnosis.reclaimCommands`) as the literal string "[Circular]",
+    // even though it is only shared, not truly cyclic.
+    reclaimable: [...diagnosis.reclaimCommands],
+    note: diagnosis.summary,
   };
 }
 
@@ -987,17 +1005,10 @@ type ReclaimOptions = {
 export async function reclaim(options: ReclaimOptions = {}) {
   const runtime = createPreviewRuntime();
   const semaphore = runtime.createPreviewSemaphoreResourceClient();
-  const githubToken =
-    options.githubToken?.trim() || runtime.commandEnvironment.GITHUB_TOKEN?.trim();
-  const fetchPullRequestState = githubToken
-    ? makePullRequestStateFetcher(
-        githubToken,
-        runtime.commandEnvironment.GITHUB_REPOSITORY?.trim() || defaultRepositoryFullName,
-      )
-    : null;
+  const { fetchPullRequestState } = resolvePreviewGithubContext(runtime, options);
   if (!fetchPullRequestState) {
     logPreview(
-      "no GITHUB_TOKEN available — cannot check whether pr-* holders are closed, so verdicts are idle-time only (orphaned PRs show as idle/active)",
+      "no GITHUB_TOKEN / gh auth — cannot check whether pr-* holders are closed, so verdicts are idle-time only (orphaned PRs show as idle/active)",
     );
   }
 
@@ -3455,6 +3466,25 @@ function makePullRequestStateFetcher(
   };
 }
 
+/**
+ * Resolve the GitHub token, repo, and PR-state fetcher shared by `status` and
+ * `reclaim`. Token precedence: explicit option → GITHUB_TOKEN → `gh auth token`.
+ * `fetchPullRequestState` is null when no token is available — callers log their
+ * own reason and fall back to idle-time-only verdicts.
+ */
+function resolvePreviewGithubContext(runtime: PreviewRuntime, options: { githubToken?: string }) {
+  const githubToken =
+    options.githubToken?.trim() ||
+    runtime.commandEnvironment.GITHUB_TOKEN?.trim() ||
+    tryReadGhAuthToken();
+  const repositoryFullName =
+    runtime.commandEnvironment.GITHUB_REPOSITORY?.trim() || defaultRepositoryFullName;
+  const fetchPullRequestState = githubToken
+    ? makePullRequestStateFetcher(githubToken, repositoryFullName)
+    : null;
+  return { githubToken, repositoryFullName, fetchPullRequestState };
+}
+
 /** Pure reporting verdict; it never authorizes an automatic lease takeover. */
 function classifyLeaseForReclaim(input: {
   holderPullRequestState: "open" | "closed" | "unknown" | null;
@@ -3482,6 +3512,175 @@ function classifyLeaseForReclaim(input: {
   }
 
   return "active";
+}
+
+type PreviewDiagnosisOpenPullRequest = {
+  number: number;
+  title: string;
+  url: string;
+  isDraft: boolean;
+  labels: string[];
+};
+
+/**
+ * Draft PRs only claim a slot when they opt in (same policy as deploy). Used
+ * by `preview status` so "9 open PRs" is not compared apples-to-oranges with
+ * the 9-slot fleet.
+ */
+function pullRequestWouldClaimPreviewSlot(pullRequest: {
+  isDraft: boolean;
+  labels: readonly string[];
+}): boolean {
+  return !pullRequest.isDraft || pullRequest.labels.includes(previewOptInLabel);
+}
+
+type PreviewDiagnosisSlot = {
+  slug: string;
+  verdict: "available" | "active" | "idle" | "orphaned";
+  holder: string | null;
+  pullRequestUrl: string | null;
+  pullRequestState: "open" | "closed" | "unknown" | null;
+  leasedUntil: string | null;
+  lastUsedAgo: string | null;
+};
+
+/**
+ * Pure capacity diagnosis: reconcile semaphore holders with open PRs so an
+ * operator can see why "only N open PRs" still means zero free slots.
+ */
+function diagnosePreviewFleetCapacity(input: {
+  openPullRequests: PreviewDiagnosisOpenPullRequest[];
+  slots: PreviewDiagnosisSlot[];
+}) {
+  const available = input.slots.filter((slot) => slot.verdict === "available");
+  const leased = input.slots.filter((slot) => slot.verdict !== "available");
+  const orphaned = leased.filter((slot) => slot.verdict === "orphaned");
+  const idle = leased.filter((slot) => slot.verdict === "idle");
+  const active = leased.filter((slot) => slot.verdict === "active");
+  const holdersWithOpenPrs = input.openPullRequests
+    .map((pullRequest) => pullRequest.number)
+    .filter((number) => leased.some((slot) => parsePullRequestHolder(slot.holder) === number));
+  const previewEligibleOpen = input.openPullRequests.filter(pullRequestWouldClaimPreviewSlot);
+  const previewEligibleWithoutSlot = previewEligibleOpen.filter(
+    (pullRequest) => !holdersWithOpenPrs.includes(pullRequest.number),
+  );
+  const openButIneligible = input.openPullRequests.filter(
+    (pullRequest) => !pullRequestWouldClaimPreviewSlot(pullRequest),
+  );
+  const closedHolders = leased.filter((slot) => slot.pullRequestState === "closed");
+  const nonPrHolders = leased.filter((slot) => parsePullRequestHolder(slot.holder) === null);
+
+  const reasons: string[] = [];
+  if (available.length === 0 && leased.length > 0) {
+    reasons.push(`All ${leased.length} preview slots are leased (0 available).`);
+  } else if (available.length > 0) {
+    reasons.push(`${available.length} of ${input.slots.length} slots are available.`);
+  }
+  if (closedHolders.length > 0) {
+    reasons.push(
+      `${closedHolders.length} leased by closed/merged PRs (cleanup failed or never ran): ${closedHolders
+        .map((slot) => `${slot.slug}←${slot.holder}`)
+        .join(", ")}.`,
+    );
+  }
+  if (idle.length > 0) {
+    reasons.push(
+      `${idle.length} idle (open holder, no deploy/test renewal recently): ${idle
+        .map(
+          (slot) =>
+            `${slot.slug}←${slot.holder}${slot.lastUsedAgo ? ` (${slot.lastUsedAgo})` : ""}`,
+        )
+        .join(", ")}.`,
+    );
+  }
+  if (nonPrHolders.length > 0) {
+    reasons.push(
+      `${nonPrHolders.length} held by non-PR holders (manual/reclaim): ${nonPrHolders
+        .map((slot) => `${slot.slug}←${slot.holder ?? "unknown"}`)
+        .join(", ")}.`,
+    );
+  }
+  if (previewEligibleWithoutSlot.length > 0) {
+    reasons.push(
+      `${previewEligibleWithoutSlot.length} open preview-eligible PR(s) have no slot: ${previewEligibleWithoutSlot
+        .map((pullRequest) => `#${pullRequest.number}`)
+        .join(", ")}.`,
+    );
+  }
+  if (openButIneligible.length > 0) {
+    reasons.push(
+      `${openButIneligible.length} open draft PR(s) without the \`${previewOptInLabel}\` label correctly claim no slot: ${openButIneligible
+        .map((pullRequest) => `#${pullRequest.number}`)
+        .join(", ")}.`,
+    );
+  }
+  if (
+    input.openPullRequests.length > 0 &&
+    closedHolders.length === 0 &&
+    available.length === 0 &&
+    previewEligibleOpen.length <= input.slots.length
+  ) {
+    reasons.push(
+      `Open-PR count alone (${input.openPullRequests.length} open, ${previewEligibleOpen.length} preview-eligible) does not explain a full fleet — check idle/manual holders above.`,
+    );
+  }
+
+  const reclaimCommands = [...orphaned, ...idle].map(
+    (slot) => `pnpm preview reclaim --slot ${slot.slug} --force`,
+  );
+
+  const summaryParts = [
+    `${available.length} available / ${leased.length} leased of ${input.slots.length}`,
+    closedHolders.length > 0 ? `${closedHolders.length} orphaned (closed PR)` : null,
+    idle.length > 0 ? `${idle.length} idle` : null,
+    active.length > 0 ? `${active.length} active` : null,
+    previewEligibleWithoutSlot.length > 0
+      ? `${previewEligibleWithoutSlot.length} open PR(s) waiting for a slot`
+      : null,
+  ].filter(Boolean);
+
+  return {
+    availableCount: available.length,
+    leasedCount: leased.length,
+    orphanedCount: orphaned.length,
+    idleCount: idle.length,
+    activeCount: active.length,
+    openPullRequestCount: input.openPullRequests.length,
+    previewEligibleOpenCount: previewEligibleOpen.length,
+    previewEligibleWithoutSlotCount: previewEligibleWithoutSlot.length,
+    holdersWithOpenPrs,
+    nextLeaseExpiryAt:
+      leased
+        .map((slot) => slot.leasedUntil)
+        .filter((value): value is string => value != null)
+        .sort()[0] ?? null,
+    reasons,
+    reclaimCommands,
+    summary: summaryParts.join(" · "),
+  };
+}
+
+async function listOpenPullRequestsForPreviewDiagnosis(
+  githubToken: string,
+  repositoryFullName: string,
+): Promise<PreviewDiagnosisOpenPullRequest[]> {
+  const octokit = new Octokit({ auth: githubToken });
+  const [owner, repo] = splitRepositoryFullName(repositoryFullName);
+  const pullRequests = await octokit.paginate(octokit.rest.pulls.list, {
+    owner,
+    repo,
+    state: "open",
+    per_page: 100,
+  });
+  return pullRequests.map((pullRequest) => ({
+    number: pullRequest.number,
+    title: pullRequest.title,
+    url: pullRequest.html_url,
+    isDraft: Boolean(pullRequest.draft),
+    labels: (pullRequest.labels ?? [])
+      .map((label) => (typeof label === "string" ? label : label.name))
+      .filter((name): name is string => typeof name === "string" && name.length > 0),
+  }));
 }
 
 async function classifyEnvironmentConfigLeases(input: {
@@ -4530,9 +4729,11 @@ export const previewInternals = {
   describeEnvironmentConfigLeases,
   describeForcePushCompareHazard,
   describeLostSlotOwnership,
+  diagnosePreviewFleetCapacity,
   evaluateCloudflareZoneCheck,
   holderPullRequestUrl,
   pullRequestHolder,
+  pullRequestWouldClaimPreviewSlot,
   requireExplicitReclaimForce,
   retakeRecordedSlotIfFree,
   resolveSlotWaitTotalMs,

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -3705,8 +3705,13 @@ function diagnosePreviewFleetCapacity(input: {
   const previewEligibleWithoutSlot = previewEligibleOpen.filter(
     (pullRequest) => !holdersWithOpenPrs.includes(pullRequest.number),
   );
+  // Drafts that opted in via a one-shot `--allow-draft` dispatch hold a slot
+  // without the label, so exclude any that actually hold one — otherwise we'd
+  // tell the operator it "correctly claims no slot" next to holdsSlot: true.
   const openButIneligible = input.openPullRequests.filter(
-    (pullRequest) => !pullRequestWouldClaimPreviewSlot(pullRequest),
+    (pullRequest) =>
+      !pullRequestWouldClaimPreviewSlot(pullRequest) &&
+      !holdersWithOpenPrs.includes(pullRequest.number),
   );
   const closedHolders = leased.filter((slot) => slot.pullRequestState === "closed");
   const nonPrHolders = leased.filter((slot) => parsePullRequestHolder(slot.holder) === null);


### PR DESCRIPTION
Reduce preview contention. Preview slots kept showing as "full" while few PRs were open, because teardown was coupled to releasing the lease: when the erase hit a Cloudflare 429 it bailed *before* releasing and renewed the lease for another day, so the fleet filled with orphans held by closed PRs. This PR fixes that leak, removes the 429 storm that caused it, and reframes teardown as a lazy, scheduled garbage collector — with everything disposable expiring 3h after last use.

**Full design & rationale: [`docs/preview-resource-gc.md`](https://github.com/iterate/iterate/blob/preview-orphan-lease-reclaim/docs/preview-resource-gc.md).**

---

## 1. Stop leaking the lease

- **No `paths` filter on cleanup.** It mirrored the deploy workflow, so a PR that closed with an empty/non-matching diff (e.g. a full revert) never ran cleanup and leaked its lease for 24h. Cleanup now runs on **every** close (no-op when the semaphore leases nothing to the PR).
- **Cleanup checks out the default branch,** not the closed PR's head — so it always runs post-#1989 code and can't reintroduce the bail-before-release bug.

## 2. Kill the 429 storm at its source (R2 lifecycle, not a delete loop)

The storm was `erase-data` walking the `-search-index` bucket with **one DELETE per object** (1521 objects on a churned slot, rate-limited against the account-wide ~1200 req/5min budget). That corpus is pure derived state, so:

- `ensure-resources` puts **R2 lifecycle expiry rules** on the preview `-search-index`, `-files`, and `-sandboxes` (`backups/`) buckets — Cloudflare GCs the objects server-side, **zero control-plane calls**. Prd keeps its data (sandbox backups 90d; corpus + files forever).
- `erase-data` hands both disposable buckets to lifecycle and **skips walking them** on previews (falls back to walking if a rule can't be ensured).
- AI Search has no server-side expiry (namespace-delete needs an empty namespace), so its per-instance sweep stays — but with the R2 whale off the shared budget, it no longer starves.

## 3. Everything disposable expires 3h after last use

Preview data is synthetic and churns; retention is a pure cost knob (`PREVIEW_DISPOSABLE_TTL_SECONDS = 3h`).

- **Lease TTL 24h → 3h:** a slot whose PR hasn't deployed/tested for 3h has an expired lease. A deploy/e2e cycle is minutes, so an active PR never lapses mid-run; a quiet PR stops costing us within ~3h instead of a day.
- **R2 objects:** deleted 3h after write (rules above).
- **Sandboxes:** containers already sleep at ~10min idle; the 3h backup expiry means an unused preview sandbox comes back fresh (restore degrades gracefully to an empty workspace). Prd sandboxes stay at 90 days.

## 4. GC sweep — reclaim expired leases off the critical path

Releasing a slot never waits on teardown. A scheduled Depot cron (`.depot/workflows/cloudflare-preview-gc.yml`, hourly) runs `pnpm preview gc`:

- Selects slots whose lease is **past expiry** (`selectExpiredLeasesForGc`) — lease expiry is the only signal; an expired lease means no live tenant.
- Takes each under a **non-force acquire** (succeeds only if genuinely free), erases it, releases it. If a PR re-leased the slot since the snapshot, the acquire fails and it's skipped — **no race, no stealing, no verdict logic**. Erase failures release anyway (next taker erases first — self-healing).
- Sequential/rate-limited, idempotent, `--dry-run` supported, needs no GitHub token.

PR-close cleanup stays the prompt path (does the O(1) DO-compute kill that stops orphaned agents burning LLM budget); the GC is the **backstop** for what cleanup missed.

### Why no generation token
Project IDs are `crypto.randomUUID()` and already baked into every R2 key (`{projectId}/…`) and AI Search instance. A new tenant mints fresh IDs, so data never collides — correctness is free, teardown is pure cost, so it can be lazy. Lease expiry alone drives GC.

## 5. `pnpm preview status` is a real diagnosis

Cross-checks holders against GitHub PR state; prints slot verdicts (orphaned/idle/active/available), which PRs hold/await a slot, why the fleet is full, and reclaim commands. No longer needs `--json '{}'`.

---

## Tests
- R2 lifecycle builder (prefix + whole-bucket) + 3h TTL guards; `ensureR2ObjectExpiryLifecycle` PUT.
- `gc` expired-lease selection (live vs expired vs available; doppler-config resolution).
- Workflow invariants: cleanup runs on every close with no paths filter + default-branch checkout; GC is scheduled, runs `preview gc`, default-branch tooling.

## Docs
- New `docs/preview-resource-gc.md` (design + rationale), linked from `CLAUDE.md`.
- `docs/dev-environments.md`: 3h lease, GC sweep, `preview gc` recipe.

## Operational note
Already freed the originally-stuck slots by hand against prd (`preview-7` reclaim; `8/9/6` release) — fleet went **0 → 4 available**. This PR is the durable fix. Existing preview slots pick up the new lifecycle rules on their next `ensure-resources`/erase; the GC cron and 3h lease take effect once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-15T12:02:13.774Z",
      "headSha": "fdada4baeca8d349c17191e4ad1b9ae12c22f709",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/50725600780328",
      "shortSha": "fdada4b",
      "cleanupDurationMs": 2229,
      "deployDurationMs": 17231,
      "testDurationMs": 205,
      "testRetries": null,
      "workerSizeKib": 4030.87,
      "workerGzipKib": 819.48,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-15T12:02:12.196Z",
      "headSha": "fdada4baeca8d349c17191e4ad1b9ae12c22f709",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/50725600780328",
      "shortSha": "fdada4b",
      "cleanupDurationMs": 650,
      "deployDurationMs": 13365,
      "testDurationMs": 20060,
      "testRetries": null,
      "workerSizeKib": 5139.6,
      "workerGzipKib": 1466.03,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-15T12:02:12.151Z",
      "headSha": "fdada4baeca8d349c17191e4ad1b9ae12c22f709",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/50725600780328",
      "shortSha": "fdada4b",
      "cleanupDurationMs": 603,
      "deployDurationMs": 6378,
      "testDurationMs": 5652,
      "testRetries": null,
      "workerSizeKib": 1139,
      "workerGzipKib": 201.58,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-15T12:02:10.388Z",
      "headSha": "fdada4baeca8d349c17191e4ad1b9ae12c22f709",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/50725600780328",
      "shortSha": "fdada4b",
      "cleanupDurationMs": 164547,
      "deployDurationMs": 85925,
      "testDurationMs": 209068,
      "testRetries": "10 retried: bring-your-own App: mint installation token in the Secret DO, act as the installation, re-mint on expiry (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · is MITM-intercepted and routed through project egress with secret substitution (vitest x1) · concurrent long-running itx scripts all complete (vitest x1) · configured processor subscriptions are recorded as configured runtime connections (vitest x1) · webhook subscriptions validate their URL before commit (vitest x1) · global streams reject webhook subscriptions before commit (vitest x1) · wake expressions traverse dynamic dispatch surfaces (the slack router shape) (vitest x1) · ephemeral events are second-class rows: excluded from default reads, delivered on ephemeral subscriptions (vitest x1) · reactivity page appends a batch and renders every delivered marker (specs x1)",
      "workerSizeKib": 16398.27,
      "workerGzipKib": 4425.79,
      "mainWorkerGzipKib": 4425.89
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-15T11:59:26.322Z",
      "headSha": "fdada4baeca8d349c17191e4ad1b9ae12c22f709",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/50725600780328",
      "shortSha": "fdada4b",
      "cleanupDurationMs": 478,
      "deployDurationMs": 14077,
      "testDurationMs": 6573,
      "testRetries": null,
      "workerSizeKib": 1914.76,
      "workerGzipKib": 440.77,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `fdada4b` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 819.5 KiB | 17.2s | 205ms |  | 2.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/50725600780328) | 2026-07-15T12:02:13.774Z | Preview app released. |
| Dummy Petshop | released | `fdada4b` | [https://dummy-petshop.iterate-preview-7.com](https://dummy-petshop.iterate-preview-7.com) | 201.6 KiB | 6.4s | 5.7s |  | 603ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/50725600780328) | 2026-07-15T12:02:12.151Z | Preview app released. |
| OS | released | `fdada4b` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 4.32 MiB (-0.1 KiB vs main) | 85.9s | 209.1s | 10 retried: bring-your-own App: mint installation token in the Secret DO, act as the installation, re-mint on expiry (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · is MITM-intercepted and routed through project egress with secret substitution (vitest x1) · concurrent long-running itx scripts all complete (vitest x1) · configured processor subscriptions are recorded as configured runtime connections (vitest x1) · webhook subscriptions validate their URL before commit (vitest x1) · global streams reject webhook subscriptions before commit (vitest x1) · wake expressions traverse dynamic dispatch surfaces (the slack router shape) (vitest x1) · ephemeral events are second-class rows: excluded from default reads, delivered on ephemeral subscriptions (vitest x1) · reactivity page appends a batch and renders every delivered marker (specs x1) | 164.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/50725600780328) | 2026-07-15T12:02:10.388Z | Preview app released. |
| Semaphore | released | `fdada4b` | [https://semaphore.iterate-preview-7.com](https://semaphore.iterate-preview-7.com) | 440.8 KiB | 14.1s | 6.6s |  | 478ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/50725600780328) | 2026-07-15T11:59:26.322Z | Preview app released. |
| Streams Example App | released | `fdada4b` | [https://streams.iterate-preview-7.com](https://streams.iterate-preview-7.com) | 1.43 MiB | 13.4s | 20.1s |  | 650ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/50725600780328) | 2026-07-15T12:02:12.196Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes preview lease timing, automated teardown/GC, and erase behavior against live Cloudflare preview slots; mitigated by erase-on-acquire, non-force GC acquires, and release-despite-teardown-failure semantics already in cleanup.
> 
> **Overview**
> Fixes preview slots staying **leased** after PR close when teardown hit Cloudflare **429**s and cleanup never ran (path-filtered closes, PR-head tooling). **Releasing the lease is no longer gated on a full erase**; teardown is lazy and rate-limited.
> 
> **CI / workflows:** PR-close **cleanup** runs on **every** closed PR (no `paths` filter) and checks out the **default branch** so current cleanup code always runs. New **hourly** `cloudflare-preview-gc.yml` runs `pnpm preview gc` (optional `--dry-run`).
> 
> **3h disposable TTL:** Preview lease renewal drops **24h → 3h** (`defaultPreviewLeaseMs`); reclaim idle threshold **6h → 3h**. Shared `PREVIEW_DISPOSABLE_TTL_SECONDS` drives preview R2 lifecycle on `-search-index`, `-files`, and sandbox `backups/` via `ensureR2ObjectExpiryLifecycle` in `ensure-resources` (prd keeps 90d sandbox backups and no corpus/files expiry).
> 
> **Erase path:** On previews, `erase-data` **ensures lifecycle rules** and **skips per-object R2 deletes** for those buckets (fallback walk if ensure fails); AI Search instance deletes remain. Cuts the delete storm that starved the shared API budget.
> 
> **`pnpm preview gc`:** Selects slots with **expired leases**, **non-force** acquires, erases, **releases even on erase failure** (next acquire wipes). **`preview status`** cross-checks GitHub, diagnoses full fleet vs open PRs, and surfaces reclaim commands. New `docs/preview-resource-gc.md` and dev-env doc updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdada4baeca8d349c17191e4ad1b9ae12c22f709. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +262 -9 | +214 -6 🟩🟩⬜⬜⬜ |
| CI & scripts | +649 -116 | +489 -89 🟩🟩🟩🟩🟥 |
| Docs | +162 -5 | +133 -5 🟩⬜⬜⬜⬜ |
| **Total** | **+1,073 -130** | **+836 -100** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between a888108 and fdada4b, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->