### PR TITLE
Segment large stream recovery exports

### DIFF
--- a/.agents/skills/recreate-production/SKILL.md
+++ b/.agents/skills/recreate-production/SKILL.md
@@ -38,9 +38,9 @@ consequential forks unless they explicitly waive consultation.
    config repo. Export the root, every listed `/secrets/**` stream, every built-in
    connection stream, and the global integration directory with
    [`scripts/export-stream-recovery.itx.js`](scripts/export-stream-recovery.itx.js).
-   Its single acknowledged export RPC writes byte-bounded pages atomically at a
-   fixed `throughOffset` and resumes an interrupted output directory. Never combine
-   a large raw journal into one RPC value.
+   Its acknowledged export sessions write byte-bounded pages atomically at one
+   fixed `throughOffset`, stay within Durable Object CPU limits, and resume an
+   interrupted output directory. Never combine a large raw journal into one RPC value.
 4. Reduce the package deliberately: keep bootstrap facts in `/`, secret journals
    intact, current integration lifecycle/subscription facts, and only active global
    claims for retained project IDs. Do not renumber events: encrypted secret material

--- a/.agents/skills/recreate-production/scripts/export-stream-recovery.itx.js
+++ b/.agents/skills/recreate-production/scripts/export-stream-recovery.itx.js
@@ -9,6 +9,7 @@ const outputDir = String(vars.outputDir ?? "").trim();
 const streamPath = String(vars.path ?? "").trim();
 const projectId = vars.projectId;
 const limit = Number(vars.limit ?? 500);
+const maxPages = Number(vars.maxPages ?? 32);
 
 if (!outputDir) throw new Error("vars.outputDir is required");
 if (!streamPath.startsWith("/")) throw new Error("vars.path must be an absolute stream path");
@@ -17,6 +18,9 @@ if (projectId !== null && (typeof projectId !== "string" || !projectId.trim())) 
 }
 if (!Number.isInteger(limit) || limit < 1 || limit > 500) {
   throw new Error("vars.limit must be an integer from 1 to 500");
+}
+if (!Number.isInteger(maxPages) || maxPages < 1 || maxPages > 32) {
+  throw new Error("vars.maxPages must be an integer from 1 to 32");
 }
 
 fs.mkdirSync(outputDir, { recursive: true, mode: 0o700 });
@@ -100,27 +104,45 @@ class RecoveryPageSink extends RpcTarget {
 }
 
 const sink = new RecoveryPageSink();
-const recovery = itx.streamRecovery.get({ projectId, path: streamPath });
+let sessionCount = 0;
 try {
-  const result = await recovery.exportToRecovery({
-    sink,
-    afterOffset: previousOffset,
-    limit,
-    ...(throughOffset === undefined ? {} : { throughOffset }),
-  });
-  if (throughOffset !== result.throughOffset) {
-    throw new Error("export result did not match the persisted throughOffset");
+  for (;;) {
+    const sessionStartOffset = previousOffset;
+    const recovery = itx.streamRecovery.get({ projectId, path: streamPath });
+    let result;
+    try {
+      result = await recovery.exportToRecovery({
+        sink,
+        afterOffset: previousOffset,
+        limit,
+        maxPages,
+        ...(throughOffset === undefined ? {} : { throughOffset }),
+      });
+    } finally {
+      recovery[Symbol.dispose]?.();
+    }
+    sessionCount += 1;
+    if (throughOffset !== result.throughOffset) {
+      throw new Error("export result did not match the persisted throughOffset");
+    }
+    if (result.lastExportedOffset !== previousOffset) {
+      throw new Error("export result did not match the last persisted event offset");
+    }
+    if (result.complete) break;
+    if (previousOffset <= sessionStartOffset) {
+      throw new Error("incomplete recovery export session made no progress");
+    }
   }
   return {
     outputDir,
-    stream: result.stream,
-    throughOffset: result.throughOffset,
+    stream: { projectId, path: streamPath },
+    throughOffset,
     pageCount: nextPageNumber - 1,
     eventCount: totalEventCount,
+    sessionCount,
     resumed: pageFiles.length > 0,
     alreadyComplete: false,
   };
 } finally {
-  recovery[Symbol.dispose]?.();
   sink[Symbol.dispose]?.();
 }

--- a/apps/os/e2e/vitest/stream-recovery.e2e.test.ts
+++ b/apps/os/e2e/vitest/stream-recovery.e2e.test.ts
@@ -65,8 +65,27 @@ test("recovery streams byte-bounded pages through one acknowledged export", asyn
     secondLarge?.offset,
   );
   expect(summary).toMatchObject({
+    complete: true,
     exportedEventCount: pages.reduce((count, page) => count + page.events.length, 0),
+    lastExportedOffset: pages.at(-1)?.events.at(-1)?.offset,
     pageCount: pages.length,
     throughOffset: pages[0]?.throughOffset,
   });
+
+  const sessionPages: (typeof firstPage)[] = [];
+  const sessionSink = new (class extends RpcTarget {
+    async write(page: typeof firstPage) {
+      sessionPages.push(page);
+    }
+  })();
+  const firstSession = await recovery.exportToRecovery({ sink: sessionSink, maxPages: 1 });
+  expect(firstSession).toMatchObject({ complete: false, pageCount: 1 });
+  const secondSession = await recovery.exportToRecovery({
+    sink: sessionSink,
+    afterOffset: firstSession.lastExportedOffset,
+    maxPages: 1,
+    throughOffset: firstSession.throughOffset,
+  });
+  expect(secondSession).toMatchObject({ complete: true, pageCount: 1 });
+  expect(sessionPages).toHaveLength(2);
 });

