### PR TITLE
Fix stream worker assets under blob URLs

### DIFF
--- a/apps/os/src/domains/streams/client-libraries/browser/stream-db.worker.ts
+++ b/apps/os/src/domains/streams/client-libraries/browser/stream-db.worker.ts
@@ -19,6 +19,7 @@ import {
   SQLITE_ROW,
 } from "@journeyapps/wa-sqlite/src/sqlite-constants.js";
 import { OPFSCoopSyncVFS } from "@journeyapps/wa-sqlite/src/examples/OPFSCoopSyncVFS.js";
+import { resolveWorkerAssetUrl } from "./worker-asset-url.ts";
 
 // Matches wa-sqlite's SQLiteCompatibleType (blobs surface as Uint8Array or number[]).
 type SqlValue = string | number | bigint | Uint8Array | number[] | null;
@@ -57,14 +58,15 @@ async function open(path: string): Promise<void> {
 }
 
 async function loadSqliteModule() {
-  const response = await fetch(wasmUrl);
+  const resolvedWasmUrl = resolveWorkerAssetUrl(wasmUrl, self.origin);
+  const response = await fetch(resolvedWasmUrl);
   if (!response.ok) {
     throw new Error(
       `Failed to fetch SQLite WASM: ${String(response.status)} ${response.statusText}`,
     );
   }
   return await SQLiteESMFactory({
-    locateFile: () => wasmUrl,
+    locateFile: () => resolvedWasmUrl,
     wasmBinary: await response.arrayBuffer(),
   });
 }

--- a/apps/os/src/domains/streams/client-libraries/browser/worker-asset-url.test.ts
+++ b/apps/os/src/domains/streams/client-libraries/browser/worker-asset-url.test.ts
@@ -1,0 +1,13 @@
+import { expect, it } from "vitest";
+import { resolveWorkerAssetUrl } from "./worker-asset-url.ts";
+
+it("resolves root-relative assets against the worker origin", () => {
+  expect(resolveWorkerAssetUrl("/assets/wa-sqlite.wasm", "https://os.iterate.com")).toBe(
+    "https://os.iterate.com/assets/wa-sqlite.wasm",
+  );
+});
+
+it("preserves absolute asset URLs", () => {
+  const assetUrl = "https://cdn.example.com/wa-sqlite.wasm";
+  expect(resolveWorkerAssetUrl(assetUrl, "https://os.iterate.com")).toBe(assetUrl);
+});

--- a/apps/os/src/domains/streams/client-libraries/browser/worker-asset-url.ts
+++ b/apps/os/src/domains/streams/client-libraries/browser/worker-asset-url.ts
@@ -1,0 +1,4 @@
+/** `blob:` cannot resolve root-relative assets, so qualify them against the worker origin. */
+export function resolveWorkerAssetUrl(assetUrl: string, workerOrigin: string): string {
+  return new URL(assetUrl, workerOrigin).href;
+}


### PR DESCRIPTION
## What

- Resolve the stream database worker’s Vite-emitted WASM URL against the worker origin before fetching it.
- Pass the same absolute URL to Emscripten’s `locateFile` callback.
- Cover root-relative resolution and absolute/CDN passthrough.

## Why

The isolated `agent-browser` harness wraps module workers in a `blob:` worker. The production bundle emits wa-sqlite as a root-relative `/assets/...wasm` URL, which cannot be parsed as a fetch URL from a blob worker. SQLite initialization then retries until stream reconciliation times out, even though the server-side subscription is healthy.

Qualifying the asset against `self.origin` preserves normal direct-worker behavior and makes the bundled worker robust to same-origin blob wrappers.

## Validation

- `pnpm --dir apps/os test:unit` — 1,809 passed, 1 skipped
- `pnpm typecheck`
- `pnpm lint` — zero warnings/errors
- `doppler run -- pnpm exec vite build`
- Inspected the emitted `stream-db.worker` bundle: the hashed WASM URL is origin-qualified and shared by `fetch`/`locateFile`
- Claude Fable review at xhigh effort — no blocking findings

## Screenshots

