### PR TITLE
Fix multi-processor RPC relay reads

### DIFF
--- a/apps/os/e2e/vitest/admin-project.itx.e2e.test.ts
+++ b/apps/os/e2e/vitest/admin-project.itx.e2e.test.ts
@@ -5,13 +5,70 @@
  * them on itx.
  */
 import { test } from "vitest";
+import type { RpcStub } from "capnweb";
 import { createTestProject } from "../test-support/create-test-project.ts";
 import { waitForCondition } from "../test-support/wait-for-condition.ts";
+import {
+  buildIntegrationRouterCreatedEvent,
+  buildIntegrationRouterSubscriptionConfiguredEvent,
+} from "../../src/domains/integrations/integration-router-events.ts";
 import type { StreamEvent } from "../../src/domains/streams/schemas.ts";
+import type { WakeableStreamProcessorRpc } from "../../src/itx-api.generated.ts";
 
 test("creates a disposable project and uses project streams through itx", async ({ expect }) => {
   await using handle = await createTestProject({ slugPrefix: "admin-fixture" });
   using itx = handle.itx();
+
+  // Project creation waits for every universally available sibling processor
+  // to consume its birth batch. This assertion deliberately goes through the
+  // public email capability: the email router shares the Project DO with the
+  // project processor, so its relay must select the email processor's own
+  // read facade rather than the host's default `processor` property.
+  expect((await itx.email.processor.snapshot()).state).toMatchObject({
+    birthCertificate: { config: {} },
+    threads: {},
+    threadByMessageId: {},
+  });
+
+  // Slack and Telegram routers have the same multi-processor hosting shape.
+  // Build their public birth batches without connecting an external account,
+  // then prove each connection handle reads its named router rather than the
+  // Project processor sharing that Durable Object instance.
+  for (const router of [
+    {
+      processorSlug: "slack",
+      slug: "slack",
+      state: { routes: {} },
+      processor: (connection: string) => itx.integrations.slack.get(connection).processor,
+    },
+    {
+      processorSlug: "telegram",
+      slug: "telegram",
+      state: { sentMessages: {}, sessionsByChat: {} },
+      processor: (connection: string) => itx.integrations.telegram.get(connection).processor,
+    },
+  ] as const) {
+    const connection = `e2e-${router.slug}-${crypto.randomUUID()}`;
+    const committed = await itx.streams.get(`/integrations/${router.slug}/${connection}`).append(
+      buildIntegrationRouterCreatedEvent({ connection, slug: router.slug }),
+      buildIntegrationRouterSubscriptionConfiguredEvent({
+        connection,
+        processorSlug: router.processorSlug,
+        projectId: handle.project.id,
+        slug: router.slug,
+      }),
+    );
+    const processor = router.processor(
+      connection,
+    ) as unknown as RpcStub<WakeableStreamProcessorRpc>;
+    await processor.waitUntilProcessed({
+      offset: Math.max(...committed.map((event) => event.offset)),
+    });
+    expect((await processor.snapshot()).state).toMatchObject({
+      birthCertificate: { config: { connection } },
+      ...router.state,
+    });
+  }
 
   const streamPath = `/e2e/admin-project/${crypto.randomUUID()}`;
   const eventType = "events.iterate.com/os/e2e-admin-stream-proof";

--- a/apps/os/src/domains/projects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/project-durable-object.ts
@@ -30,9 +30,11 @@ import {
   SecretSubstitutionError,
 } from "../secrets/utils.ts";
 import { SlackProcessor } from "../integrations/slack-processor-implementation.ts";
+import { SlackProcessorContract } from "../integrations/slack-processor-contract.ts";
 import { eyesReactionTargetFromWebhookPayload } from "../integrations/slack-agent-processor-implementation.ts";
 import { callProjectSlackWebApi } from "../integrations/slack-api.ts";
 import { TelegramProcessor } from "../integrations/telegram-processor-implementation.ts";
+import { TelegramProcessorContract } from "../integrations/telegram-processor-contract.ts";
 import { EmailProcessor } from "../email/email-processor-implementation.ts";
 import { EmailProcessorContract } from "../email/email-processor-contract.ts";
 import type { ProjectEgressIntercept, ProjectEgressInterceptor } from "./egress.ts";
@@ -140,8 +142,8 @@ export class ProjectDurableObject extends DurableObject<Env> {
   // instances addressed at `/integrations/slack/{connection}` (the host stream
   // is this DO's own path stream), where the OAuth connect flow configured
   // its subscription; registering it on every instance is harmless.
-  // Registration is the point: the registry wakes the router by slug; nothing
-  // dials the facet handle directly anymore (status is a journal fold).
+  // Registration routes wake delivery by slug; #slackReads below exposes the
+  // same runner's committed fold to the public processor inspection handle.
   protected readonly slackRouterRegistration = this.#registry.register(
     new SlackProcessor({
       stream: this.#stream,
@@ -170,6 +172,7 @@ export class ProjectDurableObject extends DurableObject<Env> {
       },
     }),
   );
+  readonly #slackReads = this.#registry.reads(this.slackRouterRegistration);
 
   // The Telegram webhook router — same hosting shape as the Slack router: it
   // only ever WAKES on `/integrations/telegram/{connection}` instances, where
@@ -183,6 +186,7 @@ export class ProjectDurableObject extends DurableObject<Env> {
       projectId: this.#name.projectId,
     }),
   );