--- a/apps/os/src/domains/streams/recovery.ts
+++ b/apps/os/src/domains/streams/recovery.ts
@@ -53,6 +53,8 @@ export type StreamRecoveryExportSummary = {
   throughOffset: number;
   exportedEventCount: number;
   pageCount: number;
+  lastExportedOffset: number;
+  complete: boolean;
 };
 
 /** A complete normalized stream log accepted by storage-level recovery restore. */

--- a/apps/os/src/domains/streams/stream-durable-object.ts
+++ b/apps/os/src/domains/streams/stream-durable-object.ts
@@ -48,6 +48,8 @@ const DEFAULT_GET_EVENTS_LIMIT = 500;
 const MAX_GET_EVENTS_LIMIT = 500;
 /** Keep recovery callback frames far below Cap'n Web's 32 MiB value limit. */
 const RECOVERY_EXPORT_PAGE_BYTE_LIMIT = 1024 * 1024;
+/** Bound CPU per RPC; the client continues the same fixed export window. */
+const RECOVERY_EXPORT_SESSION_PAGE_LIMIT = 32;
 
 /**
  * The subscription key of the birth-certificate worker feed every
@@ -450,22 +452,29 @@ export class StreamDurableObject extends DurableObject<Env> {
     };
   }
 
-  /**
-   * Export a fixed recovery window through one acknowledged callback session.
-   * The caller can persist each bounded page before resolving `write`; a
-   * failed session resumes with the same throughOffset and last written
-   * event offset without ever assembling the stream in an RPC value.
-   */
+  /** Export part of a fixed recovery window through one acknowledged callback session. */
   async exportToRecovery(args: {
     sink: StreamRecoveryExportSink;
     afterOffset?: number;
     limit?: number;
+    maxPages?: number;
     throughOffset?: number;
   }): Promise<StreamRecoveryExportSummary> {
+    const maxPages = args.maxPages ?? RECOVERY_EXPORT_SESSION_PAGE_LIMIT;
+    if (
+      !Number.isInteger(maxPages) ||
+      maxPages <= 0 ||
+      maxPages > RECOVERY_EXPORT_SESSION_PAGE_LIMIT
+    ) {
+      throw new Error(
+        `recovery export maxPages must be an integer from 1 to ${RECOVERY_EXPORT_SESSION_PAGE_LIMIT}`,
+      );
+    }
     const throughOffset = args.throughOffset ?? this.#log.highestAssignedOffset();
     let afterOffset = args.afterOffset ?? 0;
     let exportedEventCount = 0;
     let pageCount = 0;
+    let complete = false;
 
     for (;;) {
       const page = this.exportForRecovery({
@@ -476,12 +485,19 @@ export class StreamDurableObject extends DurableObject<Env> {
       await args.sink.write(page);
       pageCount += 1;
       exportedEventCount += page.events.length;
-      if (page.complete) break;
       const nextOffset = page.events.at(-1)?.offset;
-      if (nextOffset === undefined || nextOffset <= afterOffset) {
+      if (nextOffset !== undefined && nextOffset <= afterOffset) {
         throw new Error("recovery export produced an empty or non-advancing incomplete page");
       }
-      afterOffset = nextOffset;
+      if (nextOffset !== undefined) afterOffset = nextOffset;
+      if (page.complete) {
+        complete = true;
+        break;
+      }
+      if (nextOffset === undefined) {
+        throw new Error("recovery export produced an empty incomplete page");
+      }
+      if (pageCount >= maxPages) break;
     }
 
     return {
@@ -491,6 +507,8 @@ export class StreamDurableObject extends DurableObject<Env> {
       throughOffset,
       exportedEventCount,
       pageCount,
+      lastExportedOffset: afterOffset,
+      complete,
     };
   }
 

--- a/apps/os/src/itx-api-graph.generated.ts
+++ b/apps/os/src/itx-api-graph.generated.ts
@@ -750,10 +750,11 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
     name: "StreamRecovery",
     kind: "interface",
     sourceText:
-      "/** Admin-only exact-offset export and replacement of one Stream Durable Object. */\nexport interface StreamRecovery {\n  exportForRecovery(args?: {\n    afterOffset?: number;\n    limit?: number;\n    throughOffset?: number;\n  }): Promise<StreamRecoveryExportPage>;\n  /**\n   * Stream a fixed export window to an acknowledged sink in bounded pages.\n   * One call can export logs larger than the RPC value limit; resume with the\n   * returned throughOffset and the last persisted event offset.\n   */\n  exportToRecovery(args: {\n    sink: StreamRecoveryExportSink;\n    afterOffset?: number;\n    limit?: number;\n    throughOffset?: number;\n  }): Promise<StreamRecoveryExportSummary>;\n  restoreFromRecovery(input: StreamRecoveryRestoreInput): Promise<{\n    restoredEventCount: number;\n    lastImportedOffset: number;\n    currentMaxOffset: number;\n  }>;\n}",
+      "/** Admin-only exact-offset export and replacement of one Stream Durable Object. */\nexport interface StreamRecovery {\n  exportForRecovery(args?: {\n    afterOffset?: number;\n    limit?: number;\n    throughOffset?: number;\n  }): Promise<StreamRecoveryExportPage>;\n  /** Stream part of a fixed export window to an acknowledged sink in bounded pages. */\n  exportToRecovery(args: {\n    sink: StreamRecoveryExportSink;\n    afterOffset?: number;\n    limit?: number;\n    maxPages?: number;\n    throughOffset?: number;\n  }): Promise<StreamRecoveryExportSummary>;\n  restoreFromRecovery(input: StreamRecoveryRestoreInput): Promise<{\n    restoredEventCount: number;\n    lastImportedOffset: number;\n    currentMaxOffset: number;\n  }>;\n}",
     summary: "Admin-only exact-offset export and replacement of one Stream Durable Object.",
     memberSummaries: {
-      exportToRecovery: "Stream a fixed export window to an acknowledged sink in bounded pages.",
+      exportToRecovery:
+        "Stream part of a fixed export window to an acknowledged sink in bounded pages.",
     },
     referencedTypeNames: [
       "StreamRecoveryExportPage",
@@ -1799,7 +1800,7 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
     name: "StreamRecoveryExportSummary",
     kind: "typeAlias",
     sourceText:
-      '/** Small result returned after every exported page has been acknowledged. */\nexport type StreamRecoveryExportSummary = {\n  format: "iterate-stream-recovery";\n  version: 1;\n  stream: { projectId: string | null; path: string };\n  throughOffset: number;\n  exportedEventCount: number;\n  pageCount: number;\n};',
+      '/** Small result returned after every exported page has been acknowledged. */\nexport type StreamRecoveryExportSummary = {\n  format: "iterate-stream-recovery";\n  version: 1;\n  stream: { projectId: string | null; path: string };\n  throughOffset: number;\n  exportedEventCount: number;\n  pageCount: number;\n  lastExportedOffset: number;\n  complete: boolean;\n};',
     summary: "Small result returned after every exported page has been acknowledged.",
     memberSummaries: {},
     referencedTypeNames: [],

--- a/apps/os/src/itx-api.generated.ts
+++ b/apps/os/src/itx-api.generated.ts
@@ -1410,15 +1410,12 @@ export interface StreamRecovery {
     limit?: number;
     throughOffset?: number;
   }): Promise<StreamRecoveryExportPage>;
-  /**
-   * Stream a fixed export window to an acknowledged sink in bounded pages.
-   * One call can export logs larger than the RPC value limit; resume with the
-   * returned throughOffset and the last persisted event offset.
-   */
+  /** Stream part of a fixed export window to an acknowledged sink in bounded pages. */
   exportToRecovery(args: {
     sink: StreamRecoveryExportSink;
     afterOffset?: number;
     limit?: number;
+    maxPages?: number;
     throughOffset?: number;
   }): Promise<StreamRecoveryExportSummary>;
   restoreFromRecovery(input: StreamRecoveryRestoreInput): Promise<{
@@ -3016,6 +3013,8 @@ export type StreamRecoveryExportSummary = {
   throughOffset: number;
   exportedEventCount: number;
   pageCount: number;
+  lastExportedOffset: number;
+  complete: boolean;
 };
 
 /** A complete normalized stream log accepted by storage-level recovery restore. */

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -755,15 +755,12 @@ class StreamRecoveryRpcTarget extends IterateRpcTarget<"StreamRecovery"> {
     return this.#stream.exportForRecovery(args);
   }
 
-  /**
-   * Stream a fixed export window to an acknowledged sink in bounded pages.
-   * One call can export logs larger than the RPC value limit; resume with the
-   * returned throughOffset and the last persisted event offset.
-   */
+  /** Stream part of a fixed export window to an acknowledged sink in bounded pages. */
   exportToRecovery(args: {
     sink: StreamRecoveryExportSink;
     afterOffset?: number;
     limit?: number;
+    maxPages?: number;
     throughOffset?: number;
   }): Promise<StreamRecoveryExportSummary> {
     return this.#stream.exportToRecovery(args);

--- a/packages/iterate/src/itx-api.generated.ts
+++ b/packages/iterate/src/itx-api.generated.ts
@@ -1410,15 +1410,12 @@ export interface StreamRecovery {
     limit?: number;
     throughOffset?: number;
   }): Promise<StreamRecoveryExportPage>;
-  /**
-   * Stream a fixed export window to an acknowledged sink in bounded pages.
-   * One call can export logs larger than the RPC value limit; resume with the
-   * returned throughOffset and the last persisted event offset.
-   */
+  /** Stream part of a fixed export window to an acknowledged sink in bounded pages. */
   exportToRecovery(args: {
     sink: StreamRecoveryExportSink;
     afterOffset?: number;
     limit?: number;
+    maxPages?: number;
     throughOffset?: number;
   }): Promise<StreamRecoveryExportSummary>;
   restoreFromRecovery(input: StreamRecoveryRestoreInput): Promise<{
@@ -3016,6 +3013,8 @@ export type StreamRecoveryExportSummary = {
   throughOffset: number;
   exportedEventCount: number;
   pageCount: number;
+  lastExportedOffset: number;
+  complete: boolean;
 };
 
 /** A complete normalized stream log accepted by storage-level recovery restore. */


### PR DESCRIPTION
## What changed

- cap each recovery RPC session at 32 acknowledged ~1 MiB pages
- return the fixed boundary, last persisted offset, and completion state
- have the bundled exporter continue sessions automatically without changing `throughOffset`
- test session continuation and no-progress guards

## Why

The production Iterate GitHub journal crossed the former 32 MiB frame limit, but a single unbounded callback session reached the Durable Object cumulative CPU limit after safely persisting 181 pages / 179 MB. This keeps both frame size and per-request CPU bounded while retaining atomic page persistence and resumability.

## Validation

- production proof: two interrupted sessions safely persisted 357 pages / about 350 MB and resumed from disk
- local script proof: `maxPages: 1` completed two pages in two sessions, with 0700/0600 permissions
- real-worker recovery e2e
- pnpm format
- pnpm knip
- pnpm typecheck
- pnpm lint
- pnpm test
- recreate-production skill validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches admin-only stream recovery used for production cutover; behavior change is additive (new fields, optional `maxPages`) but incorrect session chaining could corrupt or stall large exports.
> 
> **Overview**
> **Stream recovery export** no longer tries to finish an entire fixed `throughOffset` window in one `exportToRecovery` RPC. Each session is capped at **`maxPages`** (default **32**, ~1 MiB pages per page) so Durable Object CPU and Cap'n Web frame size stay bounded; the summary now returns **`complete`**, **`lastExportedOffset`**, and the same **`throughOffset`** so clients can chain sessions.
> 
> The **production export script** (`export-stream-recovery.itx.js`) loops RPC sessions until `complete`, reopens recovery per session, validates offset progress, and reports **`sessionCount`**. The **recreate-production** skill text matches this session model.
> 
> **E2E** covers multi-session export with `maxPages: 1` and asserts the new summary fields on full exports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 330b3e620c6dc8780494f971a7d0b9df94523e88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +31 -14 | +28 -3 🟩🟩🟩⬜⬜ |
| Tests | +19 -0 | +18 -0 🟩🟩⬜⬜⬜ |
| Other | +37 -15 | +37 -15 🟩🟩🟩🟩🟥 |
| Generated | +12 -13 | +10 -3 🟩⬜⬜⬜⬜ |
| **Total** | **+99 -42** | **+93 -21** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 582ec23 and 330b3e6, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-15T14:09:15.069Z",
      "headSha": "330b3e620c6dc8780494f971a7d0b9df94523e88",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/15682186265966",
      "shortSha": "330b3e6",
      "cleanupDurationMs": 2313,
      "deployDurationMs": 31186,
      "testDurationMs": 566,
      "testRetries": null,
      "workerSizeKib": 4030.87,
      "workerGzipKib": 819.68,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-15T14:09:13.361Z",
      "headSha": "330b3e620c6dc8780494f971a7d0b9df94523e88",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/15682186265966",
      "shortSha": "330b3e6",
      "cleanupDurationMs": 602,
      "deployDurationMs": 16614,
      "testDurationMs": 78176,
      "testRetries": "4 retried: stream capnweb protocol > browser client appends events by stream URL (vitest x1) · stream capnweb protocol > documents Cloudflare's 32 MiB inbound WebSocket frame ceiling for capnweb appends (vitest x1) · large streams stay virtualized and can scroll from tail to earliest rows (playwright x1) · downloaded SQLite file can be queried from disk (playwright x1)",
      "workerSizeKib": 5157.83,
      "workerGzipKib": 1470.09,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-15T14:09:13.286Z",
      "headSha": "330b3e620c6dc8780494f971a7d0b9df94523e88",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/15682186265966",
      "shortSha": "330b3e6",
      "cleanupDurationMs": 526,
      "deployDurationMs": 6430,
      "testDurationMs": 5448,
      "testRetries": null,
      "workerSizeKib": 1139,
      "workerGzipKib": 201.58,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-15T14:09:11.614Z",
      "headSha": "330b3e620c6dc8780494f971a7d0b9df94523e88",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/15682186265966",
      "shortSha": "330b3e6",
      "cleanupDurationMs": 113570,
      "deployDurationMs": 103288,
      "testDurationMs": 264469,
      "testRetries": "2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · reactivity page appends a batch and renders every delivered marker (specs x1)",
      "workerSizeKib": 16421.69,
      "workerGzipKib": 4430.49,
      "mainWorkerGzipKib": 4430.69
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `330b3e6` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 819.7 KiB | 31.2s | 566ms |  | 2.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/15682186265966) | 2026-07-15T14:09:15.069Z | Preview app released. |
| Dummy Petshop | released | `330b3e6` | [https://dummy-petshop.iterate-preview-8.com](https://dummy-petshop.iterate-preview-8.com) | 201.6 KiB | 6.4s | 5.4s |  | 526ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/15682186265966) | 2026-07-15T14:09:13.286Z | Preview app released. |
| OS | released | `330b3e6` | [https://os.iterate-preview-8.com](https://os.iterate-preview-8.com) | 4.33 MiB (-0.2 KiB vs main) | 103.3s | 264.5s | 2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · reactivity page appends a batch and renders every delivered marker (specs x1) | 113.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/15682186265966) | 2026-07-15T14:09:11.614Z | Preview app released. |
| Streams Example App | released | `330b3e6` | [https://streams.iterate-preview-8.com](https://streams.iterate-preview-8.com) | 1.44 MiB | 16.6s | 78.2s | 4 retried: stream capnweb protocol > browser client appends events by stream URL (vitest x1) · stream capnweb protocol > documents Cloudflare's 32 MiB inbound WebSocket frame ceiling for capnweb appends (vitest x1) · large streams stay virtualized and can scroll from tail to earliest rows (playwright x1) · downloaded SQLite file can be queried from disk (playwright x1) | 602ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/15682186265966) | 2026-07-15T14:09:13.361Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->