### PR TITLE
Dispose wake handshake RPC results

### DIFF
--- a/apps/os/src/domains/streams/subscriber-sinks.test.ts
+++ b/apps/os/src/domains/streams/subscriber-sinks.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test, vi } from "vitest";
+import type {
+  GetProcessorRuntimeState,
+  ProcessEventBatch,
+  StreamSubscriberPing,
+} from "./rpc-types.ts";
+import { retainWakeHandshakeResponse } from "./subscriber-sinks.ts";
+
+function remoteCallback<Arg, Result>(implementation: (arg: Arg) => Result) {
+  const rawDispose = vi.fn();
+  const duplicateDispose = vi.fn();
+  const duplicate = Object.assign((arg: Arg) => implementation(arg), {
+    [Symbol.dispose]: duplicateDispose,
+  });
+  const raw = Object.assign((arg: Arg) => implementation(arg), {
+    dup: vi.fn(() => duplicate),
+    [Symbol.dispose]: rawDispose,
+  });
+  return { duplicateDispose, raw, rawDispose };
+}
+
+describe("wake-handshake RPC ownership", () => {
+  test("retains every returned capability and disposes the original RPC result", async () => {
+    const sink = remoteCallback<Parameters<ProcessEventBatch>[0], void>(() => {});
+    const getRuntimeState = remoteCallback<void, { snapshot: { offset: number; state: object } }>(
+      () => ({ snapshot: { offset: 17, state: {} } }),
+    );
+    const ping = remoteCallback<{ t0: number }, { t0: number; t1: number; t2: number }>(
+      ({ t0 }) => ({
+        t0,
+        t1: t0 + 1,
+        t2: t0 + 2,
+      }),
+    );
+    const disposeResult = vi.fn(() => {
+      sink.raw[Symbol.dispose]();
+      getRuntimeState.raw[Symbol.dispose]();
+      ping.raw[Symbol.dispose]();
+    });
+    const disposeAuthorityRoot = vi.fn();
+
+    const retained = retainWakeHandshakeResponse({
+      onDeliveryError: vi.fn(),
+      onDisposed: disposeAuthorityRoot,
+      value: {
+        checkpointOffset: 17,
+        sink: sink.raw as ProcessEventBatch,
+        getRuntimeState: getRuntimeState.raw as GetProcessorRuntimeState,
+        ping: ping.raw as StreamSubscriberPing,
+        [Symbol.dispose]: disposeResult,
+      },
+    });
+
+    expect(disposeResult).toHaveBeenCalledOnce();
+    expect(sink.rawDispose).toHaveBeenCalledOnce();
+    expect(getRuntimeState.rawDispose).toHaveBeenCalledOnce();
+    expect(ping.rawDispose).toHaveBeenCalledOnce();
+    expect(sink.raw.dup).toHaveBeenCalledOnce();
+    expect(getRuntimeState.raw.dup).toHaveBeenCalledOnce();
+    expect(ping.raw.dup).toHaveBeenCalledOnce();
+
+    retained.sink({
+      events: [],
+      path: "/",
+      projectId: "prj_test",
+      scannedAfterOffset: 17,
+      scannedThroughOffset: 17,
+      state: {},
+      streamMaxOffset: 17,
+    });
+    expect(await retained.getRuntimeState?.()).toEqual({
+      snapshot: { offset: 17, state: {} },
+    });
+    expect(await retained.ping?.({ t0: 10 })).toEqual({ t0: 10, t1: 11, t2: 12 });
+
+    retained.sink[Symbol.dispose]();
+    expect(sink.duplicateDispose).toHaveBeenCalledOnce();
+    expect(getRuntimeState.duplicateDispose).toHaveBeenCalledOnce();
+    expect(ping.duplicateDispose).toHaveBeenCalledOnce();
+    expect(disposeAuthorityRoot).toHaveBeenCalledOnce();
+  });
+
+  test("disposes the RPC result and authority root when the handshake is invalid", () => {
+    const disposeResult = vi.fn();
+    const disposeAuthorityRoot = vi.fn();
+
+    expect(() =>
+      retainWakeHandshakeResponse({
+        onDeliveryError: vi.fn(),
+        onDisposed: disposeAuthorityRoot,
+        value: {
+          checkpointOffset: -1,
+          sink: () => {},
+          [Symbol.dispose]: disposeResult,
+        },
+      }),
+    ).toThrow("checkpointOffset");
+    expect(disposeResult).toHaveBeenCalledOnce();
+    expect(disposeAuthorityRoot).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/os/src/domains/streams/subscriber-sinks.ts
+++ b/apps/os/src/domains/streams/subscriber-sinks.ts
@@ -216,6 +216,87 @@ export type RetainedSubscriberPing = ((
 ) => StreamPingReply | Promise<StreamPingReply>) &
   Disposable;
 
+type RetainedWakeHandshakeResponse = {
+  checkpointOffset: number;
+  sink: RetainedProcessEventBatch;
+  subscriber?: unknown;
+  getRuntimeState?: GetProcessorRuntimeState & Disposable;
+  ping?: RetainedSubscriberPing;
+};
+
+/**
+ * Takes ownership of a wake handshake returned over Workers RPC.
+ *
+ * The result object owns the original sink/runtime-state/ping stubs as one
+ * disposal group. Duplicate each capability needed by the live connection,
+ * then dispose that original result immediately; otherwise workerd eventually
+ * reports the dropped group as an undisposed RPC stub. The retained
+ * capabilities and authority-root chain are all tied to the sink's lifetime.
+ */
+export function retainWakeHandshakeResponse(args: {
+  value: unknown;
+  onDeliveryError: (error: unknown) => void;
+  onDisposed: () => void;
+}): RetainedWakeHandshakeResponse {
+  let originalReleased = false;
+  const releaseOriginal = () => {
+    if (originalReleased) return;
+    originalReleased = true;
+    disposeIgnoredRpcResult(args.value);
+  };
+
+  let getRuntimeState: (GetProcessorRuntimeState & Disposable) | undefined;
+  let ping: RetainedSubscriberPing | undefined;
+  let sink: RetainedProcessEventBatch | undefined;
+  let retainedReleased = false;
+  const releaseRetainedAndRoot = () => {
+    if (retainedReleased) return;
+    retainedReleased = true;
+    let firstError: unknown;
+    for (const release of [
+      () => ping?.[Symbol.dispose](),
+      () => getRuntimeState?.[Symbol.dispose](),
+      args.onDisposed,
+    ]) {
+      try {
+        release();
+      } catch (error) {
+        firstError ??= error;
+      }
+    }
+    if (firstError !== undefined) throw firstError;
+  };
+
+  let ownershipTransferred = false;
+  try {
+    const response = parseWakeHandshake(args.value);
+    getRuntimeState = retainGetProcessorRuntimeState(response.getRuntimeState);
+    ping = retainSubscriberPing(response.ping);
+    sink = retainProcessEventBatch(response.sink, {
+      onDeliveryError: args.onDeliveryError,
+      onDisposed: releaseRetainedAndRoot,
+    });
+    releaseOriginal();
+    ownershipTransferred = true;
+    return {
+      checkpointOffset: response.checkpointOffset,
+      sink,
+      subscriber: response.subscriber,
+      getRuntimeState,
+      ping,
+    };
+  } finally {
+    if (!ownershipTransferred) {
+      try {
+        if (sink === undefined) releaseRetainedAndRoot();
+        else sink[Symbol.dispose]();
+      } finally {
+        releaseOriginal();
+      }
+    }
+  }
+}
+
 // =============================================================================
 // The dial: how the spine reaches subscribers over real transports.
 // =============================================================================
@@ -307,26 +388,20 @@ export function createSubscriberDial(deps: {
      */
     async poke(expression: ItxExpression, request: StreamSubscriberWakeRequest) {
       const { root, dispose } = await acquireAuthorityRoot();
-      let response: StreamSubscriberWakeResponse;
+      let value: unknown;
       try {
-        const { value } = await evaluateItxExpression(root, toInvocation(expression, request));
-        response = parseWakeHandshake(value);
+        ({ value } = await evaluateItxExpression(root, toInvocation(expression, request)));
       } catch (error) {
         // Disposing the chain releases whatever the failed/misshapen
         // evaluation exported along the way.
         dispose();
         throw error;
       }
-      return {
-        checkpointOffset: response.checkpointOffset,
-        sink: retainProcessEventBatch(response.sink, {
-          onDeliveryError: (error) => deps.onDurableDeliveryError(request.subscriptionKey, error),
-          onDisposed: dispose,
-        }),
-        subscriber: response.subscriber,
-        getRuntimeState: response.getRuntimeState,
-        ping: response.ping,
-      };
+      return retainWakeHandshakeResponse({
+        value,
+        onDeliveryError: (error) => deps.onDurableDeliveryError(request.subscriptionKey, error),
+        onDisposed: dispose,
+      });
     },
 
     /**


### PR DESCRIPTION
## Summary

- duplicate every capability returned by a durable subscriber wake handshake before retaining it
- dispose the original Workers RPC result object immediately after that ownership transfer
- tie retained sink, runtime-state callback, ping callback, and authority root to one connection teardown
- add regression coverage for both the live and malformed-handshake paths

## Why

The production version deployed by #2047 emitted a workerd warning that an RPC stub was not disposed. The warning surfaced during default.getEvents because that was the I/O context in which garbage collection ran; the dropped capability was the disposable result object returned by wakeStreamSubscriber. Its nested callbacks were retained individually, but the result-level disposal group itself was never released.

## Verification

- pnpm install && pnpm typecheck && pnpm lint && pnpm format && pnpm test
- focused stream ownership and teardown suites: 85 tests passed
- OS unit suite: 183 files, 1772 passed, 1 skipped

Preview proof (exact head `93da437`):

- OS deployed as version `57591c3f-3b19-49af-8460-0ca1d62e2cd8` in Preview 1; the complete OS preview suite passed without retries.
- A fresh project created ten deeply nested agents and their capability hosts. Every processor had a non-null birth certificate and caught up; container-only path segments were not catalogued as agents.
- A separate isolated agent creation exercised the wake handshake. Both processors reached offset 11 with live cursors and no retry, last error, or parked work.
- Exact-version telemetry for the isolated exercise (2026-07-17 02:42:25–02:46:04 UTC) contained zero errors, zero warnings, and zero `RPC stub was not disposed properly` messages.

The unrelated Streams Example virtualization check retried once in CI and was independently reproduced as a pre-existing flaky scroll assertion; no Streams Example code changes in this PR.
\n\n## Production proof

- Main merge `8ceb5a0e1ea52d61770561efec1d99c4b6e0d8c7` passed every exact-commit check, including tests, lint/typecheck, and the normal Auth + OS deployment.
- OS version `6876a3c3-2d9c-4848-a0c5-9746c4b2c02c` received 100% production traffic.
- Three independent existing projects appended idempotent verification events and waited for their project processors. Every processor retained a non-null birth certificate and `ready: true`; every config repo remained born, ready, initialized, and on `main`. Streams were unpaused with no pending deliveries, retry attempts, last errors, or parked offsets.
- The exercised Stream DO then served 100 additional bounded log reads to force allocation/GC pressure while its processor stayed born and ready.
- Exact-version Cloudflare telemetry from rollout at 2026-07-17 02:50:26 UTC through 02:59:21 UTC contained zero error-level logs, zero warning-level logs, zero `RPC stub was not disposed properly` messages, and zero truncated invocations.\n\n<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches durable stream subscriber connection lifecycle and Workers RPC stub disposal; behavior is localized with focused tests but incorrect teardown could affect live subscriptions.
> 
> **Overview**
> Fixes **undisposed Workers RPC stub** warnings from durable subscriber wake handshakes by correctly transferring ownership of the disposable result object returned from `wakeStreamSubscriber`.
> 
> Adds **`retainWakeHandshakeResponse`**, which parses the handshake, **dups and retains** `sink`, `getRuntimeState`, and `ping` via the existing retain helpers, then **disposes the original RPC result** immediately so workerd does not GC a dropped disposal group. **Authority root** teardown is chained to the retained sink’s lifetime together with the other capabilities. **`poke`** now passes the raw evaluation `value` through this helper instead of only retaining the sink inline.
> 
> **Regression tests** cover the happy path (original disposed, dups work, sink dispose tears down everything) and invalid handshakes (result and authority root still released).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93da4371dfa9d8a632f603b62d88a179b5f4128e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +88 -13 | +75 -13 🟩🟩🟩🟩🟥 |
| Tests | +101 -0 | +93 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+189 -13** | **+168 -13** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between ac9f2e1 and 93da437, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-17T02:51:43.964Z",
      "headSha": "93da4371dfa9d8a632f603b62d88a179b5f4128e",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/221408078391585",
      "shortSha": "93da437",
      "cleanupDurationMs": 2210,
      "deployDurationMs": 16315,
      "testDurationMs": 5178,
      "testRetries": null,
      "workerSizeKib": 4041.39,
      "workerGzipKib": 822.3,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-17T02:51:42.354Z",
      "headSha": "93da4371dfa9d8a632f603b62d88a179b5f4128e",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/221408078391585",
      "shortSha": "93da437",
      "cleanupDurationMs": 598,
      "deployDurationMs": 14575,
      "testDurationMs": 59345,
      "testRetries": "1 retried: large streams stay virtualized and can scroll from tail to earliest rows (playwright x1)",
      "workerSizeKib": 5164.22,
      "workerGzipKib": 1469.49,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-17T02:51:42.228Z",
      "headSha": "93da4371dfa9d8a632f603b62d88a179b5f4128e",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/221408078391585",
      "shortSha": "93da437",
      "cleanupDurationMs": 471,
      "deployDurationMs": 6956,
      "testDurationMs": 5308,
      "testRetries": null,
      "workerSizeKib": 1139.76,
      "workerGzipKib": 201.7,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-17T02:51:40.768Z",
      "headSha": "93da4371dfa9d8a632f603b62d88a179b5f4128e",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/221408078391585",
      "shortSha": "93da437",
      "cleanupDurationMs": 116355,
      "deployDurationMs": 105823,
      "testDurationMs": 190523,
      "testRetries": null,
      "workerSizeKib": 16527.47,
      "workerGzipKib": 4456.64,
      "mainWorkerGzipKib": 4456.07
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `93da437` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 822.3 KiB | 16.3s | 5.2s |  | 2.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/221408078391585) | 2026-07-17T02:51:43.964Z | Preview app released. |
| Dummy Petshop | released | `93da437` | [https://dummy-petshop.iterate-preview-1.com](https://dummy-petshop.iterate-preview-1.com) | 201.7 KiB | 7.0s | 5.3s |  | 471ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/221408078391585) | 2026-07-17T02:51:42.228Z | Preview app released. |
| OS | released | `93da437` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 4.35 MiB (+0.6 KiB vs main) | 105.8s | 190.5s |  | 116.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/221408078391585) | 2026-07-17T02:51:40.768Z | Preview app released. |
| Streams Example App | released | `93da437` | [https://streams.iterate-preview-1.com](https://streams.iterate-preview-1.com) | 1.44 MiB | 14.6s | 59.3s | 1 retried: large streams stay virtualized and can scroll from tail to earliest rows (playwright x1) | 598ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/221408078391585) | 2026-07-17T02:51:42.354Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->