### PR TITLE
fix(os): recover orphaned stream and processor waits

### DIFF
--- a/apps/os/e2e/vitest/setup.ts
+++ b/apps/os/e2e/vitest/setup.ts
@@ -18,7 +18,8 @@ if (baseUrl) process.env.APP_CONFIG_BASE_URL = baseUrl;
 // A stream-delivery timeout under concurrent load can surface as an UNHANDLED
 // rejection rather than inside a test's await: when one test's `waitForEvent`
 // RPC rejects (server-side `Timed out waiting for stream event` /
-// `waitUntilEvent timed out`), the promise for a *sibling* concurrent test — or
+// `waitUntilEvent timed out` / `waitUntilProcessed timed out`), the promise for
+// a *sibling* concurrent test — or
 // a background subscription whose owning test already moved on — rejects into
 // the void as capnweb's read loop drains. Node's default is to CRASH the vitest
 // worker on that, which produces zero test output and BYPASSES the CI
@@ -31,7 +32,8 @@ if (baseUrl) process.env.APP_CONFIG_BASE_URL = baseUrl;
 // a suite-killing crash into an ordinary (usually retry-absorbed) failure.
 // Every other unhandled rejection is re-thrown, which Node escalates to an
 // uncaughtException — preserving the crash-on-real-bug behaviour.
