### PR TITLE
Testing backlog round 1: operator-session engine e2e + petshop bad-port flake fix

### DIFF
--- a/apps/dummy-petshop/src/github-app.test.ts
+++ b/apps/dummy-petshop/src/github-app.test.ts
@@ -11,8 +11,8 @@
  */
 import { createHmac } from "node:crypto";
 import { createServer } from "node:http";
-import type { AddressInfo } from "node:net";
 import { describe, expect, test } from "vitest";
+import { listenOnFetchSafePort } from "./test/fetch-safe-port.ts";
 import { seedPets } from "./pets.ts";
 import { randomSealKey } from "./seal.ts";
 import { DEFAULT_APP_ID, DEFAULT_INSTALLATION_ID, PetshopStateDurableObject } from "./state.ts";
@@ -259,8 +259,7 @@ describe("GitHub App installation webhooks", () => {
         response.writeHead(200).end("ok");
       });
     });
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
-    const { port } = server.address() as AddressInfo;
+    const port = await listenOnFetchSafePort(server);
     return {
       url: `http://127.0.0.1:${port}/hook`,
       received,

--- a/apps/dummy-petshop/src/test/fetch-safe-port.ts
+++ b/apps/dummy-petshop/src/test/fetch-safe-port.ts
@@ -1,0 +1,34 @@
+import type { Server } from "node:net";
+import type { AddressInfo } from "node:net";
+
+/**
+ * Ports the WHATWG fetch spec blocks outright
+ * (https://fetch.spec.whatwg.org/#bad-port). Node's fetch (undici) refuses to
+ * connect to any of them — `TypeError: fetch failed` caused by `Error: bad
+ * port` — before a single packet is sent. `listen(0)` can be handed one of
+ * these where the OS ephemeral port range is widened past its defaults (CI
+ * containers), and because the port never changes, every delivery retry fails
+ * the same way — the "bad port" github-app.test.ts flake seen in CI
+ * 2026-07-14.
+ */
+const WHATWG_FETCH_BLOCKED_PORTS = new Set([
+  1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42, 43, 53, 69, 77, 79, 87, 95, 101, 102,
+  103, 104, 109, 110, 111, 113, 115, 117, 119, 123, 135, 137, 139, 143, 161, 179, 389, 427, 465,
+  512, 513, 514, 515, 526, 530, 531, 532, 540, 548, 554, 556, 563, 587, 601, 636, 989, 990, 993,
+  995, 1719, 1720, 1723, 2049, 3659, 4045, 4190, 5060, 5061, 6000, 6566, 6665, 6666, 6667, 6668,
+  6669, 6679, 6697, 10080,
+]);
+
+/**
+ * Bind `server` to an OS-assigned loopback port that fetch will actually
+ * connect to, re-rolling the rare blocked assignment. Returns the bound port.
+ */
+export async function listenOnFetchSafePort(server: Server): Promise<number> {
+  for (let attempt = 1; attempt <= 16; attempt += 1) {
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+    if (!WHATWG_FETCH_BLOCKED_PORTS.has(port)) return port;
+    await new Promise((resolve) => server.close(resolve));
+  }
+  throw new Error("no fetch-safe loopback port assigned after 16 attempts");
+}

--- a/apps/dummy-petshop/src/worker.test.ts
+++ b/apps/dummy-petshop/src/worker.test.ts
@@ -6,8 +6,8 @@
  */
 import { createHmac } from "node:crypto";
 import { createServer } from "node:http";
-import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, test, vi } from "vitest";
+import { listenOnFetchSafePort } from "./test/fetch-safe-port.ts";
 import { seedPets } from "./pets.ts";
 import { pkceS256, randomSealKey } from "./seal.ts";
 import {
@@ -473,8 +473,7 @@ describe("webhooks", () => {
         response.writeHead(200).end("ok");
       });
     });
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
-    const { port } = server.address() as AddressInfo;
+    const port = await listenOnFetchSafePort(server);
     return {
       url: `http://127.0.0.1:${port}/hook`,
       received,

--- a/apps/os/e2e/vitest/operator-sessions.e2e.test.ts
+++ b/apps/os/e2e/vitest/operator-sessions.e2e.test.ts
@@ -1,0 +1,99 @@
+// Engine e2e for the operator-session surface: issue → redeem, fetch-only.
+//
+// PR #2000 deleted runtime-smoke.test.ts, which was the only automated
+// exercise of these routes; docs/smoke-testing.md kept the manual curl recipe.
+// This suite pins the same contract against the deployed slot. Source of
+// truth: handleOperatorSessionRequest in apps/os/src/auth/operator-session.ts —
+// issuance is admin-bearer-gated, redemption is origin-bound (foreign Origin
+// → 403 and NO cookie; same-origin → the HttpOnly SameSite=Strict cookie).
+//
+// Tests run concurrently in CI, so each redemption test issues its own grant.
+
+import { expect, test } from "vitest";
+import { adminSecret, buildUrl } from "./test-helpers.ts";
+
+const SESSION_COOKIE = "iterate-operator-session";
+
+test("anonymous operator-session issuance is rejected with 401", async () => {
+  const response = await fetch(buildUrl({ path: "/api/operator-sessions" }), {
+    body: JSON.stringify({ kind: "admin", operatorId: "e2e" }),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  });
+  expect(response).toMatchObject({ status: 401 });
+  expect(response.headers.getSetCookie()).toEqual([]);
+});
+
+test("admin-bearer issuance returns a signed grant and its redeem URL", async () => {
+  const grant = await issueAdminGrant("e2e");
+  expect(grant).toMatchObject({ kind: "admin" });
+  // <base64url payload>.<base64url signature> — the shape verifyOperatorGrant splits.
+  expect(grant.token).toMatch(/^[\w-]+\.[\w-]+$/);
+  // The browser URL carries the token in the FRAGMENT (never the query), on
+  // the issuing origin's redeem route.
+  const browserUrl = new URL(grant.browserUrl);
+  expect(browserUrl).toMatchObject({
+    origin: new URL(buildUrl({ path: "/" })).origin,
+    pathname: "/api/operator-sessions/redeem",
+    search: "",
+  });
+  expect(new URLSearchParams(browserUrl.hash.slice(1)).get("token")).toBe(grant.token);
+});
+
+test("redeeming from a foreign Origin is a 403 that sets no cookie", async () => {
+  const grant = await issueAdminGrant("e2e-foreign-origin");
+  const response = await redeem(grant.token, "https://attacker.example");
+  expect(response).toMatchObject({ status: 403 });
+  // The exact origin-gate body, not a token-validity 401: the grant itself is
+  // good, the cross-origin caller is what gets rejected.
+  expect(await response.text()).toBe("Forbidden origin");
+  expect(response.headers.getSetCookie()).toEqual([]);
+});
+
+test("same-origin redemption installs the HttpOnly SameSite=Strict session cookie", async () => {
+  const grant = await issueAdminGrant("e2e-same-origin");
+  const redeemUrl = new URL(buildUrl({ path: "/api/operator-sessions/redeem" }));
+  const response = await redeem(grant.token, redeemUrl.origin);
+  expect(response).toMatchObject({ status: 200 });
+  // Admin grants default returnTo to /admin (createOperatorSessionResponse).
+  expect(await response.json()).toEqual({ ok: true, returnTo: "/admin" });
+
+  const sessionCookie = response.headers
+    .getSetCookie()
+    .find((cookie) => cookie.startsWith(`${SESSION_COOKIE}=`));
+  expect(sessionCookie).toBeDefined();
+  const [pair, ...attributes] = sessionCookie!.split("; ");
+  // The cookie value is the signed grant itself; rotation of the admin secret
+  // is what invalidates it.
+  expect(pair).toBe(`${SESSION_COOKIE}=${grant.token}`);
+  expect(attributes).toContain("Path=/");
+  expect(attributes).toContain("HttpOnly");
+  expect(attributes).toContain("SameSite=Strict");
+  const maxAge = attributes.find((attribute) => attribute.startsWith("Max-Age="));
+  expect(Number(maxAge?.slice("Max-Age=".length))).toBeGreaterThan(0);
+  // Secure rides only on https deployments (local dev serves plain http).
+  expect(attributes.includes("Secure")).toBe(redeemUrl.protocol === "https:");
+});
+
+async function issueAdminGrant(operatorId: string) {
+  const response = await fetch(buildUrl({ path: "/api/operator-sessions" }), {
+    body: JSON.stringify({ kind: "admin", operatorId }),
+    headers: {
+      authorization: `Bearer ${adminSecret()}`,
+      "content-type": "application/json",
+    },
+    method: "POST",
+  });
+  expect(response).toMatchObject({ status: 200 });
+  return (await response.json()) as { browserUrl: string; kind: string; token: string };
+}
+
+/** The redeem POST exactly as the redeem page's script sends it: the signed
+ * token as a text/plain body, with the supplied Origin. */
+function redeem(token: string, origin: string) {
+  return fetch(buildUrl({ path: "/api/operator-sessions/redeem" }), {
+    body: token,
+    headers: { "content-type": "text/plain", origin },
+    method: "POST",
+  });
+}


### PR DESCRIPTION
Two independent fixes from the testing-strategy backlog.

## Item 1 — operator-session engine e2e

PR #2000 deleted `runtime-smoke.test.ts`; its operator-session coverage (issue → redeem → cross-origin rejection) had no automated exercise left — only the manual curl recipe in `docs/smoke-testing.md`. New `apps/os/e2e/vitest/operator-sessions.e2e.test.ts` (regular engine e2e lane, fetch-only, no browser) pins the contract straight from the source, `handleOperatorSessionRequest` in `apps/os/src/auth/operator-session.ts`:

| Assertion | Route source |
|---|---|
| Anonymous `POST /api/operator-sessions` → exact **401**, zero `Set-Cookie` | `createOperatorSessionResponse`: `authenticateAdminApiSecret` fails → `new Response("Unauthorized", …, 401)` |
| Admin-bearer + `{"kind":"admin","operatorId":"e2e"}` → **200** with signed `<base64url>.<base64url>` token; `browserUrl` is the issuing origin's `/api/operator-sessions/redeem` with the token in the **fragment**, never the query | token from `signOperatorGrant` (`payload.signature`); `browserUrl = \`${audience}/api/operator-sessions/redeem#${new URLSearchParams({ token })}\`` |
| Redeem with `origin: https://attacker.example` → exact **403** body `"Forbidden origin"`, zero `Set-Cookie` | `redeemOperatorSessionResponse` → `isSameOriginBrowserRequest` → `forbiddenOriginResponse()` (no cookie append on that path) |
| Same-origin redeem (`text/plain` token body, exactly like the redeem page's script) → **200** `{ok:true, returnTo:"/admin"}` + `iterate-operator-session` cookie asserted attribute-by-attribute: `Path=/`, `HttpOnly`, `SameSite=Strict`, positive `Max-Age`, `Secure` iff https | `operatorSessionCookie()` builds exactly that list; admin default `returnTo` is `/admin` |

Each redemption test issues its own grant, so the file is safe under the CI concurrent scheduler (no cross-test token coupling).

**Live proof** (shared dev is fully local, so I proved against a deployed slot instead — stronger than waiting for preview CI, which will also run this file since the lane includes `e2e/vitest/**/*.test.ts`):

```
doppler run --project os --config preview_3 -- pnpm e2e run e2e/vitest/operator-sessions.e2e.test.ts
✓ e2e/vitest/operator-sessions.e2e.test.ts (4 tests) 1388ms — 4 passed, vs https://os.iterate-preview-3.com
```

## Item 2 — petshop `github-app.test.ts` "bad port" flake

Root cause is **not** a hardcoded-port race — the receiver already did `listen(0)` + `server.address()`. It's WHATWG fetch **port blocking**: undici implements the spec's bad-port list (`fetch.spec.whatwg.org/#bad-port`; see `badPortsSet` in undici's `lib/web/fetch/constants.js`, enforced in `fetch/index.js` → `makeNetworkError('bad port')`). The list contains ports above 1024 (1719, 1720, 1723, 2049, 3659, 4045, 4190, 5060, 5061, 6000, 6566, 6665–6669, 6679, 6697, 10080) that an OS ephemeral range can assign — especially in CI containers with a widened `ip_local_port_range`. When `listen(0)` lands on one, `deliverWebhook`'s `fetch(receiver.url)` is blocked before a single packet is sent, and the test's existing delivery retries can never recover because the port never changes.

Fix at the root: `apps/dummy-petshop/src/test/fetch-safe-port.ts` — `listenOnFetchSafePort()` re-rolls the OS assignment until it's off the blocked list (bounded, throws loudly if impossible). Used by both identical receivers: `github-app.test.ts` **and** `worker.test.ts` (same `deliverWebhook` fetch path, same exposure). No retry wrappers, nothing speculative.

**Evidence:**

- Mechanism reproduced locally: a healthy HTTP listener bound to 10080 + `fetch("http://127.0.0.1:10080/")` → `TypeError: fetch failed`, `cause: Error: bad port` — the exact CI failure string carried into `fired.error`.
- Helper proven: with `listen` monkeypatched to force the first bind onto 10080, `listenOnFetchSafePort` re-rolled to a fetchable port and the follow-up fetch returned 200.
- 20× loop (real exit codes, no pipes): `for i in $(seq 20); do pnpm --dir apps/dummy-petshop exec vitest run src/github-app.test.ts || break; done` → **20/20 exit 0, zero failures**. Honest caveat: macOS's ephemeral range (49152–65535) contains no blocked ports, so the loop demonstrates no regression; the flake itself is only reachable on CI-shaped port ranges, which the repro scripts above cover.

## Gates

- `pnpm exec oxlint . --threads 1 --deny-warnings` → 0 warnings / 0 errors
- `pnpm typecheck` → pass (all workspaces)
- `pnpm knip` → pass
- `doppler run -- pnpm --dir apps/os test` → 155 files, 1448 passed / 1 skipped, exit 0
- `pnpm --dir apps/dummy-petshop test` → 7 files, 89 passed, exit 0
- `pnpm format` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test and e2e code; production auth behavior is exercised, not modified.
> 
> **Overview**
> Restores automated coverage for **operator sessions** after the old runtime smoke suite was removed, and fixes a **CI flake** in dummy-petshop webhook tests when ephemeral ports land on WHATWG “bad ports.”
> 
> Adds `apps/os/e2e/vitest/operator-sessions.e2e.test.ts`, a fetch-only engine e2e suite against a deployed slot: unauthenticated issuance → **401** with no cookies; admin-bearer issuance → signed token and redeem `browserUrl` with the token in the **hash**; foreign `Origin` on redeem → **403** `"Forbidden origin"` with no cookie; same-origin redeem → **200** plus `iterate-operator-session` with **HttpOnly**, **SameSite=Strict**, **Path=/**, **Max-Age**, and **Secure** when HTTPS.
> 
> Introduces `listenOnFetchSafePort` in `apps/dummy-petshop/src/test/fetch-safe-port.ts`, which re-binds loopback listeners until the OS-assigned port is not on fetch’s blocked list (so `fetch` to the test webhook receiver does not fail with `bad port`). **github-app.test.ts** and **worker.test.ts** webhook receivers use it instead of raw `listen(0)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42634c0cd5771ef2766301888055a3726995167e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-15T14:23:18.362Z",
      "headSha": "42634c0cd5771ef2766301888055a3726995167e",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/207817494299196",
      "shortSha": "42634c0",
      "cleanupDurationMs": 2256,
      "deployDurationMs": 19057,
      "testDurationMs": 498,
      "testRetries": null,
      "workerSizeKib": 4030.87,
      "workerGzipKib": 819.5,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-15T14:23:16.764Z",
      "headSha": "42634c0cd5771ef2766301888055a3726995167e",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/207817494299196",
      "shortSha": "42634c0",
      "cleanupDurationMs": 656,
      "deployDurationMs": 22495,
      "testDurationMs": 22159,
      "testRetries": null,
      "workerSizeKib": 5139.6,
      "workerGzipKib": 1466.03,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-15T14:23:16.678Z",
      "headSha": "42634c0cd5771ef2766301888055a3726995167e",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/207817494299196",
      "shortSha": "42634c0",
      "cleanupDurationMs": 569,
      "deployDurationMs": 7597,
      "testDurationMs": 5768,
      "testRetries": null,
      "workerSizeKib": 1139,
      "workerGzipKib": 201.58,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-15T14:23:14.900Z",
      "headSha": "42634c0cd5771ef2766301888055a3726995167e",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/207817494299196",
      "shortSha": "42634c0",
      "cleanupDurationMs": 172532,
      "deployDurationMs": 113361,
      "testDurationMs": 199287,
      "testRetries": "4 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · webhook subscriptions validate their URL before commit (vitest x1) · global streams reject webhook subscriptions before commit (vitest x1) · project REPL accepts a forged session (specs x1)",
      "workerSizeKib": 16398.11,
      "workerGzipKib": 4425.84,
      "mainWorkerGzipKib": 4425.84
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-15T14:20:22.866Z",
      "headSha": "42634c0cd5771ef2766301888055a3726995167e",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/207817494299196",
      "shortSha": "42634c0",
      "cleanupDurationMs": 496,
      "deployDurationMs": 27410,
      "testDurationMs": 5790,
      "testRetries": null,
      "workerSizeKib": 1914.73,
      "workerGzipKib": 440.76,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `42634c0` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 819.5 KiB | 19.1s | 498ms |  | 2.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/207817494299196) | 2026-07-15T14:23:18.362Z | Preview app released. |
| Dummy Petshop | released | `42634c0` | [https://dummy-petshop.iterate-preview-1.com](https://dummy-petshop.iterate-preview-1.com) | 201.6 KiB | 7.6s | 5.8s |  | 569ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/207817494299196) | 2026-07-15T14:23:16.678Z | Preview app released. |
| OS | released | `42634c0` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 4.32 MiB (±0 vs main) | 113.4s | 199.3s | 4 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · webhook subscriptions validate their URL before commit (vitest x1) · global streams reject webhook subscriptions before commit (vitest x1) · project REPL accepts a forged session (specs x1) | 172.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/207817494299196) | 2026-07-15T14:23:14.900Z | Preview app released. |
| Semaphore | released | `42634c0` | [https://semaphore.iterate-preview-1.com](https://semaphore.iterate-preview-1.com) | 440.8 KiB | 27.4s | 5.8s |  | 496ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/207817494299196) | 2026-07-15T14:20:22.866Z | Preview app released. |
| Streams Example App | released | `42634c0` | [https://streams.iterate-preview-1.com](https://streams.iterate-preview-1.com) | 1.43 MiB | 22.5s | 22.2s |  | 656ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/207817494299196) | 2026-07-15T14:23:16.764Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +34 -0 | +18 -0 🟩⬜⬜⬜⬜ |
| Tests | +103 -6 | +73 -6 🟩🟩🟩🟩🟩 |
| **Total** | **+137 -6** | **+91 -6** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 9a415a8 and 42634c0, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->