### PR TITLE
Use useSyncExternalStore for agent live clocks

### DIFF
--- a/apps/os/src/components/agent-feed.tsx
+++ b/apps/os/src/components/agent-feed.tsx
@@ -1,12 +1,4 @@
-import {
-  memo,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-  type ReactNode,
-} from "react";
+import { memo, useCallback, useLayoutEffect, useRef, useState, type ReactNode } from "react";
 import { Link } from "@tanstack/react-router";
 import {
   BanIcon,
@@ -51,6 +43,7 @@ import {
   looksLikeCode,
 } from "~/lib/feed-format.ts";
 import { linkOptionsForStreamPath } from "~/lib/stream-routes.ts";
+import { useTickingNowMs } from "~/lib/use-ticking-now-ms.ts";
 
 // The clean agent chat rows: user and assistant messages plus archived
 // activity rows ("Ran code 2× · 3 requests · 7.4 s"), and the live in-flight
@@ -859,15 +852,11 @@ function liveStepHasVisibleContent(step: AgentUiStep) {
 /**
  * Live CLI-style elapsed counter (`0.9s`) while code is running. Ticks every
  * 100ms so the tenths place moves; idle when `startedAtMs` is null.
+ * Clock is a useSyncExternalStore subscription (react-doctor happy path),
+ * not a useState+setInterval effect loop.
  */
 function useElapsedLabel(startedAtMs: number | null): string | null {
-  const [nowMs, setNowMs] = useState(() => Date.now());
-  useEffect(() => {
-    if (startedAtMs == null) return;
-    setNowMs(Date.now());
-    const interval = setInterval(() => setNowMs(Date.now()), 100);
-    return () => clearInterval(interval);
-  }, [startedAtMs]);
+  const nowMs = useTickingNowMs(100, startedAtMs != null);
   if (startedAtMs == null) return null;
   return formatElapsedSeconds(nowMs - startedAtMs);
 }

--- a/apps/os/src/components/agent-roster.tsx
+++ b/apps/os/src/components/agent-roster.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Link } from "@tanstack/react-router";
 import {
   ChevronDown,
@@ -26,6 +26,7 @@ import { agentPathIcon, agentPathLabel } from "~/lib/agent-roster-labels.ts";
 import { agentBusyPhaseLabel } from "~/lib/feed-format.ts";
 import { formatTimeAgo } from "~/lib/format-relative-time.ts";
 import { linkOptionsForStreamPath } from "~/lib/stream-routes.ts";
+import { useTickingNowMs } from "~/lib/use-ticking-now-ms.ts";
 
 /** Coarse tick for relative "ago" labels in the sidebar (matches stream switcher). */
 const CLOCK_TICK_MS = 15_000;
@@ -88,15 +89,6 @@ function useAgentRoster(projectId: string): RosterRow[] {
   }, [roster.value]);
 }
 