+  readonly #telegramReads = this.#registry.reads(this.telegramRouterRegistration);
 
   // The email thread router — same hosting shape as the Slack router: it only
   // ever WAKES on the Durable Object instance addressed at
@@ -204,6 +208,18 @@ export class ProjectDurableObject extends DurableObject<Env> {
   /** The registry's shared DO alarm (runner keepalives) — see stream-processor-registry.ts. */
   alarm(alarmInfo?: AlarmInvocationInfo): Promise<void> {
     return this.#registry.handleAlarm(alarmInfo);
+  }
+
+  get slackProcessor() {
+    return new StreamProcessorRpcTarget(this.#slackReads, {
+      catchUpBeforeSnapshot: () => this.#registry.catchUp(SlackProcessorContract.slug),
+    });
+  }
+
+  get telegramProcessor() {
+    return new StreamProcessorRpcTarget(this.#telegramReads, {
+      catchUpBeforeSnapshot: () => this.#registry.catchUp(TelegramProcessorContract.slug),
+    });
   }
 
   get emailProcessor() {

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -3140,7 +3140,8 @@ class ProjectIntegrationsRpcTarget extends IterateRpcTarget<"ProjectIntegrations
                 path: `/integrations/slack/${connection}`,
                 projectId: this.props.projectId,
               }),
-            ) as unknown as ProcessorHostStub,
+            ) as unknown as ProjectRouterProcessorHostStub,
+          processorFacade: (host) => host.slackProcessor,
         });
         if (method.length === 1) return relay;
         return await replayPathCall(relay, { args, path: method.slice(1) });
@@ -3252,7 +3253,8 @@ class ProjectIntegrationsRpcTarget extends IterateRpcTarget<"ProjectIntegrations
                 path: `/integrations/telegram/${connection}`,
                 projectId: this.props.projectId,
               }),
-            ) as unknown as ProcessorHostStub,
+            ) as unknown as ProjectRouterProcessorHostStub,
+          processorFacade: (host) => host.telegramProcessor,
         });
         if (method.length === 1) return relay;
         return await replayPathCall(relay, { args, path: method.slice(1) });
@@ -3554,7 +3556,8 @@ class EmailCapabilityRpcTarget extends IterateRpcTarget<"EmailCapability"> {
             path: EMAIL_INTEGRATION_STREAM_PATH,
             projectId: this.props.projectId,
           }),
-        ) as unknown as ProcessorHostStub,
+        ) as unknown as ProjectRouterProcessorHostStub,
+      processorFacade: (host) => host.emailProcessor,
     });
   }
 
@@ -6434,6 +6437,16 @@ type ProcessorHostStub = {
   wakeStreamSubscriber(request: StreamSubscriberWakeRequest): Promise<StreamSubscriberWakeResponse>;
 };
 