Not applicable: this is worker asset loading with no visual change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to worker WASM loading with tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **stream DB worker** initialization when the worker runs under a **`blob:`** URL (e.g. isolated `agent-browser` harness) by resolving Vite’s root-relative **`/assets/...wasm`** path against **`self.origin`** before **`fetch`** and Emscripten’s **`locateFile`**.
> 
> Adds **`resolveWorkerAssetUrl`** in `worker-asset-url.ts` and unit tests for root-relative resolution and absolute/CDN passthrough.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2388e625f0805753b647dc692017de454ebec1be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +8 -2 | +7 -2 🟩🟩🟩🟥⬜ |
| Tests | +13 -0 | +11 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+21 -2** | **+18 -2** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 1cc426d and 2388e62, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-17T08:52:56.663Z",
      "headSha": "2388e625f0805753b647dc692017de454ebec1be",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/525740683011950",
      "shortSha": "2388e62",
      "cleanupDurationMs": 2793,
      "deployDurationMs": 18206,
      "testDurationMs": 2969,
      "testRetries": null,
      "workerSizeKib": 4041.39,
      "workerGzipKib": 822.25,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-17T08:53:04.162Z",
      "headSha": "2388e625f0805753b647dc692017de454ebec1be",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/525740683011950",
      "shortSha": "2388e62",
      "cleanupDurationMs": 10291,
      "deployDurationMs": 14115,
      "testDurationMs": 60350,
      "testRetries": null,
      "workerSizeKib": 5170.47,
      "workerGzipKib": 1471.4,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-17T08:52:54.598Z",
      "headSha": "2388e625f0805753b647dc692017de454ebec1be",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/525740683011950",
      "shortSha": "2388e62",
      "cleanupDurationMs": 725,
      "deployDurationMs": 6603,
      "testDurationMs": 6753,
      "testRetries": null,
      "workerSizeKib": 1139.76,
      "workerGzipKib": 201.7,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-17T08:52:52.825Z",
      "headSha": "2388e625f0805753b647dc692017de454ebec1be",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/525740683011950",
      "shortSha": "2388e62",
      "cleanupDurationMs": 107934,
      "deployDurationMs": 81486,
      "testDurationMs": 183702,
      "testRetries": null,
      "workerSizeKib": 16541.47,
      "workerGzipKib": 4459.54,
      "mainWorkerGzipKib": 4459.52
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-17T08:51:05.340Z",
      "headSha": "2388e625f0805753b647dc692017de454ebec1be",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/525740683011950",
      "shortSha": "2388e62",
      "cleanupDurationMs": 447,
      "deployDurationMs": 13185,
      "testDurationMs": 23934,
      "testRetries": null,
      "workerSizeKib": 1914.49,
      "workerGzipKib": 440.74,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `2388e62` | [https://auth.iterate-preview-4.com](https://auth.iterate-preview-4.com) | 822.3 KiB | 18.2s | 3.0s |  | 2.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/525740683011950) | 2026-07-17T08:52:56.663Z | Preview app released. |
| Dummy Petshop | released | `2388e62` | [https://dummy-petshop.iterate-preview-4.com](https://dummy-petshop.iterate-preview-4.com) | 201.7 KiB | 6.6s | 6.8s |  | 725ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/525740683011950) | 2026-07-17T08:52:54.598Z | Preview app released. |
| OS | released | `2388e62` | [https://os.iterate-preview-4.com](https://os.iterate-preview-4.com) | 4.36 MiB (+0.0 KiB vs main) | 81.5s | 183.7s |  | 107.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/525740683011950) | 2026-07-17T08:52:52.825Z | Preview app released. |
| Semaphore | released | `2388e62` | [https://semaphore.iterate-preview-4.com](https://semaphore.iterate-preview-4.com) | 440.7 KiB | 13.2s | 23.9s |  | 447ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/525740683011950) | 2026-07-17T08:51:05.340Z | Preview app released. |
| Streams Example App | released | `2388e62` | [https://streams.iterate-preview-4.com](https://streams.iterate-preview-4.com) | 1.44 MiB | 14.1s | 60.4s |  | 10.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/525740683011950) | 2026-07-17T08:53:04.162Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->