### PR TITLE
task: preview slot utilization & contention dashboard (from semaphore events)

### DIFF
--- a/tasks/preview-slot-utilization-dashboard.md
+++ b/tasks/preview-slot-utilization-dashboard.md
@@ -1,0 +1,69 @@
+---
+status: todo
+size: medium
+branch: none
+---
+
+# Preview slot utilization & contention dashboard (from semaphore events)
+
+We have nine preview slots leased through the semaphore
+(`environment-config-lease`), and we now reclaim them off the critical path
+(3h lease TTL + the hourly GC sweep — see `docs/preview-resource-gc.md`, PR
+#2009). What we _don't_ have is any historical view of how the fleet is
+actually used. Every question about capacity is answered by eyeballing
+`pnpm preview status` at a single instant. We want a post-hoc dashboard.
+
+## Why
+
+- Is nine slots the right number, or are we chronically contended / chronically
+  idle? Right now it's a vibe, not a measurement.
+- When PRs wait for a slot, how long do they wait, and how often? (Contention.)
+- How much of a slot's leased time is actually _used_ (deploy/test renewals)
+  vs. idle-holding? (Utilization vs. squatting.)
+- Are orphaned/leaked leases and GC reclaims trending down after #2009? (The
+  whole point of that work — we should be able to see it.)
+- Cost proxy: slot-hours held, and how much the 3h TTL actually saved vs. 24h.
+
+## Data source
+
+The semaphore coordinator (`apps/semaphore`, D1-backed) already logs every
+lease transition — acquired / renewed / evicted / expired / force-released —
+as an event, keyed by slot slug + holder (`pr-<n>` / `manual-<user>` / `gc`).
+That event log is the raw material; no new instrumentation on the preview
+tooling side should be needed (confirm the events carry: slug, holder, kind,
+timestamp, and leasedUntil).
+
+## Metrics to derive
+
+- **Utilization**: per-slot and fleet-wide % of wall-clock leased, and % of
+  leased time with a renewal in the trailing window (used vs. idle-held).
+- **Contention**: count + duration of "waiting for a slot" episodes (the
+  deploy wait loop already logs these; may need to emit them as events too),
+  and how often the fleet hit 0 available.
+- **Lease lifecycle**: median/p95 lease duration, renewals per lease, holder
+  breakdown (PR vs manual vs gc).
+- **Health**: orphaned-at-detection count, GC reclaims/run, force-releases —
+  trend over time (proves #2009 works and stays working).
+
+## Delivery options (decide during grooming)
+
+1. **PostHog** (lowest effort): pipe semaphore lease-transition events to
+   PostHog and build the dashboard there. Fits "post-hoc dashboard", no new UI
+   to maintain, and we already use PostHog. Downside: another event sink to
+   wire from the semaphore worker.
+2. **In-OS-app page**: a `/preview-fleet` view in os.iterate.com querying the
+   semaphore's event log via RPC. More control, more to build/own.
+3. **Extend semaphore.iterate.com**: it already shows live leases; add
+   historical/aggregate charts next to them. Keeps everything in one place.
+
+Lean: start with (1) PostHog for the numbers, since the events already exist
+and the value is the measurement, not a bespoke UI.
+
+## Open questions
+
+- Do the semaphore events already persist long enough for post-hoc analysis,
+  or do they need a retention bump / export?
+- Are "waiting for a slot" episodes events yet, or only log lines? Contention
+  is the most valuable metric and may need to be emitted explicitly.
+
+Raised by Jonas 2026-07-15 as a follow-up to the preview-resource-GC work.


### PR DESCRIPTION
Tracks a follow-up Jonas raised while shipping the preview-resource-GC work (#2009): we have no historical view of how the preview fleet is actually used — every capacity question is answered by eyeballing `pnpm preview status` at a single instant.

Adds `tasks/preview-slot-utilization-dashboard.md` scoping a dashboard fed by the semaphore's existing lease-transition events (acquired/renewed/evicted/expired/force-released):

- **Metrics**: utilization (leased vs. used), contention (slot-wait episodes, fleet-at-zero), lease lifecycle (durations, renewals, holder mix), health (orphans/GC-reclaims/force-releases trending down).
- **Delivery options** to decide during grooming: PostHog (lean — events already exist), an in-OS-app page, or extending semaphore.iterate.com. Leaning PostHog first.
- **Open questions**: event retention for post-hoc analysis; whether "waiting for a slot" is emitted as an event yet (the most valuable contention metric).

Docs/task only — no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only task scoping with no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`tasks/preview-slot-utilization-dashboard.md`**, a grooming task for a **historical** preview-fleet dashboard (follow-up to preview-resource GC / #2009). Today capacity is only visible via a live `pnpm preview status` snapshot; the doc proposes deriving **utilization**, **contention**, **lease lifecycle**, and **health** metrics from existing semaphore lease-transition events in `apps/semaphore`.
> 
> It compares delivery paths (**PostHog** first, vs OS `/preview-fleet` or extending semaphore.iterate.com) and lists open questions on **event retention** and whether **slot-wait** episodes are persisted as events vs logs only.
> 
> **Docs/task only — no application or infrastructure code in this PR.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bd5c1e596b52dd620c5fadb4f9c6c73eaf4e62a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Docs | +69 -0 | +55 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+69 -0** | **+55 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 591d7a4 and 2bd5c1e, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->