-function useTickingNowMs(): number {
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    const interval = setInterval(() => setNow(Date.now()), CLOCK_TICK_MS);
-    return () => clearInterval(interval);
-  }, []);
-  return now;
-}
-
 /**
  * The agents roster in the project sidebar, newest activity first: a live
  * busy dot, the agent's title, last activity, and its expandable status line.
@@ -113,7 +105,7 @@ export function SidebarRecentAgents({
   projectSlug: string;
 }) {
   const rows = useAgentRoster(projectId);
-  const nowMs = useTickingNowMs();
+  const nowMs = useTickingNowMs(CLOCK_TICK_MS);
   if (rows.length === 0) return null;
   return (
     <>
@@ -145,7 +137,7 @@ export function AgentRosterList({
   projectSlug: string;
 }) {
   const rows = useAgentRoster(projectId);
-  const nowMs = useTickingNowMs();
+  const nowMs = useTickingNowMs(CLOCK_TICK_MS);
   if (rows.length === 0) return null;
   return (
     <SidebarMenu>

--- a/apps/os/src/lib/use-ticking-now-ms.ts
+++ b/apps/os/src/lib/use-ticking-now-ms.ts
@@ -1,0 +1,72 @@
+import { useCallback, useSyncExternalStore } from "react";
+
+/**
+ * A wall-clock subscribed via `useSyncExternalStore`, not `useState` +
+ * `setInterval` in an effect. That keeps concurrent rendering correct and
+ * matches react-doctor's prefer-use-sync-external-store guidance: the
+ * snapshot is a stable scalar between ticks, and the interval only runs
+ * while something is subscribed.
+ */
+function createTickingClock(intervalMs: number) {
+  let now = Date.now();
+  const listeners = new Set<() => void>();
+  let timer: ReturnType<typeof setInterval> | undefined;
+
+  function ensureTimer() {
+    if (timer != null || listeners.size === 0) return;
+    timer = setInterval(() => {
+      now = Date.now();
+      for (const listener of listeners) listener();
+    }, intervalMs);
+  }
+
+  function maybeStopTimer() {
+    if (timer == null || listeners.size > 0) return;
+    clearInterval(timer);
+    timer = undefined;
+  }
+
+  return {
+    subscribe(onStoreChange: () => void) {
+      listeners.add(onStoreChange);
+      // Fresh snapshot so a late subscriber is not stuck on a stale `now`.
+      now = Date.now();
+      ensureTimer();
+      return () => {
+        listeners.delete(onStoreChange);
+        maybeStopTimer();
+      };
+    },
+    getSnapshot() {
+      return now;
+    },
+  };
+}
+
+/** One shared clock per interval so many components do not each own a timer. */
+const clocks = new Map<number, ReturnType<typeof createTickingClock>>();
+
+function clockFor(intervalMs: number) {
+  let clock = clocks.get(intervalMs);
+  if (clock == null) {
+    clock = createTickingClock(intervalMs);
+    clocks.set(intervalMs, clock);
+  }
+  return clock;
+}
+
+/**
+ * Live wall-clock milliseconds. Ticks every `intervalMs` while `enabled` is
+ * true; when disabled, returns a frozen snapshot and holds no timer.
+ */
+export function useTickingNowMs(intervalMs: number, enabled = true): number {
+  const clock = clockFor(intervalMs);
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (!enabled) return () => {};
+      return clock.subscribe(onStoreChange);
+    },
+    [clock, enabled],
+  );
+  return useSyncExternalStore(subscribe, clock.getSnapshot, clock.getSnapshot);
+}

