### PR TITLE
fix(preview): self-install the sandbox backup expiry rule (sandboxes weren't getting the 3h TTL)

### DIFF
--- a/apps/os/scripts/ensure-resources.ts
+++ b/apps/os/scripts/ensure-resources.ts
@@ -24,6 +24,7 @@ import {
   PREVIEW_DISPOSABLE_TTL_SECONDS,
   PREVIEW_FILES_OBJECT_EXPIRY,
   PREVIEW_SEARCH_INDEX_OBJECT_EXPIRY,
+  SANDBOX_BACKUP_EXPIRY_RULE,
   SANDBOX_BACKUP_TTL_SECONDS_PRD,
 } from "../../../scripts/lib/deploy-helpers.ts";
 import { resolveEnvContext } from "../../../scripts/lib/env-context.ts";
@@ -153,9 +154,8 @@ export default async function ensureResources(
   // restoring a reaped backup degrades to an empty workspace, so the sandbox
   // simply comes back fresh after ~3h of no use.
   await ensureR2ObjectExpiryLifecycle(ctx, sandboxesBucket, {
-    ruleId: "expire-sandbox-workspace-backups",
+    ...SANDBOX_BACKUP_EXPIRY_RULE,
     ttlSeconds: isPreview ? PREVIEW_DISPOSABLE_TTL_SECONDS : SANDBOX_BACKUP_TTL_SECONDS_PRD,
-    prefix: "backups/",
   });
   if (isPreview) {
     await ensureR2ObjectExpiryLifecycle(

--- a/apps/os/scripts/erase-data.ts
+++ b/apps/os/scripts/erase-data.ts
@@ -36,8 +36,10 @@ import { createBuiltInPrompts, createCli, isAgent, yamlTableConsoleLogger } from
 import { envs } from "../../../envs.ts";
 import {
   ensureR2ObjectExpiryLifecycle,
+  PREVIEW_DISPOSABLE_TTL_SECONDS,
   PREVIEW_FILES_OBJECT_EXPIRY,
   PREVIEW_SEARCH_INDEX_OBJECT_EXPIRY,
+  SANDBOX_BACKUP_EXPIRY_RULE,
   wipeD1Tables,
 } from "../../../scripts/lib/deploy-helpers.ts";
 import { resetWorkerDurableObjects } from "../../../scripts/lib/do-reset.ts";
@@ -204,6 +206,22 @@ export default async function eraseData(options: {
           `R2 ${bucket} lifecycle ensure failed — falling back to walking it: ${String(error).slice(0, 200)}`,
         );
       }
+    }
+    // Also self-heal the sandbox backups expiry (3h). ensure-resources sets it
+    // too, but CI never runs that, so without this preview sandbox backups keep
+    // whatever rule they had (often none → they accumulate forever). We only
+    // install the rule; the sandboxes bucket's data is never walked here (its
+    // containers own it — see the DO section).
+    try {
+      await ensureR2ObjectExpiryLifecycle(ctx, `${env.osWorkerName}-sandboxes`, {
+        ...SANDBOX_BACKUP_EXPIRY_RULE,
+        ttlSeconds: PREVIEW_DISPOSABLE_TTL_SECONDS,
+      });
+      console.log(
+        `R2 ${env.osWorkerName}-sandboxes: backups/ set to ${PREVIEW_DISPOSABLE_TTL_SECONDS}s lifecycle expiry`,
+      );
+    } catch (error) {
+      console.warn(`R2 sandboxes lifecycle ensure failed: ${String(error).slice(0, 200)}`);
     }
   }
   const bucketsToWalk = [searchIndexBucket, filesBucket].filter(

--- a/docs/preview-resource-gc.md
+++ b/docs/preview-resource-gc.md
@@ -72,8 +72,10 @@ One TTL governs it: **3 hours** (`PREVIEW_DISPOSABLE_TTL_SECONDS` in
   goes quiet stops costing us within ~3h instead of a full day.
 - **R2 lifecycle** on the preview `-search-index`, `-files`, and `-sandboxes`
   (`backups/`) buckets: objects are deleted 3h after they're written.
-  `ensure-resources` installs these rules for preview slots only; prd keeps its
-  data (sandbox backups 90 days, corpus + files forever).
+  `ensure-resources` installs these rules for preview slots only, and
+  `erase-data` re-installs all three on every acquire/cleanup so existing slots
+  self-heal without a manual `ensure-resources` run (CI never runs that). Prd
+  keeps its data (sandbox backups 90 days, corpus + files forever).
 - **Sandboxes**: containers already sleep after ~10 min idle
   (`onActivityExpired` snapshots then destroys the container). The 3h backup
   expiry finishes the job — a preview sandbox not used for 3h loses its backup,

--- a/scripts/lib/deploy-helpers.test.ts
+++ b/scripts/lib/deploy-helpers.test.ts
@@ -6,6 +6,7 @@ import {
   PREVIEW_DISPOSABLE_TTL_SECONDS,
   PREVIEW_FILES_OBJECT_EXPIRY,
   PREVIEW_SEARCH_INDEX_OBJECT_EXPIRY,
+  SANDBOX_BACKUP_EXPIRY_RULE,
   SANDBOX_BACKUP_TTL_SECONDS_PRD,
   smokeResponse,
 } from "./deploy-helpers.ts";
@@ -99,11 +100,16 @@ describe("R2 object-expiry lifecycle", () => {
     ]);
   });
 
-  it("scopes to a prefix when given one (e.g. the sandbox backups/ rule)", () => {
-    const rules = buildR2ObjectExpiryLifecycleRules({
+  it("scopes the shared sandbox rule to backups/ (prd 90d ttl here)", () => {
+    // Same rule id + prefix as ensure-resources and erase-data both install
+    // (they differ only in ttl: 3h preview, 90d prd).
+    expect(SANDBOX_BACKUP_EXPIRY_RULE).toEqual({
       ruleId: "expire-sandbox-workspace-backups",
-      ttlSeconds: SANDBOX_BACKUP_TTL_SECONDS_PRD,
       prefix: "backups/",
+    });
+    const rules = buildR2ObjectExpiryLifecycleRules({
+      ...SANDBOX_BACKUP_EXPIRY_RULE,
+      ttlSeconds: SANDBOX_BACKUP_TTL_SECONDS_PRD,
     });
 
     expect(rules[0]?.conditions).toEqual({ prefix: "backups/" });

--- a/scripts/lib/deploy-helpers.ts
+++ b/scripts/lib/deploy-helpers.ts
@@ -266,6 +266,18 @@ export const PREVIEW_DISPOSABLE_TTL_SECONDS = 3 * 60 * 60;
 export const SANDBOX_BACKUP_TTL_SECONDS_PRD = 90 * 24 * 60 * 60;
 
 /**
+ * The sandbox workspace backup expiry rule — shared id + `backups/` prefix so
+ * ensure-resources and erase-data install the SAME rule (the ttl differs: 3h on
+ * preview, 90 days on prd). Sandboxes snapshot `/workspace` under `backups/`
+ * and the DO only checks the ttl at restore time, so this rule is what actually
+ * reaps them.
+ */
+export const SANDBOX_BACKUP_EXPIRY_RULE = {
+  ruleId: "expire-sandbox-workspace-backups",
+  prefix: "backups/",
+} as const;
+
+/**
  * The disposable per-slot R2 corpus (the itx.search `-search-index` bucket):
  * pure derived state the worker re-mirrors, which on a churned preview slot
  * grows to thousands of objects. Erasing it object-by-object is the single


### PR DESCRIPTION
Follow-up to #2009, found while babysitting it to prod.

**The gap:** #2009 put the sandbox `backups/` 3h lifecycle rule only in `ensure-resources`, which CI never runs. So preview sandbox backups never actually got the "deleted after 3h" behaviour — they kept whatever rule they had, often none, and accumulate forever. Meanwhile the search-index and files rules *do* self-install (via `erase-data` on every acquire).

**Verified live** on `os-preview-2-sandboxes` (a slot deployed after #2009 merged): only Cloudflare's default multipart-abort rule, no expiry — whereas `os-preview-2-search-index` and `-files` correctly showed `expire-preview-*`, `maxAge: 10800` (3h).

**The fix:** `erase-data` now also (re)installs the sandbox backup expiry (preview, 3h) on every acquire/cleanup — install-only, the sandboxes bucket's data is never walked here (its containers own it). A shared `SANDBOX_BACKUP_EXPIRY_RULE` (id + `backups/` prefix) keeps `ensure-resources` and `erase-data` in sync; the ttl still differs (3h preview, 90d prd).

Verified: `scripts` + `apps/os` typecheck ✅, deploy-helpers tests ✅, oxlint/oxfmt ✅. Doc updated (`docs/preview-resource-gc.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Preview-only lifecycle install during existing erase-data runs; no prod TTL change and no new object walks on the sandboxes bucket.
> 
> **Overview**
> Preview sandbox `backups/` objects were supposed to expire after 3h like search-index and files, but that lifecycle rule was only applied in **`ensure-resources`**, which CI never runs—so live preview sandboxes buckets often had **no expiry** and backups accumulated indefinitely.
> 
> This PR adds **`SANDBOX_BACKUP_EXPIRY_RULE`** (`ruleId` + `backups/` prefix) in `deploy-helpers.ts` so **`ensure-resources`** and **`erase-data`** install the same rule (TTL still differs: 3h preview, 90d prd). On every preview **acquire/cleanup**, **`erase-data`** now (re)installs the 3h sandbox backup lifecycle on `{worker}-sandboxes`—install-only; the bucket is still not walked. Docs note that all three disposable R2 rules self-heal through **`erase-data`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d24bb59c5c34281ab8afd15f0f149e7914ee3d28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +9 -3 | +7 -3 🟩🟥⬜⬜⬜ |
| CI & scripts | +32 -2 | +19 -2 🟩🟩🟩🟩🟩 |
| Docs | +4 -2 | +4 -2 🟩⬜⬜⬜⬜ |
| **Total** | **+45 -7** | **+30 -7** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 591d7a4 and d24bb59, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-15T12:32:34.419Z",
      "headSha": "d24bb59c5c34281ab8afd15f0f149e7914ee3d28",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/47637341469641",
      "shortSha": "d24bb59",
      "cleanupDurationMs": 2539,
      "deployDurationMs": 17968,
      "testDurationMs": 515,
      "testRetries": null,
      "workerSizeKib": 4030.87,
      "workerGzipKib": 819.48,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-15T12:32:32.542Z",
      "headSha": "d24bb59c5c34281ab8afd15f0f149e7914ee3d28",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/47637341469641",
      "shortSha": "d24bb59",
      "cleanupDurationMs": 661,
      "deployDurationMs": 21152,
      "testDurationMs": 18579,
      "testRetries": null,
      "workerSizeKib": 5139.6,
      "workerGzipKib": 1466.03,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-15T12:32:32.580Z",
      "headSha": "d24bb59c5c34281ab8afd15f0f149e7914ee3d28",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/47637341469641",
      "shortSha": "d24bb59",
      "cleanupDurationMs": 697,
      "deployDurationMs": 6040,
      "testDurationMs": 5713,
      "testRetries": null,
      "workerSizeKib": 1139,
      "workerGzipKib": 201.58,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-15T12:32:30.714Z",
      "headSha": "d24bb59c5c34281ab8afd15f0f149e7914ee3d28",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/47637341469641",
      "shortSha": "d24bb59",
      "cleanupDurationMs": 113572,
      "deployDurationMs": 79247,
      "testDurationMs": 209577,
      "testRetries": "4 retried: catalogue example \"provide-itx-expression\" runs identically across runtimes (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · hydrates the client-only integrations route without rebuilding the shell (specs x1) · reactivity page replays already appended events after reload (specs x1)",
      "workerSizeKib": 16398.11,
      "workerGzipKib": 4425.84,
      "mainWorkerGzipKib": 4425.84
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-15T12:30:37.888Z",
      "headSha": "d24bb59c5c34281ab8afd15f0f149e7914ee3d28",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/47637341469641",
      "shortSha": "d24bb59",
      "cleanupDurationMs": 743,
      "deployDurationMs": 15894,
      "testDurationMs": 7072,
      "testRetries": null,
      "workerSizeKib": 1914.73,
      "workerGzipKib": 440.76,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `d24bb59` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 819.5 KiB | 18.0s | 515ms |  | 2.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/47637341469641) | 2026-07-15T12:32:34.419Z | Preview app released. |
| Dummy Petshop | released | `d24bb59` | [https://dummy-petshop.iterate-preview-7.com](https://dummy-petshop.iterate-preview-7.com) | 201.6 KiB | 6.0s | 5.7s |  | 697ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/47637341469641) | 2026-07-15T12:32:32.580Z | Preview app released. |
| OS | released | `d24bb59` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 4.32 MiB (±0 vs main) | 79.2s | 209.6s | 4 retried: catalogue example "provide-itx-expression" runs identically across runtimes (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · hydrates the client-only integrations route without rebuilding the shell (specs x1) · reactivity page replays already appended events after reload (specs x1) | 113.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/47637341469641) | 2026-07-15T12:32:30.714Z | Preview app released. |
| Semaphore | released | `d24bb59` | [https://semaphore.iterate-preview-7.com](https://semaphore.iterate-preview-7.com) | 440.8 KiB | 15.9s | 7.1s |  | 743ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/47637341469641) | 2026-07-15T12:30:37.888Z | Preview app released. |
| Streams Example App | released | `d24bb59` | [https://streams.iterate-preview-7.com](https://streams.iterate-preview-7.com) | 1.43 MiB | 21.2s | 18.6s |  | 661ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/47637341469641) | 2026-07-15T12:32:32.542Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->