### PR TITLE
fix(e2e): eliminate preview browser races

### DIFF
--- a/apps/streams-example-app/e2e/playwright/stream-browser.spec.ts
+++ b/apps/streams-example-app/e2e/playwright/stream-browser.spec.ts
@@ -297,7 +297,9 @@ test("stream page reload starts at the bottom of an existing local mirror", asyn
   await expect(page.getByTestId("event-count")).toHaveText(String(expectedCount), {
     timeout: 30_000,
   });
-  await expect(page.locator(`[data-index='${expectedCount - 1}']`)).toBeVisible();
+  const tailRow = page.locator(`[data-index='${expectedCount - 1}']`);
+  await expect(tailRow.getByTestId("event-meta")).toBeVisible();
+  await expect(tailRow).toHaveCSS("height", "40px");
   await expectAtStreamEnd(page);
 
   await page.reload();

--- a/apps/streams-example-app/src/routes/-stream-page.tsx
+++ b/apps/streams-example-app/src/routes/-stream-page.tsx
@@ -631,7 +631,7 @@ function EventRows({
   onEventTypeFilterChange(eventType: string): void;
 }) {
   const topScrollAffordanceHeight = 48;
-  const estimatedEventRowHeight = 38;
+  const estimatedEventRowHeight = 40; // Pending + pb-2 must measure exactly this.
   const parentRef = useRef<HTMLDivElement>(null);
   const previousEventCount = useRef(eventCount);
   const initialScrollOffset = useRef(
@@ -1051,7 +1051,7 @@ function EventRowWindow({
       >
         {event === undefined ? (
           <article
-            className="box-border h-[30px] rounded-md border border-[#e1e5eb]"
+            className="box-border h-8 rounded-md border border-[#e1e5eb]"
             data-testid="event-row-pending"
           />
         ) : (

--- a/specs/stream-resume-after-suspend.spec.ts
+++ b/specs/stream-resume-after-suspend.spec.ts
@@ -19,6 +19,7 @@ import { test } from "./test-support/test.ts";
 
 const ONBOARDING_AGENT_PATH = "/agents/onboarding";
 const MARKER_EVENT_TYPE = "events.iterate.test/spec/suspend-marker";
+const WEB_MESSAGE_SENT = "events.iterate.com/agents/web-message-sent";
 
 // Two liveness-probe intervals (LIVENESS_PROBE_INTERVAL_MS = 10s): a clean
 // socket close is invisible to the runtime (the view's factory never wires
@@ -210,9 +211,20 @@ test("feed resumes after the /api WebSocket goes half-open (no close frame)", as
   const keys = runtimeDebugKeys(fixture.project.id);
   await waitForSubscribed(page, keys);
 
-  // The onboarding greeting turn may still be streaming, and a live turn swaps
-  // the send button for "Stop generation" — wait for the settled composer so
-  // the mid-outage send below has a button to click.
+  // The composer initially renders a Send button before the onboarding
+  // greeting's activity reaches the browser. Waiting on that button alone can
+  // therefore race with the greeting and watch it turn into Stop generation
+  // while the test fills its draft. First require the greeting's durable
+  // response event and its painted row; only then is Send a settled control.
+  await agent.stream.waitForEvent({
+    afterOffset: 0,
+    eventTypes: [WEB_MESSAGE_SENT],
+    timeoutMs: 120_000,
+  });
+  await page
+    .locator('[data-testid="agent-feed-message"][data-kind="assistant"]')
+    .first()
+    .waitFor({ timeout: 30_000 });
   await page.getByRole("button", { name: "Send message" }).waitFor({ timeout: 120_000 });
 
   // Blackhole the transport WITHOUT a close event — what a suspend-killed TCP


### PR DESCRIPTION
## Summary

- align the Streams example virtual-row estimate with the exact measured placeholder and rendered-row height
- assert the rendered tail-row height before exercising reload anchoring
- wait for the durable, painted onboarding greeting before the half-open WebSocket test treats Send as settled

## Why

Fresh preview deployments exposed two absorbed Playwright retries. The Streams reload test could under-estimate a long list by two pixels per rendered row, and the OS recovery test could observe the initial Send control just before onboarding activity replaced it with Stop generation. Both were real synchronization defects even though their retries passed.

## Validation

- pnpm test: OS 183 files passed; 1,772 tests passed and 1 skipped
- pnpm typecheck: all 15 workspaces passed
- pnpm lint and pnpm format passed
- React Doctor changed-file scan found no diagnostic
- Streams target tests passed 20/20 against a live preview with retries disabled
- OS half-open recovery target passed 3/3 against a live preview with retries disabled
- Fable xhigh final review: APPROVE, no blockers

## Screenshots

Not applicable: the two-pixel row correction restores an existing layout invariant; the other change is test-only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI constant tweak plus e2e synchronization; no auth, data, or production runtime logic changes.
> 
> **Overview**
> Aligns the Streams example **virtual list** with a **40px** row estimate (was 38px) and sets pending placeholders to **`h-8`** so estimated height matches measured rows and reload tail anchoring stays stable on long lists.
> 
> The stream-browser reload test now waits for **`event-meta`** on the tail row and asserts **40px** height before exercising reload anchoring.
> 
> The half-open WebSocket suspend spec waits for the durable **`web-message-sent`** event and a painted **assistant** feed message before treating **Send message** as settled, avoiding a race where onboarding swaps Send for Stop generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cebd6bfb66326fbd3ebe4ba4d2d05ad48f6c8667. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +2 -2 | +2 -2 🟩⬜⬜⬜⬜ |
| Tests | +18 -4 | +13 -1 🟩🟩🟩🟩🟩 |
| **Total** | **+20 -6** | **+15 -3** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 876b055 and cebd6bf, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-17T06:39:00.268Z",
      "headSha": "cebd6bfb66326fbd3ebe4ba4d2d05ad48f6c8667",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/73407508378063",
      "shortSha": "cebd6bf",
      "cleanupDurationMs": 2299,
      "deployDurationMs": 16656,
      "testDurationMs": 3472,
      "testRetries": null,
      "workerSizeKib": 4041.39,
      "workerGzipKib": 822.28,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-17T06:38:58.758Z",
      "headSha": "cebd6bfb66326fbd3ebe4ba4d2d05ad48f6c8667",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/73407508378063",
      "shortSha": "cebd6bf",
      "cleanupDurationMs": 788,
      "deployDurationMs": 15082,
      "testDurationMs": 56687,
      "testRetries": null,
      "workerSizeKib": 5164.22,
      "workerGzipKib": 1469.49,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-17T06:38:58.595Z",
      "headSha": "cebd6bfb66326fbd3ebe4ba4d2d05ad48f6c8667",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/73407508378063",
      "shortSha": "cebd6bf",
      "cleanupDurationMs": 623,
      "deployDurationMs": 7146,
      "testDurationMs": 5398,
      "testRetries": null,
      "workerSizeKib": 1139.76,
      "workerGzipKib": 201.7,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-17T06:38:56.625Z",
      "headSha": "cebd6bfb66326fbd3ebe4ba4d2d05ad48f6c8667",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/73407508378063",
      "shortSha": "cebd6bf",
      "cleanupDurationMs": 112049,
      "deployDurationMs": 86540,
      "testDurationMs": 184304,
      "testRetries": "2 retried: Late agent subscriptions replay history after an earlier birth certificate (vitest x1) · reactivity page repaints from a stream subscription after a page action (specs x1)",
      "workerSizeKib": 16527.47,
      "workerGzipKib": 4456.64,
      "mainWorkerGzipKib": 4457.19
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-17T06:37:05.049Z",
      "headSha": "cebd6bfb66326fbd3ebe4ba4d2d05ad48f6c8667",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/73407508378063",
      "shortSha": "cebd6bf",
      "cleanupDurationMs": 470,
      "deployDurationMs": 14527,
      "testDurationMs": 15107,
      "testRetries": null,
      "workerSizeKib": 1914.49,
      "workerGzipKib": 440.74,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `cebd6bf` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 822.3 KiB | 16.7s | 3.5s |  | 2.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/73407508378063) | 2026-07-17T06:39:00.268Z | Preview app released. |
| Dummy Petshop | released | `cebd6bf` | [https://dummy-petshop.iterate-preview-1.com](https://dummy-petshop.iterate-preview-1.com) | 201.7 KiB | 7.1s | 5.4s |  | 623ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/73407508378063) | 2026-07-17T06:38:58.595Z | Preview app released. |
| OS | released | `cebd6bf` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 4.35 MiB (-0.5 KiB vs main) | 86.5s | 184.3s | 2 retried: Late agent subscriptions replay history after an earlier birth certificate (vitest x1) · reactivity page repaints from a stream subscription after a page action (specs x1) | 112.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/73407508378063) | 2026-07-17T06:38:56.625Z | Preview app released. |
| Semaphore | released | `cebd6bf` | [https://semaphore.iterate-preview-1.com](https://semaphore.iterate-preview-1.com) | 440.7 KiB | 14.5s | 15.1s |  | 470ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/73407508378063) | 2026-07-17T06:37:05.049Z | Preview app released. |
| Streams Example App | released | `cebd6bf` | [https://streams.iterate-preview-1.com](https://streams.iterate-preview-1.com) | 1.44 MiB | 15.1s | 56.7s |  | 788ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/73407508378063) | 2026-07-17T06:38:58.758Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->