### PR TITLE
Make stream recovery exports resumable

### DIFF
--- a/.agents/skills/recreate-production/SKILL.md
+++ b/.agents/skills/recreate-production/SKILL.md
@@ -34,11 +34,13 @@ consequential forks unless they explicitly waive consultation.
    `session.streamRecovery.get({ projectId, path }).exportForRecovery()` read-only
    through `pnpm cli itx run` in production.
    A breaking PR cannot introduce and use this plumbing in the same deployment.
-3. Create a temporary itx script rather than adding a permanent orchestrator. For
-   each selected project, inventory secrets, built-in integrations, and the config
-   repo. Export the root, every listed `/secrets/**` stream, every built-in connection
-   stream, and the global integration directory. Page with a fixed `throughOffset`;
-   save `{format, version, stream, events, highestAssignedOffset: throughOffset}`.
+3. For each selected project, inventory secrets, built-in integrations, and the
+   config repo. Export the root, every listed `/secrets/**` stream, every built-in
+   connection stream, and the global integration directory with
+   [`scripts/export-stream-recovery.itx.js`](scripts/export-stream-recovery.itx.js).
+   Its single acknowledged export RPC writes byte-bounded pages atomically at a
+   fixed `throughOffset` and resumes an interrupted output directory. Never combine
+   a large raw journal into one RPC value.
 4. Reduce the package deliberately: keep bootstrap facts in `/`, secret journals
    intact, current integration lifecycle/subscription facts, and only active global
    claims for retained project IDs. Do not renumber events: encrypted secret material
@@ -67,8 +69,9 @@ consequential forks unless they explicitly waive consultation.
 ## Finish only after proof
 
 Verify project IDs/routing, every secret through a harmless real consumer, every
