### PR TITLE
Testing-doc loose ends: sweep remaining drift, document the .itx. infix, dated-skip expiry convention

### DIFF
--- a/apps/os/e2e/AGENTS.md
+++ b/apps/os/e2e/AGENTS.md
@@ -9,7 +9,9 @@ Active e2e tests drive OS through **itx** — the same project capability handle
 REPL, and CLI use. The oRPC product surface is gone; nothing here talks to oRPC anymore.
 
 - `vitest.config.ts` owns run-level config, artifact roots, and console capture. `pnpm e2e` runs
-  `e2e/vitest/**/*.test.ts` plus the itx e2e suites in `e2e/vitest/**/*.e2e.test.ts` through it.
+  `e2e/vitest/**/*.test.ts` plus the cross-runtime examples matrix in
+  `e2e/examples/*.e2e.test.ts` through it (those are the two `include` globs; nothing filters
+  on any other filename shape).
 - `test-support/os-client.ts` exposes the admin itx handle (`createAdminOsItx`) plus base-URL /
   bearer-token resolution.
 - `test-support/create-test-project.ts` creates a disposable OS project via itx
@@ -27,16 +29,35 @@ How to target local dev / previews / prd and the canonical env vars
 in [docs/testing.md](../../../docs/testing.md).
 
 - Live deployment tests: `pnpm e2e` (one config, `e2e/vitest.config.ts`, one project named
-  `node`). It runs the engine suites in `e2e/vitest/` (agents, admin-project, preview
-  smoke) and the cross-runtime example matrix in `e2e/examples/`. Browser coverage for the
-  catalogue lives in `specs/repl-examples.spec.ts`, which drives the real REPL.
-- Egress + secret substitution coverage lives in `e2e/vitest/itx-egress.e2e.test.ts`
-  (the old `itx.e2e.test.ts` monolith was split across the `itx-*.e2e.test.ts` files).
+  `node`). It runs the engine suites in `e2e/vitest/` (the itx catalogue, streams, agents,
+  integrations, sandbox, ingress, preview smoke, …) and the cross-runtime example matrix in
+  `e2e/examples/`. Browser coverage for the catalogue lives in
+  `specs/repl-examples.spec.ts`, which drives the real REPL.
 - Preview smoke: `pnpm e2e -t "OS preview smoke"` (`preview-smoke.e2e.test.ts`) exercises a
   deployed preview, including its project MCP route (it derives its project slug from
   `GITHUB_SHA` when set).
 - Stream TUI behavior specs: `tsx ./e2e/tui-test/run.ts` (see `tui-test/README.md`). The script
