### PR TITLE
Remove URL-controlled PostHog identity bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,32 @@
 
 Monorepo for Iterate's Cloudflare Workers platform. **`apps/os`** is the main app — the product dashboard at `os.iterate.com`.
 
+## Irrevocable engineering principle: no deviant system behaviour
+
+We do not accept unexplained, unbounded, or silently tolerated system
+behaviour. An error is either an explicitly modelled and correctly classified
+expected outcome, or it is a product defect. The same rule applies to retry
+storms, stuck work, silent data loss, unexplained latency, state drift, and
+resource leaks.
+
+- Never normalize an error counter merely because it is noisy or longstanding.
+  Classify every contributing outcome, remove expected outcomes from error
+  telemetry, and fix the rest.
+- Never swallow, endlessly retry, or hide failures behind fallbacks or
+  compatibility shims. Recovery must be bounded, observable, and preserve a
+  durable explanation of what happened.
+- A healthy request is not enough if it leaves corrupt, stalled, or divergent
+  state behind. Verify the resulting state and the relevant production-shaped
+  telemetry.
+- Green tests are necessary but not sufficient. For operational changes, the
+  acceptance proof includes a preview deployment and evidence that its traces,
+  logs, metrics, and state transitions are coherent, correctly classified, and
+  free of new unexplained errors.
+
+Treat any unexplained error volume as a release blocker until evidence proves
+that each outcome is expected and correctly represented outside the error
+signal. "Unavoidable error spam" is not a category.
+
 ## Environments
 
 - The root `envs.ts` is the typed map of every deployed environment

--- a/apps/os/scripts/generate-wrangler-config.test.ts
+++ b/apps/os/scripts/generate-wrangler-config.test.ts
@@ -6,10 +6,17 @@ import {
   config,
   localAuthServiceBinding,
   OPTIONAL_SECRETS,
+  REQUIRED_SECRETS,
 } from "./generate-wrangler-config.ts";
 