--- a/apps/os/src/lib/use-ticking-now-ms.ts
+++ b/apps/os/src/lib/use-ticking-now-ms.ts
@@ -30,8 +30,12 @@ function createTickingClock(intervalMs: number) {
     subscribe(onStoreChange: () => void) {
       listeners.add(onStoreChange);
       // Fresh snapshot so a late subscriber is not stuck on a stale `now`.
+      // Notify after subscribe returns — useSyncExternalStore re-reads
+      // getSnapshot on notification; updating `now` alone without notifying
+      // leaves the render-time snapshot in place until the next interval tick.
       now = Date.now();
       ensureTimer();
+      queueMicrotask(onStoreChange);
       return () => {
         listeners.delete(onStoreChange);
         maybeStopTimer();

--- a/apps/os/src/lib/use-ticking-now-ms.ts
+++ b/apps/os/src/lib/use-ticking-now-ms.ts
@@ -33,9 +33,13 @@ function createTickingClock(intervalMs: number) {
       // Notify after subscribe returns — useSyncExternalStore re-reads
       // getSnapshot on notification; updating `now` alone without notifying
       // leaves the render-time snapshot in place until the next interval tick.
+      // Only fire if still registered (Strict Mode / enabled flip can
+      // unsubscribe before the microtask runs).
       now = Date.now();
       ensureTimer();
-      queueMicrotask(onStoreChange);
+      queueMicrotask(() => {
+        if (listeners.has(onStoreChange)) onStoreChange();
+      });
       return () => {
         listeners.delete(onStoreChange);
         maybeStopTimer();

--- a/apps/os/src/lib/use-ticking-now-ms.ts
+++ b/apps/os/src/lib/use-ticking-now-ms.ts
@@ -1,4 +1,4 @@
-import { useCallback, useSyncExternalStore } from "react";
+import { useCallback, useRef, useSyncExternalStore } from "react";
 
 /**
  * A wall-clock subscribed via `useSyncExternalStore`, not `useState` +
@@ -29,14 +29,10 @@ function createTickingClock(intervalMs: number) {
   return {
     subscribe(onStoreChange: () => void) {
       listeners.add(onStoreChange);
-      // Fresh snapshot so a late subscriber is not stuck on a stale `now`.
-      // Notify after subscribe returns — useSyncExternalStore re-reads
-      // getSnapshot on notification; updating `now` alone without notifying
-      // leaves the render-time snapshot in place until the next interval tick.
-      // Only fire if still registered (Strict Mode / enabled flip can
-      // unsubscribe before the microtask runs).
       now = Date.now();
       ensureTimer();
+      // Notify after subscribe returns so a remount/re-enable re-reads
+      // getSnapshot. Skip if already unsubscribed (Strict Mode remount).
       queueMicrotask(() => {
         if (listeners.has(onStoreChange)) onStoreChange();
       });
@@ -46,6 +42,14 @@ function createTickingClock(intervalMs: number) {
       };
     },
     getSnapshot() {
+      // Idle clock: refresh only when wall time has moved by a full tick so
+      // the first render after a long idle is current, but consecutive
+      // getSnapshot calls in the same tick stay Object.is-stable (avoids
+      // useSyncExternalStore infinite re-render loops).
+      if (timer == null) {
+        const wall = Date.now();
+        if (wall - now >= intervalMs) now = wall;
+      }
       return now;
     },
   };
@@ -69,6 +73,13 @@ function clockFor(intervalMs: number) {
  */
 export function useTickingNowMs(intervalMs: number, enabled = true): number {
   const clock = clockFor(intervalMs);
+  // Stable freeze while disabled so getSnapshot does not return a fresh
+  // Date.now() every call (that would infinite-loop useSyncExternalStore).
+  const frozenWhileDisabledRef = useRef(Date.now());
+  if (enabled) {
+    frozenWhileDisabledRef.current = clock.getSnapshot();
+  }
+
   const subscribe = useCallback(
     (onStoreChange: () => void) => {
       if (!enabled) return () => {};
@@ -76,5 +87,11 @@ export function useTickingNowMs(intervalMs: number, enabled = true): number {
     },
     [clock, enabled],
   );
-  return useSyncExternalStore(subscribe, clock.getSnapshot, clock.getSnapshot);
+
+  const getSnapshot = useCallback(() => {
+    if (!enabled) return frozenWhileDisabledRef.current;
+    return clock.getSnapshot();
+  }, [clock, enabled]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }

--- a/packages/iterate/src/stream-tui/agent-chat-terminal.tsx
+++ b/packages/iterate/src/stream-tui/agent-chat-terminal.tsx
@@ -282,6 +282,9 @@ function subscribeLiveCodeClock(onStoreChange: () => void) {
       for (const listener of liveCodeClockListeners) listener();
     }, 100);
   }
+  // Notify after subscribe returns so the first snapshot is current wall time
+  // (updating the scalar alone does not re-render useSyncExternalStore).
+  queueMicrotask(onStoreChange);
   return () => {
     liveCodeClockListeners.delete(onStoreChange);
     if (liveCodeClockListeners.size === 0 && liveCodeClockTimer != null) {

--- a/packages/iterate/src/stream-tui/agent-chat-terminal.tsx
+++ b/packages/iterate/src/stream-tui/agent-chat-terminal.tsx
@@ -298,6 +298,12 @@ function subscribeLiveCodeClock(onStoreChange: () => void) {
 }
 
 function getLiveCodeClockSnapshot() {
+  // Idle: refresh only when a full tick has elapsed so remounts aren't stuck
+  // on a stale freeze, but consecutive getSnapshot calls stay Object.is-stable.
+  if (liveCodeClockTimer == null) {
+    const wall = Date.now();
+    if (wall - liveCodeClockNow >= 100) liveCodeClockNow = wall;
+  }
   return liveCodeClockNow;
 }
 

--- a/packages/iterate/src/stream-tui/agent-chat-terminal.tsx
+++ b/packages/iterate/src/stream-tui/agent-chat-terminal.tsx
@@ -14,7 +14,7 @@
 import { StyledText, bg, fg } from "@opentui/core";
 import { createCliRenderer } from "@opentui/core";
 import { createRoot, useKeyboard } from "@opentui/react";
-import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
+import { useCallback, useState, useSyncExternalStore } from "react";
 import type {
   AgentUiActivity,
   AgentUiItem,
@@ -267,19 +267,48 @@ function SettledActivity(props: { activity: AgentUiActivity }) {
   );
 }
 
+/** Shared 100ms clock for live "Running code 0.9s" — useSyncExternalStore,
+ * not useState+setInterval, so the snapshot is stable between ticks. */
+let liveCodeClockNow = Date.now();
+const liveCodeClockListeners = new Set<() => void>();
+let liveCodeClockTimer: ReturnType<typeof setInterval> | undefined;
+
+function subscribeLiveCodeClock(onStoreChange: () => void) {
+  liveCodeClockListeners.add(onStoreChange);
+  liveCodeClockNow = Date.now();
+  if (liveCodeClockTimer == null) {
+    liveCodeClockTimer = setInterval(() => {
+      liveCodeClockNow = Date.now();
+      for (const listener of liveCodeClockListeners) listener();
+    }, 100);
+  }
+  return () => {
+    liveCodeClockListeners.delete(onStoreChange);
+    if (liveCodeClockListeners.size === 0 && liveCodeClockTimer != null) {
+      clearInterval(liveCodeClockTimer);
+      liveCodeClockTimer = undefined;
+    }
+  };
+}
+
+function getLiveCodeClockSnapshot() {
+  return liveCodeClockNow;
+}
+
 function LiveActivity(props: { activity: AgentUiActivity }) {
   // Tick while code runs so "Running code 0.9s" counts up without waiting
   // for feed events (script execution often emits nothing mid-run).
   const codeRunning = props.activity.steps.some(
     (step) => step.kind === "code" && step.status === "running",
   );
-  const [nowMs, setNowMs] = useState(() => Date.now());
-  useEffect(() => {
-    if (!codeRunning) return;
-    setNowMs(Date.now());
-    const interval = setInterval(() => setNowMs(Date.now()), 100);
-    return () => clearInterval(interval);
-  }, [codeRunning]);
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (!codeRunning) return () => {};
+      return subscribeLiveCodeClock(onStoreChange);
+    },
+    [codeRunning],
+  );
+  const nowMs = useSyncExternalStore(subscribe, getLiveCodeClockSnapshot, getLiveCodeClockSnapshot);
 
   const lastStep = props.activity.steps[props.activity.steps.length - 1];
   const thinking = lastStep?.kind === "llm" ? streamingTail(lastStep.thinkingText) : "";

--- a/packages/iterate/src/stream-tui/agent-chat-terminal.tsx
+++ b/packages/iterate/src/stream-tui/agent-chat-terminal.tsx
@@ -284,7 +284,10 @@ function subscribeLiveCodeClock(onStoreChange: () => void) {
   }
   // Notify after subscribe returns so the first snapshot is current wall time
   // (updating the scalar alone does not re-render useSyncExternalStore).
-  queueMicrotask(onStoreChange);
+  // Skip if already unsubscribed (Strict Mode remount / codeRunning flip).
+  queueMicrotask(() => {
+    if (liveCodeClockListeners.has(onStoreChange)) onStoreChange();
+  });
   return () => {
     liveCodeClockListeners.delete(onStoreChange);
     if (liveCodeClockListeners.size === 0 && liveCodeClockTimer != null) {


### PR DESCRIPTION
## Summary

Follow-up to #2029 so the live clocks use the pattern react-doctor prefers:

- New `useTickingNowMs` helper via `useSyncExternalStore` (stable snapshot between ticks, shared timer per interval)
- Agent feed "Running code 0.9s" elapsed counter uses it instead of `useState` + `setInterval` in an effect
- Agent roster "ago" clock uses the same helper
- TUI `LiveActivity` uses the same store subscription approach

`npx react-doctor@latest --scope changed --base origin/main` reports **no new issues** on the changed files.

## Test plan

- [x] oxlint clean on touched files
- [x] react-doctor `--scope changed` clean for apps/os and packages/iterate
- [ ] Smoke: agent chat shows ticking `Running code 0.Xs` while a script runs
- [ ] Smoke: roster relative times still update

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only timing refactor with careful snapshot stability; no auth, data, or API behavior changes.
> 
> **Overview**
> Replaces **`useState` + `setInterval` in effects** with **`useSyncExternalStore`** for wall-clock ticks in agent UI, following react-doctor guidance and keeping snapshots stable between ticks.
> 
> Adds shared **`useTickingNowMs`** in `apps/os` (one timer per interval, optional `enabled` to freeze without subscribing). **Agent feed** elapsed “Running code 0.Xs” and **sidebar roster** “ago” labels use it; local roster clock helpers are removed.
> 
> **Stream TUI** `LiveActivity` gets the same subscription pattern via a module-level 100ms clock (parallel to the OS helper, not shared across packages).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 812e84c5698017a46bed2bccd4a60081c4d43441. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +146 -8 | +106 -8 🟩🟩🟩🟩🟩 |
| UI components | +9 -28 | +7 -27 🟥⬜⬜⬜⬜ |
| **Total** | **+155 -36** | **+113 -35** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 6901a0c and 812e84c, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-15T19:27:47.709Z",
      "headSha": "812e84c5698017a46bed2bccd4a60081c4d43441",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/62280622002322",
      "shortSha": "812e84c",
      "cleanupDurationMs": 3535,
      "deployDurationMs": 20782,
      "testDurationMs": 758,
      "testRetries": null,
      "workerSizeKib": 4030.87,
      "workerGzipKib": 819.81,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-15T19:27:45.000Z",
      "headSha": "5064bcbb03d30f33f651d96b959be3613c6d3757",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/213374751596626",
      "shortSha": "5064bcb",
      "cleanupDurationMs": 824,
      "deployDurationMs": 27507,
      "testDurationMs": 119125,
      "testRetries": "3 retried: stream capnweb protocol > documents Cloudflare's 32 MiB inbound WebSocket frame ceiling for capnweb appends (vitest x1) · large streams stay virtualized and can scroll from tail to earliest rows (playwright x1) · two tabs: follower blast survives a DO kill and both mirrors converge (playwright x1)",
      "workerSizeKib": 5160.64,
      "workerGzipKib": 1470.36,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-15T19:27:44.841Z",
      "headSha": "812e84c5698017a46bed2bccd4a60081c4d43441",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/62280622002322",
      "shortSha": "812e84c",
      "cleanupDurationMs": 664,
      "deployDurationMs": 13616,
      "testDurationMs": 7026,
      "testRetries": null,
      "workerSizeKib": 1139,
      "workerGzipKib": 201.58,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-15T19:27:43.082Z",
      "headSha": "812e84c5698017a46bed2bccd4a60081c4d43441",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/62280622002322",
      "shortSha": "812e84c",
      "cleanupDurationMs": 120393,
      "deployDurationMs": 87733,
      "testDurationMs": 261621,
      "testRetries": "7 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · concurrent long-running itx scripts all complete (vitest x1) · stream getEvents defaults to a bounded page and supports event type filters (vitest x1) · cross-posts do not recursively copy events that are already cross-posted (vitest x1) · hydrates the client-only integrations route without rebuilding the shell (specs x1) · reactivity page replays already appended events after reload (specs x1) · runs \"scheduler-agent-checkin\" through the project REPL (specs x1)",
      "workerSizeKib": 16427.13,
      "workerGzipKib": 4431.36,
      "mainWorkerGzipKib": 4430.92
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-15T19:25:43.286Z",
      "headSha": "5064bcbb03d30f33f651d96b959be3613c6d3757",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/213374751596626",
      "shortSha": "5064bcb",
      "cleanupDurationMs": 594,
      "deployDurationMs": 13478,
      "testDurationMs": 35246,
      "testRetries": null,
      "workerSizeKib": 1914.49,
      "workerGzipKib": 440.74,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `812e84c` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 819.8 KiB | 20.8s | 758ms |  | 3.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/62280622002322) | 2026-07-15T19:27:47.709Z | Preview app released. |
| Dummy Petshop | released | `812e84c` | [https://dummy-petshop.iterate-preview-8.com](https://dummy-petshop.iterate-preview-8.com) | 201.6 KiB | 13.6s | 7.0s |  | 664ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/62280622002322) | 2026-07-15T19:27:44.841Z | Preview app released. |
| OS | released | `812e84c` | [https://os.iterate-preview-8.com](https://os.iterate-preview-8.com) | 4.33 MiB (+0.4 KiB vs main) | 87.7s | 261.6s | 7 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · concurrent long-running itx scripts all complete (vitest x1) · stream getEvents defaults to a bounded page and supports event type filters (vitest x1) · cross-posts do not recursively copy events that are already cross-posted (vitest x1) · hydrates the client-only integrations route without rebuilding the shell (specs x1) · reactivity page replays already appended events after reload (specs x1) · runs "scheduler-agent-checkin" through the project REPL (specs x1) | 120.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/62280622002322) | 2026-07-15T19:27:43.082Z | Preview app released. |
| Semaphore | released | `5064bcb` | [https://semaphore.iterate-preview-8.com](https://semaphore.iterate-preview-8.com) | 440.7 KiB | 13.5s | 35.2s |  | 594ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/213374751596626) | 2026-07-15T19:25:43.286Z | Preview app released. |
| Streams Example App | released | `5064bcb` | [https://streams.iterate-preview-8.com](https://streams.iterate-preview-8.com) | 1.44 MiB | 27.5s | 119.1s | 3 retried: stream capnweb protocol > documents Cloudflare's 32 MiB inbound WebSocket frame ceiling for capnweb appends (vitest x1) · large streams stay virtualized and can scroll from tail to earliest rows (playwright x1) · two tabs: follower blast survives a DO kill and both mirrors converge (playwright x1) | 824ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/213374751596626) | 2026-07-15T19:27:45.000Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->