### PR TITLE
Finish production recovery restore runbook

### DIFF
--- a/.agents/skills/recreate-production/SKILL.md
+++ b/.agents/skills/recreate-production/SKILL.md
@@ -59,11 +59,17 @@ consequential forks unless they explicitly waive consultation.
 2. Merge, check out the exact merged commit, run
    `pnpm erase-data --env prd --yes-i-mean-prd --preserve-auth`, and manually deploy
    **OS only** from that commit. Stop on unexplained erase or deploy warnings.
-3. Use a temporary itx script to call `restoreFromRecovery()` in this order: project
-   root, secret streams, integration streams, then the global directory. The target
-   code validates and folds the complete journal before replacing storage.
-4. For each project, call `repo.linkGithub()` with the recorded connection/owner/repo,
-   then `repo.syncFromGithub({ force: true })` with no depth. Let GitHub win.
+3. Restore each reduced payload with
+   [`scripts/restore-stream-recovery.itx.js`](scripts/restore-stream-recovery.itx.js),
+   in this order: project root, secret streams, integration streams, then the global
+   directory. Pass `vars.inputFile` as an absolute path. The target code validates and
+   folds the complete journal before replacing storage; never send an unreduced large
+   traffic journal as one restore value.
+4. The erased Artifacts config repo does not come back from root-stream facts alone.
+   For each project, call `await itx.repo.create()`, then `repo.linkGithub()` with the
+   recorded connection/owner/repo, then `repo.syncFromGithub({ force: true })` with no
+   depth. Require the synced local head to equal the recorded GitHub head. Let GitHub
+   win and retain its full history.
 5. Re-enable automatic deployment if it was disabled.
 
 ## Finish only after proof

--- a/.agents/skills/recreate-production/scripts/restore-stream-recovery.itx.js
+++ b/.agents/skills/recreate-production/scripts/restore-stream-recovery.itx.js
@@ -1,0 +1,31 @@
+// Run from apps/os with `pnpm cli itx run --file ... --vars ...`.
+// The itx CLI evaluates this body locally, so the sensitive recovery payload
+// is read from the operator's mode-0700 package and sent only to the selected
+// admin recovery target. Only the small restore summary is printed.
+
+const fs = process.getBuiltinModule("node:fs");
+
+const inputFile = String(vars.inputFile ?? "").trim();
+if (!inputFile) throw new Error("vars.inputFile is required");
+
+const input = JSON.parse(fs.readFileSync(inputFile, "utf8"));
+if (input?.format !== "iterate-stream-recovery" || input?.version !== 1) {
+  throw new Error("inputFile is not an Iterate stream recovery payload");
+}
+if (
+  !input.stream ||
+  (input.stream.projectId !== null &&
+    (typeof input.stream.projectId !== "string" || !input.stream.projectId.trim())) ||
+  typeof input.stream.path !== "string" ||
+  !input.stream.path.startsWith("/")
+) {
+  throw new Error("inputFile has an invalid stream coordinate");
+}
+
+const recovery = itx.streamRecovery.get(input.stream);
+try {
+  const result = await recovery.restoreFromRecovery(input);
+  return { inputFile, stream: input.stream, ...result };
+} finally {
+  recovery[Symbol.dispose]?.();
+}

--- a/.agents/skills/recreate-production/scripts/restore-stream-recovery.itx.js
+++ b/.agents/skills/recreate-production/scripts/restore-stream-recovery.itx.js
@@ -3,12 +3,10 @@
 // is read from the operator's mode-0700 package and sent only to the selected
 // admin recovery target. Only the small restore summary is printed.
 
-const fs = process.getBuiltinModule("node:fs");
-
 const inputFile = String(vars.inputFile ?? "").trim();
 if (!inputFile) throw new Error("vars.inputFile is required");
 
-const input = JSON.parse(fs.readFileSync(inputFile, "utf8"));
+const input = JSON.parse(process.getBuiltinModule("node:fs").readFileSync(inputFile, "utf8"));
 if (input?.format !== "iterate-stream-recovery" || input?.version !== 1) {
   throw new Error("inputFile is not an Iterate stream recovery payload");
 }

--- a/.agents/skills/recreate-production/scripts/restore-stream-recovery.itx.js
+++ b/.agents/skills/recreate-production/scripts/restore-stream-recovery.itx.js
@@ -22,8 +22,7 @@ if (
 
 const recovery = itx.streamRecovery.get(input.stream);
 try {
-  const result = await recovery.restoreFromRecovery(input);
-  return { inputFile, stream: input.stream, ...result };
+  return { inputFile, stream: input.stream, ...(await recovery.restoreFromRecovery(input)) };
 } finally {
   recovery[Symbol.dispose]?.();
 }


### PR DESCRIPTION
Closes the last gap found while rehearsing production recovery.

- bundles the local restore helper instead of relying on an improvised script
- creates the erased config repo before relinking and full-history GitHub sync
- warns against sending unreduced traffic journals as one restore RPC

Production rehearsal evidence:
- all 22 Iterate recovery payloads restored successfully against local OS
- reduced 40,786-event GitHub journal restored as 8 durable facts
- fresh config repo creation succeeded at the preserved project ID
- lint, format, and skill validation pass

Follow-up to #2026 and #2027.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to agent runbook documentation and a local itx operator script; no application runtime or auth paths are modified.
> 
> **Overview**
> **Production recreation cutover** now points operators at a checked-in **`restore-stream-recovery.itx.js`** helper (parallel to the export script) instead of improvising temporary itx bodies. Restores run in the documented order with **`vars.inputFile`** as an absolute path, and the runbook explicitly warns **not** to ship unreduced large traffic journals as a single restore RPC.
> 
> **GitHub config repos** after erase: the runbook adds that root-stream facts alone do not resurrect the Artifacts config repo—each project needs **`await itx.repo.create()`** before **`linkGithub`** and a full-history **`syncFromGithub`**, with the synced head required to match the recorded GitHub head.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 482d164f8837d95f0506d88350c8e53c2c2c20fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Other | +39 -5 | +32 -5 🟩🟩🟩🟩🟥 |
| **Total** | **+39 -5** | **+32 -5** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 91b232f and 482d164, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->