### PR TITLE
fix(ci): right-size Test job to 4x16 to stop main sandbox kills

### DIFF
--- a/.depot/workflows/test.yml
+++ b/.depot/workflows/test.yml
@@ -11,8 +11,13 @@ concurrency:
   cancel-in-progress: true
 jobs:
   test:
+    # Measured on main (run w301hvp2xr): peak ~37% CPU / ~8% memory on 8x32
+    # (~3 cores, ~2.5GB). Keep 4x16 for parallel workspace headroom; avoid a
+    # second large sandbox competing with lint-typecheck on main pushes
+    # (that pattern ends in "Sandbox terminated before worker reported
+    # completion" with no logs/metrics).
     runs-on:
-      size: 8x32
+      size: 4x16
       image: 0p91s0lz49.registry.depot.dev/iterate-preview-ci:node24-pnpm10-worktree
     timeout-minutes: 20
     steps:

--- a/docs/depot-ci.md
+++ b/docs/depot-ci.md
@@ -246,11 +246,14 @@ freshness:
   Auth + OS gets 45 minutes because its bounded worst case includes both
   deployments, JWKS propagation, and four sequential smoke probes.
 - Runner size follows observed peak CPU and memory, with headroom. Lint stays
-  on `8x32`; Auth + OS deploy uses `4x16`; short deploy, notification, and
-  autofix jobs use `2x8`. Re-check with `depot ci metrics --run <run-id>` before
-  increasing a size.
+  on `8x32` (parallel oxlint/typecheck/knip). Unit tests use `4x16` — measured
+  peaks on `8x32` were ~3 cores / ~2.5GB, and a second large sandbox next to
+  lint is the common trigger for no-log `Sandbox terminated before worker
+reported completion` on main. Auth + OS deploy uses `4x16`; short deploy,
+  notification, and autofix jobs use `2x8`. Re-check with
+  `depot ci metrics --run <run-id>` before increasing a size.
 
-These defaults keep a normal all-app main push to 32 requested vCPUs before
+These defaults keep a normal all-app main push to 28 requested vCPUs before
 notification jobs, down from 72, without reducing the parallel lint lane that
 uses the larger machine. Path filters avoid deploying iterate.com for unrelated
 monorepo changes.

--- a/scripts/ci/depot-workflows.test.ts
+++ b/scripts/ci/depot-workflows.test.ts
@@ -151,7 +151,7 @@ describe("Depot validation capacity", () => {
       file: ".depot/workflows/test.yml",
       group: "test-${{ github.head_ref || github.ref_name || github.run_id }}",
       jobId: "test",
-      size: "8x32",
+      size: "4x16",
       timeoutMinutes: 20,
     },
     {


### PR DESCRIPTION
## Summary

Main tip (`9e1efa9f`) went red on **Test / test** with:

> Sandbox terminated before worker reported completion

No logs, no metrics samples — the known Depot provisioning failure from #1952 when large custom-image sandboxes compete.

Evidence:

- Same tip **passed on retry** (attempt #2 of run `t3h7sf1njb`) → not an application regression from #2028 (docs-only).
- Successful main Test run `w301hvp2xr` metrics: **peak ~37% CPU / ~8% memory on 8x32** (~3 cores, ~2.5GB).
- Lint stays on `8x32` (it needs the parallel oxlint/typecheck/knip lane). Test was a second full `8x32` with no measured need.

### Fix

- `.depot/workflows/test.yml`: `8x32` → `4x16`
- Update capacity invariants + docs so the next person does not re-inflate it without metrics

## Test plan

- [x] `pnpm --dir scripts exec vitest run ci/depot-workflows.test.ts` (14 passed)
- [x] Main tip Test re-run already green (proves no code failure)
- [ ] PR Depot **Test / test** green on `4x16`
- [ ] Merge to main; next main push Test should first-attempt green under normal load

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI runner sizing and documentation only; no application or deploy logic changes.
> 
> **Overview**
> **Reduces Depot Test runner size from `8x32` to `4x16`** after main runs showed low peak usage (~3 cores / ~2.5GB) and first-attempt failures with no logs when Test competed with lint-typecheck on another large sandbox.
> 
> The workflow adds an inline comment documenting that sizing rationale. **`docs/depot-ci.md`** now records the split (lint stays `8x32`, tests `4x16`) and updates the normal main-push capacity figure from **32 to 28** requested vCPUs. **`scripts/ci/depot-workflows.test.ts`** expects `4x16` for the Test job so the change stays enforced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e15509d0b2c6280817e111a5a284260be7ad6625. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +1 -1 | +1 -1 🟩⬜⬜⬜⬜ |
| CI & scripts | +6 -1 | +6 -1 🟩🟩🟩⬜⬜ |
| Docs | +8 -5 | +7 -4 🟩🟩🟩🟥🟥 |
| **Total** | **+15 -7** | **+14 -6** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 9e1efa9 and e15509d, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->