### PR TITLE
fix(os): bound project directory writes

### DIFF
--- a/apps/os/src/project-directory.test.ts
+++ b/apps/os/src/project-directory.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import { primeProjectDirectory, type ProjectDirectoryRecord } from "./project-directory.ts";
+
+const record: ProjectDirectoryRecord = {
+  id: "prj_alpha",
+  slug: "alpha",
+  organizationId: null,
+  name: "Alpha",
+};
+
+function directoryWithPut(put: ReturnType<typeof vi.fn>): KVNamespace {
+  return { put } as unknown as KVNamespace;
+}
+
+describe("primeProjectDirectory", () => {
+  it("writes both durable lookup keys", async () => {
+    const put = vi.fn().mockResolvedValue(undefined);
+
+    await primeProjectDirectory(directoryWithPut(put), record);
+
+    const body = JSON.stringify(record);
+    expect(put.mock.calls).toEqual([
+      ["slug:alpha", body],
+      ["project:prj_alpha", body],
+    ]);
+  });
+
+  it("recovers from one timed-out attempt and observes its late rejection", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const rejectLate: Array<(error: Error) => void> = [];
+      const put = vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise<void>((_resolve, reject) => {
+              rejectLate.push(reject);
+            }),
+        )
+        .mockImplementationOnce(
+          () =>
+            new Promise<void>((_resolve, reject) => {
+              rejectLate.push(reject);
+            }),
+        )
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(undefined);
+      const primed = primeProjectDirectory(directoryWithPut(put), record);
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      await expect(primed).resolves.toBeUndefined();
+
+      expect(put).toHaveBeenCalledTimes(4);
+      expect(warn).toHaveBeenCalledWith(
+        "[project-directory] write failed; retrying",
+        expect.objectContaining({ attempt: 1, maxAttempts: 2 }),
+      );
+      for (const reject of rejectLate) reject(new Error("late platform cancellation"));
+      await Promise.resolve();
+    } finally {
+      warn.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects after two failed attempts instead of swallowing the dependency error", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const put = vi.fn().mockRejectedValue(new Error("KV unavailable"));
+
+      await expect(primeProjectDirectory(directoryWithPut(put), record)).rejects.toThrow(
+        "Project directory write failed after 2 attempts: KV unavailable",
+      );
+      expect(put).toHaveBeenCalledTimes(4);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("rejects after two bounded attempts when KV never settles", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const put = vi.fn(() => new Promise<void>(() => {}));
+      const primed = primeProjectDirectory(directoryWithPut(put), record);
+      const rejected = expect(primed).rejects.toThrow(
+        "Project directory write failed after 2 attempts: Project directory KV write timed out after 10000ms",
+      );
+
+      await vi.advanceTimersByTimeAsync(20_000);
+
+      await rejected;
+      expect(put).toHaveBeenCalledTimes(4);
+    } finally {
+      warn.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/os/src/project-directory.test.ts
+++ b/apps/os/src/project-directory.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it, vi } from "vitest";
-import { primeProjectDirectory, type ProjectDirectoryRecord } from "./project-directory.ts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  primeProjectDirectory,
+  readProjectBySlug,
+  type ProjectDirectoryRecord,
+} from "./project-directory.ts";
+
+const auth = vi.hoisted(() => ({ getProjectBySlug: vi.fn() }));
+vi.mock("./env.ts", () => ({ itxEnv: { AUTH: auth } }));
 
 const record: ProjectDirectoryRecord = {
   id: "prj_alpha",
@@ -13,6 +20,8 @@ function directoryWithPut(put: ReturnType<typeof vi.fn>): KVNamespace {
 }
 
 describe("primeProjectDirectory", () => {
+  beforeEach(() => auth.getProjectBySlug.mockReset());
+
   it("writes both durable lookup keys", async () => {
     const put = vi.fn().mockResolvedValue(undefined);
 
@@ -92,6 +101,37 @@ describe("primeProjectDirectory", () => {
 
       await rejected;
       expect(put).toHaveBeenCalledTimes(4);
+    } finally {
+      warn.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("readProjectBySlug", () => {
+  beforeEach(() => auth.getProjectBySlug.mockReset());
+
+  it("returns the authoritative auth result when its optional cache fill times out", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const authRecord = { ...record, id: "prj_auth", slug: "auth-only" };
+      auth.getProjectBySlug.mockResolvedValue(authRecord);
+      const directory = {
+        get: vi.fn().mockResolvedValue(null),
+        put: vi.fn(() => new Promise<void>(() => {})),
+      } as unknown as KVNamespace;
+      const reading = readProjectBySlug(directory, authRecord.slug);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      await expect(reading).resolves.toEqual(authRecord);
+      expect(directory.get).toHaveBeenCalledWith("slug:auth-only", "json");
+      expect(auth.getProjectBySlug).toHaveBeenCalledWith({ projectSlug: "auth-only" });
+      expect(warn).toHaveBeenCalledWith(
+        "[project-directory] cache fill failed; using auth result",
+        expect.objectContaining({ reason: expect.stringContaining("timed out after 1000ms") }),
+      );
     } finally {
       warn.mockRestore();
       vi.useRealTimers();

--- a/apps/os/src/project-directory.ts
+++ b/apps/os/src/project-directory.ts
@@ -25,8 +25,9 @@ export type ProjectDirectoryRecord = {
 const MEMO_TTL_MS = 15_000;
 // These writes are exact and idempotent. One retry absorbs a transient KV
 // stall while two short windows keep this required create step bounded.
-const WRITE_ATTEMPT_TIMEOUT_MS = 10_000;
-const WRITE_MAX_ATTEMPTS = 2;
+const REQUIRED_WRITE_ATTEMPT_TIMEOUT_MS = 10_000;
+const REQUIRED_WRITE_MAX_ATTEMPTS = 2;
+const CACHE_FILL_TIMEOUT_MS = 1_000;
 
 const slugMemo = new Map<string, { expiresAt: number; record: ProjectDirectoryRecord | null }>();
 
@@ -76,7 +77,20 @@ export async function readProjectBySlug(
       }
     : null;
   memoize(slug, record);
-  if (record) await writeThrough(directory, record);
+  if (record) {
+    try {
+      await writeThrough(directory, record, {
+        attemptTimeoutMs: CACHE_FILL_TIMEOUT_MS,
+        maxAttempts: 1,
+      });
+    } catch (error) {
+      // Auth is authoritative for this lane. A cache-fill failure is a
+      // bounded, observable degradation, not a reason to discard its answer.
+      console.warn("[project-directory] cache fill failed; using auth result", {
+        reason: errorMessage(error),
+      });
+    }
+  }
   return record;
 }
 
@@ -124,7 +138,10 @@ export async function primeProjectDirectory(
   directory: KVNamespace,
   record: ProjectDirectoryRecord,
 ): Promise<void> {
-  await writeThrough(directory, record);
+  await writeThrough(directory, record, {
+    attemptTimeoutMs: REQUIRED_WRITE_ATTEMPT_TIMEOUT_MS,
+    maxAttempts: REQUIRED_WRITE_MAX_ATTEMPTS,
+  });
   memoize(record.slug, record);
 }
 
@@ -132,23 +149,27 @@ function memoize(slug: string, record: ProjectDirectoryRecord | null) {
   slugMemo.set(slug, { expiresAt: Date.now() + MEMO_TTL_MS, record });
 }
 
-async function writeThrough(directory: KVNamespace, record: ProjectDirectoryRecord) {
+async function writeThrough(
+  directory: KVNamespace,
+  record: ProjectDirectoryRecord,
+  policy: { attemptTimeoutMs: number; maxAttempts: number },
+) {
   // No expiration: slugs are immutable and `projects.create` overwrites the
   // keys it primes, so entries never go stale — and admin-lane projects
   // (auth mints only an id, no directory row) have NO auth fallback, so an
   // expiring cache would break their slug ingress after the TTL.
   const body = JSON.stringify(record);
   let lastError: unknown;
-  for (let attempt = 1; attempt <= WRITE_MAX_ATTEMPTS; attempt += 1) {
+  for (let attempt = 1; attempt <= policy.maxAttempts; attempt += 1) {
     try {
-      await writeDirectoryRecord(directory, record, body);
+      await writeDirectoryRecord(directory, record, body, policy.attemptTimeoutMs);
       return;
     } catch (error) {
       lastError = error;
-      if (attempt < WRITE_MAX_ATTEMPTS) {
+      if (attempt < policy.maxAttempts) {
         console.warn("[project-directory] write failed; retrying", {
           attempt,
-          maxAttempts: WRITE_MAX_ATTEMPTS,
+          maxAttempts: policy.maxAttempts,
           reason: errorMessage(error),
         });
       }
@@ -156,7 +177,7 @@ async function writeThrough(directory: KVNamespace, record: ProjectDirectoryReco
   }
 
   throw new Error(
-    `Project directory write failed after ${WRITE_MAX_ATTEMPTS} attempts: ${errorMessage(lastError)}`,
+    `Project directory write failed after ${policy.maxAttempts} attempts: ${errorMessage(lastError)}`,
     { cause: lastError },
   );
 }
@@ -165,6 +186,7 @@ async function writeDirectoryRecord(
   directory: KVNamespace,
   record: ProjectDirectoryRecord,
   body: string,
+  timeoutMs: number,
 ): Promise<void> {
   const write = Promise.all([
     directory.put(slugKey(record.slug), body),
@@ -176,11 +198,8 @@ async function writeDirectoryRecord(
       write,
       new Promise<never>((_resolve, reject) => {
         timer = setTimeout(
-          () =>
-            reject(
-              new Error(`Project directory KV write timed out after ${WRITE_ATTEMPT_TIMEOUT_MS}ms`),
-            ),
-          WRITE_ATTEMPT_TIMEOUT_MS,
+          () => reject(new Error(`Project directory KV write timed out after ${timeoutMs}ms`)),
+          timeoutMs,
         );
       }),
     ]);

--- a/apps/os/src/project-directory.ts
+++ b/apps/os/src/project-directory.ts
@@ -23,6 +23,10 @@ export type ProjectDirectoryRecord = {
 };
 
 const MEMO_TTL_MS = 15_000;
+// These writes are exact and idempotent. One retry absorbs a transient KV
+// stall while two short windows keep this required create step bounded.
+const WRITE_ATTEMPT_TIMEOUT_MS = 10_000;
+const WRITE_MAX_ATTEMPTS = 2;
 
 const slugMemo = new Map<string, { expiresAt: number; record: ProjectDirectoryRecord | null }>();
 
@@ -120,8 +124,8 @@ export async function primeProjectDirectory(
   directory: KVNamespace,
   record: ProjectDirectoryRecord,
 ): Promise<void> {
+  await writeThrough(directory, record);
   memoize(record.slug, record);
-  await writeThrough(directory, record).catch(() => {});
 }
 
 function memoize(slug: string, record: ProjectDirectoryRecord | null) {
@@ -134,8 +138,59 @@ async function writeThrough(directory: KVNamespace, record: ProjectDirectoryReco
   // (auth mints only an id, no directory row) have NO auth fallback, so an
   // expiring cache would break their slug ingress after the TTL.
   const body = JSON.stringify(record);
-  await Promise.all([
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= WRITE_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      await writeDirectoryRecord(directory, record, body);
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt < WRITE_MAX_ATTEMPTS) {
+        console.warn("[project-directory] write failed; retrying", {
+          attempt,
+          maxAttempts: WRITE_MAX_ATTEMPTS,
+          reason: errorMessage(error),
+        });
+      }
+    }
+  }
+
+  throw new Error(
+    `Project directory write failed after ${WRITE_MAX_ATTEMPTS} attempts: ${errorMessage(lastError)}`,
+    { cause: lastError },
+  );
+}
+
+async function writeDirectoryRecord(
+  directory: KVNamespace,
+  record: ProjectDirectoryRecord,
+  body: string,
+): Promise<void> {
+  const write = Promise.all([
     directory.put(slugKey(record.slug), body),
     directory.put(projectKey(record.id), body),
   ]);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      write,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () =>
+            reject(
+              new Error(`Project directory KV write timed out after ${WRITE_ATTEMPT_TIMEOUT_MS}ms`),
+            ),
+          WRITE_ATTEMPT_TIMEOUT_MS,
+        );
+      }),
+    ]);
+  } finally {
+    // Promise.race keeps rejection handlers attached to the write after a
+    // timeout, so a late platform rejection remains observed.
+    clearTimeout(timer);
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }


### PR DESCRIPTION
## Why

Validation of #2050 exposed a pre-existing project-creation defect rather than a feature failure. The first preview attempt timed out and Vitest absorbed a retry:

- request trace `e107b422d392766b06ace523c4a7fa25` ran for 137.827s
- `ProjectCollection.create` spent 136.364s in `prime-directory`
- its two `PROJECT_DIRECTORY` KV puts remained open for 59.980s and 83.463s
- the request ended only when the 120s test timeout disposed the client session
- the retry trace `0935c7f94467bac6d446598cd5d4857c` completed the same create in 10.915s

Directory priming was both unbounded and followed by `.catch(() => {})`. That is unsafe: admin-lane projects have no auth directory row, so these KV keys are required state rather than an optional cache.

## What

- bound each exact, idempotent directory write attempt to 10 seconds
- retry once to absorb a transient KV stall, then reject with the preserved dependency cause
- keep late platform rejections observed after a deadline
- emit an explicit structured warning when recovery advances to attempt two
- populate the in-isolate slug memo only after the required durable writes succeed
- preserve authoritative auth lookup results when an optional cache fill degrades
- bound optional cache fills to one 1-second attempt and warn with the failure reason
- remove the silent failure swallow

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm lint` — 1,154 files, zero warnings/errors
- `pnpm format` — clean working tree
- `pnpm test` — all workspace packages green; OS: 183 files, 1,775 passed, 1 skipped
- focused deadline suite covers immediate success, transient timeout recovery plus late rejection, permanent rejection, complete timeout exhaustion, and auth-result preservation when a cache fill never settles

This is a focused prerequisite for #2050: it fixes the operational defect discovered by that PR's preview evidence without mixing the change into the UX diff or its line budget.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches project-create critical path and ingress directory state (KV is required for admin-lane projects), but changes are narrowly scoped to write timeouts/retries and explicit failure semantics rather than lookup logic.
> 
> **Overview**
> Replaces **unbounded, silently swallowed** project-directory KV writes with **deadline-bound** behavior so project creation cannot hang for minutes on stuck `put` calls.
> 
> **Required priming** (`primeProjectDirectory`): each attempt races against **10s**, with **one retry** on failure, then rejects with the underlying cause; the in-isolate slug memo is updated **only after** durable writes succeed. **Optional cache fill** on slug reads uses a **1s** single attempt—failures log a warning and the **auth lookup result is still returned**.
> 
> Adds Vitest coverage for success, transient timeout recovery, permanent KV errors, full timeout exhaustion, and auth-result preservation when cache fill never settles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce0bd6683cbec4b583aaa81c2bf4b459eaa1d4e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +78 -4 | +69 -4 🟩🟩🟩⬜⬜ |
| Tests | +140 -0 | +121 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+218 -4** | **+190 -4** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 70bd714 and ce0bd66, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-17T07:23:35.060Z",
      "headSha": "ce0bd6683cbec4b583aaa81c2bf4b459eaa1d4e9",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/61588078200850",
      "shortSha": "ce0bd66",
      "cleanupDurationMs": 2717,
      "deployDurationMs": 23408,
      "testDurationMs": 15270,
      "testRetries": null,
      "workerSizeKib": 4041.39,
      "workerGzipKib": 822.61,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-17T07:23:32.930Z",
      "headSha": "ce0bd6683cbec4b583aaa81c2bf4b459eaa1d4e9",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/61588078200850",
      "shortSha": "ce0bd66",
      "cleanupDurationMs": 585,
      "deployDurationMs": 6670,
      "testDurationMs": 5901,
      "testRetries": null,
      "workerSizeKib": 1139.76,
      "workerGzipKib": 201.7,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-17T07:23:31.180Z",
      "headSha": "ce0bd6683cbec4b583aaa81c2bf4b459eaa1d4e9",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/61588078200850",
      "shortSha": "ce0bd66",
      "cleanupDurationMs": 112120,
      "deployDurationMs": 86066,
      "testDurationMs": 170369,
      "testRetries": null,
      "workerSizeKib": 16540.19,
      "workerGzipKib": 4459.38,
      "mainWorkerGzipKib": 4458.88
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-17T07:23:41.655Z",
      "headSha": "ce0bd6683cbec4b583aaa81c2bf4b459eaa1d4e9",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/61588078200850",
      "shortSha": "ce0bd66",
      "cleanupDurationMs": 9309,
      "deployDurationMs": 16420,
      "testDurationMs": 60282,
      "testRetries": null,
      "workerSizeKib": 5170.29,
      "workerGzipKib": 1471.3,
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-17T07:21:39.567Z",
      "headSha": "ce0bd6683cbec4b583aaa81c2bf4b459eaa1d4e9",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/61588078200850",
      "shortSha": "ce0bd66",
      "cleanupDurationMs": 504,
      "deployDurationMs": 14041,
      "testDurationMs": 19865,
      "testRetries": null,
      "workerSizeKib": 1914.49,
      "workerGzipKib": 440.74,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `ce0bd66` | [https://auth.iterate-preview-6.com](https://auth.iterate-preview-6.com) | 822.6 KiB | 23.4s | 15.3s |  | 2.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/61588078200850) | 2026-07-17T07:23:35.060Z | Preview app released. |
| Dummy Petshop | released | `ce0bd66` | [https://dummy-petshop.iterate-preview-6.com](https://dummy-petshop.iterate-preview-6.com) | 201.7 KiB | 6.7s | 5.9s |  | 585ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/61588078200850) | 2026-07-17T07:23:32.930Z | Preview app released. |
| OS | released | `ce0bd66` | [https://os.iterate-preview-6.com](https://os.iterate-preview-6.com) | 4.35 MiB (+0.5 KiB vs main) | 86.1s | 170.4s |  | 112.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/61588078200850) | 2026-07-17T07:23:31.180Z | Preview app released. |
| Semaphore | released | `ce0bd66` | [https://semaphore.iterate-preview-6.com](https://semaphore.iterate-preview-6.com) | 440.7 KiB | 14.0s | 19.9s |  | 504ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/61588078200850) | 2026-07-17T07:21:39.567Z | Preview app released. |
| Streams Example App | released | `ce0bd66` | [https://streams.iterate-preview-6.com](https://streams.iterate-preview-6.com) | 1.44 MiB | 16.4s | 60.3s |  | 9.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/61588078200850) | 2026-07-17T07:23:41.655Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->