-integration's connected status and external ID, active directory claims, Slack
-webhook delivery, an authenticated GitHub request, equal local/remote config heads,
+integration's connected status and external ID, active directory claims,
+[Slack webhook delivery](../../../docs/slack-testing.md#post-recreation-proof), the
+complete [GitHub production smoke](../../../docs/github-smoke-testing.md),
 project-worker boot, and AI Search reindexing. Add PR-specific checks for whatever
 changed. Do not trigger externally visible provider actions without approval.
 

--- a/.agents/skills/recreate-production/scripts/export-stream-recovery.itx.js
+++ b/.agents/skills/recreate-production/scripts/export-stream-recovery.itx.js
@@ -1,0 +1,127 @@
+// Run from apps/os with `pnpm cli itx run --file ... --vars ...`.
+// The itx CLI evaluates this body locally, so the RpcTarget below persists
+// each server-pushed page before acknowledging it.
+
+const fs = process.getBuiltinModule("node:fs");
+const pathModule = process.getBuiltinModule("node:path");
+
+const outputDir = String(vars.outputDir ?? "").trim();
+const streamPath = String(vars.path ?? "").trim();
+const projectId = vars.projectId;
+const limit = Number(vars.limit ?? 500);
+
+if (!outputDir) throw new Error("vars.outputDir is required");
+if (!streamPath.startsWith("/")) throw new Error("vars.path must be an absolute stream path");
+if (projectId !== null && (typeof projectId !== "string" || !projectId.trim())) {
+  throw new Error("vars.projectId must be a project ID or null");
+}
+if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
+  throw new Error("vars.limit must be an integer from 1 to 500");
+}
+
+fs.mkdirSync(outputDir, { recursive: true, mode: 0o700 });
+fs.chmodSync(outputDir, 0o700);
+
+const pageNamePattern = /^\d{8}\.json$/;
+const pageFiles = fs
+  .readdirSync(outputDir)
+  .filter((name) => pageNamePattern.test(name))
+  .sort();
+let throughOffset;
+let previousOffset = 0;
+let totalEventCount = 0;
+let alreadyComplete = false;
+
+function validatePage(page, name) {
+  if (page?.format !== "iterate-stream-recovery" || page?.version !== 1) {
+    throw new Error(`${name} is not an Iterate stream recovery page`);
+  }
+  if (page.stream?.projectId !== projectId || page.stream?.path !== streamPath) {
+    throw new Error(`${name} belongs to a different stream`);
+  }
+  if (!Number.isInteger(page.throughOffset) || page.throughOffset < 0) {
+    throw new Error(`${name} has an invalid throughOffset`);
+  }
+  if (throughOffset === undefined) throughOffset = page.throughOffset;
+  if (page.throughOffset !== throughOffset) {
+    throw new Error(`${name} changed the fixed throughOffset`);
+  }
+  if (!Array.isArray(page.events)) throw new Error(`${name} has no events array`);
+  for (const event of page.events) {
+    if (!Number.isInteger(event?.offset) || event.offset <= previousOffset) {
+      throw new Error(`${name} has a non-increasing event offset`);
+    }
+    previousOffset = event.offset;
+  }
+  totalEventCount += page.events.length;
+}
+
+for (const [index, name] of pageFiles.entries()) {
+  const page = JSON.parse(fs.readFileSync(pathModule.join(outputDir, name), "utf8"));
+  validatePage(page, name);
+  if (page.complete && index !== pageFiles.length - 1) {
+    throw new Error(`${name} is complete but later pages exist`);
+  }
+  if (!page.complete && page.events.length === 0) {
+    throw new Error(`${name} is an empty incomplete page`);
+  }
+  alreadyComplete = page.complete;
+}
+
+if (alreadyComplete) {
+  return {
+    outputDir,
+    stream: { projectId, path: streamPath },
+    throughOffset,
+    pageCount: pageFiles.length,
+    eventCount: totalEventCount,
+    resumed: true,
+    alreadyComplete: true,
+  };
+}
+
+let nextPageNumber = pageFiles.length + 1;
+class RecoveryPageSink extends RpcTarget {
+  async write(page) {
+    const name = `${String(nextPageNumber).padStart(8, "0")}.json`;
+    validatePage(page, name);
+    const finalPath = pathModule.join(outputDir, name);
+    const temporaryPath = `${finalPath}.${process.pid}.${crypto.randomUUID()}.tmp`;
+    const fd = fs.openSync(temporaryPath, "wx", 0o600);
+    try {
+      fs.writeFileSync(fd, `${JSON.stringify(page)}\n`);
+      fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+    fs.renameSync(temporaryPath, finalPath);
+    fs.chmodSync(finalPath, 0o600);
+    nextPageNumber += 1;
+  }
+}
+
+const sink = new RecoveryPageSink();
+const recovery = itx.streamRecovery.get({ projectId, path: streamPath });
+try {
+  const result = await recovery.exportToRecovery({
+    sink,
+    afterOffset: previousOffset,
+    limit,
+    ...(throughOffset === undefined ? {} : { throughOffset }),
+  });
+  if (throughOffset !== result.throughOffset) {
+    throw new Error("export result did not match the persisted throughOffset");
+  }
+  return {
+    outputDir,
+    stream: result.stream,
+    throughOffset: result.throughOffset,
+    pageCount: nextPageNumber - 1,
+    eventCount: totalEventCount,
+    resumed: pageFiles.length > 0,
+    alreadyComplete: false,
+  };
+} finally {
+  recovery[Symbol.dispose]?.();
+  sink[Symbol.dispose]?.();
+}

--- a/.agents/skills/recreate-production/scripts/export-stream-recovery.itx.js
+++ b/.agents/skills/recreate-production/scripts/export-stream-recovery.itx.js
@@ -22,10 +22,9 @@ if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
 fs.mkdirSync(outputDir, { recursive: true, mode: 0o700 });
 fs.chmodSync(outputDir, 0o700);
 
-const pageNamePattern = /^\d{8}\.json$/;
 const pageFiles = fs
   .readdirSync(outputDir)
-  .filter((name) => pageNamePattern.test(name))
+  .filter((name) => /^\d{8}\.json$/.test(name))
   .sort();
 let throughOffset;
 let previousOffset = 0;

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ from your machine, and when you need a public callback URL. Doppler/Cloudflare/d
 - [TypeScript conventions](docs/typescript-conventions.md)
 - [Design system & React](docs/design-system.md)
 - [Slack testing](docs/slack-testing.md) — real Slack flows; **`SLACK_CI_BOT_TOKEN` trigger actor**; channel membership (`#slack-agent-e2e-test`); preview setup; duplicate-bot caveats
+- [GitHub production smoke testing](docs/github-smoke-testing.md) — post-recreation config sync, authenticated requests, and webhook routing
 - [Slack preview OAuth clients](docs/slack-preview-oauth-clients.md) — bulk-create preview Slack apps and collect Doppler secrets
 - [Slack bot token migration](docs/slack-bot-token-migration.md) — per-app bot token fallback links and Doppler shape
 - [Testing](docs/testing.md) — test lanes, how to run them against any environment, the canonical env vars, and the retry/timeout policy (one retry layer, fail-fast watchdogs, retry telemetry)

--- a/apps/os/e2e/vitest/stream-recovery.e2e.test.ts
+++ b/apps/os/e2e/vitest/stream-recovery.e2e.test.ts
@@ -1,3 +1,4 @@
+import { RpcTarget } from "capnweb";
 import { expect, test } from "vitest";
 import { adminSecret, withItxSession } from "./test-helpers.ts";
 
@@ -32,4 +33,40 @@ test("recovery rejects incompatible core events before replacing the live stream
   await expect(
     stream.append({ type: "events.iterate.test/recovery-still-live", payload: {} }),
   ).resolves.toHaveLength(1);
+});
+
+test("recovery streams byte-bounded pages through one acknowledged export", async () => {
+  const path = `/recovery-streamed-${crypto.randomUUID()}`;
+  using transport = withItxSession();
+  using session = transport.authenticate({ type: "admin-secret", secret: adminSecret() });
+  using stream = session.streams.get(path);
+  using recovery = session.streamRecovery.get({ projectId: null, path });
+
+  const [firstLarge, secondLarge] = await stream.append(
+    { type: "events.iterate.test/recovery-large", payload: { value: "a".repeat(600_000) } },
+    { type: "events.iterate.test/recovery-large", payload: { value: "b".repeat(600_000) } },
+  );
+  const firstPage = await recovery.exportForRecovery({ limit: 500 });
+  expect(firstPage).toMatchObject({ complete: false });
+  expect(firstPage.events.some((event) => event.offset === firstLarge?.offset)).toBe(true);
+  expect(firstPage.events.some((event) => event.offset === secondLarge?.offset)).toBe(false);
+
+  const pages: (typeof firstPage)[] = [];
+  const sink = new (class extends RpcTarget {
+    async write(page: typeof firstPage) {
+      pages.push(page);
+    }
+  })();
+  const summary = await recovery.exportToRecovery({ sink, limit: 500 });
+
+  expect(pages.length).toBeGreaterThan(1);
+  expect(pages.at(-1)?.complete).toBe(true);
+  expect(pages.flatMap((page) => page.events).map((event) => event.offset)).toContain(
+    secondLarge?.offset,
+  );
+  expect(summary).toMatchObject({
+    exportedEventCount: pages.reduce((count, page) => count + page.events.length, 0),
+    pageCount: pages.length,
+    throughOffset: pages[0]?.throughOffset,
+  });
 });