-  creates a disposable OS project before launching Microsoft TUI Test and deletes it afterward.
+  creates a disposable OS project before launching Microsoft TUI Test (disposal is a no-op
+  until itx grows `projects.remove`, like every other test project).
+
+## File names in `e2e/vitest/`
+
+Two similar-looking shapes mean different things:
+
+- **`itx-<topic>.e2e.test.ts`** (prefix) — the hand-written itx engine contract. These are the
+  shards of the old `itx.e2e.test.ts` monolith, split in PR #1824 purely so file-level workers
+  can spread them (test bodies unchanged; e.g. egress + secret substitution landed in
+  `itx-egress.e2e.test.ts`). Each carries the header
+  `// These are hand written tests - they MUST pass`, which dates back to the itx-v4 engine's
+  original test file: hand-authored contract assertions, as opposed to the catalogue-driven
+  examples matrix next door whose covered scripts evolve with the examples catalogue. A failure
+  here is a product regression — fix the product, never weaken the assertion to green it.
+- **`<feature>.itx.e2e.test.ts`** (infix) — historical, not a control. The `.itx.` marker was
+  born in PR #1488 to distinguish the itx ports of the oRPC-era suites from their (since
+  deleted) `*.orpc-legacy.ts` reference siblings, and then spread by convention to feature
+  suites that drive OS purely through a project's itx handle with no raw HTTP/WebSocket
+  probes. Every active e2e test drives itx now, and nothing — vitest include, CI, lint —
+  keys off the infix. Treat it as informational; don't add it to new files.
 
 ## Scripts in tests
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3,7 +3,7 @@
 How the test lanes are organized, how to run each against any environment,
 the canonical environment variables, and [the retry/timeout
 policy](#retries-and-timeouts) every lane follows. For unit-test style (fake
-timers, inline snapshots, `test.for` tables), see
+timers, `test.for` tables with hand-written literal expectations), see
 [Vitest patterns](vitest-patterns.md).
 
 ## Philosophy

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -422,3 +422,28 @@ retries: ...` (the `RetryTelemetryReporter` in
 
 When telemetry trends up without failures, treat it exactly like a budget
 `::warning::`: find the cause, don't wait for red.
+
+### Parked tests expire
+
+A skip/fixme/todo marker that parks a KNOWN issue is a loan against the
+suite, and it carries its terms in a comment on (or right above) the marker:
+
+```ts
+// parked: <what is broken, with evidence> — revisit by 2026-08-15
+test.fixme(true, "Known regression: ...");
+```
+
+— or it points at a tracking task (`tasks/<name>.md`) that owns the revisit
+instead. Markers without a date are for **structural** reasons only:
+platform- or env-gated suites that cannot run in a given context (the
+email-OTP specs skip on deployments with OTP disabled — that is a property
+of the target, not a parked bug).
+
+`lint/dated-skips.test.ts` enforces this in the unit lane: it scans the
+test corpus for skip/fixme/todo markers and **fails on any `revisit by`
+date in the past**, printing the file and the parked reason. An expired
+date is a decision point, not a nag to bump: fix and un-park the test, or
+renew the date with the reason re-argued. Undated markers must be either
+task-referenced or allowlisted in that guard with a note — structural
+gates live there permanently; parked markers that predate this convention
+are grandfathered there once and the grandfather list only shrinks.

--- a/docs/vitest-patterns.md
+++ b/docs/vitest-patterns.md
@@ -7,26 +7,18 @@ previews / prd, and the canonical env vars — see [Testing](testing.md).
 ## Core Principles
 
 - Use vi mocks and vi fake timers for time-based assertions
-- Prefer `.toMatchInlineSnapshot()` for snapshot tests
+- Prefer table-based tests with hand-written literal expectations (`test.for`
+  with object rows) over snapshots
 - Tests are colocated next to source files as `*.test.ts`
 
-## Table-based Testing with describe.for and test.for
+## Table-based Testing with test.for
 
-Use `describe.for` and `test.for` for table-driven tests. Unlike `.each`, `.for` doesn't spread array elements - it passes the entire element as a single argument:
+Use `test.for` with object rows for table-driven tests: a `name` per row,
+`$name` as the title, inputs and the expected value written out as literals in
+the row. Unlike `.each`, `.for` doesn't spread array elements - it passes the
+entire row as a single argument, so it destructures cleanly:
 
 ```typescript