-it("does not ship the retired APP_CONFIG_LOGS secret", () => {
-  expect(OPTIONAL_SECRETS).not.toContain("APP_CONFIG_LOGS");
+it.each([
+  "APP_CONFIG_LOGS",
+  "APP_CONFIG_GEMINI_API_KEY",
+  "APP_CONFIG_SLACK_BOT_TOKEN",
+  "APP_CONFIG_X_AI_API_KEY",
+])("does not ship the retired %s override", (name) => {
+  expect(OPTIONAL_SECRETS).not.toContain(name);
+  expect(REQUIRED_SECRETS).not.toContain(name);
 });
 
 // Wrangler tags every `--env` deploy with `cf:service=<top-level name>` and

--- a/apps/os/scripts/generate-wrangler-config.ts
+++ b/apps/os/scripts/generate-wrangler-config.ts
@@ -53,7 +53,6 @@ export const REQUIRED_SECRETS = [
  */
 export const OPTIONAL_SECRETS = [
   "APP_CONFIG_CLOUDFLARE__API_TOKEN",
-  "APP_CONFIG_GEMINI_API_KEY",
   // Iterate-owned Exa/Parallel API keys (platform-secrets.ts registry
   // entries) — collectSecrets ships only names listed here, so a key absent
   // from this list never reaches a deployed worker even when Doppler has it.
@@ -69,8 +68,6 @@ export const OPTIONAL_SECRETS = [
   "APP_CONFIG_ITERATE_AUTH__EMAIL_OTP_ENABLED",
   "APP_CONFIG_ITERATE_AUTH__RESOURCE",
   "APP_CONFIG_POSTHOG",
-  "APP_CONFIG_SLACK_BOT_TOKEN",
-  "APP_CONFIG_X_AI_API_KEY",
   // R2 S3-API credentials the Sandbox SDK uses to presign workspace-backup
   // transfers (exact names the SDK reads). Optional: without them the
   // sandbox DO falls back to streaming archives through the BACKUP_BUCKET

--- a/apps/os/src/lib/posthog-url-bootstrap.test.ts
+++ b/apps/os/src/lib/posthog-url-bootstrap.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const posthogInit = vi.fn();
+// Resolve from packages/ui, which owns the SDK dependency; OS intentionally does not.
+const posthogModuleSpecifier = "../../../../packages/ui/node_modules/posthog-js";
+
+describe("shared PostHog initialization", () => {
+  afterEach(() => {
+    posthogInit.mockReset();
+    vi.doUnmock(posthogModuleSpecifier);
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("does not read identity or session state from the URL", async () => {
+    vi.stubEnv("SSR", false);
+    vi.doMock(posthogModuleSpecifier, () => ({ default: { init: posthogInit } }));
+    vi.stubGlobal("window", {
+      location: {
+        origin: "https://os.iterate.com",
+        get search(): never {
+          throw new Error("PostHog initialization read URL parameters");
+        },
+      },
+    });
+
+    const { initPosthog } = await import("@iterate-com/ui/components/posthog");
+    initPosthog({ apiKey: "phc_test" });
+
+    await vi.waitFor(() => expect(posthogInit).toHaveBeenCalledOnce());
+    expect(posthogInit.mock.calls[0]?.[1]).not.toHaveProperty("bootstrap");
+  });
+});

--- a/docs/posthog.md
+++ b/docs/posthog.md
@@ -1,48 +1,27 @@
-# PostHog Analytics Setup
+# PostHog browser setup
 
-Cross-domain tracking between iterate.com (marketing) and the OS product app (`apps/os`).
+OS and Semaphore initialize PostHog through the shared UI package. The
+marketing site has a separate provider.
 
-## Architecture
+## Identity Boundary
 
-```
-iterate.com (anonymous)          os.iterate.com / os.iterate.com (identified)
-┌─────────────────────┐         ┌─────────────────────────────┐
-│ User visits         │         │ User signs up               │
-│ marketing page      │         │                             │
-│                     │   URL   │ PostHog bootstraps with     │
-│ PostHog assigns     │ ──────► │ distinct_id from URL        │
-│ distinct_id: abc123 │ params  │                             │
-│                     │         │ identify(userId) merges     │
-│ Tracks: $pageview   │         │ abc123 → userId             │
-└─────────────────────┘         └─────────────────────────────┘
-```
-
-## Cross-Domain Tracking
-
-Different origins do not share cookies. The reading side exists in shared code: `setupPosthog` in `packages/ui/src/components/posthog.tsx` bootstraps PostHog from `ph_distinct_id` / `ph_session_id` URL query params when `bootstrapFromUrl` is enabled (the default in `packages/ui/src/apps/providers.tsx`). Nothing currently appends those params to outbound links — a sender would need to add them for cross-domain identity to merge.
+The shared provider does not accept PostHog distinct or session IDs from URL
+parameters because query parameters are untrusted input. Any future
+cross-domain identity handoff needs a separately reviewed, server-issued,
+integrity-protected design.
 
 ## Key Files
 
-| File                                                       | Purpose                                                  |
-| ---------------------------------------------------------- | -------------------------------------------------------- |
-| `packages/ui/src/components/posthog.tsx`                   | Shared client init; bootstraps from `ph_*` URL params    |
-| `packages/ui/src/apps/providers.tsx`                       | Wires `setupPosthog` + `PostHogProvider` into app shells |
-| `apps/iterate-com/backend/components/posthog-provider.tsx` | PostHog init for marketing site                          |
-| `apps/os/src/routes/posthog-proxy.$.ts`                    | Worker proxy route for PostHog ingest                    |
-| `packages/shared/src/posthog/`                             | Shared proxy + sourcemap helpers                         |
-
-Search `apps/os` for PostHog client init and identity hooks when wiring new UI surfaces.
-
-## Environment Variables
-
-Configured in Doppler for `os` and `iterate-com`:
-
-- `POSTHOG_PUBLIC_KEY` — server-side project API key
-- `VITE_POSTHOG_PUBLIC_KEY` — client key (often aliased from `POSTHOG_PUBLIC_KEY`)
-- `VITE_APP_STAGE` — included as `$environment` on events (`dev_*`, `preview_N`, `prd`)
+| File                                                       | Purpose                                   |
+| ---------------------------------------------------------- | ----------------------------------------- |
+| `packages/ui/src/components/posthog.tsx`                   | Shared OS/Semaphore client initialization |
+| `packages/ui/src/apps/providers.tsx`                       | Initializes PostHog in shared app shells  |
+| `apps/iterate-com/backend/components/posthog-provider.tsx` | PostHog init for marketing site           |
+| `apps/os/src/routes/posthog-proxy.$.ts`                    | Worker proxy route for PostHog ingest     |
+| `packages/shared/src/posthog/`                             | Shared PostHog ingest proxy helper        |
 
 ## Verification
 
-1. Open an app with `?ph_distinct_id=<id>` appended → PostHog bootstraps with that distinct id
-2. Browse a few pages → events arrive in PostHog under that distinct id with the expected `$environment`
-3. Exercise billing flows → confirm subscription/payment events if enabled for the environment
+1. `apps/os/src/lib/posthog-url-bootstrap.test.ts` proves URL parameters cannot
+   influence shared initialization.
+2. Browse a few pages and confirm events arrive in the intended PostHog project.

--- a/packages/ui/src/apps/providers.tsx
+++ b/packages/ui/src/apps/providers.tsx
@@ -25,7 +25,6 @@ export function AppProviders<TConfig>(props: {
   const proxyUrl = props.posthog?.proxyUrl ?? "/posthog-proxy";
   const uiHost = props.posthog?.uiHost;
   const appStage = props.posthog?.appStage;
-  const bootstrapFromUrl = props.posthog?.bootstrapFromUrl ?? true;
   const sessionRecording = props.posthog?.sessionRecording;
   const posthogEnabled = props.posthog?.enabled ?? shouldEnablePosthog(posthogApiKey);
 
@@ -35,7 +34,6 @@ export function AppProviders<TConfig>(props: {
       proxyUrl,
       uiHost,
       appStage,
-      bootstrapFromUrl,
       sessionRecording,
     });
   }

--- a/packages/ui/src/components/posthog.tsx
+++ b/packages/ui/src/components/posthog.tsx
@@ -7,7 +7,6 @@ export interface SetupPosthogOptions {
   proxyUrl?: string;
   uiHost?: string;
   appStage?: string;
-  bootstrapFromUrl?: boolean;
   sessionRecording?: boolean;
 }
 
@@ -33,23 +32,10 @@ function resolveBrowserUrl(url?: string) {
   }
 }
 
-function getBootstrapConfig() {
-  if (typeof window === "undefined") return undefined;
-  const urlParams = new URLSearchParams(window.location.search);
-  const distinctId = urlParams.get("ph_distinct_id");
-  const sessionId = urlParams.get("ph_session_id");
-  if (!distinctId) return undefined;
-  return {
-    distinctID: distinctId,
-    sessionID: sessionId ?? undefined,
-  };
-}
-
 function buildPosthogInitOptions(options: SetupPosthogOptions) {
   return {
     api_host: resolveBrowserUrl(options.proxyUrl ?? "/api/integrations/posthog/proxy"),
     ui_host: resolveBrowserUrl(options.uiHost ?? "https://eu.posthog.com"),
-    bootstrap: options.bootstrapFromUrl ? getBootstrapConfig() : undefined,
     defaults: "2026-01-30" as const,
     capture_pageleave: true,
     capture_exceptions: true,


### PR DESCRIPTION
## Outcome

OS and Semaphore no longer let URL query parameters choose PostHog's browser `distinctID` or `sessionID`.

The removed path accepted `ph_distinct_id` and `ph_session_id` from untrusted query strings, then passed them to `posthog.init({ bootstrap: ... })`. There is no sender for this dormant cross-origin handoff in the repository, so it provided no working product capability while weakening analytics identity and session-correlation integrity.

This is an analytics-integrity boundary, not an application-authentication fix.

## What changed

### Runtime: deletion only

- Delete the `bootstrapFromUrl` option from the shared PostHog API.
- Delete both query-parameter reads and the bootstrap object they produced.
- Delete the shared provider's default-on wiring.
- Preserve page-leave capture, exception capture, replay settings, environment registration, proxy routing, and once-only initialization byte-for-byte.

The shared initializer is used by OS and Semaphore. The marketing site's separate provider is unchanged.

### Regression proof

The new boundary test runs the real public `initPosthog` entry point and its private option builder. It gives `window.location.search` a throwing getter and asserts that the SDK sink receives no `bootstrap` property.

The SDK is mocked only inside this test. OS intentionally does not gain a `posthog-js` dependency, no package API is exposed for testing, and there is no suite-wide alias.

### Documentation

`docs/posthog.md` no longer describes the deleted URL handoff as the architecture. It now records the identity boundary and the actual split between shared OS/Semaphore initialization and the marketing provider. Stale claims about shared `$environment` wiring and nonexistent sourcemap helpers were removed.

## Why bootstrap controlled identity

The pinned PostHog SDK explicitly defines `bootstrap.distinctID` and `bootstrap.sessionID`, installs the distinct ID during initialization, and installs a valid supplied session ID:

- [bootstrap configuration type](https://github.com/PostHog/posthog-js/blob/posthog-js%401.360.2/packages/types/src/posthog-config.ts#L127-L140)
- [distinct-ID installation](https://github.com/PostHog/posthog-js/blob/posthog-js%401.360.2/packages/browser/src/posthog-core.ts#L632-L641)
- [session-ID installation](https://github.com/PostHog/posthog-js/blob/posthog-js%401.360.2/packages/browser/src/sessionid.ts#L99-L105)

## Scope boundaries

- No compatibility alias, deprecation path, or legacy shim.
- No migration or cleanup of browser identifiers already persisted before this change.
- No changes to PostHog replay, exception capture, route tracking, server telemetry, or ingest proxies.
- No broader identity handoff is introduced. A future cross-origin handoff must be separately reviewed, server-issued, and integrity-protected.

## Stack and merge order

This is layer 3 of the intentionally small observability stack and should be reviewed against `agent/observability-01-retired-secrets`:

1. #2016 — engineering principle only (`+26/-0`)
2. #2008 — stop rebinding retired app-config secrets (`+9/-5`)
3. This PR — remove URL-controlled PostHog bootstrap (`+52/-55`)

## Change budget

| Area | Diff | Complexity cost |
| --- | ---: | --- |
| Shared runtime/provider | `+0/-16` | Deletes one option, one parser, and one bootstrap path |
| Boundary regression | `+34/-0` | One test; test-local SDK sink |
| Documentation | `+18/-39` | Replaces obsolete architecture with the actual boundary |
| **Total** | **`+52/-55`** | **Net -3 lines; no runtime abstraction added** |

## Verification

- Three independent simplicity/security review rounds; every blocker addressed.
- Focused stack tests: 16/16 passed.
- Full OS unit suite: 156 files, 1,440 passed, one existing skip.
- OS typecheck passed.
- UI typecheck passed.
- Full repository lint passed with zero warnings/errors.
- Repository formatting and `git diff --check` passed.

## Screenshots

Not applicable: this changes an invisible analytics identity boundary and has no user-interface state. The executable proof is the boundary regression above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletion-only analytics boundary change with no auth or data-path impact; marketing PostHog provider is untouched.
> 
> **Overview**
> **Removes untrusted URL query parameters (`ph_distinct_id` / `ph_session_id`) from shared PostHog browser initialization** for OS and Semaphore via `packages/ui`. The `bootstrapFromUrl` option, URL parsing, and `posthog.init({ bootstrap })` wiring are deleted; proxy, replay, exception capture, and environment registration are unchanged.
> 
> **Adds** `apps/os/src/lib/posthog-url-bootstrap.test.ts`, which asserts `initPosthog` never reads `window.location.search` and does not pass `bootstrap` to the SDK.
> 
> **Updates** `docs/posthog.md` to document the identity boundary (no URL handoff) and drops the old cross-domain bootstrap architecture and stale verification steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9972db424fc1e15d92a82f8d1418037b8eca7e5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| UI components | +0 -16 | +0 -15 🟥⬜⬜⬜⬜ |
| Tests | +34 -0 | +28 -0 🟩🟩🟩⬜⬜ |
| Docs | +18 -39 | +18 -33 🟩🟩🟥🟥🟥 |
| **Total** | **+52 -55** | **+46 -48** 🟩🟩🟥🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 84dbcd4 and 9972db4, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-15T12:07:15.507Z",
      "headSha": "9972db424fc1e15d92a82f8d1418037b8eca7e5c",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/7855133639822",
      "shortSha": "9972db4",
      "cleanupDurationMs": 2162,
      "deployDurationMs": 19092,
      "testDurationMs": 810,
      "testRetries": null,
      "workerSizeKib": 4030.87,
      "workerGzipKib": 819.57,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-15T12:07:13.936Z",
      "headSha": "9972db424fc1e15d92a82f8d1418037b8eca7e5c",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/7855133639822",
      "shortSha": "9972db4",
      "cleanupDurationMs": 591,
      "deployDurationMs": 16459,
      "testDurationMs": 20881,
      "testRetries": null,
      "workerSizeKib": 5139.6,
      "workerGzipKib": 1466.03,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-15T12:07:13.923Z",
      "headSha": "9972db424fc1e15d92a82f8d1418037b8eca7e5c",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/7855133639822",
      "shortSha": "9972db4",
      "cleanupDurationMs": 576,
      "deployDurationMs": 6247,
      "testDurationMs": 8235,
      "testRetries": null,
      "workerSizeKib": 1139,
      "workerGzipKib": 201.58,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-15T12:07:12.211Z",
      "headSha": "9972db424fc1e15d92a82f8d1418037b8eca7e5c",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/7855133639822",
      "shortSha": "9972db4",
      "cleanupDurationMs": 11299,
      "deployDurationMs": 83844,
      "testDurationMs": 217080,
      "testRetries": "3 retried: bring-your-own App: mint installation token in the Secret DO, act as the installation, re-mint on expiry (vitest x1) · Project repos, workers, runScript, and dynamic worker refs compose (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1)",
      "workerSizeKib": 16398.19,
      "workerGzipKib": 4425.87,
      "mainWorkerGzipKib": 4425.89
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-15T12:07:01.361Z",
      "headSha": "9972db424fc1e15d92a82f8d1418037b8eca7e5c",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/7855133639822",
      "shortSha": "9972db4",
      "cleanupDurationMs": 444,
      "deployDurationMs": 15870,
      "testDurationMs": 6005,
      "testRetries": null,
      "workerSizeKib": 1914.73,
      "workerGzipKib": 440.76,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `9972db4` | [https://auth.iterate-preview-9.com](https://auth.iterate-preview-9.com) | 819.6 KiB | 19.1s | 810ms |  | 2.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/7855133639822) | 2026-07-15T12:07:15.507Z | Preview app released. |
| Dummy Petshop | released | `9972db4` | [https://dummy-petshop.iterate-preview-9.com](https://dummy-petshop.iterate-preview-9.com) | 201.6 KiB | 6.2s | 8.2s |  | 576ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/7855133639822) | 2026-07-15T12:07:13.923Z | Preview app released. |
| OS | released | `9972db4` | [https://os.iterate-preview-9.com](https://os.iterate-preview-9.com) | 4.32 MiB (-0.0 KiB vs main) | 83.8s | 217.1s | 3 retried: bring-your-own App: mint installation token in the Secret DO, act as the installation, re-mint on expiry (vitest x1) · Project repos, workers, runScript, and dynamic worker refs compose (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) | 11.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/7855133639822) | 2026-07-15T12:07:12.211Z | Preview app released. |
| Semaphore | released | `9972db4` | [https://semaphore.iterate-preview-9.com](https://semaphore.iterate-preview-9.com) | 440.8 KiB | 15.9s | 6.0s |  | 444ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/7855133639822) | 2026-07-15T12:07:01.361Z | Preview app released. |
| Streams Example App | released | `9972db4` | [https://streams.iterate-preview-9.com](https://streams.iterate-preview-9.com) | 1.43 MiB | 16.5s | 20.9s |  | 591ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/7855133639822) | 2026-07-15T12:07:13.936Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->