+/** The Project DO hosts three integration routers alongside its primary
+ * Project processor. Their public handles must select the matching runner-
+ * backed read facade; the default `processor` property intentionally remains
+ * the Project processor. */
+type ProjectRouterProcessorHostStub = ProcessorHostStub & {
+  emailProcessor: PromiseLike<unknown>;
+  slackProcessor: PromiseLike<unknown>;
+  telegramProcessor: PromiseLike<unknown>;
+};
+
 /**
  * Isolate-side relay for a Durable-Object-hosted processor facade.
  *
@@ -6455,21 +6468,27 @@ type ProcessorHostStub = {
  * the host's durable checkpoint (the same hole `StreamProcessorRpcTarget`
  * exists to close for `ingest`).
  */
-class ProcessorRelayRpcTarget<State>
+class ProcessorRelayRpcTarget<State, Host extends ProcessorHostStub = ProcessorHostStub>
   extends IterateRpcRelay<"StreamProcessorRpc">
   implements WakeableStreamProcessorRpc<State>
 {
   readonly #auth: ItxAuth;
-  readonly #host: () => ProcessorHostStub;
+  readonly #host: () => Host;
+  readonly #processorFacade: (host: Host) => PromiseLike<unknown>;
 
-  constructor(args: { auth: ItxAuth; host: () => ProcessorHostStub }) {
+  constructor(args: {
+    auth: ItxAuth;
+    host: () => Host;
+    processorFacade?: (host: Host) => PromiseLike<unknown>;
+  }) {
     super();
     this.#auth = args.auth;
     this.#host = args.host;
+    this.#processorFacade = args.processorFacade ?? ((host) => host.processor);
   }
 
   async #processor(): Promise<StreamProcessorRpc<State>> {
-    return (await this.#host().processor) as StreamProcessorRpc<State>;
+    return (await this.#processorFacade(this.#host())) as StreamProcessorRpc<State>;
   }
 
   async snapshot() {


### PR DESCRIPTION
## Summary

- make email, Slack, and Telegram processor handles read their own runner-backed processor facades on the shared Project Durable Object
- preserve the existing host-level wake handshake while allowing read/wait relays to select a named processor facade
- add a deployed-shape ITX regression that creates and inspects explicit birth batches for all three routers

## Production finding

After #2038 deployed onto a clean production engine, `project.create()` reached ready but `itx.email.processor.snapshot()` returned Project processor state with `birthCertificate: null`. The email stream contained `email/created` and a connected `processorSlug: "email"` subscription, proving delivery was configured correctly; the read relay was selecting the host default `.processor` instead of `.emailProcessor`. Slack and Telegram used the same incorrect relay shape.

## Verification

- red before fix: targeted admin-project ITX E2E returned Project state for the email processor
- green after fix: targeted admin-project ITX E2E creates and verifies email, Slack, and Telegram router births
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm --dir apps/os test:unit` — 167 files passed; 1,661 tests passed; 1 skipped
- full workspace `pnpm test` passed every non-OS package; its parallel run starved two unrelated OS timing tests, both passed immediately in isolation and the complete OS suite passed alone

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes RPC routing for integration processor inspection on a shared multi-processor DO; incorrect wiring would surface wrong policy/state to ingress and dashboards, but scope is limited to read relays and named facades with a targeted E2E guard.
> 
> **Overview**
> Fixes a production bug where **`itx.email.processor.snapshot()`** (and Slack/Telegram connection processor handles) returned **Project** processor state because the relay always used the host’s default **`processor`** property on a Project Durable Object that hosts several runners.
> 
> The **Project DO** now exposes **`slackProcessor`**, **`telegramProcessor`**, and keeps **`emailProcessor`** on runner-backed reads, mirroring **`processor`** for the main project fold. **`ProcessorRelayRpcTarget`** gains an optional **`processorFacade`** selector; email, Slack, and Telegram itx paths pass the matching named getter while host-level **`wakeStreamSubscriber`** behavior stays unchanged.
> 
> An **admin-project ITX E2E** asserts email birth state after project create and seeds Slack/Telegram router birth batches to confirm each public **`processor`** handle reads its own router state, not the shared Project processor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81a572478b3f4af192b95f86d42499a9f0d5f8df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +44 -9 | +35 -7 🟩🟩🟩🟩🟥 |
| Tests | +57 -0 | +46 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+101 -9** | **+81 -7** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 65e06e7 and 81a5724, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-16T11:11:37.062Z",
      "headSha": "81a572478b3f4af192b95f86d42499a9f0d5f8df",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/275442472095569",
      "shortSha": "81a5724",
      "cleanupDurationMs": 2841,
      "deployDurationMs": 19690,
      "testDurationMs": 4875,
      "testRetries": null,
      "workerSizeKib": 4030.87,
      "workerGzipKib": 819.79,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-16T11:11:34.762Z",
      "headSha": "81a572478b3f4af192b95f86d42499a9f0d5f8df",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/275442472095569",
      "shortSha": "81a5724",
      "cleanupDurationMs": 540,
      "deployDurationMs": 15916,
      "testDurationMs": 58428,
      "testRetries": "2 retried: stream capnweb protocol > documents Cloudflare's 32 MiB inbound WebSocket frame ceiling for capnweb appends (vitest x1) · large streams stay virtualized and can scroll from tail to earliest rows (playwright x1)",
      "workerSizeKib": 5171.2,
      "workerGzipKib": 1470.23,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-16T11:11:34.880Z",
      "headSha": "81a572478b3f4af192b95f86d42499a9f0d5f8df",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/275442472095569",
      "shortSha": "81a5724",
      "cleanupDurationMs": 656,
      "deployDurationMs": 7033,
      "testDurationMs": 5895,
      "testRetries": null,
      "workerSizeKib": 1139,
      "workerGzipKib": 201.58,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-16T11:11:33.118Z",
      "headSha": "81a572478b3f4af192b95f86d42499a9f0d5f8df",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/275442472095569",
      "shortSha": "81a5724",
      "cleanupDurationMs": 108602,
      "deployDurationMs": 93332,
      "testDurationMs": 206077,
      "testRetries": "2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · project streams are born with the project-worker push feed and replace it by key (vitest x1)",
      "workerSizeKib": 16502.82,
      "workerGzipKib": 4448.07,
      "mainWorkerGzipKib": 4448.72
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-16T11:09:45.026Z",
      "headSha": "81a572478b3f4af192b95f86d42499a9f0d5f8df",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/275442472095569",
      "shortSha": "81a5724",
      "cleanupDurationMs": 506,
      "deployDurationMs": 14552,
      "testDurationMs": 21593,
      "testRetries": null,
      "workerSizeKib": 1914.49,
      "workerGzipKib": 440.74,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `81a5724` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 819.8 KiB | 19.7s | 4.9s |  | 2.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/275442472095569) | 2026-07-16T11:11:37.062Z | Preview app released. |
| Dummy Petshop | released | `81a5724` | [https://dummy-petshop.iterate-preview-1.com](https://dummy-petshop.iterate-preview-1.com) | 201.6 KiB | 7.0s | 5.9s |  | 656ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/275442472095569) | 2026-07-16T11:11:34.880Z | Preview app released. |
| OS | released | `81a5724` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 4.34 MiB (-0.7 KiB vs main) | 93.3s | 206.1s | 2 retried: DESIRED: a live-capability fetch handler serves WebSockets at an app host (vitest x1) · project streams are born with the project-worker push feed and replace it by key (vitest x1) | 108.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/275442472095569) | 2026-07-16T11:11:33.118Z | Preview app released. |
| Semaphore | released | `81a5724` | [https://semaphore.iterate-preview-1.com](https://semaphore.iterate-preview-1.com) | 440.7 KiB | 14.6s | 21.6s |  | 506ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/275442472095569) | 2026-07-16T11:09:45.026Z | Preview app released. |
| Streams Example App | released | `81a5724` | [https://streams.iterate-preview-1.com](https://streams.iterate-preview-1.com) | 1.44 MiB | 15.9s | 58.4s | 2 retried: stream capnweb protocol > documents Cloudflare's 32 MiB inbound WebSocket frame ceiling for capnweb appends (vitest x1) · large streams stay virtualized and can scroll from tail to earliest rows (playwright x1) | 540ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/275442472095569) | 2026-07-16T11:11:34.762Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->