--- a/apps/os/src/domains/streams/recovery.ts
+++ b/apps/os/src/domains/streams/recovery.ts
@@ -11,7 +11,7 @@ const StreamRecoveryCoordinate = z
   })
   .strict();
 
-/** One bounded page from the storage-level recovery export of a stream. */
+/** One byte- and count-bounded page from the storage-level recovery export of a stream. */
 export const StreamRecoveryExportPage = z
   .object({
     format: z.literal(STREAM_RECOVERY_FORMAT),
@@ -39,6 +39,22 @@ export const StreamRecoveryRestoreInput = z
 
 /** One bounded page of a stream's storage-level recovery export. */
 export type StreamRecoveryExportPage = z.infer<typeof StreamRecoveryExportPage>;
+
+/** Acknowledged page sink used by one long-running recovery export RPC. */
+export type StreamRecoveryExportSink = {
+  write(page: StreamRecoveryExportPage): Promise<void>;
+};
+
+/** Small result returned after every exported page has been acknowledged. */
+export type StreamRecoveryExportSummary = {
+  format: "iterate-stream-recovery";
+  version: 1;
+  stream: { projectId: string | null; path: string };
+  throughOffset: number;
+  exportedEventCount: number;
+  pageCount: number;
+};
+
 /** A complete normalized stream log accepted by storage-level recovery restore. */
 export type StreamRecoveryRestoreInput = z.infer<typeof StreamRecoveryRestoreInput>;
 

--- a/apps/os/src/domains/streams/stream-durable-object.ts
+++ b/apps/os/src/domains/streams/stream-durable-object.ts
@@ -19,6 +19,8 @@ import {
   STREAM_RECOVERY_VERSION,
   StreamRecoveryRestoreInput as StreamRecoveryRestoreInputSchema,
   type StreamRecoveryExportPage,
+  type StreamRecoveryExportSink,
+  type StreamRecoveryExportSummary,
   type StreamRecoveryRestoreInput,
 } from "./recovery.ts";
 import { compileEventSelector } from "./event-selector.ts";
@@ -44,6 +46,8 @@ import {
 
 const DEFAULT_GET_EVENTS_LIMIT = 500;
 const MAX_GET_EVENTS_LIMIT = 500;
+/** Keep recovery callback frames far below Cap'n Web's 32 MiB value limit. */
+const RECOVERY_EXPORT_PAGE_BYTE_LIMIT = 1024 * 1024;
 
 /**
  * The subscription key of the birth-certificate worker feed every
@@ -411,19 +415,82 @@ export class StreamDurableObject extends DurableObject<Env> {
         `recovery export throughOffset must be an integer from 0 to ${currentHighestAssignedOffset}`,
       );
     }
-    const events = this.#log.getRange({
+    const sizes = this.#log.getRangeSizes({
       afterOffset,
       beforeOffset: throughOffset + 1,
       limit,
       includeEphemeral: true,
     });
+    let pageLength = sizes.length;
+    let pageBytes = 0;
+    for (let index = 0; index < sizes.length; index += 1) {
+      pageBytes += sizes[index]!.byteLength;
+      // A single event may exceed the soft cap, but is still the smallest
+      // possible recovery unit. Ordinary stream events are already RPC-sized.
+      if (pageBytes > RECOVERY_EXPORT_PAGE_BYTE_LIMIT && index > 0) {
+        pageLength = index;
+        break;
+      }
+    }
+    const events = this.#log.getRange({
+      afterOffset,
+      beforeOffset: throughOffset + 1,
+      limit: pageLength,
+      includeEphemeral: true,
+    });
+    const truncatedByBytes = pageLength < sizes.length;
     return {
       format: STREAM_RECOVERY_FORMAT,
       version: STREAM_RECOVERY_VERSION,
       stream: { projectId: this.name.projectId, path: this.name.path },
       events,
       throughOffset,
-      complete: events.length < limit || events.at(-1)?.offset === throughOffset,
+      complete:
+        !truncatedByBytes && (sizes.length < limit || events.at(-1)?.offset === throughOffset),
+    };
+  }
+
+  /**
+   * Export a fixed recovery window through one acknowledged callback session.
+   * The caller can persist each bounded page before resolving `write`; a
+   * failed session resumes with the same throughOffset and last written
+   * event offset without ever assembling the stream in an RPC value.
+   */
+  async exportToRecovery(args: {
+    sink: StreamRecoveryExportSink;
+    afterOffset?: number;
+    limit?: number;
+    throughOffset?: number;
+  }): Promise<StreamRecoveryExportSummary> {
+    const throughOffset = args.throughOffset ?? this.#log.highestAssignedOffset();
+    let afterOffset = args.afterOffset ?? 0;
+    let exportedEventCount = 0;
+    let pageCount = 0;
+
+    for (;;) {
+      const page = this.exportForRecovery({
+        afterOffset,
+        limit: args.limit,
+        throughOffset,
+      });
+      await args.sink.write(page);
+      pageCount += 1;
+      exportedEventCount += page.events.length;
+      if (page.complete) break;
+      const nextOffset = page.events.at(-1)?.offset;
+      if (nextOffset === undefined || nextOffset <= afterOffset) {
+        throw new Error("recovery export produced an empty or non-advancing incomplete page");
+      }
+      afterOffset = nextOffset;
+    }
+
+    return {
+      format: STREAM_RECOVERY_FORMAT,
+      version: STREAM_RECOVERY_VERSION,
+      stream: { projectId: this.name.projectId, path: this.name.path },
+      throughOffset,
+      exportedEventCount,
+      pageCount,
     };
   }
 

--- a/apps/os/src/domains/streams/stream-storage.test.ts
+++ b/apps/os/src/domains/streams/stream-storage.test.ts
@@ -95,7 +95,7 @@ describe("StreamEventLog.getRange", () => {
     expect(read(log, { afterOffset: 0, eventTypes: [], limit: 3 })).toEqual([]);
   });
 
-  it("insert reports serialized byte lengths and getRangeSized reads the same sizes back", () => {
+  it("insert and range metadata report the stored serialized byte lengths", () => {
     const log = new StreamEventLog(wrapSqlStorage(new DatabaseSync(":memory:")), "/tests/stream");
     const committedEvents = [
       event(1, "events.iterate.com/test/sized"),
@@ -116,6 +116,17 @@ describe("StreamEventLog.getRange", () => {
     });
     expect(sized.map((entry) => entry.byteLength)).toEqual(insertedByteLengths);
     expect(sized.map((entry) => entry.event)).toEqual(committedEvents);
+
+    expect(
+      log.getRangeSizes({
+        afterOffset: 0,
+        beforeOffset: Number.MAX_SAFE_INTEGER,
+        limit: 10,
+      }),
+    ).toEqual([
+      { offset: 1, byteLength: insertedByteLengths[0] },
+      { offset: 2, byteLength: insertedByteLengths[1] },
+    ]);
   });
 
   it("excludes ephemeral rows from range reads unless asked; point reads always return them", () => {

--- a/apps/os/src/domains/streams/stream-storage.ts
+++ b/apps/os/src/domains/streams/stream-storage.ts
@@ -33,6 +33,7 @@ const textEncoder = new TextEncoder();
  * cap with these instead of re-stringifying every event on every read.
  */
 export type SizedStreamEvent = { event: StreamEvent; byteLength: number };
+export type StreamEventSize = { offset: number; byteLength: number };
 
 export class StreamEventLog {
   constructor(
@@ -170,6 +171,50 @@ export class StreamEventLog {
     includeEphemeral?: boolean;
   }): StreamEvent[] {
     return this.getRangeSized(args).map((sized) => sized.event);
+  }
+
+  /**
+   * Read only offsets and serialized sizes for a replay window. Recovery uses
+   * this to choose a byte-bounded page before hydrating any event JSON, so a
+   * large candidate window never becomes one large Durable Object allocation.
+   */
+  getRangeSizes(args: {
+    afterOffset: number;
+    beforeOffset: number;
+    eventTypes?: readonly string[];
+    limit: number;
+    includeEphemeral?: boolean;
+  }): StreamEventSize[] {
+    if (args.eventTypes?.length === 0) return [];
+    const eventTypes =
+      args.eventTypes === undefined || args.eventTypes.includes("*") ? undefined : args.eventTypes;
+    const eventTypeClause =
+      eventTypes === undefined ? "" : `and type in (${eventTypes.map(() => "?").join(", ")})`;
+    const ephemeralClause = args.includeEphemeral === true ? "" : "and ephemeral = 0";
+    return this.sql
+      .exec<{ offset: number; byteLength: number }>(
+        `
+          select selected.offset as offset, sum(length(event_chunks.chunk_bytes)) as byteLength
+          from (
+            select offset
+            from events
+            where offset > ?
+              and offset < ?
+              ${ephemeralClause}
+              ${eventTypeClause}
+            order by offset asc
+            limit ?
+          ) selected
+          join event_chunks on event_chunks.offset = selected.offset
+          group by selected.offset
+          order by selected.offset asc
+        `,
+        args.afterOffset,
+        args.beforeOffset,
+        ...(eventTypes ?? []),
+        args.limit,
+      )
+      .toArray();
   }
 
   /**

--- a/apps/os/src/domains/streams/stream-storage.ts
+++ b/apps/os/src/domains/streams/stream-storage.ts
@@ -33,7 +33,6 @@ const textEncoder = new TextEncoder();
  * cap with these instead of re-stringifying every event on every read.
  */
 export type SizedStreamEvent = { event: StreamEvent; byteLength: number };
-export type StreamEventSize = { offset: number; byteLength: number };
 
 export class StreamEventLog {
   constructor(
@@ -184,7 +183,7 @@ export class StreamEventLog {
     eventTypes?: readonly string[];
     limit: number;
     includeEphemeral?: boolean;
-  }): StreamEventSize[] {
+  }): { offset: number; byteLength: number }[] {
     if (args.eventTypes?.length === 0) return [];
     const eventTypes =
       args.eventTypes === undefined || args.eventTypes.includes("*") ? undefined : args.eventTypes;

--- a/apps/os/src/itx-api-graph.generated.ts
+++ b/apps/os/src/itx-api-graph.generated.ts
@@ -750,10 +750,17 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
     name: "StreamRecovery",
     kind: "interface",
     sourceText:
-      "/** Admin-only exact-offset export and replacement of one Stream Durable Object. */\nexport interface StreamRecovery {\n  exportForRecovery(args?: {\n    afterOffset?: number;\n    limit?: number;\n    throughOffset?: number;\n  }): Promise<StreamRecoveryExportPage>;\n  restoreFromRecovery(input: StreamRecoveryRestoreInput): Promise<{\n    restoredEventCount: number;\n    lastImportedOffset: number;\n    currentMaxOffset: number;\n  }>;\n}",
+      "/** Admin-only exact-offset export and replacement of one Stream Durable Object. */\nexport interface StreamRecovery {\n  exportForRecovery(args?: {\n    afterOffset?: number;\n    limit?: number;\n    throughOffset?: number;\n  }): Promise<StreamRecoveryExportPage>;\n  /**\n   * Stream a fixed export window to an acknowledged sink in bounded pages.\n   * One call can export logs larger than the RPC value limit; resume with the\n   * returned throughOffset and the last persisted event offset.\n   */\n  exportToRecovery(args: {\n    sink: StreamRecoveryExportSink;\n    afterOffset?: number;\n    limit?: number;\n    throughOffset?: number;\n  }): Promise<StreamRecoveryExportSummary>;\n  restoreFromRecovery(input: StreamRecoveryRestoreInput): Promise<{\n    restoredEventCount: number;\n    lastImportedOffset: number;\n    currentMaxOffset: number;\n  }>;\n}",
     summary: "Admin-only exact-offset export and replacement of one Stream Durable Object.",
-    memberSummaries: {},
-    referencedTypeNames: ["StreamRecoveryExportPage", "StreamRecoveryRestoreInput"],
+    memberSummaries: {
+      exportToRecovery: "Stream a fixed export window to an acknowledged sink in bounded pages.",
+    },
+    referencedTypeNames: [
+      "StreamRecoveryExportPage",
+      "StreamRecoveryExportSink",
+      "StreamRecoveryExportSummary",
+      "StreamRecoveryRestoreInput",
+    ],
   },
   {
     name: "StreamProcessorRpc",
@@ -1776,6 +1783,24 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
     sourceText:
       '/** One bounded page of a stream\'s storage-level recovery export. */\nexport type StreamRecoveryExportPage = {\n  format: "iterate-stream-recovery";\n  version: 1;\n  stream: { projectId: string | null; path: string };\n  events: {\n    type: string;\n    payload?: Record<string, unknown> | undefined;\n    metadata?: Record<string, unknown> | undefined;\n    source?:\n      | {\n          processor?:\n            | {\n                slug: string;\n                version: string;\n                stream: { path: string; projectId: string | null };\n                whileProcessing?: { offset: number; type: string } | undefined;\n              }\n            | undefined;\n          crossPostedFrom?:\n            | {\n                subscriptionKey: string;\n                createdAt: string;\n                offset: number;\n                path: string;\n                projectId: string | null;\n                type: string;\n              }[]\n            | undefined;\n        }\n      | undefined;\n    idempotencyKey?: string | undefined;\n    ephemeral?: true | undefined;\n    offset: number;\n    createdAt: string;\n    path: string;\n  }[];\n  throughOffset: number;\n  complete: boolean;\n};',
     summary: "One bounded page of a stream's storage-level recovery export.",
+    memberSummaries: {},
+    referencedTypeNames: [],
+  },
+  {
+    name: "StreamRecoveryExportSink",
+    kind: "typeAlias",
+    sourceText:
+      "/** Acknowledged page sink used by one long-running recovery export RPC. */\nexport type StreamRecoveryExportSink = {\n  write(page: StreamRecoveryExportPage): Promise<void>;\n};",
+    summary: "Acknowledged page sink used by one long-running recovery export RPC.",
+    memberSummaries: {},
+    referencedTypeNames: ["StreamRecoveryExportPage"],
+  },
+  {
+    name: "StreamRecoveryExportSummary",
+    kind: "typeAlias",
+    sourceText:
+      '/** Small result returned after every exported page has been acknowledged. */\nexport type StreamRecoveryExportSummary = {\n  format: "iterate-stream-recovery";\n  version: 1;\n  stream: { projectId: string | null; path: string };\n  throughOffset: number;\n  exportedEventCount: number;\n  pageCount: number;\n};',
+    summary: "Small result returned after every exported page has been acknowledged.",
     memberSummaries: {},
     referencedTypeNames: [],
   },

--- a/apps/os/src/itx-api.generated.ts
+++ b/apps/os/src/itx-api.generated.ts
@@ -1410,6 +1410,17 @@ export interface StreamRecovery {
     limit?: number;
     throughOffset?: number;
   }): Promise<StreamRecoveryExportPage>;
+  /**
+   * Stream a fixed export window to an acknowledged sink in bounded pages.
+   * One call can export logs larger than the RPC value limit; resume with the
+   * returned throughOffset and the last persisted event offset.
+   */
+  exportToRecovery(args: {
+    sink: StreamRecoveryExportSink;
+    afterOffset?: number;
+    limit?: number;
+    throughOffset?: number;
+  }): Promise<StreamRecoveryExportSummary>;
   restoreFromRecovery(input: StreamRecoveryRestoreInput): Promise<{
     restoredEventCount: number;
     lastImportedOffset: number;
@@ -2990,6 +3001,21 @@ export type StreamRecoveryExportPage = {
   }[];
   throughOffset: number;
   complete: boolean;
+};
+
+/** Acknowledged page sink used by one long-running recovery export RPC. */
+export type StreamRecoveryExportSink = {
+  write(page: StreamRecoveryExportPage): Promise<void>;
+};
+
+/** Small result returned after every exported page has been acknowledged. */
+export type StreamRecoveryExportSummary = {
+  format: "iterate-stream-recovery";
+  version: 1;
+  stream: { projectId: string | null; path: string };
+  throughOffset: number;
+  exportedEventCount: number;
+  pageCount: number;
 };
 
 /** A complete normalized stream log accepted by storage-level recovery restore. */

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -60,6 +60,8 @@ import { projectStub } from "./domains/projects/egress.ts";
 import { ProjectProcessorContract } from "./domains/projects/project-processor-contract.ts";
 import type {
   StreamRecoveryExportPage,
+  StreamRecoveryExportSink,
+  StreamRecoveryExportSummary,
   StreamRecoveryRestoreInput,
 } from "./domains/streams/recovery.ts";
 import { projectEgressFetcher } from "./domains/projects/utils.ts";
@@ -751,6 +753,20 @@ class StreamRecoveryRpcTarget extends IterateRpcTarget<"StreamRecovery"> {
     throughOffset?: number;
   }): Promise<StreamRecoveryExportPage> {
     return this.#stream.exportForRecovery(args);
+  }
+
+  /**
+   * Stream a fixed export window to an acknowledged sink in bounded pages.
+   * One call can export logs larger than the RPC value limit; resume with the
+   * returned throughOffset and the last persisted event offset.
+   */
+  exportToRecovery(args: {
+    sink: StreamRecoveryExportSink;
+    afterOffset?: number;
+    limit?: number;
+    throughOffset?: number;
+  }): Promise<StreamRecoveryExportSummary> {
+    return this.#stream.exportToRecovery(args);
   }
 
   restoreFromRecovery(input: StreamRecoveryRestoreInput): Promise<{

--- a/docs/github-smoke-testing.md
+++ b/docs/github-smoke-testing.md
@@ -1,0 +1,135 @@
+# GitHub production smoke testing
+
+Use this after a planned production recreation to prove the `iterate` project's
+GitHub connection, config-repo synchronization, webhook assignment, and PR
+routing. It creates one temporary draft PR in `iterate/config`; do not put
+`@iterate` in its title or body, so it cannot wake an LLM turn.
+
+Run OS commands from `apps/os`. Resolve the production project ID rather than
+hard-coding it:
+
+```bash
+doppler run --config prd -- pnpm cli itx run -e '
+  const projects = await itx.projects.list({ scope: "deployment" });
+  return projects.filter((project) => project.slug === "iterate");
+'
+```
+
+## Prove the connection and config repo
+
+Use the resolved ID as `--context`. This makes an authenticated GitHub request,
+pulls GitHub's default branch into Artifacts, pushes the equal head back through
+the linked repo, and reports all heads:
+
+```bash
+doppler run --config prd -- pnpm cli itx run --context <iterate-project-id> -e '
+  const before = await itx.repo.processor.snapshot();
+  const github = before.state.github;
+  if (github === null) throw new Error("config repo is not linked to GitHub");
+  const status = await itx.integrations.getConnection({
+    provider: "github",
+    connection: github.connection,
+  });
+  const octokit = itx.integrations.github.get(github.connection).octokit;
+  const repository = await octokit.rest.repos.get({ owner: github.owner, repo: github.repo });
+  const branch = repository.data.default_branch;
+  const remoteBefore = await octokit.rest.git.getRef({
+    owner: github.owner,
+    repo: github.repo,
+    ref: `heads/${branch}`,
+  });
+  const sync = await itx.repo.syncFromGithub({ force: true });
+  const push = await itx.repo.pushToGithub({});
+  const local = await itx.repo.listFiles();
+  return {
+    status,
+    link: github,
+    fullName: repository.data.full_name,
+    remoteHead: remoteBefore.data.object.sha,
+    localHead: local.commitOid,
+    sync,
+    push,
+  };
+'
+```
+
+Require a connected status with the recorded installation ID, `iterate/config`,
+and equal remote, local, sync, and push commit OIDs. This proves both GitHub App
+requests and full-history config synchronization; it does not yet prove webhook
+routing.
+
+## Prove webhook routing with `gh`
+
+Create an empty-commit draft PR from a temporary clone. The user must have
+authorized this externally visible smoke action (the recreation operator normally
+asks once before cutover):
+
+```bash
+TMP=$(mktemp -d)
+gh repo clone iterate/config "$TMP/config"
+cd "$TMP/config"
+BRANCH="smoke/recreate-production-$(date -u +%Y%m%d-%H%M%S)"
+git switch -c "$BRANCH"
+git commit --allow-empty -m "Smoke test production GitHub routing"
+git push -u origin "$BRANCH"
+gh pr create --repo iterate/config --base main --head "$BRANCH" --draft \
+  --title "Smoke: production GitHub routing" \
+  --body "Temporary post-recreation webhook-routing smoke. No review requested."
+```
+
+Record the PR number. Then compute its deterministic routed stream from the
+restored config-repo link and inspect the raw delivery:
+
+```bash
+doppler run --config prd -- pnpm cli itx run \
+  --context <iterate-project-id> \
+  --vars '{"pullRequest":123}' \
+  -e '
+    const snapshot = await itx.repo.processor.snapshot();
+    const github = snapshot.state.github;
+    if (github === null) throw new Error("config repo is not linked to GitHub");
+    const identity = JSON.stringify([
+      "/repos/config",
+      github.installationId,
+      github.owner,
+      github.repo,
+    ]);
+    const digest = new Uint8Array(
+      await crypto.subtle.digest("SHA-256", new TextEncoder().encode(identity)),
+    );
+    const fingerprint = [...digest]
+      .map((byte) => byte.toString(16).padStart(2, "0"))
+      .join("");
+    const path = `/agents/repos/g~${fingerprint}/pull-requests/${vars.pullRequest}`;
+    const events = await itx.streams.get(path).getEvents({
+      eventTypes: ["events.iterate.com/github/webhook-received"],
+      limit: 500,
+    });
+    return {
+      path,
+      deliveries: events
+        .filter((event) => event.payload?.body?.action === "opened")
+        .map((event) => ({
+          offset: event.offset,
+          connection: event.payload?.connection,
+          installationId: event.payload?.installationId,
+          repository: event.payload?.body?.repository?.full_name,
+          pullRequest: event.payload?.body?.pull_request?.number,
+        })),
+    };
+  '
+```
+
+Webhook delivery is asynchronous; retry the read for up to a minute. Require one
+`opened` delivery for the smoke PR, `iterate/config`, and the recorded connection
+and installation. This proves the global GitHub directory claim assigned the
+webhook to the Iterate project and the restored repo link routed it.
+
+Close the PR and delete its branch after recording evidence:
+
+```bash
+gh pr close --repo iterate/config <number> --delete-branch
+```
+
+The post-recreation GitHub smoke is complete only when both sections pass. A PR
+created before the recreation is baseline evidence, not restore evidence.

--- a/docs/slack-testing.md
+++ b/docs/slack-testing.md
@@ -167,6 +167,30 @@ To confirm membership / reactions from the CI actor:
 # reactions.get / conversations.replies on the message ts
 ```
 
+### Post-recreation proof
+
+After recreating production, use a real human `@iterate` mention and retain its
+permalink. A product-bot reply in the same thread proves signed webhook ingress,
+the global workspace-to-project claim, the restored project connection and bot
+token, agent routing, and outbound Slack delivery.
+
+Read the thread back through the restored project connection as a second check.
+Convert the permalink's final `p...` value back to Slack's dotted timestamp and
+use the recorded connection explicitly:
+
+```bash
+# from apps/os; do not print any token
+doppler run --config prd -- pnpm cli itx run \
+  --context <iterate-project-id> \
+  --vars '{"connection":"t0675psn873","channel":"C...","ts":"178...123456"}' \
+  -e 'return await itx.integrations.slack.get(vars.connection).conversations.replies({ channel: vars.channel, ts: vars.ts })'
+```
+
+Require `ok: true`, the human root message, and a reply whose user is the
+recorded product-bot user. Save the permalink, timestamps, and reply text in
+the cutover evidence. A pre-cutover thread is only a baseline; repeat this
+after restore.
+
 ## Manual preview smoke test
 
 1. Create or repair the preview Slack app with the preview manifest.

--- a/packages/iterate/src/itx-api.generated.ts
+++ b/packages/iterate/src/itx-api.generated.ts
@@ -1410,6 +1410,17 @@ export interface StreamRecovery {
     limit?: number;
     throughOffset?: number;
   }): Promise<StreamRecoveryExportPage>;
+  /**
+   * Stream a fixed export window to an acknowledged sink in bounded pages.
+   * One call can export logs larger than the RPC value limit; resume with the
+   * returned throughOffset and the last persisted event offset.
+   */
+  exportToRecovery(args: {
+    sink: StreamRecoveryExportSink;
+    afterOffset?: number;
+    limit?: number;
+    throughOffset?: number;
+  }): Promise<StreamRecoveryExportSummary>;
   restoreFromRecovery(input: StreamRecoveryRestoreInput): Promise<{
     restoredEventCount: number;
     lastImportedOffset: number;
@@ -2990,6 +3001,21 @@ export type StreamRecoveryExportPage = {
   }[];
   throughOffset: number;
   complete: boolean;
+};
+
+/** Acknowledged page sink used by one long-running recovery export RPC. */
+export type StreamRecoveryExportSink = {
+  write(page: StreamRecoveryExportPage): Promise<void>;
+};
+
+/** Small result returned after every exported page has been acknowledged. */
+export type StreamRecoveryExportSummary = {
+  format: "iterate-stream-recovery";
+  version: 1;
+  stream: { projectId: string | null; path: string };
+  throughOffset: number;
+  exportedEventCount: number;
+  pageCount: number;
 };
 
 /** A complete normalized stream log accepted by storage-level recovery restore. */


### PR DESCRIPTION
## What changed

- export stream recovery through one acknowledged RPC with byte-bounded callback pages and resume support
- select pages from lightweight offset/byte metadata before hydrating event JSON
- add the reusable recreate-production export script
- document the Slack and GitHub post-recreation production smoke tests

## Why

The existing count-paged export can exceed CapnWeb’s 32 MiB value limit: the Iterate GitHub journal produced a 43.7 MB 500-event page. This keeps each frame near 1 MiB and persists every page before acknowledgement.

## Validation

- pnpm typecheck
- pnpm lint
- pnpm format
- pnpm test
- real-worker stream-recovery e2e (two 600 KB events, multiple acknowledged pages)
- recreate-production skill validation
- local export-script fresh/resume/completed-rerun checks
- pre-recreation production Slack thread and GitHub config/webhook baselines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes admin-only stream recovery and production cutover export paths; behavior is additive with tests, but mistakes could affect large-stream backups or recreation.
> 
> **Overview**
> Adds **acknowledged, resumable stream recovery export** so large journals (e.g. multi‑MB GitHub streams) no longer blow past Cap'n Web’s ~32 MiB RPC limit.
> 
> **`exportForRecovery`** now caps pages by **serialized byte size** (~1 MiB) using lightweight **`getRangeSizes`** metadata before loading event JSON, while still honoring count limits. New **`exportToRecovery`** pushes fixed-window pages through an **`StreamRecoveryExportSink`**; each page is acknowledged before the next, and callers resume with the same `throughOffset` and last written offset.
> 
> Ships **`export-stream-recovery.itx.js`** for the recreate-production runbook (atomic page files, resume, validation) and updates that skill plus **post-recreation proof** docs: Slack thread checks and a new **GitHub production smoke** guide (config sync + webhook routing). E2E covers multi-page export with ~600 KB events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31002adb0d7bfd4effdc97ff5294354a87b2d24e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +146 -3 | +116 -2 🟩🟩🟩🟩⬜ |
| Tests | +49 -1 | +44 -1 🟩🟩⬜⬜⬜ |
| Docs | +160 -0 | +139 -0 🟩🟩🟩🟩🟩 |
| Other | +136 -7 | +123 -7 🟩🟩🟩🟩🟩 |
| Generated | +80 -3 | +62 -3 🟩🟩⬜⬜⬜ |
| **Total** | **+571 -14** | **+484 -13** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 9a415a8 and 31002ad, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-15T13:47:19.027Z",
      "headSha": "31002adb0d7bfd4effdc97ff5294354a87b2d24e",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/264777085345208",
      "shortSha": "31002ad",
      "cleanupDurationMs": 2067,
      "deployDurationMs": 17395,
      "testDurationMs": 460,
      "testRetries": null,
      "workerSizeKib": 4030.87,
      "workerGzipKib": 819.49,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-15T13:47:17.782Z",
      "headSha": "31002adb0d7bfd4effdc97ff5294354a87b2d24e",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/264777085345208",
      "shortSha": "31002ad",
      "cleanupDurationMs": 820,
      "deployDurationMs": 13014,
      "testDurationMs": 18486,
      "testRetries": null,
      "workerSizeKib": 5156.52,
      "workerGzipKib": 1469.68,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-15T13:47:17.454Z",
      "headSha": "31002adb0d7bfd4effdc97ff5294354a87b2d24e",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/264777085345208",
      "shortSha": "31002ad",
      "cleanupDurationMs": 490,
      "deployDurationMs": 6238,
      "testDurationMs": 5895,
      "testRetries": null,
      "workerSizeKib": 1139,
      "workerGzipKib": 201.58,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-15T13:47:15.795Z",
      "headSha": "31002adb0d7bfd4effdc97ff5294354a87b2d24e",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/264777085345208",
      "shortSha": "31002ad",
      "cleanupDurationMs": 12821,
      "deployDurationMs": 79502,
      "testDurationMs": 269481,
      "testRetries": "3 retried: catalogue example \"repo-read-file\" runs identically across runtimes (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · reactivity page repaints from a stream subscription after a page action (specs x1)",
      "workerSizeKib": 16421.49,
      "workerGzipKib": 4430.69,
      "mainWorkerGzipKib": 4429.07
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `31002ad` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 819.5 KiB | 17.4s | 460ms |  | 2.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/264777085345208) | 2026-07-15T13:47:19.027Z | Preview app released. |
| Dummy Petshop | released | `31002ad` | [https://dummy-petshop.iterate-preview-7.com](https://dummy-petshop.iterate-preview-7.com) | 201.6 KiB | 6.2s | 5.9s |  | 490ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/264777085345208) | 2026-07-15T13:47:17.454Z | Preview app released. |
| OS | released | `31002ad` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 4.33 MiB (+1.6 KiB vs main) | 79.5s | 269.5s | 3 retried: catalogue example "repo-read-file" runs identically across runtimes (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · reactivity page repaints from a stream subscription after a page action (specs x1) | 12.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/264777085345208) | 2026-07-15T13:47:15.795Z | Preview app released. |
| Streams Example App | released | `31002ad` | [https://streams.iterate-preview-7.com](https://streams.iterate-preview-7.com) | 1.44 MiB | 13.0s | 18.5s |  | 820ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/264777085345208) | 2026-07-15T13:47:17.782Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->