### PR TITLE
Unit-test table conversions, round 2 (final): browser-repl, custom-domains, repo-ide, integrations mid-tier, execution gate, repo-task harness

### DIFF
--- a/apps/os/src/components/repo-ide/repo-json-schema.test.ts
+++ b/apps/os/src/components/repo-ide/repo-json-schema.test.ts
@@ -12,80 +12,197 @@ import { expect, test } from "vitest";
 import { repoFileKind } from "./repo-file-kinds.ts";
 import { parseJsonDocumentColonFixed, repoFileSchemaUrl } from "./repo-json-schema.ts";
 
-test("well-known filenames map to schemastore URLs", () => {
-  expect(resolveJson("package.json", "{}")).toBe("https://www.schemastore.org/package.json");
-  expect(resolveJson("packages/foo/package.json", "{}")).toBe(
-    "https://www.schemastore.org/package.json",
-  );
-  expect(resolveJson("tsconfig.json", "{}")).toBe("https://www.schemastore.org/tsconfig.json");
-  expect(resolveJson("tsconfig.build.json", "{}")).toBe(
-    "https://www.schemastore.org/tsconfig.json",
-  );
-  expect(resolveJson("jsconfig.json", "{}")).toBe("https://www.schemastore.org/jsconfig.json");
-  expect(resolveYaml("pnpm-workspace.yaml", "")).toBe(
-    "https://www.schemastore.org/pnpm-workspace.json",
-  );
-  expect(resolveYaml(".github/workflows/ci.yml", "")).toBe(
-    "https://www.schemastore.org/github-workflow.json",
-  );
-  expect(resolveYaml("nested/.github/workflows/deploy.yaml", "")).toBe(
-    "https://www.schemastore.org/github-workflow.json",
-  );
+test.for([
+  {
+    name: "maps package.json to its schemastore URL",
+    language: "json",
+    path: "package.json",
+    content: "{}",
+    expected: "https://www.schemastore.org/package.json",
+  },
+  {
+    name: "maps nested package.json files by basename",
+    language: "json",
+    path: "packages/foo/package.json",
+    content: "{}",
+    expected: "https://www.schemastore.org/package.json",
+  },
+  {
+    name: "maps tsconfig.json to its schemastore URL",
+    language: "json",
+    path: "tsconfig.json",
+    content: "{}",
+    expected: "https://www.schemastore.org/tsconfig.json",
+  },
+  {
+    name: "maps tsconfig-variant filenames to the tsconfig schema",
+    language: "json",
+    path: "tsconfig.build.json",
+    content: "{}",
+    expected: "https://www.schemastore.org/tsconfig.json",
+  },
+  {
+    name: "maps jsconfig.json to its schemastore URL",
+    language: "json",
+    path: "jsconfig.json",
+    content: "{}",
+    expected: "https://www.schemastore.org/jsconfig.json",
+  },
+  {
+    name: "maps pnpm-workspace.yaml to its schemastore URL",
+    language: "yaml",
+    path: "pnpm-workspace.yaml",
+    content: "",
+    expected: "https://www.schemastore.org/pnpm-workspace.json",
+  },
+  {
+    name: "maps GitHub workflow files to the workflow schema",
+    language: "yaml",
+    path: ".github/workflows/ci.yml",
+    content: "",
+    expected: "https://www.schemastore.org/github-workflow.json",
+  },
+  {
+    name: "maps nested GitHub workflow files to the workflow schema",
+    language: "yaml",
+    path: "nested/.github/workflows/deploy.yaml",
+    content: "",
+    expected: "https://www.schemastore.org/github-workflow.json",
+  },
+  {
+    name: "resolves unassociated JSON files to null",
+    language: "json",
+    path: "data.json",
+    content: "{}",
+    expected: null,
+  },
+  {
+    name: "resolves unassociated YAML files to null",
+    language: "yaml",
+    path: "config.yaml",
+    content: "key: value",
+    expected: null,
+  },
+  {
+    name: "ignores workflow-shaped paths outside .github/",
+    language: "yaml",
+    path: "workflows/ci.yml",
+    content: "",
+    expected: null,
+  },
+  {
+    name: "lets a top-level $schema prop win over the filename map",
+    language: "json",
+    path: "package.json",
+    content: JSON.stringify({ $schema: "https://example.com/custom.json", name: "x" }),
+    expected: "https://example.com/custom.json",
+  },
+  {
+    // Cut off mid-edit so JSON.parse fails — the regex fallback still sees it.
+    name: "keeps $schema through mid-edit invalid JSON via the regex fallback",
+    language: "json",
+    path: "data.json",
+    content: '{\n  "$schema": "https://example.com/custom.json",\n  "name": ',
+    expected: "https://example.com/custom.json",
+  },
+  {
+    name: "upgrades http $schema URLs to https (mixed content)",
+    language: "json",
+    path: "data.json",
+    content: JSON.stringify({ $schema: "http://json.schemastore.org/tsconfig.json" }),
+    expected: "https://json.schemastore.org/tsconfig.json",
+  },
+  {
+    name: "ignores relative $schema paths, falling back to the filename map",
+    language: "json",
+    path: "package.json",
+    content: JSON.stringify({ $schema: "./local-schema.json" }),
+    expected: "https://www.schemastore.org/package.json",
+  },
+  {
+    name: "ignores relative $schema paths in unassociated files",
+    language: "json",
+    path: "data.json",
+    content: JSON.stringify({ $schema: "./local-schema.json" }),
+    expected: null,
+  },
+  {
+    // A vendored-schema-collection shape, cut off mid-edit so JSON.parse fails.
+    name: "regex fallback ignores deeply-indented (nested) $schema mid-edit",
+    language: "json",
+    path: "data.json",
+    content: '{\n  "vendored": {\n      "$schema": "https://example.com/nested.json",\n  ',
+    expected: null,
+  },
+  {
+    name: "regex fallback still matches the minified top-level form",
+    language: "json",
+    path: "data.json",
+    content: '{"$schema": "https://example.com/custom.json", "name": ',
+    expected: "https://example.com/custom.json",
+  },
+  {
+    name: "does not count nested $schema props when the doc parses",
+    language: "json",
+    path: "data.json",
+    content: JSON.stringify({ nested: { $schema: "https://example.com/custom.json" } }),
+    expected: null,
+  },
+  {
+    name: "lets a yaml modeline comment win over the filename map",
+    language: "yaml",
+    path: "pnpm-workspace.yaml",
+    content: "# yaml-language-server: $schema=https://example.com/custom.json\nkey: value\n",
+    expected: "https://example.com/custom.json",
+  },
+  {
+    name: "honors the yaml modeline in unassociated files",
+    language: "yaml",
+    path: "anything.yaml",
+    content: "# yaml-language-server: $schema=https://example.com/custom.json\nkey: value\n",
+    expected: "https://example.com/custom.json",
+  },
+  {
+    name: "jsonc: $schema extraction works through comments and trailing commas",
+    language: "jsonc",
+    path: "anything.jsonc",
+    content: '{\n  // pick a schema\n  "$schema": "https://example.com/custom.json",\n}',
+    expected: "https://example.com/custom.json",
+  },
+  {
+    name: "jsonc: the well-known filename map applies to tsconfig-family files",
+    language: "jsonc",
+    path: "tsconfig.json",
+    content: "{\n  // hi\n}",
+    expected: "https://www.schemastore.org/tsconfig.json",
+  },
+])("$name", ({ content, expected, language, path }) => {
+  // Row strings widen; the (unexported) language union is re-stated here.
+  expect(
+    repoFileSchemaUrl({ path, language: language as "json" | "jsonc" | "yaml", content }),
+  ).toBe(expected);
 });
 
-test("files without a schema association resolve to null", () => {
-  expect(resolveJson("data.json", "{}")).toBeNull();
-  expect(resolveYaml("config.yaml", "key: value")).toBeNull();
-  expect(resolveYaml("workflows/ci.yml", "")).toBeNull(); // not under .github/
-});
-
-test("a top-level $schema prop wins over the filename map", () => {
-  const content = JSON.stringify({ $schema: "https://example.com/custom.json", name: "x" });
-  expect(resolveJson("package.json", content)).toBe("https://example.com/custom.json");
-});
-
-test("$schema survives mid-edit invalid JSON via the regex fallback", () => {
-  const content = '{\n  "$schema": "https://example.com/custom.json",\n  "name": '; // cut off mid-edit
-  expect(resolveJson("data.json", content)).toBe("https://example.com/custom.json");
-});
-
-test("http $schema URLs are upgraded to https (mixed content)", () => {
-  const content = JSON.stringify({ $schema: "http://json.schemastore.org/tsconfig.json" });
-  expect(resolveJson("data.json", content)).toBe("https://json.schemastore.org/tsconfig.json");
-});
-
-test("relative $schema paths are ignored, falling back to the filename map", () => {
-  const content = JSON.stringify({ $schema: "./local-schema.json" });
-  expect(resolveJson("package.json", content)).toBe("https://www.schemastore.org/package.json");
-  expect(resolveJson("data.json", content)).toBeNull();
-});
-
-test("regex fallback ignores deeply-indented (nested) $schema mid-edit", () => {
-  // A vendored-schema-collection shape, cut off mid-edit so JSON.parse fails.
-  const content = '{\n  "vendored": {\n      "$schema": "https://example.com/nested.json",\n  ';
-  expect(resolveJson("data.json", content)).toBeNull();
-});
-
-test("regex fallback still matches the minified top-level form", () => {
-  const content = '{"$schema": "https://example.com/custom.json", "name": '; // cut off mid-edit
-  expect(resolveJson("data.json", content)).toBe("https://example.com/custom.json");
-});
-
-test("nested $schema props do not count when the doc parses", () => {
-  const content = JSON.stringify({ nested: { $schema: "https://example.com/custom.json" } });
-  expect(resolveJson("data.json", content)).toBeNull();
-});
-
-test("yaml modeline comment wins over the filename map", () => {
-  const content = "# yaml-language-server: $schema=https://example.com/custom.json\nkey: value\n";
-  expect(resolveYaml("pnpm-workspace.yaml", content)).toBe("https://example.com/custom.json");
-  expect(resolveYaml("anything.yaml", content)).toBe("https://example.com/custom.json");
-});
-
-test("json diagnostics: schema violations become red squigglies with positions", () => {
-  const doc = '{\n  "name": 123\n}';
-  const diagnostics = jsonDiagnostics(doc, FIXTURE_SCHEMA);
-  expect(diagnostics).toMatchObject([
+// One row per linter lane: the violation must squiggle the VALUE (not the
+// colon), with real document positions.
+test.for([
+  {
+    name: "json diagnostics: schema violations become red squigglies with positions",
+    doc: '{\n  "name": 123\n}',
+    lint: (doc: string) => jsonDiagnostics(doc, FIXTURE_SCHEMA),
+  },
+  {
+    name: "yaml diagnostics: schema violations become red squigglies with positions",
+    doc: "name: 123\n",
+    lint: (doc: string) => yamlDiagnostics(doc, FIXTURE_SCHEMA),
+  },
+  {
+    name: "jsonc: schema violations still squiggle, positioned on the value (not the colon)",
+    doc: '{\n  // a comment\n  "name": 123,\n}',
+    lint: (doc: string) => jsoncSchemaDiagnostics(doc, FIXTURE_SCHEMA),
+  },
+])("$name", ({ doc, lint }) => {
+  expect(lint(doc)).toMatchObject([
     {
       severity: "error",
       message: expect.stringMatching(/string/),
@@ -99,35 +216,53 @@ test("json diagnostics: a valid doc has none", () => {
   expect(jsonDiagnostics('{\n  "name": "iterate"\n}', FIXTURE_SCHEMA)).toEqual([]);
 });
 
-test("yaml diagnostics: schema violations become red squigglies with positions", () => {
-  const doc = "name: 123\n";
-  const diagnostics = yamlDiagnostics(doc, FIXTURE_SCHEMA);
-  expect(diagnostics).toMatchObject([
-    {
-      severity: "error",
-      message: expect.stringMatching(/string/),
-      from: doc.indexOf("123"),
-      to: doc.indexOf("123") + "123".length,
-    },
-  ]);
-});
-
 test("yaml diagnostics: a valid doc has none", () => {
   expect(yamlDiagnostics("name: iterate\n", FIXTURE_SCHEMA)).toEqual([]);
 });
 
-test("jsonc-by-convention paths open with the jsonc language; plain .json stays json", () => {
-  expect(repoFileKind("tsconfig.json")).toEqual({ kind: "text", language: "jsonc" });
-  expect(repoFileKind("packages/foo/tsconfig.build.json")).toEqual({
-    kind: "text",
-    language: "jsonc",
-  });
-  expect(repoFileKind("jsconfig.json")).toEqual({ kind: "text", language: "jsonc" });
-  expect(repoFileKind("config/settings.jsonc")).toEqual({ kind: "text", language: "jsonc" });
-  expect(repoFileKind(".vscode/settings.json")).toEqual({ kind: "text", language: "jsonc" });
-  expect(repoFileKind("nested/.vscode/launch.json")).toEqual({ kind: "text", language: "jsonc" });
-  expect(repoFileKind("package.json")).toEqual({ kind: "text", language: "json" });
-  expect(repoFileKind("data.json")).toEqual({ kind: "text", language: "json" });
+test.for([
+  {
+    name: "tsconfig.json opens with the jsonc language",
+    path: "tsconfig.json",
+    expected: { kind: "text", language: "jsonc" },
+  },
+  {
+    name: "nested tsconfig variants open with the jsonc language",
+    path: "packages/foo/tsconfig.build.json",
+    expected: { kind: "text", language: "jsonc" },
+  },
+  {
+    name: "jsconfig.json opens with the jsonc language",
+    path: "jsconfig.json",
+    expected: { kind: "text", language: "jsonc" },
+  },
+  {
+    name: ".jsonc files open with the jsonc language",
+    path: "config/settings.jsonc",
+    expected: { kind: "text", language: "jsonc" },
+  },
+  {
+    name: ".vscode settings open with the jsonc language",
+    path: ".vscode/settings.json",
+    expected: { kind: "text", language: "jsonc" },
+  },
+  {
+    name: "nested .vscode files open with the jsonc language",
+    path: "nested/.vscode/launch.json",
+    expected: { kind: "text", language: "jsonc" },
+  },
+  {
+    name: "package.json stays plain json",
+    path: "package.json",
+    expected: { kind: "text", language: "json" },
+  },
+  {
+    name: "ordinary .json files stay plain json",
+    path: "data.json",
+    expected: { kind: "text", language: "json" },
+  },
+])("repoFileKind: $name", ({ expected, path }) => {
+  expect(repoFileKind(path)).toEqual(expected);
 });
 
 test("jsonc: a valid commented tsconfig with a trailing comma has no diagnostics", async () => {
@@ -144,18 +279,6 @@ test("jsonc: a valid commented tsconfig with a trailing comma has no diagnostics
   expect(jsoncSchemaDiagnostics(doc, TSCONFIG_LIKE_SCHEMA)).toEqual([]);
 });
 
-test("jsonc: schema violations still squiggle, positioned on the value (not the colon)", () => {
-  const doc = '{\n  // a comment\n  "name": 123,\n}';
-  expect(jsoncSchemaDiagnostics(doc, FIXTURE_SCHEMA)).toMatchObject([
-    {
-      severity: "error",
-      message: expect.stringMatching(/string/),
-      from: doc.indexOf("123"),
-      to: doc.indexOf("123") + "123".length,
-    },
-  ]);
-});
-
 test("jsonc: real syntax errors still squiggle", async () => {
   const diagnostics = await jsoncParseDiagnostics('{\n  "name": ,\n}');
   expect(diagnostics).toMatchObject([{ severity: "error" }]);
@@ -167,17 +290,6 @@ test("json stays strict: a comment in plain package.json is a parse error", () =
   expect(diagnostics).toMatchObject([{ severity: "error", from: doc.indexOf("//") }]);
 });
 
-test("jsonc: $schema extraction works through comments and trailing commas", () => {
-  const doc = '{\n  // pick a schema\n  "$schema": "https://example.com/custom.json",\n}';
-  expect(resolveJsonc("anything.jsonc", doc)).toBe("https://example.com/custom.json");
-});
-
-test("jsonc: the well-known filename map applies to tsconfig-family files", () => {
-  expect(resolveJsonc("tsconfig.json", "{\n  // hi\n}")).toBe(
-    "https://www.schemastore.org/tsconfig.json",
-  );
-});
-
 // --- helpers ---
 
 /** A tiny inline schema so diagnostics tests need no network. */
@@ -187,18 +299,6 @@ const FIXTURE_SCHEMA: JSONSchema7 = {
     name: { type: "string", description: "The name." },
   },
 };
-
-function resolveJson(path: string, content: string) {
-  return repoFileSchemaUrl({ path, language: "json", content });
-}
-
-function resolveJsonc(path: string, content: string) {
-  return repoFileSchemaUrl({ path, language: "jsonc", content });
-}
-
-function resolveYaml(path: string, content: string) {
-  return repoFileSchemaUrl({ path, language: "yaml", content });
-}
 
 // The linters only read `view.state`, so a headless EditorState (with the
 // language extension for position mapping) exercises the real diagnostics

--- a/apps/os/src/components/repo-ide/repo-tasks.test.ts
+++ b/apps/os/src/components/repo-ide/repo-tasks.test.ts
@@ -23,116 +23,198 @@ import {
   updateRepoTaskState,
 } from "./repo-tasks.ts";
 
-test("recognizes Markdown files in any tasks directory", () => {
-  expect(isRepoTaskPath("tasks/ship-it.md")).toBe(true);
-  expect(isRepoTaskPath("apps/os/tasks/ship-it.markdown")).toBe(true);
-  expect(isRepoTaskPath("apps/os/tasks/notes/ship-it.md")).toBe(true);
-  expect(isRepoTaskPath("apps/os/task/ship-it.md")).toBe(false);
-  expect(isRepoTaskPath("apps/os/tasks/ship-it.txt")).toBe(false);
+test.for([
+  { name: "a Markdown file in a root tasks directory", path: "tasks/ship-it.md", expected: true },
+  {
+    name: "a .markdown file in a nested tasks directory",
+    path: "apps/os/tasks/ship-it.markdown",
+    expected: true,
+  },
+  {
+    name: "a Markdown file below a tasks directory",
+    path: "apps/os/tasks/notes/ship-it.md",
+    expected: true,
+  },
+  { name: "a near-miss directory name", path: "apps/os/task/ship-it.md", expected: false },
+  {
+    name: "a non-Markdown file in a tasks directory",
+    path: "apps/os/tasks/ship-it.txt",
+    expected: false,
+  },
+])("isRepoTaskPath recognizes $name", ({ path, expected }) => {
+  expect(isRepoTaskPath(path)).toBe(expected);
+});
+
+test("taskDirectoryForPath finds the owning tasks directory", () => {
   expect(taskDirectoryForPath("apps/os/tasks/notes/ship-it.md")).toBe("apps/os/tasks");
 });
 
-test("projects a bare Markdown file into a task", () => {
-  expect(
-    parseRepoTask("apps/os/tasks/speed-up.md", "# Make OS faster\n\nMeasure first.\n"),
-  ).toEqual({
+// Each row pins the COMPLETE projection: the shared body adds only the
+// identity fields (path, content) the parser echoes back from its input.
+test.for([
+  {
+    name: "projects a bare Markdown file into a task",
     path: "apps/os/tasks/speed-up.md",
-    taskDirectoryPath: "apps/os/tasks",
-    folderPath: "/apps/os",
-    title: "Make OS faster",
-    description: "Measure first.",
-    state: "todo",
-    labels: [],
-    agent: undefined,
-    comments: [],
     content: "# Make OS faster\n\nMeasure first.\n",
-  });
+    expected: {
+      taskDirectoryPath: "apps/os/tasks",
+      folderPath: "/apps/os",
+      title: "Make OS faster",
+      description: "Measure first.",
+      state: "todo",
+      labels: [],
+      comments: [],
+    },
+  },
+  {
+    name: "falls back to the filename and infers the root folder",
+    path: "tasks/fix-auth.md",
+    content: "There is no heading yet.",
+    expected: {
+      taskDirectoryPath: "tasks",
+      folderPath: "/",
+      title: "fix-auth",
+      description: "There is no heading yet.",
+      state: "todo",
+      labels: [],
+      comments: [],
+    },
+  },
+  {
+    name: "reads canonical frontmatter fields literally",
+    path: "packages/ui/tasks/card.md",
+    content: "---\nstate: in-progress\nlabels: [ui, polish]\n---\n# Card\n",
+    expected: {
+      taskDirectoryPath: "packages/ui/tasks",
+      folderPath: "/packages/ui",
+      title: "Card",
+      description: "",
+      state: "in-progress",
+      labels: ["ui", "polish"],
+      comments: [],
+    },
+  },
+  {
+    name: "treats non-canonical frontmatter keys as ordinary metadata",
+    path: "tasks/unrelated.md",
+    content: "---\nstatus: in-review\ntags: backend\n---\nOther keys are ordinary metadata\n",
+    expected: {
+      taskDirectoryPath: "tasks",
+      folderPath: "/",
+      title: "unrelated",
+      description: "Other keys are ordinary metadata",
+      state: "todo",
+      labels: [],
+      comments: [],
+    },
+  },
+  {
+    name: "keeps the legacy backlog state literal",
+    path: "tasks/backlog.md",
+    content: "---\nstate: backlog\n---\n# Backlog\n",
+    expected: {
+      taskDirectoryPath: "tasks",
+      folderPath: "/",
+      title: "Backlog",
+      description: "",
+      state: "backlog",
+      labels: [],
+      comments: [],
+    },
+  },
+  {
+    name: "uses an explicit title before the first heading",
+    path: "tasks/rename-me.md",
+    content: "---\ntitle: Frontmatter title\n---\n# Heading title\n\nDescription.\n",
+    expected: {
+      taskDirectoryPath: "tasks",
+      folderPath: "/",
+      title: "Frontmatter title",
+      description: "Description.",
+      state: "todo",
+      labels: [],
+      comments: [],
+    },
+  },
+  {
+    name: "reads an assigned agent and a permissive final comments log",
+    path: "tasks/assigned.md",
+    content:
+      "---\nagent: /agents/repos/config/tasks/assigned\n---\n# Assigned\n\nDo it.\n\n## Comments\n\nA loose note.\n\n### 2026-07-13T12:00:00Z — agent\n\nStarted.\n\n### malformed but fine\nDone.\n",
+    expected: {
+      taskDirectoryPath: "tasks",
+      folderPath: "/",
+      title: "Assigned",
+      description: "Do it.",
+      state: "todo",
+      labels: [],
+      agent: "/agents/repos/config/tasks/assigned",
+      comments: [
+        { heading: undefined, body: "A loose note." },
+        { heading: "2026-07-13T12:00:00Z — agent", body: "Started." },
+        { heading: "malformed but fine", body: "Done." },
+      ],
+    },
+  },
+  {
+    name: "treats an unstructured comments section as one lightweight comment",
+    path: "tasks/log.md",
+    content: "# Log\n\nBody.\n\n## Comments\nnot structured",
+    expected: {
+      taskDirectoryPath: "tasks",
+      folderPath: "/",
+      title: "Log",
+      description: "Body.",
+      state: "todo",
+      labels: [],
+      comments: [{ heading: undefined, body: "not structured" }],
+    },
+  },
+])("parseRepoTask $name", ({ content, expected, path }) => {
+  expect(parseRepoTask(path, content)).toEqual({ ...expected, content, path });
 });
 
-test("falls back to the filename and infers the root folder", () => {
-  const task = parseRepoTask("tasks/fix-auth.md", "There is no heading yet.");
-  expect(task?.title).toBe("fix-auth");
-  expect(task?.description).toBe("There is no heading yet.");
-  expect(task?.folderPath).toBe("/");
-  expect(task?.labels).toEqual([]);
-});
-
-test("reads canonical frontmatter fields literally", () => {
-  const canonical = parseRepoTask(
-    "packages/ui/tasks/card.md",
-    "---\nstate: in-progress\nlabels: [ui, polish]\n---\n# Card\n",
-  );
-  expect(canonical?.state).toBe("in-progress");
-  expect(canonical?.folderPath).toBe("/packages/ui");
-  expect(canonical?.labels).toEqual(["ui", "polish"]);
-
-  const unrelatedMetadata = parseRepoTask(
-    "tasks/unrelated.md",
-    "---\nstatus: in-review\ntags: backend\n---\nOther keys are ordinary metadata\n",
-  );
-  expect(unrelatedMetadata?.state).toBe("todo");
-  expect(unrelatedMetadata?.labels).toEqual([]);
-
-  const backlog = parseRepoTask("tasks/backlog.md", "---\nstate: backlog\n---\n# Backlog\n");
-  expect(backlog?.state).toBe("backlog");
-});
-
-test("uses an explicit title before the first heading", () => {
-  const task = parseRepoTask(
-    "tasks/rename-me.md",
-    "---\ntitle: Frontmatter title\n---\n# Heading title\n\nDescription.\n",
-  );
-  expect(task?.title).toBe("Frontmatter title");
-  expect(task?.description).toBe("Description.");
-});
-
-test("reads an assigned agent and a permissive final comments log", () => {
-  const task = parseRepoTask(
-    "tasks/assigned.md",
-    "---\nagent: /agents/repos/config/tasks/assigned\n---\n# Assigned\n\nDo it.\n\n## Comments\n\nA loose note.\n\n### 2026-07-13T12:00:00Z — agent\n\nStarted.\n\n### malformed but fine\nDone.\n",
-  );
-
-  expect(task?.description).toBe("Do it.");
-  expect(task?.agent).toBe("/agents/repos/config/tasks/assigned");
-  expect(task?.comments).toEqual([
-    { heading: undefined, body: "A loose note." },
-    { heading: "2026-07-13T12:00:00Z — agent", body: "Started." },
-    { heading: "malformed but fine", body: "Done." },
-  ]);
-});
-
-test("treats an unstructured comments section as one lightweight comment", () => {
-  const task = parseRepoTask("tasks/log.md", "# Log\n\nBody.\n\n## Comments\nnot structured");
-  expect(task?.description).toBe("Body.");
-  expect(task?.comments).toEqual([{ heading: undefined, body: "not structured" }]);
-});
-
-test("updates state while preserving unrelated YAML, comments, and Markdown", () => {
-  const content = "---\n# keep this\nstate: todo\nsize: small\n---\n\n# Ship it\n\nBody.\n";
-  const updated = updateRepoTaskState(content, "in-progress");
-  expect(updated).toContain("# keep this");
-  expect(updated).toContain("state: in-progress");
-  expect(updated).toContain("size: small");
-  expect(updated.endsWith("\n# Ship it\n\nBody.\n")).toBe(true);
-});
-
-test("adds canonical state frontmatter", () => {
-  expect(updateRepoTaskState("# New task\n", "done")).toBe("---\nstate: done\n---\n\n# New task\n");
-});
-
-test("updates labels stored in frontmatter", () => {
-  const updated = updateRepoTaskLabels("# Labels\n", ["frontend", "frontend", "v1"]);
-  expect(updated).toBe("---\nlabels:\n  - frontend\n  - v1\n---\n\n# Labels\n");
-  expect(updated).not.toContain("folder:");
-
-  const removed = updateRepoTaskLabels(updated, []);
-  expect(removed).toBe("\n# Labels\n");
-});
-
-test("updates and clears an agent property", () => {
-  const assigned = updateRepoTaskAgent("# Assign me\n", "/agents/repos/config/tasks/assign-me");
-  expect(assigned).toContain("agent: /agents/repos/config/tasks/assign-me");
-  expect(updateRepoTaskAgent(assigned, undefined)).toBe("\n# Assign me\n");
+test.for([
+  {
+    name: "updates state while preserving unrelated YAML, comments, and Markdown",
+    act: () =>
+      updateRepoTaskState(
+        "---\n# keep this\nstate: todo\nsize: small\n---\n\n# Ship it\n\nBody.\n",
+        "in-progress",
+      ),
+    expected: "---\n# keep this\nstate: in-progress\nsize: small\n---\n\n# Ship it\n\nBody.\n",
+  },
+  {
+    name: "adds canonical state frontmatter",
+    act: () => updateRepoTaskState("# New task\n", "done"),
+    expected: "---\nstate: done\n---\n\n# New task\n",
+  },
+  {
+    name: "stores deduped labels in frontmatter",
+    act: () => updateRepoTaskLabels("# Labels\n", ["frontend", "frontend", "v1"]),
+    expected: "---\nlabels:\n  - frontend\n  - v1\n---\n\n# Labels\n",
+  },
+  {
+    name: "drops the frontmatter block when the last labels are removed",
+    act: () => updateRepoTaskLabels("---\nlabels:\n  - frontend\n  - v1\n---\n\n# Labels\n", []),
+    expected: "\n# Labels\n",
+  },
+  {
+    name: "records an assigned agent in frontmatter",
+    act: () => updateRepoTaskAgent("# Assign me\n", "/agents/repos/config/tasks/assign-me"),
+    expected: "---\nagent: /agents/repos/config/tasks/assign-me\n---\n\n# Assign me\n",
+  },
+  {
+    name: "clears an assigned agent",
+    act: () =>
+      updateRepoTaskAgent(
+        "---\nagent: /agents/repos/config/tasks/assign-me\n---\n\n# Assign me\n",
+        undefined,
+      ),
+    expected: "\n# Assign me\n",
+  },
+])("$name", ({ act, expected }) => {
+  expect(act()).toBe(expected);
 });
 
 test("creates a bare task with a stable collision-free path", () => {
@@ -217,15 +299,24 @@ test("picks a collision-free path when moving a task between folders", () => {
   expect(repoTaskPathInDirectory("tasks/plan.md", "tasks", paths)).toBe("tasks/plan.md");
 });
 
-test("validates an edited task path before projecting the task there", () => {
+// The edited-path validator, over a task at tasks/old.md with tasks/taken.md
+// reserved.
+test.for([
+  { name: "accepts a slash-prefixed new path", target: "/tasks/new.md", expected: "tasks/new.md" },
+  { name: "keeps the task's own path", target: "tasks/old.md", expected: "tasks/old.md" },
+  { name: "rejects a reserved path", target: "tasks/taken.md", expected: null },
+  { name: "rejects traversal outside the repo", target: "tasks/../outside.md", expected: null },
+  { name: "rejects non-task paths", target: "not-a-task.md", expected: null },
+])("repoTaskWithPath $name", ({ expected, target }) => {
   const task = parseRepoTask("tasks/old.md", "# Old\n")!;
   const reserved = new Set([task.path, "tasks/taken.md"]);
 
-  expect(repoTaskWithPath(task, "/tasks/new.md", reserved)?.path).toBe("tasks/new.md");
-  expect(repoTaskWithPath(task, task.path, reserved)?.path).toBe(task.path);
-  expect(repoTaskWithPath(task, "tasks/taken.md", reserved)).toBeNull();
-  expect(repoTaskWithPath(task, "tasks/../outside.md", reserved)).toBeNull();
-  expect(repoTaskWithPath(task, "not-a-task.md", reserved)).toBeNull();
+  const result = repoTaskWithPath(task, target, reserved);
+  if (expected === null) {
+    expect(result).toBeNull();
+  } else {
+    expect(result?.path).toBe(expected);
+  }
 });
 
 test("reserves a task path that exists at HEAD while its deletion is pending", () => {

--- a/apps/os/src/domains/integrations/github-api.test.ts
+++ b/apps/os/src/domains/integrations/github-api.test.ts
@@ -51,42 +51,42 @@ describe("normalizeGithubError", () => {
     expect(GITHUB_CALL_GRAMMAR).toContain(".octokit.graphql(query, variables)");
   });
 
-  // Both replayPathCall miss shapes must answer with the grammar: a live
-  // agent invented `.api.request(...)` (a MID-path miss — "hit undefined"),
-  // got a generic failure, and burned turns rediscovering the surface.
-  test("mid-path miss (hit undefined) gets the call grammar", () => {
-    const error = normalizeGithubError(
-      new Error("Capability path api.request hit undefined."),
-      "acme",
-    );
-    expect(error.message).toBe(GITHUB_CALL_GRAMMAR);
-  });
-
-  test("leaf miss (did not resolve to a function) gets the call grammar", () => {
-    const error = normalizeGithubError(
-      new Error("Capability path repos.list did not resolve to a function."),
-      "acme",
-    );
-    expect(error.message).toBe(GITHUB_CALL_GRAMMAR);
-  });
-
-  test("real API failures keep their status and message", () => {
-    const error = normalizeGithubError(
-      Object.assign(new Error("Not Found"), { status: 404 }),
-      "acme",
-    );
-    expect(error.message).toBe("GitHub API failed with HTTP 404: Not Found");
-  });
-
-  // Reserved-segment rejections share the "Capability path" prefix but are a
-  // protocol violation, not a wrong guess at the surface — the real reason
-  // must survive, not be rewritten to the grammar.
-  test("reserved-segment errors pass through", () => {
-    const error = normalizeGithubError(
-      new Error('Capability path segment "constructor" is reserved.'),
-      "acme",
-    );
-    expect(error.message).toContain("is reserved");
+  test.for([
+    {
+      // Both replayPathCall miss shapes must answer with the grammar: a live
+      // agent invented `.api.request(...)` (a MID-path miss — "hit
+      // undefined"), got a generic failure, and burned turns rediscovering
+      // the surface.
+      name: "mid-path miss (hit undefined) gets the call grammar",
+      error: new Error("Capability path api.request hit undefined."),
+      expectedMessage: GITHUB_CALL_GRAMMAR,
+    },
+    {
+      name: "leaf miss (did not resolve to a function) gets the call grammar",
+      error: new Error("Capability path repos.list did not resolve to a function."),
+      expectedMessage: GITHUB_CALL_GRAMMAR,
+    },
+    {
+      name: "real API failures keep their status and message",
+      error: Object.assign(new Error("Not Found"), { status: 404 }),
+      expectedMessage: "GitHub API failed with HTTP 404: Not Found",
+    },
+    {
+      // Reserved-segment rejections share the "Capability path" prefix but
+      // are a protocol violation, not a wrong guess at the surface — the real
+      // reason must survive, not be rewritten to the grammar.
+      name: "reserved-segment errors pass through",
+      error: new Error('Capability path segment "constructor" is reserved.'),
+      expectedContains: "is reserved",
+    },
+  ])("$name", ({ error, expectedContains, expectedMessage }) => {
+    const normalized = normalizeGithubError(error, "acme");
+    if (expectedMessage !== undefined) {
+      expect(normalized.message).toBe(expectedMessage);
+    }
+    if (expectedContains !== undefined) {
+      expect(normalized.message).toContain(expectedContains);
+    }
   });
 });
 

--- a/apps/os/src/domains/integrations/integration-webhook-api.test.ts
+++ b/apps/os/src/domains/integrations/integration-webhook-api.test.ts
@@ -38,6 +38,16 @@ function config() {
   });
 }
 
+/** The github config without a webhook secret (the 503 lane). */
+function bareConfig() {
+  return parseConfig({
+    APP_CONFIG: JSON.stringify({
+      integrations: { github: { oauthClientId: "x", oauthClientSecret: "y" } },
+      openAiApiKey: "k",
+    }),
+  });
+}
+
 function githubRequest(body: string, signature?: string) {
   const sig =
     signature ?? `sha256=${createHmac("sha256", GITHUB_WEBHOOK_SECRET).update(body).digest("hex")}`;
@@ -53,122 +63,131 @@ function githubRequest(body: string, signature?: string) {
   });
 }
 
+function slackRequest(body: string) {
+  const ts = String(Math.floor(Date.now() / 1000));
+  const sig = `v0=${createHmac("sha256", SLACK_SIGNING_SECRET).update(`v0:${ts}:${body}`).digest("hex")}`;
+  return new Request("https://os.example.test/api/integrations/slack/webhook", {
+    body,
+    headers: {
+      "content-type": "application/json",
+      "x-slack-request-timestamp": ts,
+      "x-slack-signature": sig,
+    },
+    method: "POST",
+  });
+}
+
 describe("handleIntegrationWebhookApiRequest (github)", () => {
   afterEach(() => routeIntegrationWebhook.mockReset());
 
-  test("valid signature + claimed installation → routes on (github, installation_id) and 200", async () => {
-    routeIntegrationWebhook.mockResolvedValue({
-      connection: "install-42",
-      ok: true,
-      projectId: "prj_1",
-    });
-    const body = JSON.stringify({ action: "opened", installation: { id: 42 } });
-    const response = await handleIntegrationWebhookApiRequest({
-      config: config(),
-      request: githubRequest(body),
-    });
+  test.for([
+    {
+      name: "valid signature + claimed installation → routes on (github, installation_id) and 200",
+      body: JSON.stringify({ action: "opened", installation: { id: 42 } }),
+      mockRoute: { connection: "install-42", ok: true, projectId: "prj_1" },
+      expectedStatus: 200,
+      expectedJson: { ok: true },
+      expectedCall: {
+        slug: "github",
+        externalId: "42",
+        event: {
+          type: "events.iterate.com/github/webhook-received",
+          idempotencyKey: "github-webhook:delivery-1",
+          payload: { appSlug: "iterate-test", installationId: "42" },
+        },
+      },
+    },
+    {
+      name: "bad signature → 401, never routes (the trust boundary)",
+      body: JSON.stringify({ installation: { id: 42 } }),
+      signature: "sha256=deadbeef",
+      expectedStatus: 401,
+      expectedJson: { error: "Invalid GitHub signature." },
+    },
+    {
+      name: "no webhook secret configured → 503",
+      bare: true,
+      body: JSON.stringify({ installation: { id: 42 } }),
+      expectedStatus: 503,
+      expectedJson: { error: "GitHub integration is not configured." },
+    },
+    {
+      name: "valid signature but no installation → 200 ACK-drop, never routes",
+      body: JSON.stringify({ zen: "ping without an installation" }),
+      expectedStatus: 200,
+      expectedJson: { ignored: "no-installation", ok: true },
+    },
+    {
+      name: "valid signature, unclaimed installation → 200 ACK-drop (distributed-app rule)",
+      body: JSON.stringify({ installation: { id: 999 } }),
+      mockRoute: { ignored: "external-id-not-claimed", ok: true },
+      expectedStatus: 200,
+      expectedJson: { ignored: "external-id-not-claimed", ok: true },
+      expectedCall: { slug: "github", externalId: "999" },
+    },
+  ])(
+    "$name",
+    async ({ bare, body, expectedCall, expectedJson, expectedStatus, mockRoute, signature }) => {
+      if (mockRoute !== undefined) routeIntegrationWebhook.mockResolvedValue(mockRoute);
 
-    expect(response?.status).toBe(200);
-    expect(routeIntegrationWebhook).toHaveBeenCalledTimes(1);
-    const call = routeIntegrationWebhook.mock.calls[0]![0];
-    expect(call.slug).toBe("github");
-    expect(call.externalId).toBe("42");
-    expect(call.event.type).toBe("events.iterate.com/github/webhook-received");
-    expect(call.event.idempotencyKey).toBe("github-webhook:delivery-1");
-    expect(call.event.payload).toMatchObject({ appSlug: "iterate-test", installationId: "42" });
-  });
+      const response = await handleIntegrationWebhookApiRequest({
+        config: bare === true ? bareConfig() : config(),
+        request: githubRequest(body, signature),
+      });
 
-  test("bad signature → 401, never routes (the trust boundary)", async () => {
-    const body = JSON.stringify({ installation: { id: 42 } });
-    const response = await handleIntegrationWebhookApiRequest({
-      config: config(),
-      request: githubRequest(body, "sha256=deadbeef"),
-    });
-    expect(response?.status).toBe(401);
-    expect(routeIntegrationWebhook).not.toHaveBeenCalled();
-  });
-
-  test("no webhook secret configured → 503", async () => {
-    const bare = parseConfig({
-      APP_CONFIG: JSON.stringify({
-        integrations: { github: { oauthClientId: "x", oauthClientSecret: "y" } },
-        openAiApiKey: "k",
-      }),
-    });
-    const body = JSON.stringify({ installation: { id: 42 } });
-    const response = await handleIntegrationWebhookApiRequest({
-      config: bare,
-      request: githubRequest(body),
-    });
-    expect(response?.status).toBe(503);
-  });
-
-  test("valid signature but no installation → 200 ACK-drop, never routes", async () => {
-    const body = JSON.stringify({ zen: "ping without an installation" });
-    const response = await handleIntegrationWebhookApiRequest({
-      config: config(),
-      request: githubRequest(body),
-    });
-    expect(response?.status).toBe(200);
-    expect(await response?.json()).toMatchObject({ ignored: "no-installation" });
-    expect(routeIntegrationWebhook).not.toHaveBeenCalled();
-  });
-
-  test("valid signature, unclaimed installation → 200 ACK-drop (distributed-app rule)", async () => {
-    routeIntegrationWebhook.mockResolvedValue({ ignored: "external-id-not-claimed", ok: true });
-    const body = JSON.stringify({ installation: { id: 999 } });
-    const response = await handleIntegrationWebhookApiRequest({
-      config: config(),
-      request: githubRequest(body),
-    });
-    expect(response?.status).toBe(200);
-    expect(await response?.json()).toMatchObject({ ignored: "external-id-not-claimed" });
-  });
+      expect(response?.status).toBe(expectedStatus);
+      expect(await response?.json()).toEqual(expectedJson);
+      if (expectedCall === undefined) {
+        expect(routeIntegrationWebhook).not.toHaveBeenCalled();
+      } else {
+        expect(routeIntegrationWebhook).toHaveBeenCalledTimes(1);
+        expect(routeIntegrationWebhook.mock.calls[0]![0]).toMatchObject(expectedCall);
+      }
+    },
+  );
 });
 
 describe("handleIntegrationWebhookApiRequest (slack + routing)", () => {
   afterEach(() => routeIntegrationWebhook.mockReset());
 
-  function slackRequest(body: string) {
-    const ts = String(Math.floor(Date.now() / 1000));
-    const sig = `v0=${createHmac("sha256", SLACK_SIGNING_SECRET).update(`v0:${ts}:${body}`).digest("hex")}`;
-    return new Request("https://os.example.test/api/integrations/slack/webhook", {
-      body,
-      headers: {
-        "content-type": "application/json",
-        "x-slack-request-timestamp": ts,
-        "x-slack-signature": sig,
+  test.for([
+    {
+      name: "url_verification handshake echoes the challenge, never routes",
+      body: JSON.stringify({ challenge: "abc123", type: "url_verification" }),
+      expectedJson: { challenge: "abc123" },
+    },
+    {
+      name: "claimed team routes on (slack, team_id) with the exact agent-facing shape",
+      body: JSON.stringify({ event_id: "Ev1", team_id: "T42", event: { type: "message" } }),
+      mockRoute: { connection: "acme", ok: true, projectId: "prj_1" },
+      expectedStatus: 200,
+      expectedJson: { ok: true },
+      expectedCall: {
+        slug: "slack",
+        externalId: "T42",
+        routerProcessorSlug: "slack",
+        event: {
+          type: "events.iterate.com/slack/webhook-received",
+          idempotencyKey: "slack-webhook:Ev1",
+          payload: { slackTeamId: "T42" },
+        },
       },
-      method: "POST",
-    });
-  }
+    },
+  ])("$name", async ({ body, expectedCall, expectedJson, expectedStatus, mockRoute }) => {
+    if (mockRoute !== undefined) routeIntegrationWebhook.mockResolvedValue(mockRoute);
 
-  test("url_verification handshake echoes the challenge, never routes", async () => {
-    const body = JSON.stringify({ challenge: "abc123", type: "url_verification" });
-    const response = await handleIntegrationWebhookApiRequest({
-      config: config(),
-      request: slackRequest(body),
-    });
-    expect(await response?.json()).toEqual({ challenge: "abc123" });
-    expect(routeIntegrationWebhook).not.toHaveBeenCalled();
-  });
-
-  test("claimed team routes on (slack, team_id) with the exact agent-facing shape", async () => {
-    routeIntegrationWebhook.mockResolvedValue({ connection: "acme", ok: true, projectId: "prj_1" });
-    const body = JSON.stringify({ event_id: "Ev1", team_id: "T42", event: { type: "message" } });
     const response = await handleIntegrationWebhookApiRequest({
       config: config(),
       request: slackRequest(body),
     });
 
-    expect(response?.status).toBe(200);
-    const call = routeIntegrationWebhook.mock.calls[0]![0];
-    expect(call.slug).toBe("slack");
-    expect(call.externalId).toBe("T42");
-    expect(call.routerProcessorSlug).toBe("slack");
-    expect(call.event.type).toBe("events.iterate.com/slack/webhook-received");
-    expect(call.event.idempotencyKey).toBe("slack-webhook:Ev1");
-    expect(call.event.payload).toMatchObject({ slackTeamId: "T42" });
+    if (expectedStatus !== undefined) expect(response?.status).toBe(expectedStatus);
+    expect(await response?.json()).toEqual(expectedJson);
+    if (expectedCall === undefined) {
+      expect(routeIntegrationWebhook).not.toHaveBeenCalled();
+    } else {
+      expect(routeIntegrationWebhook.mock.calls[0]![0]).toMatchObject(expectedCall);
+    }
   });
 
   test("non-webhook path → null (not mine)", async () => {

--- a/apps/os/src/domains/integrations/oauth-state.test.ts
+++ b/apps/os/src/domains/integrations/oauth-state.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import { createOAuthState, parseOAuthStateUnverified, verifyOAuthState } from "./oauth-state.ts";
 import { verifySlackSignature } from "./slack-signature.ts";
 
 const KEY = "test-secret-encryption-key";
 
 describe("oauth state", () => {
-  it("round-trips through create -> verify", async () => {
+  test("round-trips through create -> verify", async () => {
     const state = await createOAuthState(
       {
         callbackUrl: "https://example.com/settings",
@@ -24,7 +24,7 @@ describe("oauth state", () => {
     });
   });
 
-  it("parses routing fields without the key but never verifies them", async () => {
+  test("parses routing fields without the key but never verifies them", async () => {
     const state = await createOAuthState(
       { projectId: "prj_2", provider: "google", userId: "usr_1", codeVerifier: "ver" },
       KEY,
@@ -35,46 +35,76 @@ describe("oauth state", () => {
     });
   });
 
-  it("rejects tampered payloads, wrong keys, and provider mismatches", async () => {
+  test.for([
+    {
+      name: "rejects a provider mismatch",
+      verify: (state: string) => verifyOAuthState({ provider: "google", state }, KEY),
+    },
+    {
+      name: "rejects a wrong key",
+      verify: (state: string) => verifyOAuthState({ provider: "slack", state }, "other-key"),
+    },
+    {
+      name: "rejects a tampered payload",
+      verify: (state: string) => {
+        const [version, payload, signature] = state.split(".");
+        const tamperedPayload = Buffer.from(
+          JSON.stringify({
+            ...(JSON.parse(Buffer.from(payload!, "base64url").toString()) as object),
+            projectId: "prj_evil",
+          }),
+        ).toString("base64url");
+        return verifyOAuthState(
+          { provider: "slack", state: `${version}.${tamperedPayload}.${signature}` },
+          KEY,
+        );
+      },
+    },
+    {
+      // Appending garbage breaks the signature — the only way to hold an
+      // expired-or-otherwise-doctored state without the key.
+      name: "rejects a state with a broken signature",
+      verify: (state: string) => verifyOAuthState({ provider: "slack", state: `${state}x` }, KEY),
+    },
+  ])("$name", async ({ verify }) => {
     const state = await createOAuthState(
       { projectId: "prj_1", provider: "slack", userId: "usr_1" },
       KEY,
     );
-    expect(await verifyOAuthState({ provider: "google", state }, KEY)).toBeNull();
-    expect(await verifyOAuthState({ provider: "slack", state }, "other-key")).toBeNull();
+    // Sanity: the fixture state is live (carries a future expiry), so every
+    // rejection below is the verifier's doing, never mere expiry.
+    expect(parseOAuthStateUnverified(state)!.expiresAt).toBeGreaterThan(Date.now());
 
-    const [version, payload, signature] = state.split(".");
-    const tamperedPayload = Buffer.from(
-      JSON.stringify({
-        ...(JSON.parse(Buffer.from(payload!, "base64url").toString()) as object),
-        projectId: "prj_evil",
-      }),
-    ).toString("base64url");
-    expect(
-      await verifyOAuthState(
-        { provider: "slack", state: `${version}.${tamperedPayload}.${signature}` },
-        KEY,
-      ),
-    ).toBeNull();
-  });
-
-  it("rejects expired states", async () => {
-    const state = await createOAuthState(
-      { projectId: "prj_1", provider: "slack", userId: "usr_1" },
-      KEY,
-    );
-    const [version, payload, signature] = state.split(".");
-    // Sanity: the parsed payload carries a future expiry…
-    expect(
-      parseOAuthStateUnverified(`${version}.${payload}.${signature}`)!.expiresAt,
-    ).toBeGreaterThan(Date.now());
-    // …and an expired one (re-signed with the wrong key) can never verify.
-    expect(await verifyOAuthState({ provider: "slack", state: `${state}x` }, KEY)).toBeNull();
+    expect(await verify(state)).toBeNull();
   });
 });
 
+type SlackSignatureInput = {
+  body: string;
+  signature: string | null;
+  signingSecret: string;
+  timestamp: string;
+};
+
 describe("verifySlackSignature", () => {
-  it("accepts a correctly signed body and rejects everything else", async () => {
+  test.for([
+    { name: "accepts a correctly signed body", expected: true },
+    {
+      name: "rejects a tampered body",
+      tamper: (input: SlackSignatureInput) => ({ ...input, body: `${input.body} ` }),
+      expected: false,
+    },
+    {
+      name: "rejects a stale timestamp",
+      tamper: (input: SlackSignatureInput) => ({ ...input, timestamp: "1" }),
+      expected: false,
+    },
+    {
+      name: "rejects a missing signature",
+      tamper: (input: SlackSignatureInput) => ({ ...input, signature: null }),
+      expected: false,
+    },
+  ])("$name", async ({ expected, tamper }) => {
     const signingSecret = "8f742231b10e8888abcd99yyyzzz85a5";
     const body = JSON.stringify({ type: "event_callback", team_id: "T1" });
     const timestamp = String(Math.floor(Date.now() / 1000));
@@ -91,15 +121,7 @@ describe("verifySlackSignature", () => {
     );
     const signature = `v0=${Array.from(mac, (byte) => byte.toString(16).padStart(2, "0")).join("")}`;
 
-    expect(await verifySlackSignature({ body, signature, signingSecret, timestamp })).toBe(true);
-    expect(
-      await verifySlackSignature({ body: `${body} `, signature, signingSecret, timestamp }),
-    ).toBe(false);
-    expect(await verifySlackSignature({ body, signature, signingSecret, timestamp: "1" })).toBe(
-      false,
-    );
-    expect(await verifySlackSignature({ body, signature: null, signingSecret, timestamp })).toBe(
-      false,
-    );
+    const input: SlackSignatureInput = { body, signature, signingSecret, timestamp };
+    expect(await verifySlackSignature(tamper === undefined ? input : tamper(input))).toBe(expected);
   });
 });

--- a/apps/os/src/domains/integrations/slack-api.test.ts
+++ b/apps/os/src/domains/integrations/slack-api.test.ts
@@ -57,114 +57,149 @@ describe("connectionSlackClient", () => {
 
   afterEach(() => vi.unstubAllGlobals());
 
-  test("a WebClient call rides project egress with a placeholder auth header", async () => {
-    const slack = connectionSlackClient({ connection: "main", projectId: "prj_1" });
-    const result = await slack.chat.postMessage({ channel: "C1", text: "hi" });
+  test.for([
+    {
+      name: "a WebClient call rides project egress and succeeds first try",
+      act: () =>
+        connectionSlackClient({ connection: "main", projectId: "prj_1" }).chat.postMessage({
+          channel: "C1",
+          text: "hi",
+        }),
+      expectedEgressUrls: ["https://slack.com/api/chat.postMessage"],
+      expectedDeploymentPaths: [],
+    },
+    {
+      name: "an invalid connection token retries with the same-workspace deployment token",
+      primaryResult: { error: "invalid_auth", ok: false },
+      act: () =>
+        connectionSlackClient({ connection: "main", projectId: "prj_1" }).chat.postMessage({
+          channel: "C1",
+          text: "hi",
+        }),
+      expectedEgressUrls: ["https://slack.com/api/chat.postMessage"],
+      expectedDeploymentPaths: ["/api/auth.test", "/api/chat.postMessage"],
+    },
+    {
+      name: "does not retry with a deployment token from another workspace",
+      primaryResult: { error: "invalid_auth", ok: false },
+      fallbackTeamId: "T_OTHER",
+      act: () =>
+        connectionSlackClient({ connection: "main", projectId: "prj_1" }).chat.postMessage({
+          channel: "C1",
+          text: "hi",
+        }),
+      expectedRejection: "invalid_auth",
+      expectedEgressUrls: ["https://slack.com/api/chat.postMessage"],
+      expectedDeploymentPaths: ["/api/auth.test"],
+    },
+    {
+      name: "the hand-rolled Web API path uses the same recovery policy",
+      primaryResult: { error: "token_revoked", ok: false },
+      act: () =>
+        callProjectSlackWebApi({
+          body: { channel: "C1", name: "eyes", timestamp: "1700000000.000100" },
+          connection: "main",
+          method: "reactions.add",
+          projectId: "prj_1",
+        }),
+      expectedEgressUrls: ["https://slack.com/api/reactions.add"],
+      expectedDeploymentPaths: ["/api/auth.test", "/api/reactions.add"],
+    },
+    {
+      name: "never retries auth.revoke with the deployment credential",
+      primaryResult: { error: "invalid_auth", ok: false },
+      act: () =>
+        callProjectSlackWebApi({
+          body: {},
+          connection: "main",
+          method: "auth.revoke",
+          projectId: "prj_1",
+        }),
+      expectedRejection: "invalid_auth",
+      expectedEgressUrls: ["https://slack.com/api/auth.revoke"],
+      expectedDeploymentPaths: [],
+    },
+  ])(
+    "$name",
+    async ({
+      act,
+      expectedDeploymentPaths,
+      expectedEgressUrls,
+      expectedRejection,
+      fallbackTeamId,
+      primaryResult,
+    }) => {
+      if (primaryResult !== undefined) mocks.primaryResult = primaryResult;
+      if (fallbackTeamId !== undefined) mocks.fallbackTeamId = fallbackTeamId;
 
-    expect(result.ok).toBe(true);
-    const request = mocks.requests[0]!;
-    expect(new URL(request.url).href).toBe("https://slack.com/api/chat.postMessage");
-    expect(request.headers.get("authorization")).toBe(
-      'Bearer getSecret({ path: "/secrets/integrations/slack/main/bot-token" })',
-    );
-  });
+      if (expectedRejection === undefined) {
+        const result = await act();
+        expect(result.ok).toBe(true);
+      } else {
+        await expect(act()).rejects.toThrow(expectedRejection);
+      }
 
-  test("an invalid connection token retries with the same-workspace deployment token", async () => {
-    mocks.primaryResult = { error: "invalid_auth", ok: false };
-
-    const slack = connectionSlackClient({ connection: "main", projectId: "prj_1" });
-    const result = await slack.chat.postMessage({ channel: "C1", text: "hi" });
-
-    expect(result.ok).toBe(true);
-    expect(mocks.requests.map((request) => new URL(request.url).pathname)).toEqual([
-      "/api/chat.postMessage",
-    ]);
-    expect(mocks.deploymentRequests.map((request) => new URL(request.url).pathname)).toEqual([
-      "/api/auth.test",
-      "/api/chat.postMessage",
-    ]);
-    expect(mocks.deploymentRequests.map((request) => request.headers.get("authorization"))).toEqual(
-      ["Bearer deployment-slack-token", "Bearer deployment-slack-token"],
-    );
-  });
-
-  test("does not retry with a deployment token from another workspace", async () => {
-    mocks.primaryResult = { error: "invalid_auth", ok: false };
-    mocks.fallbackTeamId = "T_OTHER";
-
-    const slack = connectionSlackClient({ connection: "main", projectId: "prj_1" });
-
-    await expect(slack.chat.postMessage({ channel: "C1", text: "hi" })).rejects.toThrow(
-      "invalid_auth",
-    );
-    expect(mocks.requests).toHaveLength(1);
-    expect(mocks.deploymentRequests).toHaveLength(1);
-  });
-
-  test("the hand-rolled Web API path uses the same recovery policy", async () => {
-    mocks.primaryResult = { error: "token_revoked", ok: false };
-
-    const result = await callProjectSlackWebApi({
-      body: { channel: "C1", name: "eyes", timestamp: "1700000000.000100" },
-      connection: "main",
-      method: "reactions.add",
-      projectId: "prj_1",
-    });
-
-    expect(result.ok).toBe(true);
-    expect(mocks.deploymentRequests.map((request) => new URL(request.url).pathname)).toEqual([
-      "/api/auth.test",
-      "/api/reactions.add",
-    ]);
-  });
-
-  test("never retries auth.revoke with the deployment credential", async () => {
-    mocks.primaryResult = { error: "invalid_auth", ok: false };
-
-    await expect(
-      callProjectSlackWebApi({
-        body: {},
-        connection: "main",
-        method: "auth.revoke",
-        projectId: "prj_1",
-      }),
-    ).rejects.toThrow("invalid_auth");
-    expect(mocks.deploymentRequests).toHaveLength(0);
-  });
+      expect(mocks.requests.map((request) => new URL(request.url).href)).toEqual(
+        expectedEgressUrls,
+      );
+      expect(mocks.deploymentRequests.map((request) => new URL(request.url).pathname)).toEqual(
+        expectedDeploymentPaths,
+      );
+      // Every egress request carries the placeholder (the real token never
+      // leaves the Secret DO); every deployment-lane request carries the
+      // deployment credential.
+      for (const request of mocks.requests) {
+        expect(request.headers.get("authorization")).toBe(
+          'Bearer getSecret({ path: "/secrets/integrations/slack/main/bot-token" })',
+        );
+      }
+      for (const request of mocks.deploymentRequests) {
+        expect(request.headers.get("authorization")).toBe("Bearer deployment-slack-token");
+      }
+    },
+  );
 });
 
 describe("normalizeSlackError", () => {
-  test("a secret-pipeline error names the connection and points at discovery", () => {
-    const err = normalizeSlackError({ data: { error: "secret_no_material" } }, "main");
-    expect(err.message).toContain('Slack connection "main"');
-    expect(err.message).toContain("itx.integrations.list()");
-  });
-
-  // The forgot-the-connection shape: `slack.chat.postMessage(...)` makes the
-  // replay treat `chat` as the connection and try `postMessage` on the
-  // WebClient, which misses. That miss must surface as the call grammar, not
-  // the raw path-proxy string.
-  test("a path-resolution miss becomes the call grammar", () => {
-    const err = normalizeSlackError(
-      new Error("Capability path postMessage did not resolve to a function."),
-      "chat",
-    );
-    expect(err.message).toBe(SLACK_CALL_GRAMMAR);
-    expect(err.message).toMatch(/use itx\.integrations\.list\(\) to see connections/);
-  });
-
-  // A MID-path miss (an invented namespace like `.api.postMessage`) dies on
-  // `api` being undefined, not on the leaf — same grammar answer.
-  test("a mid-path miss (hit undefined) becomes the call grammar", () => {
-    const err = normalizeSlackError(
-      new Error("Capability path api.postMessage hit undefined."),
-      "main",
-    );
-    expect(err.message).toBe(SLACK_CALL_GRAMMAR);
-  });
-
-  test("an unrecognized Slack error passes through verbatim", () => {
-    const err = normalizeSlackError({ message: "channel_not_found" }, "main");
-    expect(err.message).toBe("channel_not_found");
+  test.for([
+    {
+      name: "a secret-pipeline error names the connection and points at discovery",
+      error: { data: { error: "secret_no_material" } } as unknown,
+      connection: "main",
+      expectedContains: ['Slack connection "main"', "itx.integrations.list()"],
+    },
+    {
+      // The forgot-the-connection shape: `slack.chat.postMessage(...)` makes
+      // the replay treat `chat` as the connection and try `postMessage` on the
+      // WebClient, which misses. That miss must surface as the call grammar,
+      // not the raw path-proxy string.
+      name: "a path-resolution miss becomes the call grammar",
+      error: new Error("Capability path postMessage did not resolve to a function."),
+      connection: "chat",
+      expectedMessage: SLACK_CALL_GRAMMAR,
+      expectedContains: ["use itx.integrations.list() to see connections"],
+    },
+    {
+      // A MID-path miss (an invented namespace like `.api.postMessage`) dies
+      // on `api` being undefined, not on the leaf — same grammar answer.
+      name: "a mid-path miss (hit undefined) becomes the call grammar",
+      error: new Error("Capability path api.postMessage hit undefined."),
+      connection: "main",
+      expectedMessage: SLACK_CALL_GRAMMAR,
+    },
+    {
+      name: "an unrecognized Slack error passes through verbatim",
+      error: { message: "channel_not_found" } as unknown,
+      connection: "main",
+      expectedMessage: "channel_not_found",
+    },
+  ])("$name", ({ connection, error, expectedContains, expectedMessage }) => {
+    const err = normalizeSlackError(error, connection);
+    if (expectedMessage !== undefined) {
+      expect(err.message).toBe(expectedMessage);
+    }
+    for (const needle of expectedContains ?? []) {
+      expect(err.message).toContain(needle);
+    }
   });
 });

--- a/apps/os/src/domains/integrations/telegram-webhook.test.ts
+++ b/apps/os/src/domains/integrations/telegram-webhook.test.ts
@@ -14,74 +14,132 @@ const SECRET_ENCRYPTION_KEY = "test-secret-encryption-key";
 const BOT_ID = "7000001";
 
 describe("fetchTelegramWebhook", () => {
-  test("valid secret token + claimed bot → routes on (telegram, botId) and 200", async () => {
-    const { fetchWebhook, routed } = setup();
-    const response = await fetchWebhook({
-      config: config(),
-      request: await webhookRequest({ update: update(1001) }),
-    });
-
-    expect(response?.status).toBe(200);
-    expect(await response?.json()).toEqual({ ok: true });
-    expect(routed).toHaveLength(1);
-    expect(routed[0]).toMatchObject({
-      slug: "telegram",
-      externalId: BOT_ID,
-      routerProcessorSlug: "telegram",
-      event: {
-        idempotencyKey: `telegram-webhook:${BOT_ID}:1001`,
-        type: "events.iterate.com/telegram/webhook-received",
-        payload: { botId: BOT_ID, body: update(1001) },
+  test.for([
+    {
+      name: "valid secret token + claimed bot → routes on (telegram, botId) and 200",
+      update: update(1001),
+      expectedStatus: 200,
+      expectedBody: { ok: true },
+      expectedRoutedCount: 1,
+      expectedRouted: {
+        slug: "telegram",
+        externalId: BOT_ID,
+        routerProcessorSlug: "telegram",
+        event: {
+          idempotencyKey: `telegram-webhook:${BOT_ID}:1001`,
+          type: "events.iterate.com/telegram/webhook-received",
+          payload: { botId: BOT_ID, body: update(1001) },
+        },
       },
-    });
-  });
+    },
+    {
+      name: "wrong secret token → 401, never routes (the trust boundary)",
+      secretToken: "not-the-derived-token",
+      update: update(1),
+      expectedStatus: 401,
+      expectedBody: { error: "Invalid Telegram secret token." },
+      expectedRoutedCount: 0,
+    },
+    {
+      name: "missing secret token header → 401",
+      secretToken: null,
+      update: update(1),
+      expectedStatus: 401,
+      expectedBody: { error: "Invalid Telegram secret token." },
+      expectedRoutedCount: 0,
+    },
+    {
+      name: "a token derived for ANOTHER bot id does not open this bot's door",
+      secretTokenForBotId: "9999999",
+      update: update(1),
+      expectedStatus: 401,
+      expectedBody: { error: "Invalid Telegram secret token." },
+      expectedRoutedCount: 0,
+    },
+    {
+      name: "authenticated but unclaimed bot → 200 ACK-and-drop",
+      claimed: false,
+      update: update(1),
+      expectedStatus: 200,
+      expectedBody: { ignored: "external-id-not-claimed", ok: true },
+      expectedRoutedCount: 0,
+    },
+    {
+      name: "unparseable payloads → 200 ACK-and-drop",
+      rawBody: "not json{",
+      expectedStatus: 200,
+      expectedBody: { ignored: "unparseable-payload", ok: true },
+      expectedRoutedCount: 0,
+    },
+    {
+      name: "update_id-less payloads → 200 ACK-and-drop",
+      rawBody: JSON.stringify({ message: { text: "hi" } }),
+      expectedStatus: 200,
+      expectedBody: { ignored: "no-update-id", ok: true },
+      expectedRoutedCount: 0,
+    },
+    {
+      name: "another integration's webhook path → null (not mine)",
+      path: "/api/integrations/slack/webhook",
+      expectedStatus: null,
+      expectedRoutedCount: 0,
+    },
+    {
+      name: "the bot-id-less telegram webhook path → null (not mine)",
+      path: "/api/integrations/telegram/webhook",
+      expectedStatus: null,
+      expectedRoutedCount: 0,
+    },
+    {
+      name: "extra path segments after the bot id → null (not mine)",
+      path: `/api/integrations/telegram/webhook/${BOT_ID}/extra`,
+      expectedStatus: null,
+      expectedRoutedCount: 0,
+    },
+  ])(
+    "$name",
+    async ({
+      claimed,
+      expectedBody,
+      expectedRouted,
+      expectedRoutedCount,
+      expectedStatus,
+      path,
+      rawBody,
+      secretToken,
+      secretTokenForBotId,
+      update: updateBody,
+    }) => {
+      const { fetchWebhook, routed } = setup(claimed === false ? { claimed } : {});
+      const request =
+        path !== undefined
+          ? new Request(`https://os.example.test${path}`, { body: "{}", method: "POST" })
+          : await webhookRequest({
+              rawBody,
+              secretToken:
+                secretTokenForBotId === undefined
+                  ? secretToken
+                  : await telegramWebhookSecretToken({
+                      botId: secretTokenForBotId,
+                      keyMaterial: SECRET_ENCRYPTION_KEY,
+                    }),
+              update: updateBody,
+            });
 
-  test("wrong secret token → 401, never routes (the trust boundary)", async () => {
-    const { fetchWebhook, routed } = setup();
-    const response = await fetchWebhook({
-      config: config(),
-      request: await webhookRequest({ secretToken: "not-the-derived-token", update: update(1) }),
-    });
-    expect(response?.status).toBe(401);
-    expect(routed).toHaveLength(0);
-  });
+      const response = await fetchWebhook({ config: config(), request });
 
-  test("missing secret token header → 401", async () => {
-    const { fetchWebhook, routed } = setup();
-    const response = await fetchWebhook({
-      config: config(),
-      request: new Request(`https://os.example.test/api/integrations/telegram/webhook/${BOT_ID}`, {
-        body: JSON.stringify(update(1)),
-        method: "POST",
-      }),
-    });
-    expect(response?.status).toBe(401);
-    expect(routed).toHaveLength(0);
-  });
-
-  test("a token derived for ANOTHER bot id does not open this bot's door", async () => {
-    const { fetchWebhook, routed } = setup();
-    const otherBotToken = await telegramWebhookSecretToken({
-      botId: "9999999",
-      keyMaterial: SECRET_ENCRYPTION_KEY,
-    });
-    const response = await fetchWebhook({
-      config: config(),
-      request: await webhookRequest({ secretToken: otherBotToken, update: update(1) }),
-    });
-    expect(response?.status).toBe(401);
-    expect(routed).toHaveLength(0);
-  });
-
-  test("authenticated but unclaimed bot → 200 ACK-and-drop", async () => {
-    const { fetchWebhook } = setup({ claimed: false });
-    const response = await fetchWebhook({
-      config: config(),
-      request: await webhookRequest({ update: update(1) }),
-    });
-    expect(response?.status).toBe(200);
-    expect(await response?.json()).toMatchObject({ ignored: "external-id-not-claimed" });
-  });
+      if (expectedStatus === null) {
+        expect(response).toBeNull();
+      } else {
+        expect(response?.status).toBe(expectedStatus);
+        expect(await response?.json()).toEqual(expectedBody);
+      }
+      expect(routed).toHaveLength(expectedRoutedCount);
+      if (expectedRouted !== undefined) {
+        expect(routed[0]).toMatchObject(expectedRouted);
+      }
+    },
+  );
 
   test("duplicate update_id dedupes (Telegram retries undelivered updates)", async () => {
     const { fetchWebhook, routedEvents } = setup();
@@ -102,39 +160,6 @@ describe("fetchTelegramWebhook", () => {
     });
     expect(next?.status).toBe(200);
     expect(routedEvents).toHaveLength(2);
-  });
-
-  test("unparseable and update_id-less payloads → 200 ACK-and-drop", async () => {
-    const { fetchWebhook, routed } = setup();
-    const unparseable = await fetchWebhook({
-      config: config(),
-      request: await webhookRequest({ rawBody: "not json{" }),
-    });
-    expect(unparseable?.status).toBe(200);
-    expect(await unparseable?.json()).toMatchObject({ ignored: "unparseable-payload" });
-
-    const noUpdateId = await fetchWebhook({
-      config: config(),
-      request: await webhookRequest({ rawBody: JSON.stringify({ message: { text: "hi" } }) }),
-    });
-    expect(noUpdateId?.status).toBe(200);
-    expect(await noUpdateId?.json()).toMatchObject({ ignored: "no-update-id" });
-    expect(routed).toHaveLength(0);
-  });
-
-  test("non-telegram paths → null (not mine)", async () => {
-    const { fetchWebhook } = setup();
-    for (const path of [
-      "/api/integrations/slack/webhook",
-      "/api/integrations/telegram/webhook", // no bot id segment
-      `/api/integrations/telegram/webhook/${BOT_ID}/extra`,
-    ]) {
-      const response = await fetchWebhook({
-        config: config(),
-        request: new Request(`https://os.example.test${path}`, { body: "{}", method: "POST" }),
-      });
-      expect(response).toBeNull();
-    }
   });
 });
 
@@ -160,19 +185,21 @@ function update(updateId: number) {
   };
 }
 
+/** `secretToken` undefined → the valid derived token; null → omit the header. */
 async function webhookRequest(input: {
   rawBody?: string;
-  secretToken?: string;
+  secretToken?: string | null;
   update?: Record<string, unknown>;
 }) {
   const secretToken =
-    input.secretToken ??
-    (await telegramWebhookSecretToken({ botId: BOT_ID, keyMaterial: SECRET_ENCRYPTION_KEY }));
+    input.secretToken === undefined
+      ? await telegramWebhookSecretToken({ botId: BOT_ID, keyMaterial: SECRET_ENCRYPTION_KEY })
+      : input.secretToken;
   return new Request(`https://os.example.test/api/integrations/telegram/webhook/${BOT_ID}`, {
     body: input.rawBody ?? JSON.stringify(input.update),
     headers: {
       "content-type": "application/json",
-      "x-telegram-bot-api-secret-token": secretToken,
+      ...(secretToken === null ? {} : { "x-telegram-bot-api-secret-token": secretToken }),
     },
     method: "POST",
   });

--- a/apps/os/src/domains/projects/custom-domains.test.ts
+++ b/apps/os/src/domains/projects/custom-domains.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 import { parseConfig } from "../../config.ts";
 import {
   primeProjectHostname,
@@ -10,6 +10,272 @@ import {
   createCloudflareCustomDomainProvisioner,
   normalizeProjectCustomDomain,
 } from "./custom-domains.ts";
+
+const project: ProjectDirectoryRecord = {
+  id: "prj_garple",
+  name: "Garple",
+  organizationId: "org_1",
+  slug: "garple",
+};
+
+const otherProject: ProjectDirectoryRecord = {
+  id: "prj_other",
+  name: "Other",
+  organizationId: "org_1",
+  slug: "other",
+};
+
+describe("custom domain provisioning", () => {
+  test("normalizes custom domains and rejects reserved project hostnames", () => {
+    expect(
+      normalizeProjectCustomDomain({
+        hostname: " Garple.Com:443. ",
+        projectHostnameBases: ["iterate.app"],
+      }),
+    ).toBe("garple.com");
+    expect(() =>
+      normalizeProjectCustomDomain({
+        hostname: "garple.iterate.app",
+        projectHostnameBases: ["iterate.app"],
+      }),
+    ).toThrow(/reserved/);
+  });
+
+  test("creates a wildcard Cloudflare custom hostname without routing before validation is active", async () => {
+    const { cloudflare, directory, provisioner } = setup();
+
+    const snapshot = await provisioner.ensure({ hostname: "garple.com", project });
+
+    expect(cloudflare.createdBodies).toEqual([
+      {
+        custom_metadata: {
+          projectId: "prj_garple",
+          projectSlug: "garple",
+          source: "iterate-os",
+        },
+        hostname: "garple.com",
+        ssl: {
+          method: "txt",
+          settings: { min_tls_version: "1.2" },
+          type: "dv",
+          wildcard: true,
+        },
+      },
+    ]);
+    expect(snapshot).toMatchObject({
+      cloudflareHostnameId: "custom-hostname-1",
+      hostname: "garple.com",
+      status: "pending_validation",
+      validationRecords: [
+        {
+          name: "_acme-challenge.garple.com",
+          status: "pending",
+          value: "ssl-token",
+        },
+      ],
+      wildcard: true,
+    });
+    await expect(readProjectHostnameRegistration(directory, "garple.com")).resolves.toBeNull();
+    await expect(readProjectByHostname(directory, "counter.garple.com")).resolves.toBeNull();
+  });
+
+  test("calls Cloudflare fetch without binding the client input as this", async () => {
+    const cloudflare = createCloudflareFetchMock();
+    let fetchCalls = 0;
+    const fetchWithThisAssertion = async function (
+      this: unknown,
+      ...args: Parameters<typeof fetch>
+    ) {
+      fetchCalls += 1;
+      expect(this).toBeUndefined();
+      return await cloudflare.fetch(...args);
+    } as typeof fetch;
+    const { provisioner } = setup({ fetch: fetchWithThisAssertion });
+
+    await expect(provisioner.ensure({ hostname: "garple.com", project })).resolves.toMatchObject({
+      hostname: "garple.com",
+    });
+    expect(fetchCalls).toBeGreaterThan(0);
+  });
+
+  test("rejects apex domains that would cover another project's explicit subdomain", async () => {
+    let fetchCalls = 0;
+    const { directory, provisioner } = setup({
+      fetch: (async () => {
+        fetchCalls += 1;
+        throw new Error("Cloudflare should not be called for unavailable hostnames.");
+      }) as typeof fetch,
+    });
+    await primeProjectHostname(directory, "www.garple.com", otherProject);
+
+    await expect(provisioner.ensure({ hostname: "garple.com", project })).rejects.toThrow(
+      /overlaps existing custom domain "www\.garple\.com"/,
+    );
+    expect(fetchCalls).toBe(0);
+    await expect(readProjectHostnameRegistration(directory, "garple.com")).resolves.toBeNull();
+  });
+
+  test.for([
+    {
+      name: "refreshes an existing Cloudflare hostname and heals missing routing KV",
+      hostnames: [cloudflareHostname()],
+      expectedSnapshot: { status: "active" },
+      expectedAppHost: { appSlug: "counter", record: project },
+    },
+    {
+      name: "refreshes a recorded Cloudflare hostname id even when metadata is missing",
+      hostnames: [cloudflareHostname({ id: "custom-hostname-1" })],
+      nullifyMetadata: true,
+      refreshInput: { cloudflareHostnameId: "custom-hostname-1" },
+      expectedSnapshot: { status: "active" },
+    },
+    {
+      name: "falls back to hostname lookup when the recorded Cloudflare hostname id is stale",
+      hostnames: [cloudflareHostname({ id: "custom-hostname-2" })],
+      nullifyMetadata: true,
+      refreshInput: { cloudflareHostnameId: "stale-custom-hostname-id" },
+      expectedSnapshot: {
+        cloudflareHostnameId: "custom-hostname-2",
+        hostname: "garple.com",
+        status: "active",
+      },
+    },
+  ])(
+    "$name",
+    async ({ expectedAppHost, expectedSnapshot, hostnames, nullifyMetadata, refreshInput }) => {
+      const { cloudflare, directory, provisioner } = setup({ hostnames });
+      if (nullifyMetadata) cloudflare.hostnames.get("garple.com")!.custom_metadata = null;
+      await expect(readProjectHostnameRegistration(directory, "garple.com")).resolves.toBeNull();
+
+      const snapshot = await provisioner.refresh({
+        hostname: "garple.com",
+        project,
+        ...refreshInput,
+      });
+
+      expect(snapshot).toMatchObject(expectedSnapshot);
+      await expect(readProjectHostnameRegistration(directory, "garple.com")).resolves.toEqual(
+        project,
+      );
+      if (expectedAppHost !== undefined) {
+        await expect(readProjectByHostname(directory, "counter.garple.com")).resolves.toEqual(
+          expectedAppHost,
+        );
+      }
+    },
+  );
+
+  test("removes same-project routing KV when a refreshed hostname is no longer active", async () => {
+    const { cloudflare, directory, provisioner } = setup({ hostnames: [cloudflareHostname()] });
+
+    await expect(provisioner.refresh({ hostname: "garple.com", project })).resolves.toMatchObject({
+      status: "active",
+    });
+    await expect(readProjectHostnameRegistration(directory, "garple.com")).resolves.toEqual(
+      project,
+    );
+
+    cloudflare.hostnames.set("garple.com", cloudflareHostname({ status: "pending" }));
+    await expect(provisioner.refresh({ hostname: "garple.com", project })).resolves.toMatchObject({
+      status: "pending_validation",
+    });
+    await expect(readProjectHostnameRegistration(directory, "garple.com")).resolves.toBeNull();
+  });
+
+  test.for([
+    {
+      name: "refuses to adopt a Cloudflare hostname owned by another project",
+      hostnames: [cloudflareHostname({ project: otherProject })],
+      act: (provisioner: Provisioner) => provisioner.ensure({ hostname: "garple.com", project }),
+      expectedRejection: /owned by another project/,
+      expectedRegistration: null,
+    },
+    {
+      name: "refuses to remove a Cloudflare hostname owned by another project",
+      hostnames: [cloudflareHostname({ project: otherProject })],
+      seedRegistration: otherProject,
+      act: (provisioner: Provisioner) =>
+        provisioner.remove({ cloudflareHostnameId: "stale-id", hostname: "garple.com", project }),
+      expectedRejection: /owned by another project/,
+      expectedRegistration: otherProject,
+    },
+    {
+      name: "clears a failed local custom domain without deleting another project's Cloudflare hostname",
+      hostnames: [cloudflareHostname({ project: otherProject })],
+      act: (provisioner: Provisioner) =>
+        provisioner.remove({ cloudflareHostnameId: null, hostname: "garple.com", project }),
+      expectedRegistration: null,
+    },
+    {
+      // The recorded id 404s on Cloudflare: the delete is attempted, the 404
+      // swallowed as already-removed, and same-project routing still clears.
+      name: "treats stale Cloudflare delete ids as already removed and clears same-project routing",
+      hostnames: [],
+      seedRegistration: project,
+      act: (provisioner: Provisioner) =>
+        provisioner.remove({ cloudflareHostnameId: "stale-id", hostname: "garple.com", project }),
+      expectedDeletedIds: ["stale-id"],
+      expectedRegistration: null,
+    },
+  ])(
+    "$name",
+    async ({
+      act,
+      expectedDeletedIds,
+      expectedRegistration,
+      expectedRejection,
+      hostnames,
+      seedRegistration,
+    }) => {
+      const { cloudflare, directory, provisioner } = setup({ hostnames });
+      if (seedRegistration !== undefined) {
+        await primeProjectHostname(directory, "garple.com", seedRegistration);
+      }
+
+      if (expectedRejection === undefined) {
+        await expect(act(provisioner)).resolves.toBeUndefined();
+      } else {
+        await expect(act(provisioner)).rejects.toThrow(expectedRejection);
+      }
+      expect(cloudflare.deletedIds).toEqual(expectedDeletedIds ?? []);
+      await expect(readProjectHostnameRegistration(directory, "garple.com")).resolves.toEqual(
+        expectedRegistration,
+      );
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type Provisioner = ReturnType<typeof createProvisioner>;
+
+/** Directory + Cloudflare fetch mock + provisioner in one call; pass `fetch`
+ * to interpose on (or replace) the mock's transport. */
+function setup(input: { fetch?: typeof fetch; hostnames?: CloudflareHostnameFixture[] } = {}) {
+  const directory = new MemoryKv() as unknown as KVNamespace;
+  const cloudflare = createCloudflareFetchMock({ hostnames: input.hostnames });
+  const provisioner = createProvisioner({ directory, fetch: input.fetch ?? cloudflare.fetch });
+  return { cloudflare, directory, provisioner };
+}
+
+function createProvisioner(input: { directory: KVNamespace; fetch: typeof fetch }) {
+  return createCloudflareCustomDomainProvisioner({
+    config: parseConfig({
+      APP_CONFIG: JSON.stringify({
+        cloudflare: {
+          accountId: "account-1",
+          apiToken: "cf-token",
+        },
+        openAiApiKey: "openai-key",
+        projectHostnameBases: ["iterate.app"],
+      }),
+    }),
+    directory: input.directory,
+    fetch: input.fetch,
+  });
+}
 
 class MemoryKv {
   readonly values = new Map<string, string>();
@@ -39,37 +305,6 @@ class MemoryKv {
       list_complete: true,
     };
   }
-}
-
-const project: ProjectDirectoryRecord = {
-  id: "prj_garple",
-  name: "Garple",
-  organizationId: "org_1",
-  slug: "garple",
-};
-
-const otherProject: ProjectDirectoryRecord = {
-  id: "prj_other",
-  name: "Other",
-  organizationId: "org_1",
-  slug: "other",
-};
-
-function createProvisioner(input: { directory: KVNamespace; fetch: typeof fetch }) {
-  return createCloudflareCustomDomainProvisioner({
-    config: parseConfig({
-      APP_CONFIG: JSON.stringify({
-        cloudflare: {
-          accountId: "account-1",
-          apiToken: "cf-token",
-        },
-        openAiApiKey: "openai-key",
-        projectHostnameBases: ["iterate.app"],
-      }),
-    }),
-    directory: input.directory,
-    fetch: input.fetch,
-  });
 }
 
 type CloudflareHostnameFixture = Record<string, unknown> & {
@@ -200,231 +435,3 @@ function createCloudflareFetchMock(
 function cloudflareNotFound() {
   return Response.json({ success: false, errors: [{ message: "not found" }] }, { status: 404 });
 }
-
-describe("custom domain provisioning", () => {
-  it("normalizes custom domains and rejects reserved project hostnames", () => {
-    expect(
-      normalizeProjectCustomDomain({
-        hostname: " Garple.Com:443. ",
-        projectHostnameBases: ["iterate.app"],
-      }),
-    ).toBe("garple.com");
-    expect(() =>
-      normalizeProjectCustomDomain({
-        hostname: "garple.iterate.app",
-        projectHostnameBases: ["iterate.app"],
-      }),
-    ).toThrow(/reserved/);
-  });
-
-  it("creates a wildcard Cloudflare custom hostname without routing before validation is active", async () => {
-    const directory = new MemoryKv() as unknown as KVNamespace;
-    const cloudflare = createCloudflareFetchMock();
-    const provisioner = createProvisioner({ directory, fetch: cloudflare.fetch });
-
-    const snapshot = await provisioner.ensure({ hostname: "garple.com", project });
-
-    expect(cloudflare.createdBodies).toEqual([
-      {
-        custom_metadata: {
-          projectId: "prj_garple",
-          projectSlug: "garple",
-          source: "iterate-os",
-        },
-        hostname: "garple.com",
-        ssl: {
-          method: "txt",
-          settings: { min_tls_version: "1.2" },
-          type: "dv",
-          wildcard: true,
-        },
-      },
-    ]);
-    expect(snapshot).toMatchObject({
-      cloudflareHostnameId: "custom-hostname-1",
-      hostname: "garple.com",
-      status: "pending_validation",
-      validationRecords: [
-        {
-          name: "_acme-challenge.garple.com",
-          status: "pending",
-          value: "ssl-token",
-        },
-      ],
-      wildcard: true,
-    });
-    await expect(readProjectHostnameRegistration(directory, "garple.com")).resolves.toBeNull();
-    await expect(readProjectByHostname(directory, "counter.garple.com")).resolves.toBeNull();
-  });
-
-  it("calls Cloudflare fetch without binding the client input as this", async () => {
-    const directory = new MemoryKv() as unknown as KVNamespace;
-    const cloudflare = createCloudflareFetchMock();
-    let fetchCalls = 0;
-    const fetchWithThisAssertion = async function (
-      this: unknown,
-      ...args: Parameters<typeof fetch>
-    ) {
-      fetchCalls += 1;
-      expect(this).toBeUndefined();
-      return await cloudflare.fetch(...args);
-    } as typeof fetch;
-    const provisioner = createProvisioner({ directory, fetch: fetchWithThisAssertion });
-
-    await expect(provisioner.ensure({ hostname: "garple.com", project })).resolves.toMatchObject({
-      hostname: "garple.com",
-    });
-    expect(fetchCalls).toBeGreaterThan(0);
-  });
-
-  it("rejects apex domains that would cover another project's explicit subdomain", async () => {
-    const directory = new MemoryKv() as unknown as KVNamespace;
-    await primeProjectHostname(directory, "www.garple.com", otherProject);
-    let fetchCalls = 0;
-    const provisioner = createProvisioner({
-      directory,
-      fetch: (async () => {
-        fetchCalls += 1;
-        throw new Error("Cloudflare should not be called for unavailable hostnames.");
-      }) as typeof fetch,
-    });
-
-    await expect(provisioner.ensure({ hostname: "garple.com", project })).rejects.toThrow(
-      /overlaps existing custom domain "www\.garple\.com"/,
-    );
-    expect(fetchCalls).toBe(0);
-    await expect(readProjectHostnameRegistration(directory, "garple.com")).resolves.toBeNull();
-  });
-
-  it("refreshes an existing Cloudflare hostname and heals missing routing KV", async () => {
-    const directory = new MemoryKv() as unknown as KVNamespace;
-    const cloudflare = createCloudflareFetchMock({
-      hostnames: [cloudflareHostname()],
-    });
-    const provisioner = createProvisioner({ directory, fetch: cloudflare.fetch });
-
-    await expect(readProjectHostnameRegistration(directory, "garple.com")).resolves.toBeNull();
-
-    const snapshot = await provisioner.refresh({ hostname: "garple.com", project });
-
-    expect(snapshot.status).toBe("active");
-    await expect(readProjectHostnameRegistration(directory, "garple.com")).resolves.toEqual(
-      project,
-    );
-    await expect(readProjectByHostname(directory, "counter.garple.com")).resolves.toEqual({
-      appSlug: "counter",
-      record: project,
-    });
-  });
-
-  it("refreshes a recorded Cloudflare hostname id even when metadata is missing", async () => {
-    const directory = new MemoryKv() as unknown as KVNamespace;
-    const cloudflare = createCloudflareFetchMock({
-      hostnames: [cloudflareHostname({ id: "custom-hostname-1" })],
-    });
-    cloudflare.hostnames.get("garple.com")!.custom_metadata = null;
-    const provisioner = createProvisioner({ directory, fetch: cloudflare.fetch });
-
-    const snapshot = await provisioner.refresh({
-      cloudflareHostnameId: "custom-hostname-1",
-      hostname: "garple.com",
-      project,
-    });
-
-    expect(snapshot.status).toBe("active");
-    await expect(readProjectHostnameRegistration(directory, "garple.com")).resolves.toEqual(
-      project,
-    );
-  });
-
-  it("falls back to hostname lookup when the recorded Cloudflare hostname id is stale", async () => {
-    const directory = new MemoryKv() as unknown as KVNamespace;
-    const cloudflare = createCloudflareFetchMock({
-      hostnames: [cloudflareHostname({ id: "custom-hostname-2" })],
-    });
-    cloudflare.hostnames.get("garple.com")!.custom_metadata = null;
-    const provisioner = createProvisioner({ directory, fetch: cloudflare.fetch });
-
-    const snapshot = await provisioner.refresh({
-      cloudflareHostnameId: "stale-custom-hostname-id",
-      hostname: "garple.com",
-      project,
-    });
-
-    expect(snapshot).toMatchObject({
-      cloudflareHostnameId: "custom-hostname-2",
-      hostname: "garple.com",
-      status: "active",
-    });
-    await expect(readProjectHostnameRegistration(directory, "garple.com")).resolves.toEqual(
-      project,
-    );
-  });
-
-  it("removes same-project routing KV when a refreshed hostname is no longer active", async () => {
-    const directory = new MemoryKv() as unknown as KVNamespace;
-    const cloudflare = createCloudflareFetchMock({
-      hostnames: [cloudflareHostname()],
-    });
-    const provisioner = createProvisioner({ directory, fetch: cloudflare.fetch });
-
-    await expect(provisioner.refresh({ hostname: "garple.com", project })).resolves.toMatchObject({
-      status: "active",
-    });
-    await expect(readProjectHostnameRegistration(directory, "garple.com")).resolves.toEqual(
-      project,
-    );
-
-    cloudflare.hostnames.set("garple.com", cloudflareHostname({ status: "pending" }));
-    await expect(provisioner.refresh({ hostname: "garple.com", project })).resolves.toMatchObject({
-      status: "pending_validation",
-    });
-    await expect(readProjectHostnameRegistration(directory, "garple.com")).resolves.toBeNull();
-  });
-
-  it("refuses to adopt or remove a Cloudflare hostname owned by another project", async () => {
-    const directory = new MemoryKv() as unknown as KVNamespace;
-    const cloudflare = createCloudflareFetchMock({
-      hostnames: [cloudflareHostname({ project: otherProject })],
-    });
-    const provisioner = createProvisioner({ directory, fetch: cloudflare.fetch });
-
-    await expect(provisioner.ensure({ hostname: "garple.com", project })).rejects.toThrow(
-      /owned by another project/,
-    );
-    await primeProjectHostname(directory, "garple.com", otherProject);
-    await expect(
-      provisioner.remove({ cloudflareHostnameId: "stale-id", hostname: "garple.com", project }),
-    ).rejects.toThrow(/owned by another project/);
-    expect(cloudflare.deletedIds).toEqual([]);
-    await expect(readProjectHostnameRegistration(directory, "garple.com")).resolves.toEqual(
-      otherProject,
-    );
-  });
-
-  it("clears a failed local custom domain without deleting another project's Cloudflare hostname", async () => {
-    const directory = new MemoryKv() as unknown as KVNamespace;
-    const cloudflare = createCloudflareFetchMock({
-      hostnames: [cloudflareHostname({ project: otherProject })],
-    });
-    const provisioner = createProvisioner({ directory, fetch: cloudflare.fetch });
-
-    await expect(
-      provisioner.remove({ cloudflareHostnameId: null, hostname: "garple.com", project }),
-    ).resolves.toBeUndefined();
-    expect(cloudflare.deletedIds).toEqual([]);
-    await expect(readProjectHostnameRegistration(directory, "garple.com")).resolves.toBeNull();
-  });
-
-  it("treats stale Cloudflare delete ids as already removed and clears same-project routing", async () => {
-    const directory = new MemoryKv() as unknown as KVNamespace;
-    await primeProjectHostname(directory, "garple.com", project);
-    const cloudflare = createCloudflareFetchMock();
-    const provisioner = createProvisioner({ directory, fetch: cloudflare.fetch });
-
-    await expect(
-      provisioner.remove({ cloudflareHostnameId: "stale-id", hostname: "garple.com", project }),
-    ).resolves.toBeUndefined();
-    await expect(readProjectHostnameRegistration(directory, "garple.com")).resolves.toBeNull();
-  });
-});

--- a/apps/os/src/domains/repos/github-agent-test-helpers.ts
+++ b/apps/os/src/domains/repos/github-agent-test-helpers.ts
@@ -1,20 +1,10 @@
 // GitHub-router/agent test fixtures over the canonical in-memory stream
-// harness (../streams/test-helpers.ts).
+// harness (../streams/test-helpers.ts). The repo/GitHub suites pin the
+// harness clock to the epoch (`now: () => 0`): they pair processor clocks
+// like `now: () => 10` with ~epoch createdAt stamps, so the 👀-ack freshness
+// gate sees a small positive age.
 
-import { MemoryStreamNetwork as CanonicalMemoryStreamNetwork } from "../streams/test-helpers.ts";
-
-export { MemoryStream, deliverNewEvents } from "../streams/test-helpers.ts";
-
-/**
- * The canonical network with its clock pinned to the epoch: the GitHub agent
- * suite pairs processor clocks like `now: () => 10` with ~epoch createdAt
- * stamps, so the 👀-ack freshness gate sees a small positive age.
- */
-export class MemoryStreamNetwork extends CanonicalMemoryStreamNetwork {
-  constructor() {
-    super(() => 0);
-  }
-}
+export { MemoryStream } from "../streams/test-helpers.ts";
 
 export const GITHUB_LINK = {
   connection: "install-789",

--- a/apps/os/src/domains/repos/repo-task-events-processor.test.ts
+++ b/apps/os/src/domains/repos/repo-task-events-processor.test.ts
@@ -1,11 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
-import {
-  GITHUB_LINK,
-  MemoryStream,
-  MemoryStreamNetwork,
-  deliverNewEvents,
-  webhookPayload,
-} from "./github-agent-test-helpers.ts";
+import { describe, expect, test, vi } from "vitest";
+import { eventsOfType, makeProcessorHarness, type MemoryStream } from "../streams/test-helpers.ts";
+import { GITHUB_LINK, webhookPayload } from "./github-agent-test-helpers.ts";
 import type { RepoCommittedFileChange } from "./repo-task-events.ts";
 import { RepoProcessor } from "./repo-processor-implementation.ts";
 
@@ -30,6 +25,19 @@ function newRepoProcessor(
     createRepoArtifact: async () => {
       throw new Error("not under test");
     },
+  });
+}
+
+/** The suite preamble: the canonical harness (epoch-pinned clock, like the
+ * repo/GitHub suites) building a RepoProcessor over /repos/config. */
+function repoHarness(
+  taskChangesForArtifactPush: Parameters<typeof newRepoProcessor>[1],
+  syncFromGithubPush?: Parameters<typeof newRepoProcessor>[2],
+) {
+  return makeProcessorHarness({
+    build: ({ stream }) => newRepoProcessor(stream, taskChangesForArtifactPush, syncFromGithubPush),
+    now: () => 0,
+    path: "/repos/config",
   });
 }
 
@@ -65,13 +73,13 @@ function artifactPush(branch: string) {
 }
 
 describe("RepoProcessor task change events", () => {
-  it("imports connected GitHub main pushes and waits for the Artifacts queue to emit facts", async () => {
-    const network = new MemoryStreamNetwork();
-    const stream = network.get("/repos/config");
+  test("imports connected GitHub main pushes and waits for the Artifacts queue to emit facts", async () => {
     const syncFromGithubPush = vi.fn(async () => ({ commitOid: "github-head" }));
     const taskChangesForArtifactPush = vi.fn(async () => []);
-    const processor = newRepoProcessor(stream, taskChangesForArtifactPush, syncFromGithubPush);
-    const cursors = new Map<object, number>();
+    const { deliver, processor, stream } = repoHarness(
+      taskChangesForArtifactPush,
+      syncFromGithubPush,
+    );
 
     await stream.append(REPO_CREATED, GITHUB_LINK_CONFIGURED, {
       type: "events.iterate.com/github/webhook-received",
@@ -80,16 +88,14 @@ describe("RepoProcessor task change events", () => {
         "push",
       ),
     });
-    await deliverNewEvents({ cursors, processor, stream });
+    await deliver();
 
     expect(syncFromGithubPush).not.toHaveBeenCalled();
     expect(
-      stream.events.some(
-        (event) => event.type === "events.iterate.com/repo/github-import-requested",
-      ),
-    ).toBe(true);
+      eventsOfType(stream, "events.iterate.com/repo/github-import-requested"),
+    ).not.toHaveLength(0);
 
-    await deliverNewEvents({ cursors, processor, stream });
+    await deliver();
     await vi.waitFor(() => expect(syncFromGithubPush).toHaveBeenCalledOnce());
 
     expect(syncFromGithubPush).toHaveBeenCalledOnce();
@@ -98,18 +104,14 @@ describe("RepoProcessor task change events", () => {
       branch: "main",
     });
     expect(taskChangesForArtifactPush).not.toHaveBeenCalled();
-    expect(
-      stream.events.some((event) => event.type === "events.iterate.com/repo/commit-completed"),
-    ).toBe(false);
+    expect(eventsOfType(stream, "events.iterate.com/repo/commit-completed")).toHaveLength(0);
 
     await vi.waitFor(() =>
       expect(
-        stream.events.some(
-          (event) => event.type === "events.iterate.com/repo/github-import-completed",
-        ),
-      ).toBe(true),
+        eventsOfType(stream, "events.iterate.com/repo/github-import-completed"),
+      ).not.toHaveLength(0),
     );
-    await deliverNewEvents({ cursors, processor, stream });
+    await deliver();
     expect(processor.state.githubImport).toBeNull();
 
     // A full journal refold sees the terminal import fact and must not dial
@@ -118,19 +120,19 @@ describe("RepoProcessor task change events", () => {
       throw new Error("refold must not sync");
     });
     const refolded = newRepoProcessor(stream, taskChangesForArtifactPush, refoldSync);
-    await deliverNewEvents({ cursors: new Map(), processor: refolded, stream });
+    await deliver(refolded);
     expect(refoldSync).not.toHaveBeenCalled();
   });
 
-  it("journals an import failure without pinning later repo events", async () => {
-    const network = new MemoryStreamNetwork();
-    const stream = network.get("/repos/config");
+  test("journals an import failure without pinning later repo events", async () => {
     const syncFromGithubPush = vi.fn(async () => {
       throw new Error("GitHub and Artifacts diverged");
     });
     const taskChangesForArtifactPush = vi.fn(async () => []);
-    const processor = newRepoProcessor(stream, taskChangesForArtifactPush, syncFromGithubPush);
-    const cursors = new Map<object, number>();
+    const { deliver, processor, stream } = repoHarness(
+      taskChangesForArtifactPush,
+      syncFromGithubPush,
+    );
 
     await stream.append(REPO_CREATED, GITHUB_LINK_CONFIGURED, {
       type: "events.iterate.com/github/webhook-received",
@@ -139,37 +141,31 @@ describe("RepoProcessor task change events", () => {
         "push",
       ),
     });
-    await deliverNewEvents({ cursors, processor, stream });
-    await deliverNewEvents({ cursors, processor, stream });
+    await deliver();
+    await deliver();
     await vi.waitFor(() =>
-      expect(
-        stream.events.some(
-          (event) => event.type === "events.iterate.com/repo/github-import-failed",
-        ),
-      ).toBe(true),
+      expect(eventsOfType(stream, "events.iterate.com/repo/github-import-failed")).not.toHaveLength(
+        0,
+      ),
     );
-    await deliverNewEvents({ cursors, processor, stream });
+    await deliver();
     expect(processor.state.githubImport).toBeNull();
 
     await stream.append(artifactPush("main"));
-    await deliverNewEvents({ cursors, processor, stream });
-    await deliverNewEvents({ cursors, processor, stream });
+    await deliver();
+    await deliver();
 
     expect(taskChangesForArtifactPush).toHaveBeenCalledWith({
       afterCommitOid: "after456",
       beforeCommitOid: "before123",
       branch: "main",
     });
-    expect(
-      stream.events.some((event) => event.type === "events.iterate.com/repo/commit-completed"),
-    ).toBe(true);
+    expect(eventsOfType(stream, "events.iterate.com/repo/commit-completed")).not.toHaveLength(0);
   });
 
-  it("re-drives an import whose running incarnation was evicted", async () => {
-    const network = new MemoryStreamNetwork();
-    const stream = network.get("/repos/config");
+  test("re-drives an import whose running incarnation was evicted", async () => {
     const syncFromGithubPush = vi.fn(async () => ({ commitOid: "current-github-head" }));
-    const processor = newRepoProcessor(stream, async () => [], syncFromGithubPush);
+    const { deliver, stream } = repoHarness(async () => [], syncFromGithubPush);
 
     await stream.append(
       REPO_CREATED,
@@ -191,32 +187,27 @@ describe("RepoProcessor task change events", () => {
         },
       },
     );
-    await deliverNewEvents({ cursors: new Map(), processor, stream });
+    await deliver();
 
     await vi.waitFor(() => expect(syncFromGithubPush).toHaveBeenCalledOnce());
     await vi.waitFor(() =>
       expect(
-        stream.events.some(
-          (event) => event.type === "events.iterate.com/repo/github-import-completed",
-        ),
-      ).toBe(true),
+        eventsOfType(stream, "events.iterate.com/repo/github-import-completed"),
+      ).not.toHaveLength(0),
     );
   });
 
-  it("projects default-branch task file changes into subscribable repo/task facts", async () => {
-    const network = new MemoryStreamNetwork();
-    const stream = network.get("/repos/config");
+  test("projects default-branch task file changes into subscribable repo/task facts", async () => {
     const taskChangesForArtifactPush = vi.fn(async () => [
       { kind: "created" as const, path: "tasks/new-task.md" },
       { kind: "updated" as const, path: "apps/os/tasks/board.markdown" },
       { kind: "deleted" as const, path: "packages/ui/tasks/old.md" },
     ]);
-    const processor = newRepoProcessor(stream, taskChangesForArtifactPush);
-    const cursors = new Map<object, number>();
+    const { deliver, stream } = repoHarness(taskChangesForArtifactPush);
 
     await stream.append(REPO_CREATED, artifactPush("main"));
-    await deliverNewEvents({ cursors, processor, stream });
-    await deliverNewEvents({ cursors, processor, stream });
+    await deliver();
+    await deliver();
 
     expect(
       stream.events
@@ -241,9 +232,9 @@ describe("RepoProcessor task change events", () => {
       },
     ]);
     expect(
-      stream.events
-        .filter((event) => event.type === "events.iterate.com/repo/commit-completed")
-        .map((event) => event.payload),
+      eventsOfType(stream, "events.iterate.com/repo/commit-completed").map(
+        (event) => event.payload,
+      ),
     ).toEqual([{ beforeCommitOid: "before123", branch: "main", commitOid: "after456" }]);
     expect(taskChangesForArtifactPush).toHaveBeenCalledWith({
       afterCommitOid: "after456",
@@ -252,41 +243,32 @@ describe("RepoProcessor task change events", () => {
     });
   });
 
-  it("ignores pushes to non-default branches", async () => {
-    const network = new MemoryStreamNetwork();
-    const stream = network.get("/repos/config");
+  test("ignores pushes to non-default branches", async () => {
     const taskChangesForArtifactPush = vi.fn(async () => []);
-    const processor = newRepoProcessor(stream, taskChangesForArtifactPush);
+    const { deliver, stream } = repoHarness(taskChangesForArtifactPush);
 
     await stream.append(REPO_CREATED, artifactPush("feature"));
-    await deliverNewEvents({ cursors: new Map(), processor, stream });
+    await deliver();
 
     expect(taskChangesForArtifactPush).not.toHaveBeenCalled();
-    expect(
-      stream.events.some((event) => event.type === "events.iterate.com/repo/commit-completed"),
-    ).toBe(false);
+    expect(eventsOfType(stream, "events.iterate.com/repo/commit-completed")).toHaveLength(0);
   });
 
-  it("is idempotent when a commit fact is refolded", async () => {
-    const network = new MemoryStreamNetwork();
-    const stream = network.get("/repos/config");
+  test("is idempotent when a commit fact is refolded", async () => {
     const taskChangesForArtifactPush = async () => [
       { kind: "created" as const, path: "tasks/new-task.md" },
     ];
-    const processor = newRepoProcessor(stream, taskChangesForArtifactPush);
-    const cursors = new Map<object, number>();
+    const { deliver, stream } = repoHarness(taskChangesForArtifactPush);
 
     await stream.append(REPO_CREATED, artifactPush("main"));
-    await deliverNewEvents({ cursors, processor, stream });
-    await deliverNewEvents({ cursors, processor, stream });
+    await deliver();
+    await deliver();
     const journalLength = stream.events.length;
 
     const refolded = newRepoProcessor(stream, taskChangesForArtifactPush);
-    await deliverNewEvents({ cursors: new Map(), processor: refolded, stream });
+    await deliver(refolded);
 
     expect(stream.events).toHaveLength(journalLength);
-    expect(
-      stream.events.filter((event) => event.type === "events.iterate.com/repo/task-created"),
-    ).toHaveLength(1);
+    expect(eventsOfType(stream, "events.iterate.com/repo/task-created")).toHaveLength(1);
   });
 });

--- a/apps/os/src/domains/typecheck/virtual-project.test.ts
+++ b/apps/os/src/domains/typecheck/virtual-project.test.ts
@@ -474,50 +474,64 @@ async function gate(code: string, capabilities: CapabilityDescription[] = []) {
   return await checkItxScriptForExecution({ capabilities, code, typechecker });
 }
 
-test("execution gate: a wrong call into the typed surface blocks with the caller's line numbers", async () => {
-  const checked = await gate(`async (itx) => {\n  return await itx.streams.gett("/");\n}`);
-  expect(checked.verdict).toBe("problems");
-  const problems = (checked as { problems: string[] }).problems;
-  expect(problems[0]).toContain("script:2");
-  expect(problems[0]).toContain("Did you mean 'get'");
-});
-
-test("execution gate: a near-miss typo on a typed mount blocks; anything else on mounts runs", async () => {
-  const typo = await gate("async (itx) => itx.tools.weather.forecastt({ city: 'Berlin' })", [
-    WEATHER_MOUNT,
-  ]);
-  expect(typo.verdict).toBe("problems");
-  expect((typo as { problems: string[] }).problems[0]).toContain("Did you mean 'forecast'");
-
-  const untyped = await gate("async (itx) => itx.legacy.whatever(1, { deep: true })", [
-    { path: ["legacy"], type: "live" },
-  ]);
-  expect(untyped).toMatchObject({ verdict: "clean" });
-});
-
-test("execution gate: only NEAR-MISS proof blocks — bare mismatches are unprovable and run", async () => {
+const GATE_ROWS: Array<{
+  name: string;
+  code: string;
+  capabilities?: CapabilityDescription[];
+  expected: "clean" | "problems" | "unchecked";
+  /** Asserted against the FIRST problem — the one the runner surfaces. */
+  problemContains?: string[];
+}> = [
+  {
+    name: "a wrong call into the typed surface blocks with the caller's line numbers",
+    code: `async (itx) => {\n  return await itx.streams.gett("/");\n}`,
+    expected: "problems",
+    problemContains: ["script:2", "Did you mean 'get'"],
+  },
+  {
+    name: "a near-miss typo on a typed mount blocks",
+    code: "async (itx) => itx.tools.weather.forecastt({ city: 'Berlin' })",
+    capabilities: [WEATHER_MOUNT],
+    expected: "problems",
+    problemContains: ["Did you mean 'forecast'"],
+  },
+  {
+    name: "anything else on an untyped mount runs",
+    code: "async (itx) => itx.legacy.whatever(1, { deep: true })",
+    capabilities: [{ path: ["legacy"], type: "live" }],
+    expected: "clean",
+  },
+  // Only NEAR-MISS proof blocks — bare mismatches are unprovable and run.
   // The declared surface lags the runtime in places (preview e2e:
   // CloudflareSandbox.exec exists at runtime but not in types, handle results
   // declared {}), so property/argument mismatches without a did-you-mean must
   // never block. These all failed loudly in preview until this policy.
-  for (const code of [
+  {
     // A capability nobody declared — journal-legal via dynamic provides.
-    "async (itx) => itx.nonexistent.doThing()",
-    // Wrong argument type into the platform surface — types may lag runtime.
-    "async (itx) => itx.docs.search(42)",
-    // Wrong argument shape into a typed mount.
-    "async (itx) => itx.tools.weather.forecast({ city: 42 })",
-  ]) {
-    const checked = await gate(code, [WEATHER_MOUNT]);
-    expect(checked, code).toMatchObject({ verdict: "clean" });
-  }
-});
-
-test("execution gate: provide-then-use in one script stays green (dynamic mounts are invisible to a static check)", async () => {
-  // The canonical catalogue example shape that preview e2e runs: mount a
-  // capability, then call it through the itx proxy two lines later.
-  const checked = await gate(
-    `async (itx) => {
+    name: "a capability nobody declared runs",
+    code: "async (itx) => itx.nonexistent.doThing()",
+    capabilities: [WEATHER_MOUNT],
+    expected: "clean",
+  },
+  {
+    // Types may lag runtime.
+    name: "a wrong argument type into the platform surface runs",
+    code: "async (itx) => itx.docs.search(42)",
+    capabilities: [WEATHER_MOUNT],
+    expected: "clean",
+  },
+  {
+    name: "a wrong argument shape into a typed mount runs",
+    code: "async (itx) => itx.tools.weather.forecast({ city: 42 })",
+    capabilities: [WEATHER_MOUNT],
+    expected: "clean",
+  },
+  {
+    // The canonical catalogue example shape that preview e2e runs: mount a
+    // capability, then call it through the itx proxy two lines later —
+    // dynamic mounts are invisible to a static check.
+    name: "provide-then-use in one script stays green",
+    code: `async (itx) => {
       await itx.capabilityHost.provideCapability({
         type: "itx-expression",
         path: ["demoStream"],
@@ -525,9 +539,213 @@ test("execution gate: provide-then-use in one script stays green (dynamic mounts
       });
       return await itx.demoStream.getEvents({ afterOffset: 0, limit: 10 });
     }`,
-  );
-  expect(checked).toMatchObject({ verdict: "clean" });
-});
+    expected: "clean",
+  },
+  {
+    name: "a stale BROKEN mount never vetoes a clean script",
+    code: "async (itx) => itx.stale.anything()",
+    capabilities: [{ path: ["stale"], type: "live", types: "export type Stale = Goone;" }],
+    expected: "clean",
+  },
+  {
+    name: "a script's OWN provable errors still block beside a stale broken mount",
+    code: "async (itx) => itx.streams.gett('/')",
+    capabilities: [{ path: ["stale"], type: "live", types: "export type Stale = Goone;" }],
+    expected: "problems",
+  },
+  {
+    // fake-gone 404s in the fake registry — the mount module errors AND the
+    // script's own import errors are both unresolved-module class, so it
+    // runs (acquisition failure ≠ proof).
+    name: "unresolved modules never block",
+    code: 'async (itx) => { const m = await import("fake-gone"); return m; }',
+    capabilities: [
+      { path: ["gone"], type: "itx-expression", types: 'export type G = import("fake-gone").X;' },
+    ],
+    expected: "clean",
+  },
+  // Shapes the checker doesn't model run unchecked (raw runScript callers).
+  {
+    name: "a plain arrow runs unchecked — the runtime accepts it",
+    code: "(itx) => itx.streams.gett('/')",
+    expected: "unchecked",
+  },
+  {
+    name: "a parenthesized async function runs unchecked",
+    code: "(async function (itx) { return 1; })",
+    expected: "unchecked",
+  },
+  {
+    name: "a function declaration runs unchecked",
+    code: "function f(itx) { return 1; }",
+    expected: "unchecked",
+  },
+  {
+    name: "oversized scripts run unchecked",
+    code: `async (itx) => { ${"x;".repeat(150_000)} }`,
+    expected: "unchecked",
+  },
+  {
+    name: "non-string code runs unchecked",
+    code: ["async (itx) => {}"] as unknown as string,
+    expected: "unchecked",
+  },
+  // Runtime idioms that execute fine stay green.
+  {
+    // The runtime calls fn(itx); extras are undefined.
+    name: "extra declared params stay green",
+    code: "async (itx, extra, more) => itx.docs.search({ q: 'x' })",
+    expected: "clean",
+  },
+  {
+    name: "a destructured itx parameter stays green",
+    code: "async ({ streams, docs }) => { await streams.get('/'); await docs.search({ q: 'x' }); }",
+    expected: "clean",
+  },
+  {
+    name: "web platform + nodejs_compat runtime globals stay green",
+    code: `async (itx) => {
+      const res = await fetch(new URL("https://example.com/?q=" + crypto.randomUUID()));
+      const body = new TextDecoder().decode(new Uint8Array(await res.arrayBuffer()));
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      console.log(structuredClone({ body: atob(btoa(body)) }), performance.now());
+      return Buffer.from(process?.env?.HOME ?? "x").toString("base64");
+    }`,
+    expected: "clean",
+  },
+  {
+    // The runtime's own wrapper uses `using`, so the shimmed
+    // Symbol.dispose/Disposable must keep scripts with them green.
+    name: "using-declarations stay green",
+    code: `async (itx) => {
+      const handle = { [Symbol.dispose]: () => {} };
+      { using h = handle; void h; }
+      return null;
+    }`,
+    expected: "clean",
+  },
+  {
+    name: "async generators, for-await, Map/Set, regex, and classes stay green",
+    code: `async (itx) => {
+      class Acc { total = 0; add(n) { this.total += n; return this; } }
+      async function* numbers() { yield 1; yield 2; }
+      const acc = new Acc();
+      for await (const n of numbers()) acc.add(n);
+      const seen = new Map([["k", new Set([1])]]);
+      return \`total=\${acc.total} \${/\\d+/.test("42")} \${seen.size}\`;
+    }`,
+    expected: "clean",
+  },
+  {
+    name: "try/catch with unknown error narrowing and rethrow stays green",
+    code: `async (itx) => {
+      try {
+        return await itx.streams.get("/");
+      } catch (error) {
+        throw new Error("wrapped: " + (error instanceof Error ? error.message : String(error)));
+      }
+    }`,
+    expected: "clean",
+  },
+  // Provable script bugs the run would only surface at runtime DO block.
+  {
+    // Misspelled local with a near-miss — TS2552 names the fix.
+    name: "a misspelled local with a near-miss blocks",
+    code: "async (itx) => { const count = 1; return cuont + 1; }",
+    expected: "problems",
+  },
+  {
+    // Misspelled platform member with a near-miss — TS2551 names the fix.
+    name: "a misspelled platform member with a near-miss blocks",
+    code: "async (itx) => itx.streams.gett('/')",
+    expected: "problems",
+  },
+  {
+    // Syntax errors — the runtime's loader would reject these anyway.
+    name: "a declaration syntax error blocks",
+    code: "async (itx) => { const = 1; }",
+    expected: "problems",
+  },
+  {
+    name: "an unbalanced-parens syntax error blocks",
+    code: "async (itx) => { return JSON.parse('{'; }",
+    expected: "problems",
+  },
+  // Regression (#1882 follow-up): ES2024+ runtime features are not blocked
+  // as syntax errors. The regex `v` flag runs in workerd; pinning target
+  // es2022 reported TS1501 ("only available when targeting es2024 or
+  // later") — a 1xxx code the gate blocked as if it were a parse error.
+  // Matching the runtime target fixes it.
+  {
+    name: "regression: the regex v flag is not blocked as TS1501",
+    code: "async (itx) => { const re = /[\\p{L}]/v; return re.test('x'); }",
+    expected: "clean",
+  },
+  {
+    // A sibling target-availability feature: `using` (ES2026 explicit
+    // resource management) inside the async body.
+    name: "regression: using-declarations are not blocked as target errors",
+    code: "async (itx) => { using d = { [Symbol.dispose]() {} }; void d; }",
+    expected: "clean",
+  },
+  // Regression: near-miss on the runtime-extensible itx root does NOT block.
+  {
+    // provide-then-use in one script: the mount does not exist statically,
+    // and its near-miss to `agent` used to bounce it (TS2551 → blocked). The
+    // root is runtime-extensible, so this must run.
+    name: "regression: a provided root mount near-missing a real member runs",
+    code: `async (itx) => {
+    await itx.capabilityHost.provideCapability({ type: "itx-expression", path: ["agentz"], expression: ["streams", ["get", "/"]] });
+    return typeof itx.agentz;
+  }`,
+    expected: "clean",
+  },
+  {
+    // A bare root-member typo reads identically to a dynamic provide —
+    // indistinguishable statically — so it too must run (the price of a
+    // runtime-extensible root; sub-member typos below stay caught).
+    name: "regression: a bare root-member typo runs",
+    code: "async (itx) => itx.strems.get('/')",
+    expected: "clean",
+  },
+  // The refinement must NOT weaken the flagship catches:
+  {
+    name: "regression guard: a near-miss on a concrete sub-surface still blocks",
+    code: "async (itx) => itx.streams.gett('/')",
+    expected: "problems",
+  },
+  {
+    name: "regression guard: a near-miss on a typed mount still blocks",
+    code: "async (itx) => itx.tools.weather.forecastt({ city: 'x' })",
+    capabilities: [WEATHER_MOUNT],
+    expected: "problems",
+  },
+  {
+    // TS2552, not a root property.
+    name: "regression guard: a misspelled LOCAL still blocks",
+    code: "async (itx) => { const count = 1; return cuont + 1; }",
+    expected: "problems",
+  },
+  {
+    // `gett` sits at 1-based column 28 in `itx.streams.gett`; the message
+    // must read :28, not the tswasm-native 0-based :27 (matches editors).
+    name: "regression: diagnostic columns are 1-based",
+    code: "async (itx) => itx.streams.gett('/')",
+    expected: "problems",
+    problemContains: ["script:1:28"],
+  },
+];
+
+test.for(GATE_ROWS)(
+  "execution gate: $name",
+  async ({ capabilities, code, expected, problemContains }) => {
+    const checked = await gate(code, capabilities ?? []);
+    expect(checked.verdict).toBe(expected);
+    for (const needle of problemContains ?? []) {
+      expect((checked as { problems: string[] }).problems[0]).toContain(needle);
+    }
+  },
+);
 
 test("execution gate: clean TypeScript scripts come back with runnable emitted JavaScript", async () => {
   // The 2026-07-14 pirate-thread script: valid TypeScript that used to crash
@@ -551,50 +769,6 @@ test("execution gate: clean TypeScript scripts come back with runnable emitted J
   ]);
   expect(withBrokenMount).toMatchObject({ verdict: "clean" });
   expect((withBrokenMount as { emittedJs?: string }).emittedJs).toContain("export default script");
-});
-
-test("execution gate: a stale BROKEN mount never vetoes a script that doesn't deserve it", async () => {
-  const staleMount: CapabilityDescription[] = [
-    { path: ["stale"], type: "live", types: "export type Stale = Goone;" },
-  ];
-  // A clean script in a scope with a rotten journaled declaration runs.
-  expect(await gate("async (itx) => itx.stale.anything()", staleMount)).toMatchObject({
-    verdict: "clean",
-  });
-  // …but the script's OWN provable errors still block in the same scope.
-  const ownTypo = await gate("async (itx) => itx.streams.gett('/')", staleMount);
-  expect(ownTypo.verdict).toBe("problems");
-});
-
-test("execution gate: unresolved modules never block (acquisition failure ≠ proof)", async () => {
-  // fake-gone 404s in the fake registry — the mount module errors AND the
-  // script's own import errors are both unresolved-module class, so it runs.
-  const checked = await gate('async (itx) => { const m = await import("fake-gone"); return m; }', [
-    { path: ["gone"], type: "itx-expression", types: 'export type G = import("fake-gone").X;' },
-  ]);
-  expect(checked).toMatchObject({ verdict: "clean" });
-});
-
-test("execution gate: shapes the checker doesn't model run unchecked (raw runScript callers)", async () => {
-  for (const code of [
-    "(itx) => itx.streams.gett('/')", // plain arrow — runtime accepts it
-    "(async function (itx) { return 1; })",
-    "function f(itx) { return 1; }",
-  ]) {
-    const checked = await gate(code);
-    expect(checked.verdict, code).toBe("unchecked");
-  }
-});
-
-test("execution gate: oversized scripts and non-string code run unchecked", async () => {
-  const huge = await gate(`async (itx) => { ${"x;".repeat(150_000)} }`);
-  expect(huge.verdict).toBe("unchecked");
-  const notString = await checkItxScriptForExecution({
-    capabilities: [],
-    code: ["async (itx) => {}"] as unknown as string,
-    typechecker,
-  });
-  expect(notString.verdict).toBe("unchecked");
 });
 
 test("execution gate: a compiler crash and an unreachable checker both run unchecked", async () => {
@@ -640,111 +814,9 @@ test("execution gate: a hanging checker hits the deadline and runs unchecked", a
   expect((checked as { reason: string }).reason).toContain("exceeded 25ms");
 });
 
-test("execution gate: runtime idioms that execute fine stay green", async () => {
-  const scripts = [
-    // Extra declared params — the runtime calls fn(itx), extras are undefined.
-    "async (itx, extra, more) => itx.docs.search({ q: 'x' })",
-    // Destructured itx parameter.
-    "async ({ streams, docs }) => { await streams.get('/'); await docs.search({ q: 'x' }); }",
-    // Runtime globals: web platform + nodejs_compat.
-    `async (itx) => {
-      const res = await fetch(new URL("https://example.com/?q=" + crypto.randomUUID()));
-      const body = new TextDecoder().decode(new Uint8Array(await res.arrayBuffer()));
-      await new Promise((resolve) => setTimeout(resolve, 10));
-      console.log(structuredClone({ body: atob(btoa(body)) }), performance.now());
-      return Buffer.from(process?.env?.HOME ?? "x").toString("base64");
-    }`,
-    // using-declarations: the runtime's own wrapper uses \`using\`, so the
-    // shimmed Symbol.dispose/Disposable must keep scripts with them green.
-    `async (itx) => {
-      const handle = { [Symbol.dispose]: () => {} };
-      { using h = handle; void h; }
-      return null;
-    }`,
-    // Async generators, for-await, Map/Set, regex, template literals, classes.
-    `async (itx) => {
-      class Acc { total = 0; add(n) { this.total += n; return this; } }
-      async function* numbers() { yield 1; yield 2; }
-      const acc = new Acc();
-      for await (const n of numbers()) acc.add(n);
-      const seen = new Map([["k", new Set([1])]]);
-      return \`total=\${acc.total} \${/\\d+/.test("42")} \${seen.size}\`;
-    }`,
-    // try/catch with unknown error narrowing and rethrow.
-    `async (itx) => {
-      try {
-        return await itx.streams.get("/");
-      } catch (error) {
-        throw new Error("wrapped: " + (error instanceof Error ? error.message : String(error)));
-      }
-    }`,
-  ];
-  for (const code of scripts) {
-    const checked = await gate(code);
-    expect(checked, code.slice(0, 60)).toMatchObject({ verdict: "clean" });
-  }
-});
-
-test("execution gate: provable script bugs the run would only surface at runtime DO block", async () => {
-  const buggy = [
-    // Misspelled local with a near-miss — TS2552 names the fix.
-    "async (itx) => { const count = 1; return cuont + 1; }",
-    // Misspelled platform member with a near-miss — TS2551 names the fix.
-    "async (itx) => itx.streams.gett('/')",
-    // Syntax errors — the runtime's loader would reject these anyway.
-    "async (itx) => { const = 1; }",
-    "async (itx) => { return JSON.parse('{'; }",
-  ];
-  for (const code of buggy) {
-    const checked = await gate(code);
-    expect(checked.verdict, code).toBe("problems");
-  }
-});
-
-// ─── Regression: prd break-test findings (follow-up to #1882) ────────────────
-// Four false-positive / robustness holes the production break-test surfaced.
-// Each asserts the RUNTIME-legal behavior the gate must now preserve.
-
-test("execution gate regression: ES2024+ runtime features are not blocked as syntax errors (TS1501)", async () => {
-  // The regex `v` flag runs in workerd; pinning target es2022 reported TS1501
-  // ("only available when targeting es2024 or later") — a 1xxx code the gate
-  // blocked as if it were a parse error. matching the runtime target fixes it.
-  const vFlag = await gate("async (itx) => { const re = /[\\p{L}]/v; return re.test('x'); }");
-  expect(vFlag).toMatchObject({ verdict: "clean" });
-  // A sibling target-availability feature: top-level-style await already inside
-  // the async body is fine; `using` (ES2026 explicit resource management) too.
-  const using = await gate("async (itx) => { using d = { [Symbol.dispose]() {} }; void d; }");
-  expect(using).toMatchObject({ verdict: "clean" });
-});
-
-test("execution gate regression: near-miss on the runtime-extensible itx root does NOT block", async () => {
-  // provide-then-use in one script: the mount does not exist statically, and
-  // its near-miss to `agent` used to bounce it (TS2551 → blocked). The root is
-  // runtime-extensible, so this must run.
-  const provideThenUse = await gate(`async (itx) => {
-    await itx.capabilityHost.provideCapability({ type: "itx-expression", path: ["agentz"], expression: ["streams", ["get", "/"]] });
-    return typeof itx.agentz;
-  }`);
-  expect(provideThenUse).toMatchObject({ verdict: "clean" });
-
-  // A bare root-member typo (`itx.strems`) reads identically to a dynamic
-  // provide — indistinguishable statically — so it too must run (the price of
-  // a runtime-extensible root; sub-member typos below stay caught).
-  const rootTypo = await gate("async (itx) => itx.strems.get('/')");
-  expect(rootTypo).toMatchObject({ verdict: "clean" });
-
-  // The refinement must NOT weaken the flagship catches: near-miss on a
-  // CONCRETE sub-surface is still provable and still blocks.
-  const subMemberTypo = await gate("async (itx) => itx.streams.gett('/')");
-  expect(subMemberTypo.verdict).toBe("problems");
-  const mountTypo = await gate("async (itx) => itx.tools.weather.forecastt({ city: 'x' })", [
-    WEATHER_MOUNT,
-  ]);
-  expect(mountTypo.verdict).toBe("problems");
-  // A misspelled LOCAL (TS2552, not a root property) still blocks.
-  const localTypo = await gate("async (itx) => { const count = 1; return cuont + 1; }");
-  expect(localTypo.verdict).toBe("problems");
-});
+// The remaining regression arms from the prd break-test findings (#1882
+// follow-up) that resist tabling: each drives a poisoned/hanging checker or
+// asserts the bail reason, not just a verdict.
 
 test("execution gate regression: pathologically-nested scripts bail to unchecked, never reaching tsc", async () => {
   // ~1200-deep nesting wedged the host DO past its storage watchdog (tsc's
@@ -766,12 +838,4 @@ test("execution gate regression: pathologically-nested scripts bail to unchecked
   // A normal script with ordinary nesting still reaches the real checker.
   const shallow = await gate("async (itx) => itx.streams.gett('/')");
   expect(shallow.verdict).toBe("problems");
-});
-
-test("execution gate regression: diagnostic columns are 1-based (match the line and editors)", async () => {
-  // `gett` sits at 1-based column 28 in `itx.streams.gett`; the message must
-  // read :28, not the tswasm-native 0-based :27.
-  const checked = await gate("async (itx) => itx.streams.gett('/')");
-  expect(checked.verdict).toBe("problems");
-  expect((checked as { problems: string[] }).problems[0]).toContain("script:1:28");
 });

--- a/apps/os/src/itx/browser-repl.test.ts
+++ b/apps/os/src/itx/browser-repl.test.ts
@@ -10,6 +10,54 @@ import {
 } from "./browser-repl.ts";
 import { ITX_EXAMPLES } from "./examples.ts";
 
+/** One snippet submitted to a persistent session: either it evaluates to
+ * `expected`, or it `declares` a scope binding the result must BE (functions
+ * and classes — values a table cannot hand-write). */
+type SessionStep = { code: string; declares?: string; expected?: unknown };
+
+const SESSION_ROWS: Array<{ name: string; steps: SessionStep[] }> = [
+  {
+    name: "session snippets can reference previous local variables",
+    steps: [
+      { code: "const answer = 41", expected: 41 },
+      { code: "answer + 1", expected: 42 },
+      { code: "const secondAnswer = answer + 1", expected: 42 },
+      { code: "secondAnswer", expected: 42 },
+    ],
+  },
+  {
+    name: "session snippets persist multiple top-level variables across lines",
+    steps: [
+      { code: "const first = 20\nconst second = 22", expected: 22 },
+      { code: "first + second", expected: 42 },
+    ],
+  },
+  {
+    name: "session snippets persist function and class declarations",
+    steps: [
+      { code: "function answer() { return 42; }", declares: "answer" },
+      { code: "answer()", expected: 42 },
+      { code: "class Box { value() { return answer(); } }", declares: "Box" },
+      { code: "new Box().value()", expected: 42 },
+      { code: "async function asyncAnswer() { return answer(); }", declares: "asyncAnswer" },
+      { code: "await asyncAnswer()", expected: 42 },
+    ],
+  },
+  {
+    // A stand-in for the esm.sh module: a data: URL is scheme'd, so the
+    // import statement itself is untouched — instead prove the REWRITTEN
+    // shape (`const x = …`) persists like any other top-level declaration.
+    name: "imported bindings persist across session snippets",
+    steps: [
+      {
+        code: 'const __replModule1 = { z: { kind: "schema" } };\nconst z = __replModule1.z;',
+        expected: { kind: "schema" },
+      },
+      { code: "z.kind", expected: "schema" },
+    ],
+  },
+];
+
 describe("browser Cap'n Web REPL", () => {
   test("default snippet uses Cap'n Web promise pipelining", async () => {
     const list = vi.fn().mockResolvedValue(["prj_123"]);
@@ -85,238 +133,88 @@ describe("browser Cap'n Web REPL", () => {
     });
   });
 
-  test("session snippets can reference previous local variables", async () => {
+  test.for(SESSION_ROWS)("$name", async ({ steps }) => {
+    const scope: Record<string, unknown> = {};
+    for (const step of steps) {
+      const result = await evalBrowserReplSessionCode({ code: step.code, itx: {}, scope });
+      if (step.declares !== undefined) {
+        expect(result).toBe(scope[step.declares]);
+        expect(result).toEqual(expect.any(Function));
+      } else {
+        expect(result).toEqual(step.expected);
+      }
+    }
+  });
+
+  test.for([
+    {
+      name: "session snippets use the final top-level expression as the result",
+      code: "const project = { total: 2 }\nproject.total + 40",
+      expected: 42,
+      expectedScope: { project: { total: 2 } } as Record<string, unknown>,
+    },
+    {
+      name: "session snippets keep multiline calls as one final expression",
+      code: "const increment = (value) => value + 1\nincrement\n(41)",
+      expected: 42,
+    },
+    {
+      name: "session snippets keep operator-start continuations in the final expression",
+      code: "40\n+ 2",
+      expected: 42,
+    },
+    {
+      name: "session snippets keep optional-chain continuations in the final expression",
+      code: "const project = { stats: { total: 42 } }\nproject.stats\n?.total",
+      expected: 42,
+    },
+    {
+      name: "session snippets keep ternary continuations in the final expression",
+      code: "true\n? 42\n: 0",
+      expected: 42,
+    },
+    {
+      name: "session snippets do not rewrite do-while statements as expressions",
+      code: "let count = 0\ndo {\n  count += 1\n} while (false)\ncount",
+      expected: 1,
+      expectedScope: { count: 1 },
+    },
+    {
+      // Regression: the appended `; return __replLastValue` used to land on the
+      // same line as a trailing comment and get swallowed → "Unexpected end of
+      // input". A trailing comment is natural in our documented examples.
+      name: "snippet ending in a line comment still returns its last value",
+      code: "const a = 41;\na + 1   // the answer",
+      expected: 42,
+    },
+    {
+      name: "session snippets do not rewrite nested local declarations",
+      code: 'function answer() {\n  const nested = 42;\n  return nested;\n}\nif (answer() !== 42) throw new Error("nested local declaration broke");\nconst persisted = answer();',
+      expected: 42,
+      expectedScope: { persisted: 42 },
+      scopeHas: ["answer"],
+      scopeMissing: ["nested"],
+    },
+    {
+      name: "snippets ending in a top-level return produce that value",
+      code: "const stream = { offset: 41 }\nreturn stream.offset + 1",
+      expected: 42,
+      expectedScope: { stream: { offset: 41 } },
+    },
+  ])("$name", async ({ code, expected, expectedScope, scopeHas, scopeMissing }) => {
     const scope: Record<string, unknown> = {};
 
-    await expect(
-      evalBrowserReplSessionCode({
-        code: "const answer = 41",
-        itx: {},
-        scope,
-      }),
-    ).resolves.toBe(41);
+    await expect(evalBrowserReplSessionCode({ code, itx: {}, scope })).resolves.toEqual(expected);
 
-    await expect(
-      evalBrowserReplSessionCode({
-        code: "answer + 1",
-        itx: {},
-        scope,
-      }),
-    ).resolves.toBe(42);
-
-    await expect(
-      evalBrowserReplSessionCode({
-        code: "const secondAnswer = answer + 1",
-        itx: {},
-        scope,
-      }),
-    ).resolves.toBe(42);
-
-    await expect(
-      evalBrowserReplSessionCode({
-        code: "secondAnswer",
-        itx: {},
-        scope,
-      }),
-    ).resolves.toBe(42);
-  });
-
-  test("session snippets persist multiple top-level variables across lines", async () => {
-    const scope: Record<string, unknown> = {};
-
-    await expect(
-      evalBrowserReplSessionCode({
-        code: "const first = 20\nconst second = 22",
-        itx: {},
-        scope,
-      }),
-    ).resolves.toBe(22);
-
-    await expect(
-      evalBrowserReplSessionCode({
-        code: "first + second",
-        itx: {},
-        scope,
-      }),
-    ).resolves.toBe(42);
-  });
-
-  test("session snippets use the final top-level expression as the result", async () => {
-    const scope: Record<string, unknown> = {};
-
-    await expect(
-      evalBrowserReplSessionCode({
-        code: `
-const project = { total: 2 }
-project.total + 40
-`.trim(),
-        itx: {},
-        scope,
-      }),
-    ).resolves.toBe(42);
-
-    expect(scope.project).toEqual({ total: 2 });
-  });
-
-  test("session snippets keep multiline calls as one final expression", async () => {
-    const scope: Record<string, unknown> = {};
-
-    await expect(
-      evalBrowserReplSessionCode({
-        code: `
-const increment = (value) => value + 1
-increment
-(41)
-`.trim(),
-        itx: {},
-        scope,
-      }),
-    ).resolves.toBe(42);
-  });
-
-  test("session snippets keep operator-start continuations in the final expression", async () => {
-    await expect(
-      evalBrowserReplSessionCode({
-        code: `
-40
-+ 2
-`.trim(),
-        itx: {},
-        scope: {},
-      }),
-    ).resolves.toBe(42);
-
-    await expect(
-      evalBrowserReplSessionCode({
-        code: `
-const project = { stats: { total: 42 } }
-project.stats
-?.total
-`.trim(),
-        itx: {},
-        scope: {},
-      }),
-    ).resolves.toBe(42);
-
-    await expect(
-      evalBrowserReplSessionCode({
-        code: `
-true
-? 42
-: 0
-`.trim(),
-        itx: {},
-        scope: {},
-      }),
-    ).resolves.toBe(42);
-  });
-
-  test("session snippets do not rewrite do-while statements as expressions", async () => {
-    const scope: Record<string, unknown> = {};
-
-    await expect(
-      evalBrowserReplSessionCode({
-        code: `
-let count = 0
-do {
-  count += 1
-} while (false)
-count
-`.trim(),
-        itx: {},
-        scope,
-      }),
-    ).resolves.toBe(1);
-
-    expect(scope.count).toBe(1);
-  });
-
-  test("snippet ending in a line comment still returns its last value", async () => {
-    // Regression: the appended `; return __replLastValue` used to land on the
-    // same line as a trailing comment and get swallowed → "Unexpected end of
-    // input". A trailing comment is natural in our documented examples.
-    await expect(
-      evalBrowserReplSessionCode({
-        code: "const a = 41;\na + 1   // the answer",
-        itx: {},
-        scope: {},
-      }),
-    ).resolves.toBe(42);
-  });
-
-  test("session snippets persist function and class declarations", async () => {
-    const scope: Record<string, unknown> = {};
-
-    const answerResult = await evalBrowserReplSessionCode({
-      code: "function answer() { return 42; }",
-      itx: {},
-      scope,
-    });
-    expect(answerResult).toBe(scope.answer);
-    expect(answerResult).toEqual(expect.any(Function));
-
-    await expect(
-      evalBrowserReplSessionCode({
-        code: "answer()",
-        itx: {},
-        scope,
-      }),
-    ).resolves.toBe(42);
-
-    const boxResult = await evalBrowserReplSessionCode({
-      code: "class Box { value() { return answer(); } }",
-      itx: {},
-      scope,
-    });
-    expect(boxResult).toBe(scope.Box);
-    expect(boxResult).toEqual(expect.any(Function));
-
-    await expect(
-      evalBrowserReplSessionCode({
-        code: "new Box().value()",
-        itx: {},
-        scope,
-      }),
-    ).resolves.toBe(42);
-
-    const asyncAnswerResult = await evalBrowserReplSessionCode({
-      code: "async function asyncAnswer() { return answer(); }",
-      itx: {},
-      scope,
-    });
-    expect(asyncAnswerResult).toBe(scope.asyncAnswer);
-    expect(asyncAnswerResult).toEqual(expect.any(Function));
-
-    await expect(
-      evalBrowserReplSessionCode({
-        code: "await asyncAnswer()",
-        itx: {},
-        scope,
-      }),
-    ).resolves.toBe(42);
-  });
-
-  test("session snippets do not rewrite nested local declarations", async () => {
-    const scope: Record<string, unknown> = {};
-
-    await expect(
-      evalBrowserReplSessionCode({
-        code: `
-function answer() {
-  const nested = 42;
-  return nested;
-}
-if (answer() !== 42) throw new Error("nested local declaration broke");
-const persisted = answer();
-`.trim(),
-        itx: {},
-        scope,
-      }),
-    ).resolves.toBe(42);
-
-    expect(scope).toHaveProperty("answer");
-    expect(scope).toHaveProperty("persisted", 42);
-    expect(scope).not.toHaveProperty("nested");
+    for (const [key, value] of Object.entries(expectedScope ?? {})) {
+      expect(scope[key]).toEqual(value);
+    }
+    for (const key of scopeHas ?? []) {
+      expect(scope).toHaveProperty(key);
+    }
+    for (const key of scopeMissing ?? []) {
+      expect(scope).not.toHaveProperty(key);
+    }
   });
 
   test("session snippets cannot shadow injected itx binding", async () => {
@@ -433,79 +331,78 @@ const persisted = answer();
     }
   });
 
-  test("snippets ending in a top-level return produce that value", async () => {
-    const scope: Record<string, unknown> = {};
-
-    await expect(
-      evalBrowserReplSessionCode({
-        code: "const stream = { offset: 41 }\nreturn stream.offset + 1",
-        itx: {},
-        scope,
-      }),
-    ).resolves.toBe(42);
-    expect(scope.stream).toEqual({ offset: 41 });
-  });
-
-  test("top-level imports rewrite to awaited esm.sh dynamic imports", () => {
-    expect(rewriteBrowserReplImports('import { z } from "zod";\nreturn z')).toBe(
-      'const __replModule1 = await import("https://esm.sh/zod");\n' +
+  test.for([
+    {
+      name: "rewrites a named import to an awaited esm.sh dynamic import",
+      code: 'import { z } from "zod";\nreturn z',
+      expected:
+        'const __replModule1 = await import("https://esm.sh/zod");\n' +
         "const z = __replModule1.z;\nreturn z",
-    );
-
-    expect(rewriteBrowserReplImports('import dayjs from "dayjs"')).toBe(
-      'const __replModule1 = await import("https://esm.sh/dayjs");\n' +
+    },
+    {
+      name: "rewrites a default import",
+      code: 'import dayjs from "dayjs"',
+      expected:
+        'const __replModule1 = await import("https://esm.sh/dayjs");\n' +
         "const dayjs = __replModule1.default;",
-    );
-
-    expect(rewriteBrowserReplImports('import lodash, { chunk as c } from "lodash-es@4"')).toBe(
-      'const __replModule1 = await import("https://esm.sh/lodash-es@4");\n' +
+    },
+    {
+      name: "rewrites a versioned default-plus-aliased-named import",
+      code: 'import lodash, { chunk as c } from "lodash-es@4"',
+      expected:
+        'const __replModule1 = await import("https://esm.sh/lodash-es@4");\n' +
         "const lodash = __replModule1.default;\n" +
         "const c = __replModule1.chunk;",
-    );
-
-    expect(rewriteBrowserReplImports('import * as R from "remeda"')).toBe(
-      'const __replModule1 = await import("https://esm.sh/remeda");\nconst R = __replModule1;',
-    );
-
-    expect(rewriteBrowserReplImports('import "side-effect-pkg"')).toBe(
-      'await import("https://esm.sh/side-effect-pkg")',
-    );
-
-    // Full URLs load as-is; type-only imports disappear.
-    expect(rewriteBrowserReplImports('import { x } from "https://example.com/mod.js"')).toBe(
-      'const __replModule1 = await import("https://example.com/mod.js");\nconst x = __replModule1.x;',
-    );
-    expect(rewriteBrowserReplImports('import type { Foo } from "zod"')).toBe("");
-  });
-
-  test("relative, scheme'd, and template-literal imports are left untouched", () => {
-    for (const untouched of [
-      'import { x } from "./local.ts"',
-      'import fs from "node:fs"',
-      'import { WorkerEntrypoint } from "cloudflare:workers"',
-      'const source = `\n  import { WorkerEntrypoint } from "cloudflare:workers";\n`;',
-      "await import(moduleName)",
-    ]) {
-      expect(rewriteBrowserReplImports(untouched)).toBe(untouched);
-    }
-  });
-
-  test("imported bindings persist across session snippets", async () => {
-    const scope: Record<string, unknown> = {};
-
-    // A stand-in for the esm.sh module: a data: URL is scheme'd, so the
-    // import statement itself is untouched — instead prove the REWRITTEN
-    // shape (`const x = …`) persists like any other top-level declaration.
-    await expect(
-      evalBrowserReplSessionCode({
-        code: 'const __replModule1 = { z: { kind: "schema" } };\nconst z = __replModule1.z;',
-        itx: {},
-        scope,
-      }),
-    ).resolves.toEqual({ kind: "schema" });
-
-    await expect(evalBrowserReplSessionCode({ code: "z.kind", itx: {}, scope })).resolves.toBe(
-      "schema",
-    );
+    },
+    {
+      name: "rewrites a namespace import",
+      code: 'import * as R from "remeda"',
+      expected:
+        'const __replModule1 = await import("https://esm.sh/remeda");\nconst R = __replModule1;',
+    },
+    {
+      name: "rewrites a side-effect import",
+      code: 'import "side-effect-pkg"',
+      expected: 'await import("https://esm.sh/side-effect-pkg")',
+    },
+    {
+      // Full URLs load as-is; type-only imports disappear.
+      name: "loads full-URL imports as-is",
+      code: 'import { x } from "https://example.com/mod.js"',
+      expected:
+        'const __replModule1 = await import("https://example.com/mod.js");\nconst x = __replModule1.x;',
+    },
+    {
+      name: "erases type-only imports",
+      code: 'import type { Foo } from "zod"',
+      expected: "",
+    },
+    {
+      name: "leaves relative imports untouched",
+      code: 'import { x } from "./local.ts"',
+      expected: 'import { x } from "./local.ts"',
+    },
+    {
+      name: "leaves node: scheme'd imports untouched",
+      code: 'import fs from "node:fs"',
+      expected: 'import fs from "node:fs"',
+    },
+    {
+      name: "leaves cloudflare: scheme'd imports untouched",
+      code: 'import { WorkerEntrypoint } from "cloudflare:workers"',
+      expected: 'import { WorkerEntrypoint } from "cloudflare:workers"',
+    },
+    {
+      name: "leaves import statements inside template literals untouched",
+      code: 'const source = `\n  import { WorkerEntrypoint } from "cloudflare:workers";\n`;',
+      expected: 'const source = `\n  import { WorkerEntrypoint } from "cloudflare:workers";\n`;',
+    },
+    {
+      name: "leaves dynamic imports untouched",
+      code: "await import(moduleName)",
+      expected: "await import(moduleName)",
+    },
+  ])("$name", ({ code, expected }) => {
+    expect(rewriteBrowserReplImports(code)).toBe(expected);
   });
 });


### PR DESCRIPTION
Second (final) round of the table-based unit-test conversion campaign, continuing #2012's style on the files it listed as "not reached in this PR": `test.for` with object rows and `$name` titles, hand-written expected literals, no assertion weakening, case counts preserved or increased, bespoke bodies only where a table would obscure. Uses #2012's shared helpers (`makeProcessorHarness`/`eventsOfType`) where applicable.

## Per-file before → after

| File | LOC | Cases | What tabled |
|---|---|---|---|
| `apps/os/src/itx/browser-repl.test.ts` | 511 → 408 | 21 → 33 | Sessions as typed step-tables (`declares` steps keep the function/class identity checks), 9-row final-expression table, 12-row import-rewrite table (the untouched-loop's 5 inputs became named rows with the expected string written out) |
| `apps/os/src/domains/projects/custom-domains.test.ts` | 430 → 437 | 11 → 12 | 3-row refresh/heal/stale-id table (shared pre-refresh null-routing check now covers all rows), 4-row ownership/removal act-table — the combined adopt+remove test split into per-op rows; the stale-delete row newly pins `deletedIds: ["stale-id"]` (attempted, 404 swallowed — verified in `remove()`); MemoryKv/fetch-mock builders folded under a `setup()` below the tests |
| `apps/os/src/components/repo-ide/repo-tasks.test.ts` | 290 → 381 | 21 → 34 | 8-row `parseRepoTask` table where every row pins the COMPLETE projection via `toEqual` (old tests asserted field subsets), 6-row exact-output mutation table (toContain walls → whole-string equality, outputs probe-verified), `isRepoTaskPath` + `repoTaskWithPath` permutation tables |
| `apps/os/src/components/repo-ide/repo-json-schema.test.ts` | 247 → 347 | 21 → 39 | 23-row schema-URL resolution table (language+path+content → url\|null; the `resolveJson/Jsonc/Yaml` wrappers died), 8-row `repoFileKind` table, 3-row squiggle-position table across the json/yaml/jsonc linter lanes |
| `apps/os/src/domains/integrations/slack-api.test.ts` | 170 → 205 | 9 → 9 | 5-row deployment-token recovery table — shared body pins the FULL egress + deployment URL lists per row and asserts both auth-header invariants on EVERY recorded request (placeholder never leaves; deployment credential on every fallback call); 4-row `normalizeSlackError` table |
| `apps/os/src/domains/integrations/github-api.test.ts` | 158 → 158 | 10 → 10 | 4-row `normalizeGithubError` table |
| `apps/os/src/domains/integrations/telegram-webhook.test.ts` | 199 → 226 | 8 → 11 | 10-row door-contract table (auth failures, ACK-drops, three not-mine paths) with exact `toEqual` response bodies incl. the 401 bodies the old tests never checked |
| `apps/os/src/domains/integrations/integration-webhook-api.test.ts` | 181 → 200 | 8 → 8 | 5-row github + 2-row slack tables; status-only/`toMatchObject` body asserts became exact `toEqual` bodies (pinned from the handlers); routed-call asserts keep their exact leaf equalities via one nested `toMatchObject` |
| `apps/os/src/domains/integrations/oauth-state.test.ts` | 105 → 127 | 5 → 10 | 4-row verify-rejection table whose shared body proves the fixture state is live for every row (previously a one-test sanity), 4-row `verifySlackSignature` tamper-table; `it` → `test` |
| `apps/os/src/domains/typecheck/virtual-project.test.ts` | 777 → 841 | 34 → 54 | The execution-gate cluster: 13 tests (many with internal loops) → one 33-row code→verdict table over the shared `gate()`, policy comments riding the rows; provide-time suite untouched |
| `apps/os/src/domains/repos/repo-task-events-processor.test.ts` | 292 → 274 | 6 → 6 | Preamble migrated onto `makeProcessorHarness` (epoch clock kept via `now: () => 0`), refolds via `deliver(refolded)`, journal scans via `eventsOfType`; bodies unchanged in strength |

Totals across the 11 files: **154 → 226 cases**. Full os suite: **1520 passed, 1 skipped** (155 files).

Support-file consequence: the migration removed the last importer of `github-agent-test-helpers.ts`'s epoch-pinned `MemoryStreamNetwork` subclass and its `deliverNewEvents` re-export, so knip forced their deletion (93 → 82 LOC); the epoch-clock rationale that two repo suites' comments point at moved into the helper's header comment.

## Declined to convert (and why)

- **github-api `connectionOctokit` transport cluster** — each of the five tests asserts a different contract (graphql body JSON + variables, paginate array equality, 5xx no-replay request count, per-endpoint paths); a uniform row schema would be per-row assertion closures, i.e. bespoke bodies wearing a table costume.
- **virtual-project compiler-crash / unreachable-hanging-checker / nesting-bailout / emitted-JS arms** — kept bespoke per the brief: poisoned checkers, bail-reason strings, and emit inspection don't fit a verdict column.
- **telegram-webhook dedupe test** — an order-dependent three-delivery sequence against one journal; a steps column would obscure it.
- **custom-domains create-wildcard / this-binding / apex-overlap** — one-of-a-kind assertion sets (createdBodies wall, `this`-binding fetch wrapper, Cloudflare-never-dialed guard).
- **browser-repl Cap'n Web pipelining / runner / console / examples tests** — bespoke mechanics (RpcTarget classes, spies, the examples invariant loop).
- Per the brief, untouched: agent-processors busy/idle cluster, iterate-auth-login refresh matrix, preview.ts deploy-selection describe, workers-ai-transport BYOK cluster, `apps/os/e2e/**`, `lint/**`, `itx/examples*`, agent-prompt-budgets, `tasks/testing-strategy.md`, stream-repros.

## Notes for review

- Strengthenings (never the reverse): full-projection `toEqual` rows in repo-tasks, exact webhook response bodies, exact egress/deployment URL lists + header invariants in slack-api, the pre-refresh null-routing check applied to all refresh rows, the stale-delete `deletedIds` pin, and the always-live oauth-state fixture sanity.
- Where an original asserted against an SUT constant (`SLACK_CALL_GRAMMAR`, `GITHUB_CALL_GRAMMAR`), the rows keep the constant reference — pinning the grammar copy verbatim would be the prompt-pinning #2012 cut.

## Verification

- `pnpm exec oxlint . --threads 1 --deny-warnings` — 0 warnings, 0 errors
- `pnpm typecheck` — all packages green
- `pnpm knip` — clean (after the orphaned-export cleanup above)
- `doppler run -- pnpm --dir apps/os test` — 1520 passed, 1 skipped
- `pnpm format` — no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with stronger assertions; no runtime or integration behavior changes in application code.
> 
> **Overview**
> Continues the table-based unit test campaign by refactoring **11** `apps/os` test files from many standalone `test()` blocks into **`vitest` `test.for`** tables with named object rows and `$name` titles. Coverage is preserved or expanded (**154 → 226** cases) while tightening several assertions (full `toEqual` projections, exact webhook JSON bodies, pinned URL/header lists).
> 
> **Repo IDE & tasks:** `repo-json-schema.test.ts` tables schema URL resolution, linter squiggle positions, and `repoFileKind`; `repo-tasks.test.ts` tables path recognition, full `parseRepoTask` projections, and frontmatter mutation exact strings.
> 
> **Integrations:** GitHub/Slack/Telegram webhook and API tests table error normalization, Slack token recovery lanes, and webhook door contracts (auth, ACK-drop, routing). `integration-webhook-api` and `oauth-state` gain shared rejection/tamper rows.
> 
> **Other:** `custom-domains.test.ts` tables refresh/ownership/removal scenarios with a shared `setup()`; `virtual-project.test.ts` collapses execution-gate cases into one large code→verdict table; `browser-repl.test.ts` tables session steps and import rewriting; `repo-task-events-processor.test.ts` uses shared `makeProcessorHarness` / `eventsOfType`. Orphaned `github-agent-test-helpers` exports (`MemoryStreamNetwork` subclass, `deliverNewEvents`) are removed after migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa1f3c542602042b306ab8f45da9085b27889e19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +5 -15 | +1 -7 🟥⬜⬜⬜⬜ |
| Tests | +1,713 -1,469 | +1,587 -1,266 🟩🟩🟩🟥🟥 |
| **Total** | **+1,718 -1,484** | **+1,588 -1,273** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 9a415a8 and aa1f3c5, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-15T15:17:05.185Z",
      "headSha": "aa1f3c542602042b306ab8f45da9085b27889e19",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/10524599576663",
      "shortSha": "aa1f3c5",
      "cleanupDurationMs": 2115,
      "deployDurationMs": 26104,
      "testDurationMs": 227,
      "testRetries": null,
      "workerSizeKib": 4030.87,
      "workerGzipKib": 819.73,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-15T15:17:03.788Z",
      "headSha": "aa1f3c542602042b306ab8f45da9085b27889e19",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/10524599576663",
      "shortSha": "aa1f3c5",
      "cleanupDurationMs": 717,
      "deployDurationMs": 22286,
      "testDurationMs": 17974,
      "testRetries": null,
      "workerSizeKib": 5139.6,
      "workerGzipKib": 1466.03,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-15T15:17:03.791Z",
      "headSha": "aa1f3c542602042b306ab8f45da9085b27889e19",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/10524599576663",
      "shortSha": "aa1f3c5",
      "cleanupDurationMs": 718,
      "deployDurationMs": 6640,
      "testDurationMs": 7816,
      "testRetries": null,
      "workerSizeKib": 1139,
      "workerGzipKib": 201.58,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-15T15:17:01.908Z",
      "headSha": "aa1f3c542602042b306ab8f45da9085b27889e19",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/10524599576663",
      "shortSha": "aa1f3c5",
      "cleanupDurationMs": 74684,
      "deployDurationMs": 88152,
      "testDurationMs": 376599,
      "testRetries": "11 retried: catalogue example \"repo-commit-files\" runs identically across runtimes (vitest x1) · catalogue example \"repo-edit-file\" runs identically across runtimes (vitest x1) · agent answers after llm model is selected (vitest x1) · Agent-only dynamic worker and durable object capabilities run from LLM scripts (vitest x1) · Project worker processEventBatch receives events from every project stream and can cross-post (vitest x1) · Project describe exposes self-describing builtin capabilities (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · ephemeral subscriptions cannot reuse a configured subscription key (vitest x1) · reactivity page appends a batch and renders every delivered marker (specs x1) · runs \"dynamic-worker-stateful\" through the project REPL (specs x1) · the seeded hello and counter apps work after creating a project (specs x1)",
      "workerSizeKib": 16398.11,
      "workerGzipKib": 4425.84,
      "mainWorkerGzipKib": 4429.07
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-15T15:15:47.849Z",
      "headSha": "aa1f3c542602042b306ab8f45da9085b27889e19",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/10524599576663",
      "shortSha": "aa1f3c5",
      "cleanupDurationMs": 620,
      "deployDurationMs": 16407,
      "testDurationMs": 5430,
      "testRetries": null,
      "workerSizeKib": 1914.73,
      "workerGzipKib": 440.76,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `aa1f3c5` | [https://auth.iterate-preview-9.com](https://auth.iterate-preview-9.com) | 819.7 KiB | 26.1s | 227ms |  | 2.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/10524599576663) | 2026-07-15T15:17:05.185Z | Preview app released. |
| Dummy Petshop | released | `aa1f3c5` | [https://dummy-petshop.iterate-preview-9.com](https://dummy-petshop.iterate-preview-9.com) | 201.6 KiB | 6.6s | 7.8s |  | 718ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/10524599576663) | 2026-07-15T15:17:03.791Z | Preview app released. |
| OS | released | `aa1f3c5` | [https://os.iterate-preview-9.com](https://os.iterate-preview-9.com) | 4.32 MiB (-3.2 KiB vs main) | 88.2s | 376.6s | 11 retried: catalogue example "repo-commit-files" runs identically across runtimes (vitest x1) · catalogue example "repo-edit-file" runs identically across runtimes (vitest x1) · agent answers after llm model is selected (vitest x1) · Agent-only dynamic worker and durable object capabilities run from LLM scripts (vitest x1) · Project worker processEventBatch receives events from every project stream and can cross-post (vitest x1) · Project describe exposes self-describing builtin capabilities (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · ephemeral subscriptions cannot reuse a configured subscription key (vitest x1) · reactivity page appends a batch and renders every delivered marker (specs x1) · runs "dynamic-worker-stateful" through the project REPL (specs x1) · the seeded hello and counter apps work after creating a project (specs x1) | 74.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/10524599576663) | 2026-07-15T15:17:01.908Z | Preview app released. |
| Semaphore | released | `aa1f3c5` | [https://semaphore.iterate-preview-9.com](https://semaphore.iterate-preview-9.com) | 440.8 KiB | 16.4s | 5.4s |  | 620ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/10524599576663) | 2026-07-15T15:15:47.849Z | Preview app released. |
| Streams Example App | released | `aa1f3c5` | [https://streams.iterate-preview-9.com](https://streams.iterate-preview-9.com) | 1.43 MiB | 22.3s | 18.0s |  | 717ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/10524599576663) | 2026-07-15T15:17:03.788Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->