-const TRANSIENT_STREAM_WAIT = /Timed out waiting for stream event|waitUntilEvent timed out/i;
+const TRANSIENT_STREAM_WAIT =
+  /Timed out waiting for stream event|waitUntilEvent timed out|waitUntilProcessed timed out/i;
 process.on("unhandledRejection", (reason) => {
   const message = reason instanceof Error ? reason.message : String(reason);
   if (TRANSIENT_STREAM_WAIT.test(message)) {

--- a/apps/os/src/domains/capability-host/capability-host-processor-implementation.ts
+++ b/apps/os/src/domains/capability-host/capability-host-processor-implementation.ts
@@ -353,13 +353,19 @@ export class CapabilityHostProcessor extends StreamProcessor<CapabilityHostProce
     const settle: {
       executionId: string;
       expiresAt: number;
+      reason: "pending-settlement" | "recovery";
       settlement: ScriptExecutionSettlementValue;
     }[] = [];
     for (const [executionId, execution] of Object.entries(args.state.scriptExecutions)) {
       if (this.#liveExecutions.has(executionId)) continue;
       const pendingSettlement = this.#pendingSettlements.get(executionId);
       if (pendingSettlement !== undefined) {
-        settle.push({ executionId, expiresAt: execution.expiresAt, settlement: pendingSettlement });
+        settle.push({
+          executionId,
+          expiresAt: execution.expiresAt,
+          reason: "pending-settlement",
+          settlement: pendingSettlement,
+        });
         continue;
       }
       if (execution.status === "requested" && now < execution.expiresAt) {
@@ -381,16 +387,21 @@ export class CapabilityHostProcessor extends StreamProcessor<CapabilityHostProce
       settle.push({
         executionId,
         expiresAt: execution.expiresAt,
+        reason: "recovery",
         settlement: settlementForUndrivenScript(execution.status),
       });
     }
     // Settle inline — this runs inside the head event's outer blocking closure
     // (see processEvent), so awaiting the single atomic append holds the frame.
     if (settle.length === 0) return;
-    for (const { executionId, settlement } of settle) {
-      console.error("[capability-host] settling undriven script execution", {
+    for (const { executionId, reason, settlement } of settle) {
+      if (reason !== "recovery") continue;
+      console.info("[capability-host] recovering undriven script execution", {
+        cancellation: settlement.status === "failed" ? settlement.cancellation : undefined,
         executionId,
-        settlement,
+        failureKind: settlement.status === "failed" ? settlement.failureKind : undefined,
+        phase: settlement.status === "failed" ? settlement.phase : undefined,
+        status: settlement.status,
       });
     }
     // One stream append is both faster and stronger than serial appends: a

--- a/apps/os/src/domains/capability-host/capability-host-processor-implementation.ts
+++ b/apps/os/src/domains/capability-host/capability-host-processor-implementation.ts
@@ -934,7 +934,7 @@ export class CapabilityHostProcessor extends StreamProcessor<CapabilityHostProce
     return this.#appendCompletionsWithin([{ ...input, expiresAt: obligationExpiresAt }]);
   }
 
-  #appendCompletionsWithin(
+  async #appendCompletionsWithin(
     inputs: {
       executionId: string;
       expiresAt: number;
@@ -952,13 +952,59 @@ export class CapabilityHostProcessor extends StreamProcessor<CapabilityHostProce
     // blocking the processor forever. A batch uses its earliest member's
     // deadline so batching cannot extend any individual obligation.
     const appendDeadline = settlementAppendDeadline(inputs, now);
-    return this.#awaitJournalAppend(
-      this.append(...inputs.map((input) => this.#completionInput(input))),
-      appendDeadline,
-      inputs.length === 1
-        ? `record the settlement of script execution "${inputs[0]!.executionId}"`
-        : `record ${inputs.length} script execution settlements`,
-    );
+    const completions = inputs.map((input) => this.#completionInput(input));
+    try {
+      await this.#awaitJournalAppend(
+        this.append(...completions),
+        appendDeadline,
+        inputs.length === 1
+          ? `record the settlement of script execution "${inputs[0]!.executionId}"`
+          : `record ${inputs.length} script execution settlements`,
+      );
+    } catch (appendError) {
+      let durableSettlements: ScriptExecutionSettlementValue[];
+      try {
+        durableSettlements = await this.#awaitJournalAppend(
+          Promise.all(
+            completions.map(async (completion, index) => {
+              const event = await this.stream.getEvent({
+                idempotencyKey: completion.idempotencyKey,
+              });
+              const settlement = settlementFromCompletionEvent(event, inputs[index]!.executionId);
+              if (settlement === undefined) throw appendError;
+              return settlement;
+            }),
+          ),
+          settlementAppendDeadline(inputs, (this.#now ?? Date.now)()),
+          "verify the durable script settlement after its append failed",
+        );
+      } catch (verificationError) {
+        if (verificationError === appendError) throw appendError;
+        throw new AggregateError(
+          [appendError, verificationError],
+          "script settlement append failed and its durable outcome could not be verified",
+        );
+      }
+
+      // A replacement incarnation may conservatively classify an execution
+      // as orphaned while the old external worker is still returning. The
+      // first settlement is authoritative. A failed append is successful
+      // reconciliation only after reading back a valid completion for every
+      // exact execution/idempotency key; the late result is then an expected,
+      // explicitly observed loser rather than error telemetry.
+      inputs.forEach((input, index) => {
+        const durableSettlement = durableSettlements[index]!;
+        console.info("[capability-host] late script settlement superseded by durable outcome", {
+          attemptedFailureKind:
+            input.settlement.status === "failed" ? input.settlement.failureKind : undefined,
+          attemptedStatus: input.settlement.status,
+          durableFailureKind:
+            durableSettlement.status === "failed" ? durableSettlement.failureKind : undefined,
+          durableStatus: durableSettlement.status,
+          executionId: input.executionId,
+        });
+      });
+    }
   }
 
   /** The one durable outcome of a script execution. The reconciler's settle
@@ -971,6 +1017,20 @@ export class CapabilityHostProcessor extends StreamProcessor<CapabilityHostProce
       settlement: input.settlement,
     });
   }
+}
+
+function settlementFromCompletionEvent(
+  event: StreamEvent | undefined,
+  executionId: string,
+): ScriptExecutionSettlementValue | undefined {
+  if (
+    event?.type !== "events.iterate.com/capability-host/script-run-settled" ||
+    event.payload?.executionId !== executionId
+  ) {
+    return undefined;
+  }
+  const parsed = ScriptExecutionSettlement.safeParse(event.payload.settlement);
+  return parsed.success ? parsed.data : undefined;
 }
 
 function assertExpressionDoesNotReferenceOwnMount(

--- a/apps/os/src/domains/capability-host/capability-host-recovery.test.ts
+++ b/apps/os/src/domains/capability-host/capability-host-recovery.test.ts
@@ -262,6 +262,74 @@ describe("script execution reconciliation", () => {
     });
   });
 
+  it("preserves a replacement incarnation's settlement when the old executor finishes late", async () => {
+    const h = makeHarness();
+    const executionFinished = Promise.withResolvers<unknown>();
+    h.run.impl = () => executionFinished.promise;
+
+    // Match production's strict idempotency contract for this race: the same
+    // completion key may dedupe only an identical event. MemoryStream is
+    // deliberately looser for generic processor tests.
+    const append = h.stream.append.bind(h.stream);
+    let conflicts = 0;
+    h.stream.append = async (...inputs) => {
+      for (const input of inputs) {
+        const existing =
+          input.idempotencyKey === undefined
+            ? undefined
+            : h.stream.events.find((event) => event.idempotencyKey === input.idempotencyKey);
+        if (
+          existing !== undefined &&
+          JSON.stringify(existing.payload) !== JSON.stringify(input.payload)
+        ) {
+          conflicts += 1;
+          throw new Error(
+            `idempotency key "${input.idempotencyKey}" already names a different event at offset ${existing.offset}`,
+          );
+        }
+      }
+      return await append(...inputs);
+    };
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    try {
+      await h.stream.append({
+        type: T.requested,
+        payload: {
+          code: "async () => 'late success'",
+          executionId: "exec-late",
+          expiresAt: h.clock.now + 60_000,
+        },
+      });
+      await h.deliverPending();
+      await vi.waitFor(() => {
+        expect(h.stream.events.some((event) => event.type === T.started)).toBe(true);
+      });
+
+      h.crash();
+      await h.deliverPending();
+      await vi.waitFor(() => {
+        expect(h.stream.events.find((event) => event.type === T.completed)?.payload).toMatchObject({
+          executionId: "exec-late",
+          settlement: { failureKind: "orphaned", status: "failed" },
+        });
+      });
+
+      executionFinished.resolve({ status: "succeeded", result: "too late" });
+      await vi.waitFor(() => expect(conflicts).toBe(1));
+      await h.settle();
+
+      expect(consoleError).not.toHaveBeenCalledWith(
+        "stream processor runner background work failed",
+        expect.anything(),
+      );
+      expect(h.stream.events.filter((event) => event.type === T.completed)).toHaveLength(1);
+    } finally {
+      executionFinished.resolve({ status: "succeeded", result: "too late" });
+      consoleError.mockRestore();
+    }
+  });
+
   it("recovers a request whose incarnation died BEFORE any attempt started (provably never ran → runs it)", async () => {
     const h = makeHarness();
     // The dead incarnation appended the request but never a started fact.

--- a/apps/os/src/domains/capability-host/capability-host-recovery.test.ts
+++ b/apps/os/src/domains/capability-host/capability-host-recovery.test.ts
@@ -239,27 +239,107 @@ describe("script execution reconciliation", () => {
 
   it("settles an orphaned execution (started, incarnation died) without re-running it", async () => {
     const h = makeHarness();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const consoleInfo = vi.spyOn(console, "info").mockImplementation(() => undefined);
     // The dead incarnation's evidence, written before it was evicted.
-    await h.stream.append(
-      {
-        type: T.requested,
-        payload: { code: "async () => 1", executionId: "exec-1", expiresAt: h.clock.now + 60_000 },
-      },
-      { type: T.started, payload: { executionId: "exec-1" } },
-    );
-    await h.deliverPending(); // run.impl throws if invoked
+    try {
+      await h.stream.append(
+        {
+          type: T.requested,
+          payload: {
+            code: "async () => 1",
+            executionId: "exec-1",
+            expiresAt: h.clock.now + 60_000,
+          },
+        },
+        { type: T.started, payload: { executionId: "exec-1" } },
+      );
+      await h.deliverPending(); // run.impl throws if invoked
 
-    await vi.waitFor(() => {
-      const completed = h.stream.events.find((event) => event.type === T.completed);
-      expect(completed?.payload).toMatchObject({
-        executionId: "exec-1",
-        settlement: {
-          status: "failed",
-          error: expect.stringContaining("orphaned"),
+      await vi.waitFor(() => {
+        const completed = h.stream.events.find((event) => event.type === T.completed);
+        expect(completed?.payload).toMatchObject({
+          executionId: "exec-1",
+          settlement: {
+            status: "failed",
+            error: expect.stringContaining("orphaned"),
+            failureKind: "orphaned",
+          },
+        });
+      });
+      expect(consoleInfo).toHaveBeenCalledWith(
+        "[capability-host] recovering undriven script execution",
+        {
+          cancellation: "external-work-may-continue",
+          executionId: "exec-1",
           failureKind: "orphaned",
+          phase: "recovery",
+          status: "failed",
+        },
+      );
+      expect(consoleInfo).toHaveBeenCalledTimes(1);
+      expect(consoleError).not.toHaveBeenCalledWith(
+        "[capability-host] settling undriven script execution",
+        expect.anything(),
+      );
+    } finally {
+      consoleError.mockRestore();
+      consoleInfo.mockRestore();
+    }
+  });
+
+  it("retries a known settlement without misclassifying it as orphan recovery", async () => {
+    const h = makeHarness();
+    h.run.impl = async () => ({ status: "succeeded" as const, result: "ok" });
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const consoleInfo = vi.spyOn(console, "info").mockImplementation(() => undefined);
+
+    try {
+      h.stream.failAppendsOfType = T.completed;
+      await h.stream.append({
+        type: T.requested,
+        payload: {
+          code: "async () => 'ok'",
+          executionId: "exec-retry",
+          expiresAt: h.clock.now + 60_000,
         },
       });
-    });
+      await h.deliverPending();
+      await vi.waitFor(() => {
+        expect(consoleError).toHaveBeenCalledWith(
+          "stream processor runner background work failed",
+          expect.anything(),
+        );
+      });
+
+      consoleError.mockClear();
+      consoleInfo.mockClear();
+      h.stream.failAppendsOfType = undefined;
+      await h.stream.append({
+        type: "events.iterate.com/stream/woken",
+        payload: { incarnationId: "settlement-retry" },
+      });
+      await h.deliverPending();
+
+      await vi.waitFor(() => {
+        expect(h.stream.events.find((event) => event.type === T.completed)?.payload).toMatchObject({
+          executionId: "exec-retry",
+          settlement: { result: "ok", status: "succeeded" },
+        });
+      });
+      expect(consoleError).not.toHaveBeenCalledWith(
+        "[capability-host] settling undriven script execution",
+        expect.anything(),
+      );
+      expect(consoleInfo).not.toHaveBeenCalledWith(
+        "[capability-host] recovering undriven script execution",
+        expect.anything(),
+      );
+    } finally {
+      h.stream.failAppendsOfType = undefined;
+      consoleError.mockRestore();
+      consoleInfo.mockRestore();
+    }
   });
 
   it("preserves a replacement incarnation's settlement when the old executor finishes late", async () => {

--- a/apps/os/src/domains/streams/stream-durable-object.ts
+++ b/apps/os/src/domains/streams/stream-durable-object.ts
@@ -26,6 +26,7 @@ import {
 } from "./stream-subscribers.ts";
 import { StreamRuntimeMetrics, type StreamThroughputMetrics } from "./stream-runtime-metrics.ts";
 import { createSubscriberDial } from "./subscriber-sinks.ts";
+import { STREAM_WAIT_TIMEOUT_MESSAGE_PREFIX } from "./stream-unavailable.ts";
 import {
   CORE_STATE_VERSION,
   CoreProcessorContract,
@@ -1210,7 +1211,7 @@ export class StreamDurableObject extends DurableObject<Env> {
       settled = true;
       found.reject(
         new Error(
-          `Timed out waiting for stream event after ${args.timeoutMs}ms ` +
+          `${STREAM_WAIT_TIMEOUT_MESSAGE_PREFIX}Timed out waiting for stream event after ${args.timeoutMs}ms ` +
             `(saw ${seenCount} events; recent types: ${recentTypes.join(", ") || "none"}).`,
         ),
       );

--- a/apps/os/src/domains/streams/stream-durable-object.ts
+++ b/apps/os/src/domains/streams/stream-durable-object.ts
@@ -374,6 +374,11 @@ export class StreamDurableObject extends DurableObject<Env> {
     });
   }
 
+  /** The committed head used to pin a recoverable public wait's replay cursor. */
+  getMaxOffset(): number {
+    return this.#coreProcessorState.maxOffset;
+  }
+
   // ===========================================================================
   // The core processor.
   //

--- a/apps/os/src/domains/streams/stream-processor-rpc-target.test.ts
+++ b/apps/os/src/domains/streams/stream-processor-rpc-target.test.ts
@@ -1,6 +1,152 @@
 import { describe, expect, it, vi } from "vitest";
-import { ProcessorRelayRpcTarget, StreamProcessorRpcTarget } from "../../rpc-targets.ts";
+import {
+  ProcessorRelayRpcTarget,
+  StreamProcessorRpcTarget,
+  StreamRpcTarget,
+} from "../../rpc-targets.ts";
+import type { StreamEvent } from "./schemas.ts";
 import type { ProcessorReads } from "./stream-processor.ts";
+
+describe("StreamRpcTarget", () => {
+  it("re-acquires when a remote stream waiter is orphaned", async () => {
+    vi.useFakeTimers();
+    const firstWait = Promise.withResolvers<StreamEvent>();
+    const event = {
+      createdAt: new Date(0).toISOString(),
+      offset: 9,
+      path: "/agents/onboarding",
+      type: "events.iterate.com/test/recovered",
+    } satisfies StreamEvent;
+    let acquisitions = 0;
+    class TestStreamRpcTarget extends StreamRpcTarget {
+      override get durableObjectStub() {
+        acquisitions += 1;
+        return {
+          waitForEvent: () => (acquisitions === 1 ? firstWait.promise : Promise.resolve(event)),
+        } as never;
+      }
+    }
+    const stream = new TestStreamRpcTarget({
+      auth: { assertCanAccessProject: vi.fn() } as never,
+      path: "/agents/onboarding",
+      projectId: "prj_test",
+    });
+
+    const waiting = stream.waitForEvent({
+      afterOffset: 8,
+      eventTypes: [event.type],
+      timeoutMs: 30_000,
+    });
+    try {
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(acquisitions).toBe(2);
+      await expect(waiting).resolves.toBe(event);
+    } finally {
+      firstWait.reject(new Error("late rejection from superseded stream waiter"));
+      await waiting.catch(() => undefined);
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a late ephemeral match from a superseded waiter", async () => {
+    vi.useFakeTimers();
+    const firstWait = Promise.withResolvers<StreamEvent>();
+    const secondWait = Promise.withResolvers<StreamEvent>();
+    const event = {
+      createdAt: new Date(0).toISOString(),
+      ephemeral: true,
+      offset: 9,
+      path: "/events",
+      type: "events.iterate.com/test/ephemeral",
+    } satisfies StreamEvent;
+    let acquisitions = 0;
+    class TestStreamRpcTarget extends StreamRpcTarget {
+      override get durableObjectStub() {
+        acquisitions += 1;
+        return {
+          waitForEvent: () => (acquisitions === 1 ? firstWait.promise : secondWait.promise),
+        } as never;
+      }
+    }
+    const stream = new TestStreamRpcTarget({
+      auth: { assertCanAccessProject: vi.fn() } as never,
+      path: "/events",
+      projectId: "prj_test",
+    });
+
+    const waiting = stream.waitForEvent({
+      afterOffset: 8,
+      eventTypes: [event.type],
+      timeoutMs: 30_000,
+    });
+    try {
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(acquisitions).toBe(2);
+
+      firstWait.resolve(event);
+      await expect(waiting).resolves.toBe(event);
+    } finally {
+      firstWait.resolve(event);
+      secondWait.reject(new Error("late rejection after the ephemeral match"));
+      await waiting.catch(() => undefined);
+      vi.useRealTimers();
+    }
+  });
+
+  it("propagates stream predicate failures without retrying", async () => {
+    const predicateError = new Error("predicate failed");
+    let acquisitions = 0;
+    class TestStreamRpcTarget extends StreamRpcTarget {
+      override get durableObjectStub() {
+        acquisitions += 1;
+        return { waitForEvent: () => Promise.reject(predicateError) } as never;
+      }
+    }
+    const stream = new TestStreamRpcTarget({
+      auth: { assertCanAccessProject: vi.fn() } as never,
+      path: "/events",
+      projectId: "prj_test",
+    });
+
+    await expect(stream.waitForEvent({ predicate: () => true, timeoutMs: 30_000 })).rejects.toBe(
+      predicateError,
+    );
+    expect(acquisitions).toBe(1);
+  });
+
+  it("keeps one public timeout across orphaned stream waiters", async () => {
+    vi.useFakeTimers();
+    let acquisitions = 0;
+    class TestStreamRpcTarget extends StreamRpcTarget {
+      override get durableObjectStub() {
+        acquisitions += 1;
+        return { waitForEvent: () => new Promise<StreamEvent>(() => undefined) } as never;
+      }
+    }
+    const stream = new TestStreamRpcTarget({
+      auth: { assertCanAccessProject: vi.fn() } as never,
+      path: "/events",
+      projectId: "prj_test",
+    });
+
+    const waiting = stream.waitForEvent({
+      eventTypes: ["events.iterate.com/test/absent"],
+      timeoutMs: 30_000,
+    });
+    const rejected = expect(waiting).rejects.toThrow(
+      "stream-wait-timeout: Timed out waiting for stream event after 30000ms",
+    );
+    try {
+      await vi.advanceTimersByTimeAsync(30_000);
+      await rejected;
+      expect(acquisitions).toBe(3);
+    } finally {
+      await waiting.catch(() => undefined);
+      vi.useRealTimers();
+    }
+  });
+});
 
 describe("StreamProcessorRpcTarget", () => {
   it("lets the runner waiter own the complete waitUntilProcessed timeout", async () => {

--- a/apps/os/src/domains/streams/stream-processor-rpc-target.test.ts
+++ b/apps/os/src/domains/streams/stream-processor-rpc-target.test.ts
@@ -321,6 +321,42 @@ describe("ProcessorRelayRpcTarget", () => {
     }
   });
 
+  it("does not start a processor call when acquisition consumes the wait slice", async () => {
+    let now = 1_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const waitUntilProcessed = vi.fn(async () => undefined);
+    const dispose = vi.fn();
+    const processor = {
+      [Symbol.dispose]: dispose,
+      getRuntimeState: async () => ({ snapshot: { offset: 0, state: {} } }),
+      snapshot: async () => ({ offset: 0, state: {} }),
+      waitUntilProcessed,
+    };
+    const relay = new ProcessorRelayRpcTarget({
+      auth: { principal: "trusted-internal" } as never,
+      host: () => ({
+        processor: Promise.resolve({}),
+        wakeStreamSubscriber: async () => {
+          throw new Error("not used");
+        },
+      }),
+      processorFacade: async () => {
+        now = 1_100;
+        return processor;
+      },
+    });
+
+    try {
+      await expect(relay.waitUntilProcessed({ offset: 3, timeoutMs: 100 })).rejects.toThrow(
+        "waitUntilProcessed timed out after 100ms waiting for offset 3",
+      );
+      expect(waitUntilProcessed).not.toHaveBeenCalled();
+      expect(dispose).toHaveBeenCalledOnce();
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
   it("keeps one public timeout across orphaned wait slices", async () => {
     vi.useFakeTimers();
     const disposals: number[] = [];

--- a/apps/os/src/domains/streams/stream-processor-rpc-target.test.ts
+++ b/apps/os/src/domains/streams/stream-processor-rpc-target.test.ts
@@ -235,4 +235,128 @@ describe("ProcessorRelayRpcTarget", () => {
       nowSpy.mockRestore();
     }
   });
+
+  it("re-acquires when a remote processor waiter is orphaned", async () => {
+    vi.useFakeTimers();
+    const firstWait = Promise.withResolvers<void>();
+    const disposals: number[] = [];
+    let acquisitions = 0;
+    const relay = new ProcessorRelayRpcTarget({
+      auth: { principal: "trusted-internal" } as never,
+      host: () => ({
+        processor: Promise.resolve({}),
+        wakeStreamSubscriber: async () => {
+          throw new Error("not used");
+        },
+      }),
+      processorFacade: () => {
+        acquisitions += 1;
+        const acquisition = acquisitions;
+        return Promise.resolve({
+          [Symbol.dispose]: () => disposals.push(acquisition),
+          getRuntimeState: async () => ({ snapshot: { offset: 0, state: {} } }),
+          snapshot: async () => ({ offset: 0, state: {} }),
+          waitUntilProcessed: () =>
+            acquisition === 1 ? firstWait.promise : Promise.resolve(undefined),
+        });
+      },
+    });
+
+    const waiting = relay.waitUntilProcessed({ offset: 3, timeoutMs: 30_000 });
+    try {
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(acquisitions).toBe(2);
+      await expect(waiting).resolves.toBeUndefined();
+      expect(disposals).toEqual([1, 2]);
+    } finally {
+      firstWait.reject(new Error("late rejection from superseded waiter"));
+      await waiting.catch(() => undefined);
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds facade acquisition and releases a facade that arrives late", async () => {
+    vi.useFakeTimers();
+    const disposals: number[] = [];
+    let acquisitions = 0;
+    const processor = (acquisition: number) => ({
+      [Symbol.dispose]: () => disposals.push(acquisition),
+      getRuntimeState: async () => ({ snapshot: { offset: 0, state: {} } }),
+      snapshot: async () => ({ offset: 0, state: {} }),
+      waitUntilProcessed: async () => undefined,
+    });
+    const firstAcquisition = Promise.withResolvers<ReturnType<typeof processor>>();
+    const relay = new ProcessorRelayRpcTarget({
+      auth: { principal: "trusted-internal" } as never,
+      host: () => ({
+        processor: Promise.resolve({}),
+        wakeStreamSubscriber: async () => {
+          throw new Error("not used");
+        },
+      }),
+      processorFacade: () => {
+        acquisitions += 1;
+        return acquisitions === 1
+          ? firstAcquisition.promise
+          : Promise.resolve(processor(acquisitions));
+      },
+    });
+
+    const waiting = relay.waitUntilProcessed({ offset: 3, timeoutMs: 30_000 });
+    try {
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      await expect(waiting).resolves.toBeUndefined();
+      expect(acquisitions).toBe(2);
+      expect(disposals).toEqual([2]);
+
+      firstAcquisition.resolve(processor(1));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(disposals).toEqual([2, 1]);
+    } finally {
+      firstAcquisition.resolve(processor(1));
+      await waiting.catch(() => undefined);
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps one public timeout across orphaned wait slices", async () => {
+    vi.useFakeTimers();
+    const disposals: number[] = [];
+    let acquisitions = 0;
+    const relay = new ProcessorRelayRpcTarget({
+      auth: { principal: "trusted-internal" } as never,
+      host: () => ({
+        processor: Promise.resolve({}),
+        wakeStreamSubscriber: async () => {
+          throw new Error("not used");
+        },
+      }),
+      processorFacade: () => {
+        acquisitions += 1;
+        const acquisition = acquisitions;
+        return Promise.resolve({
+          [Symbol.dispose]: () => disposals.push(acquisition),
+          getRuntimeState: async () => ({ snapshot: { offset: 0, state: {} } }),
+          snapshot: async () => ({ offset: 0, state: {} }),
+          waitUntilProcessed: () => new Promise<void>(() => undefined),
+        });
+      },
+    });
+
+    const waiting = relay.waitUntilProcessed({ offset: 3, timeoutMs: 30_000 });
+    const rejected = expect(waiting).rejects.toThrow(
+      "waitUntilProcessed timed out after 30000ms waiting for offset 3",
+    );
+    try {
+      await vi.advanceTimersByTimeAsync(30_000);
+      await rejected;
+      expect(acquisitions).toBe(3);
+      expect(disposals).toEqual([1, 2, 3]);
+    } finally {
+      await waiting.catch(() => undefined);
+      vi.useRealTimers();
+    }
+  });
 });

--- a/apps/os/src/domains/streams/stream-processor-rpc-target.test.ts
+++ b/apps/os/src/domains/streams/stream-processor-rpc-target.test.ts
@@ -61,11 +61,15 @@ describe("StreamRpcTarget", () => {
       type: "events.iterate.com/test/ephemeral",
     } satisfies StreamEvent;
     let acquisitions = 0;
+    const remoteTimeouts: number[] = [];
     class TestStreamRpcTarget extends StreamRpcTarget {
       override get durableObjectStub() {
         acquisitions += 1;
         return {
-          waitForEvent: () => (acquisitions === 1 ? firstWait.promise : secondWait.promise),
+          waitForEvent: (input: { timeoutMs: number }) => {
+            remoteTimeouts.push(input.timeoutMs);
+            return acquisitions === 1 ? firstWait.promise : secondWait.promise;
+          },
         } as never;
       }
     }
@@ -83,12 +87,110 @@ describe("StreamRpcTarget", () => {
     try {
       await vi.advanceTimersByTimeAsync(10_000);
       expect(acquisitions).toBe(2);
+      expect(remoteTimeouts).toEqual([20_000, 20_000]);
 
       firstWait.resolve(event);
       await expect(waiting).resolves.toBe(event);
     } finally {
       firstWait.resolve(event);
       secondWait.reject(new Error("late rejection after the ephemeral match"));
+      await waiting.catch(() => undefined);
+      vi.useRealTimers();
+    }
+  });
+
+  it("pins a cursor-less wait so a durable event in the re-arm gap is replayed", async () => {
+    vi.useFakeTimers();
+    const firstWait = Promise.withResolvers<StreamEvent>();
+    const event = {
+      createdAt: new Date(0).toISOString(),
+      offset: 9,
+      path: "/events",
+      type: "events.iterate.com/test/in-rearm-gap",
+    } satisfies StreamEvent;
+    const waitInputs: { afterOffset?: number; timeoutMs: number }[] = [];
+    let headReads = 0;
+    class TestStreamRpcTarget extends StreamRpcTarget {
+      override get durableObjectStub() {
+        return {
+          getMaxOffset: () => {
+            headReads += 1;
+            return 8;
+          },
+          waitForEvent: (input: { afterOffset?: number; timeoutMs: number }) => {
+            waitInputs.push(input);
+            if (waitInputs.length === 1) return firstWait.promise;
+            return input.afterOffset === 8
+              ? Promise.resolve(event)
+              : new Promise<StreamEvent>(() => undefined);
+          },
+        } as never;
+      }
+    }
+    const stream = new TestStreamRpcTarget({
+      auth: { assertCanAccessProject: vi.fn() } as never,
+      path: "/events",
+      projectId: "prj_test",
+    });
+
+    const waiting = stream.waitForEvent({
+      eventTypes: [event.type],
+      timeoutMs: 30_000,
+    });
+    try {
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(headReads).toBe(1);
+      expect(waitInputs).toHaveLength(2);
+      expect(waitInputs.map(({ afterOffset }) => afterOffset)).toEqual([8, 8]);
+      await expect(waiting).resolves.toBe(event);
+    } finally {
+      firstWait.reject(new Error("late rejection from superseded cursor-less wait"));
+      await waiting.catch(() => undefined);
+      vi.useRealTimers();
+    }
+  });
+
+  it("re-acquires when the cursor-pinning head read is orphaned", async () => {
+    vi.useFakeTimers();
+    const firstHead = Promise.withResolvers<number>();
+    const event = {
+      createdAt: new Date(0).toISOString(),
+      offset: 9,
+      path: "/events",
+      type: "events.iterate.com/test/after-orphaned-head-read",
+    } satisfies StreamEvent;
+    let headReads = 0;
+    let waits = 0;
+    class TestStreamRpcTarget extends StreamRpcTarget {
+      override get durableObjectStub() {
+        return {
+          getMaxOffset: () => {
+            headReads += 1;
+            return headReads === 1 ? firstHead.promise : 8;
+          },
+          waitForEvent: () => {
+            waits += 1;
+            return Promise.resolve(event);
+          },
+        } as never;
+      }
+    }
+    const stream = new TestStreamRpcTarget({
+      auth: { assertCanAccessProject: vi.fn() } as never,
+      path: "/events",
+      projectId: "prj_test",
+    });
+
+    const waiting = stream.waitForEvent({ eventTypes: [event.type], timeoutMs: 30_000 });
+    try {
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(headReads).toBe(2);
+      expect(waits).toBe(1);
+      await expect(waiting).resolves.toBe(event);
+    } finally {
+      firstHead.reject(new Error("late rejection from superseded head read"));
       await waiting.catch(() => undefined);
       vi.useRealTimers();
     }
@@ -109,8 +211,31 @@ describe("StreamRpcTarget", () => {
       projectId: "prj_test",
     });
 
-    await expect(stream.waitForEvent({ predicate: () => true, timeoutMs: 30_000 })).rejects.toBe(
-      predicateError,
+    await expect(
+      stream.waitForEvent({ afterOffset: 0, predicate: () => true, timeoutMs: 30_000 }),
+    ).rejects.toBe(predicateError);
+    expect(acquisitions).toBe(1);
+  });
+
+  it("tags an explicit stream lifecycle rejection without hiding it behind recovery", async () => {
+    const lifecycleError = Object.assign(new Error("kill requested"), {
+      durableObjectReset: true,
+    });
+    let acquisitions = 0;
+    class TestStreamRpcTarget extends StreamRpcTarget {
+      override get durableObjectStub() {
+        acquisitions += 1;
+        return { waitForEvent: () => Promise.reject(lifecycleError) } as never;
+      }
+    }
+    const stream = new TestStreamRpcTarget({
+      auth: { assertCanAccessProject: vi.fn() } as never,
+      path: "/events",
+      projectId: "prj_test",
+    });
+
+    await expect(stream.waitForEvent({ afterOffset: 0, timeoutMs: 30_000 })).rejects.toThrow(
+      "stream-unavailable: kill requested",
     );
     expect(acquisitions).toBe(1);
   });
@@ -131,6 +256,7 @@ describe("StreamRpcTarget", () => {
     });
 
     const waiting = stream.waitForEvent({
+      afterOffset: 0,
       eventTypes: ["events.iterate.com/test/absent"],
       timeoutMs: 30_000,
     });

--- a/apps/os/src/domains/streams/stream-unavailable.test.ts
+++ b/apps/os/src/domains/streams/stream-unavailable.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   isDurableObjectLifecycleError,
+  isStreamWaitTimeoutError,
   isStreamUnavailableError,
   rethrowStreamUnavailable,
   STREAM_UNAVAILABLE_MESSAGE_PREFIX,
+  STREAM_WAIT_TIMEOUT_MESSAGE_PREFIX,
 } from "./stream-unavailable.ts";
 
 const withFlag = (flag: string, value: unknown = true) =>
@@ -68,5 +70,17 @@ describe("isStreamUnavailableError", () => {
     ["unrelated app error", new Error('no capability "itx.streams.get"'), false],
   ])("%s → %s", (_name, error, expected) => {
     expect(isStreamUnavailableError(error)).toBe(expected);
+  });
+});
+
+describe("isStreamWaitTimeoutError", () => {
+  it("classifies only the explicit stream waiter timeout contract", () => {
+    expect(
+      isStreamWaitTimeoutError(
+        new Error(`${STREAM_WAIT_TIMEOUT_MESSAGE_PREFIX}Timed out waiting for stream event`),
+      ),
+    ).toBe(true);
+    expect(isStreamWaitTimeoutError(new Error("predicate failed"))).toBe(false);
+    expect(isStreamWaitTimeoutError("stream-wait-timeout: string rejection")).toBe(false);
   });
 });

--- a/apps/os/src/domains/streams/stream-unavailable.ts
+++ b/apps/os/src/domains/streams/stream-unavailable.ts
@@ -23,6 +23,13 @@
 export const STREAM_UNAVAILABLE_MESSAGE_PREFIX = "stream-unavailable: ";
 
 /**
+ * Identifies the stream DO's own one-shot waiter timeout across Workers RPC.
+ * The public facade uses shorter one-shot waits under one caller deadline, so
+ * it must distinguish an exhausted internal slice from a predicate failure.
+ */
+export const STREAM_WAIT_TIMEOUT_MESSAGE_PREFIX = "stream-wait-timeout: ";
+
+/**
  * Whether a Durable Object stub rejection is a DO-lifecycle failure (the
  * incarnation died mid-call / is overloaded) as opposed to an app-level throw
  * from the DO's own code. These property flags are workerd's error contract;
@@ -64,4 +71,9 @@ export function rethrowStreamUnavailable(error: unknown): never {
  */
 export function isStreamUnavailableError(error: unknown): boolean {
   return error instanceof Error && error.message.includes(STREAM_UNAVAILABLE_MESSAGE_PREFIX);
+}
+
+/** Whether a rejection is the stream DO's explicitly modelled waiter timeout. */
+export function isStreamWaitTimeoutError(error: unknown): boolean {
+  return error instanceof Error && error.message.startsWith(STREAM_WAIT_TIMEOUT_MESSAGE_PREFIX);
 }

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -234,6 +234,10 @@ import type {
   AgentProcessorState,
 } from "./domains/agents/agent-processor-contract.ts";
 import { CapabilityHostProcessorContract } from "./domains/capability-host/capability-host-processor-contract.ts";
+import {
+  settleByDeadline,
+  type DeadlineOutcome,
+} from "./domains/capability-host/execution-deadline.ts";
 import type { ScheduleView, SetScheduleInput } from "./domains/scheduler/types.ts";
 import { unwrapBrowserRunQuickAction } from "./domains/itx/cf-capabilities.ts";
 import type {
@@ -6457,6 +6461,8 @@ type ProjectRouterProcessorHostStub = ProcessorHostStub & {
   telegramProcessor: PromiseLike<unknown>;
 };
 
+const PROCESSOR_WAIT_REACQUIRE_MS = 10_000;
+
 /**
  * Isolate-side relay for a Durable-Object-hosted processor facade.
  *
@@ -6501,45 +6507,90 @@ export class ProcessorRelayRpcTarget<State, Host extends ProcessorHostStub = Pro
     return (await this.#processorFacade(this.#host())) as StreamProcessorRpc<State>;
   }
 
-  async #callProcessor<Result>(
+  #disposeProcessor(processor: StreamProcessorRpc<State>): void {
+    // A Workers RPC property returning an RpcTarget materializes a remote
+    // stub for every relay call. It is only needed for this one method and
+    // must be released deterministically. In-process targets are real
+    // RpcTargets and remain owned by their host.
+    if (processor instanceof RpcTarget) return;
+    try {
+      (processor as StreamProcessorRpc<State> & Partial<Disposable>)[Symbol.dispose]?.();
+    } catch (error) {
+      // Disposal is cleanup, not the authoritative processor outcome. A
+      // stale workerd RPC stub can reject disposal after its backing DO
+      // resets; preserve the success/error/retry already chosen above,
+      // while keeping the cleanup failure observable.
+      console.warn("processor relay transient facade dispose failed", { error });
+    }
+  }
+
+  async #callProcessorOutcome<Result>(
     call: (processor: StreamProcessorRpc<State>) => Promise<Result>,
-  ): Promise<Result> {
+    expiresAt?: number,
+  ): Promise<DeadlineOutcome<Result>> {
+    const settle = <Value>(promise: Promise<Value>): Promise<DeadlineOutcome<Value>> =>
+      expiresAt === undefined
+        ? promise.then<DeadlineOutcome<Value>, DeadlineOutcome<Value>>(
+            (value) => ({ status: "fulfilled", value }),
+            (error: unknown) => ({ status: "rejected", error }),
+          )
+        : settleByDeadline(promise, expiresAt, Date.now);
+
     for (let attempt = 1; attempt <= 2; attempt += 1) {
       let processor: StreamProcessorRpc<State> | undefined;
-      try {
-        processor = await this.#processor();
-        return await call(processor);
-      } catch (error) {
-        if (attempt === 1 && isDurableObjectLifecycleError(error)) {
-          // Deploys and evictions may reset a processor-hosting DO while its
-          // facade property or method call is in flight. A fresh host stub
-          // reaches the replacement incarnation; retry exactly once so this
-          // expected lifecycle transition does not strand a durable birth
-          // frame. App errors are never retried, and a second lifecycle
-          // failure propagates to the caller.
+      const acquisition = this.#processor();
+      const acquired = await settle(acquisition);
+      if (acquired.status === "deadline") {
+        // The acquisition may still materialize a remote facade after this
+        // caller has moved on. Observe both outcomes and release a late stub.
+        void acquisition.then(
+          (lateProcessor) => this.#disposeProcessor(lateProcessor),
+          () => undefined,
+        );
+        return acquired;
+      }
+      if (acquired.status === "rejected") {
+        if (attempt === 1 && isDurableObjectLifecycleError(acquired.error)) {
           console.info("processor relay retrying after Durable Object lifecycle reset");
           continue;
         }
-        throw error;
-      } finally {
-        // A Workers RPC property returning an RpcTarget materializes a remote
-        // stub for every relay call. It is only needed for this one method and
-        // must be released deterministically. In-process targets are real
-        // RpcTargets and remain owned by their host.
-        if (processor !== undefined && !(processor instanceof RpcTarget)) {
-          try {
-            (processor as StreamProcessorRpc<State> & Partial<Disposable>)[Symbol.dispose]?.();
-          } catch (error) {
-            // Disposal is cleanup, not the authoritative processor outcome. A
-            // stale workerd RPC stub can reject disposal after its backing DO
-            // resets; preserve the success/error/retry already chosen above,
-            // while keeping the cleanup failure observable.
-            console.warn("processor relay transient facade dispose failed", { error });
-          }
-        }
+        return acquired;
       }
+
+      processor = acquired.value;
+      let outcome: DeadlineOutcome<Result>;
+      try {
+        outcome = await settle(Promise.resolve().then(() => call(processor!)));
+      } finally {
+        this.#disposeProcessor(processor);
+      }
+      if (
+        outcome.status === "rejected" &&
+        attempt === 1 &&
+        isDurableObjectLifecycleError(outcome.error)
+      ) {
+        // Deploys and evictions may reset a processor-hosting DO while its
+        // facade property or method call is in flight. A fresh host stub
+        // reaches the replacement incarnation; retry exactly once. App errors
+        // are never retried, and a second lifecycle failure propagates.
+        console.info("processor relay retrying after Durable Object lifecycle reset");
+        continue;
+      }
+      return outcome;
     }
-    throw new Error("processor relay exhausted its bounded lifecycle retry");
+    return {
+      status: "rejected",
+      error: new Error("processor relay exhausted its bounded lifecycle retry"),
+    };
+  }
+
+  async #callProcessor<Result>(
+    call: (processor: StreamProcessorRpc<State>) => Promise<Result>,
+  ): Promise<Result> {
+    const outcome = await this.#callProcessorOutcome(call);
+    if (outcome.status === "fulfilled") return outcome.value;
+    if (outcome.status === "rejected") throw outcome.error;
+    throw new Error("processor relay reached an impossible unbounded deadline");
   }
 
   async snapshot() {
@@ -6551,17 +6602,38 @@ export class ProcessorRelayRpcTarget<State, Host extends ProcessorHostStub = Pro
   }
 
   async waitUntilProcessed(input: { offset: number; timeoutMs?: number }) {
-    const deadline = input.timeoutMs === undefined ? undefined : Date.now() + input.timeoutMs;
-    return await this.#callProcessor((processor) => {
-      if (deadline === undefined) return processor.waitUntilProcessed(input);
-      const timeoutMs = deadline - Date.now();
-      if (timeoutMs <= 0) {
-        throw new Error(
-          `waitUntilProcessed timed out after ${input.timeoutMs}ms waiting for offset ${input.offset}`,
-        );
-      }
-      return processor.waitUntilProcessed({ ...input, timeoutMs });
-    });
+    if (input.timeoutMs === undefined) {
+      return await this.#callProcessor((processor) => processor.waitUntilProcessed(input));
+    }
+
+    const deadline = Date.now() + input.timeoutMs;
+    const timeoutError = () =>
+      new Error(
+        `waitUntilProcessed timed out after ${input.timeoutMs}ms waiting for offset ${input.offset}`,
+      );
+    while (Date.now() < deadline) {
+      // A remote RpcTarget call can be orphaned when its hosting DO is
+      // replaced without workerd rejecting the caller. Bound the LOCAL
+      // acquisition + call as well as the remote runner's timer, then obtain a
+      // fresh facade and re-check durable progress within the one public
+      // deadline. Promise races retain rejection observers, and disposal
+      // cancels/releases the superseded remote waiter.
+      const attemptDeadline = Math.min(deadline, Date.now() + PROCESSOR_WAIT_REACQUIRE_MS);
+      const outcome = await this.#callProcessorOutcome((processor) => {
+        const timeoutMs = deadline - Date.now();
+        return timeoutMs <= 0
+          ? Promise.reject(timeoutError())
+          : processor.waitUntilProcessed({ ...input, timeoutMs });
+      }, attemptDeadline);
+      if (outcome.status === "fulfilled") return outcome.value;
+      if (outcome.status === "rejected") throw outcome.error;
+      if (attemptDeadline >= deadline) break;
+      console.info("processor relay re-acquiring after bounded wait slice", {
+        offset: input.offset,
+        remainingMs: deadline - Date.now(),
+      });
+    }
+    throw timeoutError();
   }
 
   /** The host's wake-mode delivery handshake (see {@link WakeableStreamProcessorRpc}). */

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -6558,9 +6558,17 @@ export class ProcessorRelayRpcTarget<State, Host extends ProcessorHostStub = Pro
       }
 
       processor = acquired.value;
+      if (expiresAt !== undefined && Date.now() >= expiresAt) {
+        // Acquisition won the promise race but consumed the complete slice.
+        // Do not schedule a call on a facade that cleanup must now release.
+        this.#disposeProcessor(processor);
+        return { status: "deadline" };
+      }
       let outcome: DeadlineOutcome<Result>;
       try {
-        outcome = await settle(Promise.resolve().then(() => call(processor!)));
+        outcome = await settle(call(processor));
+      } catch (error) {
+        outcome = { status: "rejected", error };
       } finally {
         this.#disposeProcessor(processor);
       }

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -142,7 +142,9 @@ import type { StreamEvent, StreamEventInput, StreamListItem } from "./domains/st
 import { retainProcessEventBatch } from "./domains/streams/subscriber-sinks.ts";
 import {
   isDurableObjectLifecycleError,
+  isStreamWaitTimeoutError,
   rethrowStreamUnavailable,
+  STREAM_WAIT_TIMEOUT_MESSAGE_PREFIX,
 } from "./domains/streams/stream-unavailable.ts";
 import {
   isObjectSchema,
@@ -424,6 +426,8 @@ function parallelOpenApiTarget(input: { egress: FetchOnly; parent: string }): Op
   );
 }
 
+const STREAM_WAIT_REACQUIRE_MS = 10_000;
+
 /**
  * Durable event stream capability.
  *
@@ -537,13 +541,69 @@ export class StreamRpcTarget extends IterateRpcTarget<"Stream"> {
    * `ephemeral: true` event appended after this wait opens, but historical
    * ephemeral rows are never replayed.
    */
-  waitForEvent(args: {
+  async waitForEvent(args: {
     afterOffset?: number;
     eventTypes?: readonly string[];
     predicate?: (event: StreamEvent) => boolean | Promise<boolean>;
     timeoutMs: number;
   }): Promise<StreamEvent> {
-    return this.durableObjectStub.waitForEvent(args).catch(rethrowStreamUnavailable);
+    // Preserve the DO's validation error for invalid timeouts instead of
+    // manufacturing a deadline from NaN/Infinity/a non-positive duration.
+    if (!Number.isFinite(args.timeoutMs) || args.timeoutMs <= 0) {
+      return await this.durableObjectStub.waitForEvent(args).catch(rethrowStreamUnavailable);
+    }
+
+    const deadline = Date.now() + args.timeoutMs;
+    const terminal = Promise.withResolvers<StreamEvent>();
+    let lifecycleRetries = 0;
+
+    while (Date.now() < deadline) {
+      const attemptDeadline = Math.min(deadline, Date.now() + STREAM_WAIT_REACQUIRE_MS);
+      const sliceTimeoutMs = Math.max(1, attemptDeadline - Date.now());
+      let wait: Promise<StreamEvent>;
+      try {
+        wait = Promise.resolve(
+          this.durableObjectStub.waitForEvent({ ...args, timeoutMs: sliceTimeoutMs }),
+        );
+      } catch (error) {
+        if (lifecycleRetries === 0 && isDurableObjectLifecycleError(error)) {
+          lifecycleRetries += 1;
+          continue;
+        }
+        rethrowStreamUnavailable(error);
+      }
+
+      // A superseded call can still report an ephemeral match that a fresh
+      // subscription cannot replay. Let that success win. Likewise, retain a
+      // late predicate/application failure as the terminal result; only the
+      // explicitly modelled slice timeout and lifecycle-reset outcomes are
+      // safe to replace with a fresh durable replay.
+      void wait.then(terminal.resolve, (error: unknown) => {
+        if (!isStreamWaitTimeoutError(error) && !isDurableObjectLifecycleError(error)) {
+          terminal.reject(error);
+        }
+      });
+
+      const outcome = await settleByDeadline(
+        Promise.race([wait, terminal.promise]),
+        attemptDeadline,
+        Date.now,
+      );
+      if (outcome.status === "fulfilled") return outcome.value;
+      if (outcome.status === "rejected") {
+        if (isStreamWaitTimeoutError(outcome.error)) continue;
+        if (lifecycleRetries === 0 && isDurableObjectLifecycleError(outcome.error)) {
+          lifecycleRetries += 1;
+          continue;
+        }
+        rethrowStreamUnavailable(outcome.error);
+      }
+    }
+
+    throw new Error(
+      `${STREAM_WAIT_TIMEOUT_MESSAGE_PREFIX}Timed out waiting for stream event after ${args.timeoutMs}ms ` +
+        "(the public deadline expired while recovery re-armed one-shot waits).",
+    );
   }
 
   /** The reduced-state snapshot (plus runtime debug info) of one configured processor. */

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -554,34 +554,65 @@ export class StreamRpcTarget extends IterateRpcTarget<"Stream"> {
     }
 
     const deadline = Date.now() + args.timeoutMs;
+    let replayAfterOffset = args.afterOffset;
+
+    // A cursor-less DO wait is live-from-the-head at which that individual
+    // subscription opens. Re-arming it with no cursor would therefore skip a
+    // durable event committed between subscriptions. Pin one post-call-start
+    // head and replay from it on every incarnation instead. Acquiring that
+    // head is itself sliced under the same public deadline: a silent orphan
+    // cannot wedge recovery before the first wait is even armed.
+    while (replayAfterOffset === undefined && Date.now() < deadline) {
+      const attemptDeadline = Math.min(deadline, Date.now() + STREAM_WAIT_REACQUIRE_MS);
+      let head: Promise<number>;
+      try {
+        head = Promise.resolve(this.durableObjectStub.getMaxOffset());
+      } catch (error) {
+        rethrowStreamUnavailable(error);
+      }
+      const outcome = await settleByDeadline(head, attemptDeadline, Date.now);
+      if (outcome.status === "fulfilled") {
+        replayAfterOffset = outcome.value;
+        break;
+      }
+      if (outcome.status === "rejected") rethrowStreamUnavailable(outcome.error);
+    }
+
     const terminal = Promise.withResolvers<StreamEvent>();
-    let lifecycleRetries = 0;
+    let lastSliceTimeout: unknown;
 
     while (Date.now() < deadline) {
       const attemptDeadline = Math.min(deadline, Date.now() + STREAM_WAIT_REACQUIRE_MS);
-      const sliceTimeoutMs = Math.max(1, attemptDeadline - Date.now());
+      // Keep the preceding healthy subscription alive for one extra slice
+      // while its replacement opens. This bounds normal overlap at two and
+      // avoids introducing an ephemeral-event gap at each recovery boundary;
+      // durable events are additionally protected by replayAfterOffset.
+      const remoteTimeoutMs = Math.max(
+        1,
+        Math.min(deadline - Date.now(), STREAM_WAIT_REACQUIRE_MS * 2),
+      );
       let wait: Promise<StreamEvent>;
       try {
         wait = Promise.resolve(
-          this.durableObjectStub.waitForEvent({ ...args, timeoutMs: sliceTimeoutMs }),
+          this.durableObjectStub.waitForEvent({
+            ...args,
+            afterOffset: replayAfterOffset,
+            timeoutMs: remoteTimeoutMs,
+          }),
         );
       } catch (error) {
-        if (lifecycleRetries === 0 && isDurableObjectLifecycleError(error)) {
-          lifecycleRetries += 1;
-          continue;
-        }
         rethrowStreamUnavailable(error);
       }
 
       // A superseded call can still report an ephemeral match that a fresh
       // subscription cannot replay. Let that success win. Likewise, retain a
-      // late predicate/application failure as the terminal result; only the
-      // explicitly modelled slice timeout and lifecycle-reset outcomes are
-      // safe to replace with a fresh durable replay.
+      // late predicate/application/lifecycle failure as the terminal result;
+      // only the explicitly modelled slice timeout is safe to replace with a
+      // fresh durable replay. In particular, an explicit kill must retain the
+      // public `stream-unavailable` rejection contract rather than being
+      // hidden behind recovery until the caller's deadline.
       void wait.then(terminal.resolve, (error: unknown) => {
-        if (!isStreamWaitTimeoutError(error) && !isDurableObjectLifecycleError(error)) {
-          terminal.reject(error);
-        }
+        if (!isStreamWaitTimeoutError(error)) terminal.reject(error);
       });
 
       const outcome = await settleByDeadline(
@@ -591,9 +622,8 @@ export class StreamRpcTarget extends IterateRpcTarget<"Stream"> {
       );
       if (outcome.status === "fulfilled") return outcome.value;
       if (outcome.status === "rejected") {
-        if (isStreamWaitTimeoutError(outcome.error)) continue;
-        if (lifecycleRetries === 0 && isDurableObjectLifecycleError(outcome.error)) {
-          lifecycleRetries += 1;
+        if (isStreamWaitTimeoutError(outcome.error)) {
+          lastSliceTimeout = outcome.error;
           continue;
         }
         rethrowStreamUnavailable(outcome.error);
@@ -603,6 +633,7 @@ export class StreamRpcTarget extends IterateRpcTarget<"Stream"> {
     throw new Error(
       `${STREAM_WAIT_TIMEOUT_MESSAGE_PREFIX}Timed out waiting for stream event after ${args.timeoutMs}ms ` +
         "(the public deadline expired while recovery re-armed one-shot waits).",
+      lastSliceTimeout === undefined ? undefined : { cause: lastSliceTimeout },
     );
   }
 


### PR DESCRIPTION
## Summary

- bound both processor-facade acquisition and `waitUntilProcessed` on the caller's wall clock
- re-acquire a fresh facade every 10 seconds while preserving one public timeout budget
- observe late resolve/reject outcomes and dispose facades that arrive after their attempt expired
- retain the existing exact-once retry for explicit Durable Object lifecycle errors
- add regressions for an orphaned method call, orphaned acquisition, late cleanup, and total-deadline exhaustion

## Why

The exact preview for #2052 exposed three project-creation retries that each spent 75 seconds in `wait-project-birth`. The directory writes fixed by #2052 were healthy (172/172 succeeded in 145–516 ms), but a Durable Object reset storm interrupted stream delivery.

For project `prj_d76cfffa85b34dbb8ad79c166c4cac9d`:

- trace `22c0df07e9b499fbbeb2ae4cd630ba92` appended every sibling birth successfully
- capability-host processor progress committed after redelivery at 02:50:23.710 and again at 02:50:25.570
- the replacement processor facade invocation ended successfully after about 5.3 seconds
- the calling Project processor never resumed and the outer waiter expired after 75.005 seconds

That is an orphaned cross-incarnation RPC waiter: durable progress advanced, but workerd neither completed nor rejected the original caller. Passing a timeout only to the remote runner therefore did not bound the caller.

This PR makes the timeout truthful locally. A superseded remote promise retains rejection observers, its facade is released, and the next short attempt reloads durable progress from the current incarnation.

## Validation

- OS unit suite: 183 files passed; 1,775 passed, 1 skipped
- root `pnpm typecheck`
- root `pnpm lint`: 1,154 files, zero warnings/errors
- root `pnpm format`

This is intentionally separate from #2052: #2052 remains solely the project-directory write/cache policy fix. Both are prerequisites to re-running and merging the agent recovery UX in #2050.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core stream coordination and processor relay timeout semantics around Durable Object lifecycle; incorrect re-arm or settlement read-back could mask real failures or mis-settle script executions.
> 
> **Overview**
> Fixes **orphaned Workers RPC waiters** when a stream or processor-host Durable Object resets mid-call: durable progress can advance while the original `waitForEvent` / `waitUntilProcessed` promise never settles, so callers could hang for the full timeout budget.
> 
> **`StreamRpcTarget.waitForEvent`** now runs under one caller deadline with ~10s re-arm slices: it pins replay cursors via new **`getMaxOffset()`**, overlaps superseded subscriptions briefly so ephemeral matches aren’t lost, and only retries on explicit **`stream-wait-timeout:`** rejections—predicate failures and **`stream-unavailable:`** lifecycle errors still surface immediately. **`ProcessorRelayRpcTarget`** applies the same pattern to facade acquisition and `waitUntilProcessed`, including disposing late materialized RPC stubs.
> 
> **Capability-host** settlement appends that fail now **read back** completions by idempotency key so reconciliation treats an existing durable outcome as success when a replacement incarnation races a late executor; orphan recovery telemetry moves to **`console.info`** and pending-settlement retries are not logged as recovery.
> 
> E2E Vitest setup also swallows dangling **`waitUntilProcessed timed out`** rejections so concurrent flakes don’t kill the worker and bypass **`retry: 1`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74ae14c278926280567eede387f17083292ba224. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +316 -56 | +243 -42 🟩🟩⬜⬜⬜ |
| Tests | +615 -19 | +570 -18 🟩🟩🟩🟩🟩 |
| **Total** | **+931 -75** | **+813 -60** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 5a26746 and 74ae14c, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-17T07:01:17.119Z",
      "headSha": "74ae14c278926280567eede387f17083292ba224",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/335670581626288",
      "shortSha": "74ae14c",
      "cleanupDurationMs": 2536,
      "deployDurationMs": 25807,
      "testDurationMs": 12687,
      "testRetries": null,
      "workerSizeKib": 4041.39,
      "workerGzipKib": 822.21,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-17T07:01:27.442Z",
      "headSha": "74ae14c278926280567eede387f17083292ba224",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/335670581626288",
      "shortSha": "74ae14c",
      "cleanupDurationMs": 12857,
      "deployDurationMs": 12953,
      "testDurationMs": 61194,
      "testRetries": null,
      "workerSizeKib": 5170.29,
      "workerGzipKib": 1471.3,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-17T07:01:15.278Z",
      "headSha": "74ae14c278926280567eede387f17083292ba224",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/335670581626288",
      "shortSha": "74ae14c",
      "cleanupDurationMs": 691,
      "deployDurationMs": 8360,
      "testDurationMs": 8065,
      "testRetries": null,
      "workerSizeKib": 1139.76,
      "workerGzipKib": 201.7,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-17T07:01:13.545Z",
      "headSha": "74ae14c278926280567eede387f17083292ba224",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/335670581626288",
      "shortSha": "74ae14c",
      "cleanupDurationMs": 94042,
      "deployDurationMs": 105823,
      "testDurationMs": 176433,
      "testRetries": null,
      "workerSizeKib": 16538.81,
      "workerGzipKib": 4458.88,
      "mainWorkerGzipKib": 4457.19
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-17T06:59:39.950Z",
      "headSha": "74ae14c278926280567eede387f17083292ba224",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/335670581626288",
      "shortSha": "74ae14c",
      "cleanupDurationMs": 443,
      "deployDurationMs": 12213,
      "testDurationMs": 15298,
      "testRetries": null,
      "workerSizeKib": 1914.49,
      "workerGzipKib": 440.74,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `74ae14c` | [https://auth.iterate-preview-9.com](https://auth.iterate-preview-9.com) | 822.2 KiB | 25.8s | 12.7s |  | 2.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/335670581626288) | 2026-07-17T07:01:17.119Z | Preview app released. |
| Dummy Petshop | released | `74ae14c` | [https://dummy-petshop.iterate-preview-9.com](https://dummy-petshop.iterate-preview-9.com) | 201.7 KiB | 8.4s | 8.1s |  | 691ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/335670581626288) | 2026-07-17T07:01:15.278Z | Preview app released. |
| OS | released | `74ae14c` | [https://os.iterate-preview-9.com](https://os.iterate-preview-9.com) | 4.35 MiB (+1.7 KiB vs main) | 105.8s | 176.4s |  | 94.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/335670581626288) | 2026-07-17T07:01:13.545Z | Preview app released. |
| Semaphore | released | `74ae14c` | [https://semaphore.iterate-preview-9.com](https://semaphore.iterate-preview-9.com) | 440.7 KiB | 12.2s | 15.3s |  | 443ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/335670581626288) | 2026-07-17T06:59:39.950Z | Preview app released. |
| Streams Example App | released | `74ae14c` | [https://streams.iterate-preview-9.com](https://streams.iterate-preview-9.com) | 1.44 MiB | 13.0s | 61.2s |  | 12.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/335670581626288) | 2026-07-17T07:01:27.442Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->