-describe.for([
-  ["add", 1, 2, 3],
-  ["subtract", 5, 2, 3],
-  ["multiply", 3, 4, 12],
-])("%s(%i, %i) -> %i", ([operation, a, b, expected]) => {
-  test("returns correct result", () => {
-    const result = calculate(operation, a, b);
-    expect(result).toBe(expected);
-  });
-});
-
-// With object cases for better readability
 test.for([
   { user: "Alice", role: "admin", canDelete: true },
   { user: "Bob", role: "user", canDelete: false },
@@ -36,6 +28,17 @@ test.for([
   expect(permissions.canDelete).toBe(canDelete);
 });
 ```
+
+`apps/os/src/ingress.test.ts` is the model at scale: dozens of routing cases
+as data, one assertion body doing `toMatchObject(expected)`, a comment on any
+row whose reason isn't obvious, and helper factories below the table.
+
+Expectations are literals a reviewer can read against the row's inputs — not
+snapshots. `.toMatchInlineSnapshot()` regenerates on demand, which turns
+review into accepting machine output and lets wrong output get ratified; it's
+all but absent from the corpus, and new tests shouldn't add it. When only part
+of a structure matters, assert that part (`toMatchObject`, or pick the fields)
+instead of snapshotting the whole thing.
 
 ## Polling and Waiting for Conditions
 
@@ -50,7 +53,7 @@ test("should eventually return expected value", async () => {
   await expect
     .poll(
       async () => {
-        const events = await orpcClient.getEvents();
+        const events = await stream.getEvents();
         return events.some((e) => e.type === "COMPLETED");
       },
       { timeout: 5000, interval: 100 },
@@ -90,23 +93,5 @@ test("should wait for condition", async () => {
     expect(response.data).toHaveProperty("id");
     return response.data;
   });
-});
-```
-
-### vi.waitUntil() - For custom conditions
-
-Similar to waitFor but returns the first truthy value.
-
-```typescript
-test("should wait until condition is truthy", async () => {
-  const element = await vi.waitUntil(
-    async () => {
-      const elements = await page.findElements(".my-class");
-      return elements.length > 0 ? elements[0] : null;
-    },
-    { timeout: 3000 },
-  );
-
-  expect(element).toBeDefined();
 });
 ```

--- a/lint/dated-skips.test.ts
+++ b/lint/dated-skips.test.ts
@@ -1,0 +1,138 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { expect, test } from "vitest";
+
+// Dated-skip expiry guard (docs/testing.md#parked-tests-expire): a
+// skip/fixme/todo marker that parks a KNOWN issue must carry
+// `parked: <reason> — revisit by YYYY-MM-DD` near the marker, or point at a
+// tracking task (`tasks/<name>.md`). This test fails on any `revisit by`
+// date in the past, printing the file and the parked reason, so parked
+// tests get re-decided instead of rotting. Undated markers must be
+// allowlisted below: structural (platform-/env-gated) gates live there
+// permanently with a note; parked markers that predate the convention are
+// grandfathered there once. Deliberately dumb and fast — git ls-files plus
+// a regex window, no AST.
+
+const repoRoot = resolve(import.meta.dirname, "..");
+const SELF = "lint/dated-skips.test.ts";
+
+// Matches marker calls only; `skipIf`/`runIf` (conditional, structural by
+// construction) deliberately do not match because of the trailing paren.
+const MARKER = /\.(skip|fixme|todo)\(/;
+const REVISIT = /revisit by (\d{4}-\d{2}-\d{2})/i;
+// How many lines on each side of the marker may carry the parked/revisit
+// comment or the tracking-task reference.
+const WINDOW = 6;
+
+interface AllowedUndated {
+  file: string;
+  /** Distinctive substring near the marker, so entries survive line drift. */
+  match: string;
+  note: string;
+}
+
+const ALLOWED_UNDATED: AllowedUndated[] = [
+  // -- Structural (env-gated): legitimately undated — the gate describes the
+  // deployment under test, not a parked bug.
+  {
+    file: "specs/signup.spec.ts",
+    match: "Email OTP sign-in is disabled for this deployment",
+    note: "env-gated: a deployment without email OTP cannot run the real signup flow",
+  },
+  {
+    file: "specs/create-project.spec.ts",
+    match: "Email OTP sign-in is disabled for this deployment",
+    note: "env-gated: same OTP gate as signup.spec.ts",
+  },
+  // -- Grandfathered parked markers (predate the convention, 2026-07-15).
+  // Do NOT add entries here — date new parked markers instead. This list
+  // only shrinks.
+  {
+    file: "apps/os/e2e/vitest/stream-lifecycle.e2e.test.ts",
+    match: "dropping a WebSocket waitForEvent caller cleans up",
+    note: "KNOWN GAP 2026-07-02: waitForEvent has no abort on transport drop",
+  },
+  {
+    file: "apps/streams-example-app/e2e/playwright/stream-browser.spec.ts",
+    match: "expanded tail rows can grow under the sticky composer",
+    note: "known tail re-pin regression, evidence in the spec comment (PR #2024)",
+  },
+  {
+    file: "apps/streams-example-app/e2e/playwright/stream-browser.spec.ts",
+    match: "Double DO kill under CI worker contention",
+    note: "CI-only mirror retry-budget boundary, needs product investigation (PR #2024)",
+  },
+];
+
+test("parked skip/fixme/todo markers carry an unexpired `revisit by` date", () => {
+  // Same universe as CI lints: tracked files, node_modules excluded for free.
+  const testFiles = execFileSync("git", ["ls-files"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  })
+    .split("\n")
+    .filter((file) => /\.(test|spec)\.(ts|tsx|mts)$/.test(file) && file !== SELF);
+
+  const today = new Date().toISOString().slice(0, 10);
+  const expired: string[] = [];
+  const undated: string[] = [];
+  const usedEntries = new Set<AllowedUndated>();
+
+  for (const file of testFiles) {
+    const lines = readFileSync(resolve(repoRoot, file), "utf8").split("\n");
+    for (let index = 0; index < lines.length; index++) {
+      if (!MARKER.test(lines[index]!)) continue;
+      const window = lines.slice(Math.max(0, index - WINDOW), index + WINDOW + 1).join("\n");
+      const where = `${file}:${index + 1}`;
+
+      const revisit = REVISIT.exec(window);
+      if (revisit) {
+        const date = revisit[1]!;
+        const reason =
+          /parked:\s*([^\n]+)/.exec(window)?.[1]?.trim() ??
+          window
+            .split("\n")
+            .find((line) => REVISIT.test(line))!
+            .trim();
+        if (Number.isNaN(Date.parse(date))) {
+          expired.push(`${where} — unparseable revisit date "${date}" — ${reason}`);
+        } else if (date < today) {
+          // Lexicographic compare is correct for YYYY-MM-DD.
+          expired.push(`${where} — expired ${date} — ${reason}`);
+        }
+        continue;
+      }
+
+      // A tracking-task reference near the marker hands the revisit to the
+      // task system (docs/task-system.md) instead of a date.
+      if (window.includes("tasks/")) continue;
+
+      const entry = ALLOWED_UNDATED.find(
+        (candidate) => candidate.file === file && window.includes(candidate.match),
+      );
+      if (entry) {
+        usedEntries.add(entry);
+        continue;
+      }
+      undated.push(`${where} — ${lines[index]!.trim()}`);
+    }
+  }
+
+  expect(
+    expired,
+    `Parked tests past their revisit-by date. Fix and un-park them, or renew the date with the reason re-argued:\n${expired.join("\n")}`,
+  ).toEqual([]);
+
+  expect(
+    undated,
+    `Undated skip/fixme/todo markers. Park known issues with \`parked: <reason> — revisit by YYYY-MM-DD\` (or reference a tracking tasks/<name>.md); structural platform-/env-gates get an allowlist entry in ${SELF}:\n${undated.join("\n")}`,
+  ).toEqual([]);
+
+  const stale = ALLOWED_UNDATED.filter((entry) => !usedEntries.has(entry));
+  expect(
+    stale,
+    `Allowlist entries in ${SELF} no longer match anything — the marker was fixed or moved; remove the entry:\n${stale.map((entry) => `${entry.file} — ${entry.match}`).join("\n")}`,
+  ).toEqual([]);
+});


### PR DESCRIPTION
Docs precision sweep from the 2026-07-14 testing-strategy audit, plus one small convention with a guard. Every drift item was re-verified against current reality before editing; one audit item turned out already fixed.

## Item 1 — doc drift

**`docs/testing.md` — "see patches/" spinner-waiter pointer: already un-drifted.** No `patch` mention survives in the file; all three spinner-waiter references already point at [middlewright](https://github.com/iterate/middlewright), and the root `package.json` depends on `"middlewright": "0.1.2"`. No edit needed beyond the pointer below. Everything else the doc names (budget values vs `e2e-policy/budgets.ts`, the four matrix runtimes, every referenced path, `stream-repros/iterate-pr-NNNN-*`, watchdog values, workflow timeout-minutes) verified accurate.

- One coupled fix: the intro's pointer at Vitest patterns advertised the abandoned style —
  > "For unit-test style (fake timers, inline snapshots, `test.for` tables)"

  → now "fake timers, `test.for` tables with hand-written literal expectations".

**`apps/os/e2e/AGENTS.md`** — aligned with what exists:

- Wrong include glob:
  > "`pnpm e2e` runs `e2e/vitest/**/*.test.ts` plus the itx e2e suites in `e2e/vitest/**/*.e2e.test.ts` through it."

  The config's actual `include` is `["./e2e/vitest/**/*.test.ts", "./e2e/examples/*.e2e.test.ts"]` — the second glob is the examples matrix, and the first already subsumes every `*.e2e.test.ts`. Fixed, and noted that nothing filters on any other filename shape.
- Stale suite list:
  > "It runs the engine suites in `e2e/vitest/` (agents, admin-project, preview smoke)"

  There is no `agents.e2e.test.ts`; the directory holds ~35 suites. Refreshed.
- False deletion claim:
  > "The script creates a disposable OS project before launching Microsoft TUI Test and deletes it afterward."

  `run.ts` comments "Disposal is currently a no-op" (itx has no `projects.remove` yet, `tasks/os-project-archival.md`). Fixed.
- **New "File names in `e2e/vitest/`" section** — the folklore, now written down (traced through git):
  - `itx-<topic>.e2e.test.ts` (prefix) = the shards of the old `itx.e2e.test.ts` monolith, split in PR #1824 purely for file-level parallelism. Each carries `// These are hand written tests - they MUST pass`, which dates back to the itx-v4 engine's original test file (pre-#1585): hand-authored engine-contract assertions, as opposed to the catalogue-driven examples matrix — a failure is a product regression, never fix it by weakening the assertion.
  - `<feature>.itx.e2e.test.ts` (infix) = **historical, not a control.** Born in PR #1488 (oRPC deletion) to distinguish the itx ports from their since-deleted `*.orpc-legacy.ts` reference siblings, then spread by convention to suites that drive OS purely through a project's itx handle (all 8 infix files contain zero raw fetch/WebSocket). Every active e2e test drives itx now and nothing — vitest include, CI, lint — keys off it. Documented as informational; don't add it to new files.

**`docs/vitest-patterns.md`** — recommendation matched to practiced style (voice kept):

- > "Prefer `.toMatchInlineSnapshot()` for snapshot tests"

  The corpus has exactly **one** inline snapshot. Rewritten to the ratified house taste: `test.for` object rows with a `name` per row, `$name` titles (32 uses), hand-written literal expectations; `apps/os/src/ingress.test.ts` documented as the model.
- The table section led with `describe.for` (**zero** corpus uses, positional-array rows with `%s` format specifiers) — now leads with the object-row pattern actually in use (41 `test.for` occurrences).
- > `const events = await orpcClient.getEvents();`

  The oRPC product surface was deleted in #1488; example de-oRPC'd.
- Dropped the `vi.waitUntil()` section: zero corpus uses, and its example called `page.findElements(".my-class")` — an API that exists nowhere in this repo.

## Item 2 — dated-skip expiry convention

- **`docs/testing.md` → "Parked tests expire"** (next to the retry/timeout policy): a skip/fixme/todo that parks a KNOWN issue must carry `parked: <reason> — revisit by YYYY-MM-DD`, or reference a tracking `tasks/<name>.md`. Undated markers are for structural platform-/env-gates only. An expired date is a decision point: fix and un-park, or renew with the reason re-argued.
- **`lint/dated-skips.test.ts`** — guard in the unit lane (wired like `oxlintrc-scope-liveness.test.ts`: `git ls-files` + a regex window, no AST, fast). Fails on any past `revisit by` date, printing file and parked reason; fails new undated markers unless task-referenced or allowlisted; fails stale allowlist entries so the list stays live. The corpus's five existing markers are handled: the two env-gated email-OTP spec skips allowlisted as structural, and the three pre-convention parked markers (stream-lifecycle waitForEvent gap, stream-browser tail-row regression, stream-browser CI double-kill) grandfathered once — no dates were added to other people's parked tests. `skipIf`/`runIf` deliberately don't match (conditional = structural by construction). Both failure arms were proven with probe files before landing.

## Gates

`oxlint --deny-warnings` 0/0 · `pnpm typecheck` all workspaces · `pnpm knip` clean · `doppler run -- pnpm --dir apps/os test` 160 files / 1608 passed · `pnpm --dir lint test` 23 passed (includes the new guard) · `pnpm format` no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a repo-wide lint guard only; no runtime, auth, or deployment behavior changes.
> 
> **Overview**
> Aligns testing documentation with current e2e layout and unit-test style, and adds a **parked tests expire** convention enforced in CI.
> 
> **Docs:** `apps/os/e2e/AGENTS.md` now matches `vitest.config.ts` includes (`e2e/examples/*.e2e.test.ts`, not a separate `*.e2e.test.ts` glob), refreshes the suite inventory, corrects TUI project disposal (no-op until `projects.remove`), and documents the difference between `itx-<topic>.e2e.test.ts` (engine contract shards) and the historical `.itx.` infix. `docs/vitest-patterns.md` steers authors toward `test.for` object rows with literal expectations instead of inline snapshots, drops unused `describe.for` / `vi.waitUntil()` guidance, and de-oRPCs examples. `docs/testing.md` links to that style and adds **Parked tests expire** (dated `parked:` comments, task refs, or structural allowlists).
> 
> **Guard:** New `lint/dated-skips.test.ts` scans tracked `*.test`/`*.spec` files for `.skip`/`.fixme`/`.todo(` markers, fails on past `revisit by` dates and undated markers unless they reference `tasks/` or an allowlist entry (env-gated OTP skips + three grandfathered parked tests); stale allowlist entries also fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 047bbd4a7b76a40e90a47d33fb95a55e96ddc0ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +166 -7 | +125 -7 🟩🟩🟩🟩🟩 |
| Docs | +45 -35 | +38 -30 🟩🟩🟥⬜⬜ |
| **Total** | **+211 -42** | **+163 -37** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between e9a3967 and 047bbd4, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-15T22:03:20.596Z",
      "headSha": "047bbd4a7b76a40e90a47d33fb95a55e96ddc0ee",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/364457319503884",
      "shortSha": "047bbd4",
      "cleanupDurationMs": 2217,
      "deployDurationMs": 20231,
      "testDurationMs": 821,
      "testRetries": null,
      "workerSizeKib": 4030.87,
      "workerGzipKib": 819.49,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-15T22:03:19.192Z",
      "headSha": "047bbd4a7b76a40e90a47d33fb95a55e96ddc0ee",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/364457319503884",
      "shortSha": "047bbd4",
      "cleanupDurationMs": 810,
      "deployDurationMs": 6389,
      "testDurationMs": 8050,
      "testRetries": null,
      "workerSizeKib": 1139,
      "workerGzipKib": 201.58,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-15T22:03:17.338Z",
      "headSha": "047bbd4a7b76a40e90a47d33fb95a55e96ddc0ee",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/364457319503884",
      "shortSha": "047bbd4",
      "cleanupDurationMs": 11662,
      "deployDurationMs": 95809,
      "testDurationMs": 245738,
      "testRetries": "3 retried: Project worker processEventBatch receives events from every project stream and can cross-post (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · runs \"workspace-files-transfer\" through the project REPL (specs x1)",
      "workerSizeKib": 16453.61,
      "workerGzipKib": 4435.78,
      "mainWorkerGzipKib": 4435.78
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `047bbd4` | [https://auth.iterate-preview-9.com](https://auth.iterate-preview-9.com) | 819.5 KiB | 20.2s | 821ms |  | 2.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/364457319503884) | 2026-07-15T22:03:20.596Z | Preview app released. |
| Dummy Petshop | released | `047bbd4` | [https://dummy-petshop.iterate-preview-9.com](https://dummy-petshop.iterate-preview-9.com) | 201.6 KiB | 6.4s | 8.1s |  | 810ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/364457319503884) | 2026-07-15T22:03:19.192Z | Preview app released. |
| OS | released | `047bbd4` | [https://os.iterate-preview-9.com](https://os.iterate-preview-9.com) | 4.33 MiB (±0 vs main) | 95.8s | 245.7s | 3 retried: Project worker processEventBatch receives events from every project stream and can cross-post (vitest x1) · DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · runs "workspace-files-transfer" through the project REPL (specs x1) | 11.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/364457319503884) | 2026-07-15T22:03:17.338Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->