### PR TITLE
Prevent reactivity route hydration mismatch

### DIFF
--- a/apps/os/src/routes/_app/projects/$projectSlug/reactivity.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/reactivity.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@iterate-com/ui/components/badge";
 import { Button } from "@iterate-com/ui/components/button";
 import type { StreamEvent } from "../../../../domains/streams/schemas.ts";
 import { ItxBoundary } from "~/components/itx-boundary.tsx";
+import { breadcrumbStaticData } from "~/lib/route-breadcrumbs.ts";
 import {
   useItx,
   useItxSubscription,
@@ -18,8 +19,9 @@ import {
 // the request isolate with no DO), and the SEPARATE raw event-log lane.
 
 export const Route = createFileRoute("/_app/projects/$projectSlug/reactivity")({
+  staticData: breadcrumbStaticData("Reactivity"),
   ssr: false,
-  loader: ({ context }) => ({ breadcrumb: "Reactivity", project: context.project }),
+  loader: ({ context }) => ({ project: context.project }),
   component: ProjectReactivityPage,
 });
 

--- a/specs/reactivity-hydration.spec.ts
+++ b/specs/reactivity-hydration.spec.ts
@@ -1,0 +1,16 @@
+import { expect } from "@playwright/test";
+import { test } from "./test-support/test.ts";
+
+test("hydrates the client-only reactivity route without rebuilding the shell", async ({
+  helpers,
+  page,
+}) => {
+  await using fixture = await helpers.createFixture("reactivity-hydration");
+  const pageErrors: Error[] = [];
+  page.on("pageerror", (error) => pageErrors.push(error));
+
+  await page.goto(`/projects/${fixture.project.slug}/reactivity`);
+  await page.getByRole("heading", { name: "Live state playground" }).waitFor();
+
+  expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
## Why

Opening a project’s client-only reactivity page caused React to discard and rebuild the app shell during hydration.

The server can only see the parent project-list match and rendered the shell breadcrumb as `Projects`. The reactivity loader is client-only, so the first browser render already used its loader breadcrumb, `Reactivity`. React correctly reported the text mismatch as an unhandled hydration error.

## What changed

- Publish `Reactivity` as static route metadata, using the same existing `breadcrumbStaticData` mechanism as the other non-stream pages.
- Make static metadata the single source of truth for the breadcrumb; the loader now returns only the project data the page consumes.
- Add a browser regression spec that rejects every uncaught page error while opening a real project’s reactivity route. This also catches production React’s minified hydration errors rather than depending on development-only wording.

There is no fallback, compatibility path, API change, schema change, environment change, or new dependency.

## Proof

On unchanged `main`, the new browser spec failed 1/1 with the exact diff:

```text
+ Reactivity
- Projects
Error: Hydration failed because the server rendered text didn't match the client.
```

With this commit, the same spec passed 3/3 against a warm local OS server with one worker and no retries.

Also green locally:

- whole-repo typecheck
- whole-repo lint (zero warnings)
- whole-repo format
- `git diff --check`

## Size and complexity

- Runtime: +3/−1 lines (one import, one static route declaration, one duplicate breadcrumb removed)
- Regression spec: +16 lines
- Total: +19/−1 across two files

This is deliberately a standalone prerequisite. It removes a real browser error discovered while proving the separate stream-delivery UI change; it does not include that change or any observability implementation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small routing metadata change plus a regression test; no API, auth, or data-path changes.
> 
> **Overview**
> Fixes a **hydration error** on the client-only project reactivity page where the shell breadcrumb showed **Projects** on the server but **Reactivity** on the first client render.
> 
> The reactivity route now sets **`staticData: breadcrumbStaticData("Reactivity")`**, matching other non-stream pages, so the breadcrumb is available during SSR even though the route’s loader does not run on the server. The loader no longer returns a duplicate `breadcrumb` and only supplies **`project`** for the page.
> 
> Adds a **Playwright** spec that opens a real project’s `/reactivity` URL and asserts **no uncaught page errors**, covering minified production hydration failures as well as dev wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6aea70d22a338a578d714e0f7335d504149403d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +3 -1 | +3 -1 🟩🟩⬜⬜⬜ |
| Tests | +16 -0 | +13 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+19 -1** | **+16 -1** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 582ec23 and d6aea70, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-15T14:22:42.625Z",
      "headSha": "d6aea70d22a338a578d714e0f7335d504149403d",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/528130630944160",
      "shortSha": "d6aea70",
      "cleanupDurationMs": 4367,
      "deployDurationMs": 18873,
      "workerSizeKib": 4030.87,
      "workerGzipKib": 819.79,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-15T14:22:39.208Z",
      "headSha": "d6aea70d22a338a578d714e0f7335d504149403d",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/528130630944160",
      "shortSha": "d6aea70",
      "cleanupDurationMs": 948,
      "deployDurationMs": 17351,
      "testDurationMs": 59459,
      "testRetries": "1 retried: stream capnweb protocol > documents Cloudflare's 32 MiB inbound WebSocket frame ceiling for capnweb appends (vitest x1)",
      "workerSizeKib": 5157.43,
      "workerGzipKib": 1470.03,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-15T14:22:37.131Z",
      "headSha": "d6aea70d22a338a578d714e0f7335d504149403d",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/528130630944160",
      "shortSha": "d6aea70",
      "cleanupDurationMs": 135454,
      "deployDurationMs": 73038,
      "workerSizeKib": 16421.58,
      "workerGzipKib": 4430.72,
      "mainWorkerGzipKib": 4430.49
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-15T14:20:22.310Z",
      "headSha": "d6aea70d22a338a578d714e0f7335d504149403d",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/528130630944160",
      "shortSha": "d6aea70",
      "cleanupDurationMs": 621,
      "deployDurationMs": 15695,
      "testDurationMs": 22480,
      "testRetries": null,
      "workerSizeKib": 1914.49,
      "workerGzipKib": 440.74,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-15T14:22:38.981Z",
      "headSha": "d6aea70d22a338a578d714e0f7335d504149403d",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/528130630944160",
      "shortSha": "d6aea70",
      "cleanupDurationMs": 716,
      "deployDurationMs": 6826,
      "workerSizeKib": 1139,
      "workerGzipKib": 201.58,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `d6aea70` | [https://auth.iterate-preview-6.com](https://auth.iterate-preview-6.com) | 819.8 KiB | 18.9s |  |  | 4.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/528130630944160) | 2026-07-15T14:22:42.625Z | Preview app released. |
| Dummy Petshop | released | `d6aea70` | [https://dummy-petshop.iterate-preview-6.com](https://dummy-petshop.iterate-preview-6.com) | 201.6 KiB | 6.8s |  |  | 716ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/528130630944160) | 2026-07-15T14:22:38.981Z | Preview app released. |
| OS | released | `d6aea70` | [https://os.iterate-preview-6.com](https://os.iterate-preview-6.com) | 4.33 MiB (+0.2 KiB vs main) | 73.0s |  |  | 135.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/528130630944160) | 2026-07-15T14:22:37.131Z | Preview app released. |
| Semaphore | released | `d6aea70` | [https://semaphore.iterate-preview-6.com](https://semaphore.iterate-preview-6.com) | 440.7 KiB | 15.7s | 22.5s |  | 621ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/528130630944160) | 2026-07-15T14:20:22.310Z | Preview app released. |
| Streams Example App | released | `d6aea70` | [https://streams.iterate-preview-6.com](https://streams.iterate-preview-6.com) | 1.44 MiB | 17.4s | 59.5s | 1 retried: stream capnweb protocol > documents Cloudflare's 32 MiB inbound WebSocket frame ceiling for capnweb appends (vitest x1) | 948ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/528130630944160) | 2026-07-15T14:22:39.208Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->