### PR TITLE
Stabilize Streams virtual row scrolling

### DIFF
--- a/apps/streams-example-app/e2e/playwright/stream-browser.spec.ts
+++ b/apps/streams-example-app/e2e/playwright/stream-browser.spec.ts
@@ -45,6 +45,30 @@ test("stream page appends through the shared browser mirror", async ({ page }) =
   await expect(eventMeta(page, type).first()).toBeVisible();
 });
 
+test("collapsed event rows keep a stable height with long metadata", async ({ page }) => {
+  const streamPath = `/e2e/${crypto.randomUUID()}`;
+  await page.goto(streamRoute({ path: streamPath }));
+  await expect(eventMeta(page, "events.iterate.com/stream/created").first()).toBeVisible();
+
+  const type = `events.iterate.com/debug/${"long-segment/".repeat(24)}`;
+  await appendComposerEvent(page, {
+    type,
+    payload: { streamPath, value: crypto.randomUUID() },
+  });
+
+  const metadata = eventMeta(page, type).first();
+  await expect(metadata).toBeVisible();
+  await expect
+    .poll(() =>
+      metadata.evaluate((element) => {
+        const row = element.closest('[data-testid="virtual-row"]');
+        if (!(row instanceof HTMLElement)) throw new Error("event metadata must be inside a row");
+        return Math.round(row.getBoundingClientRect().height);
+      }),
+    )
+    .toBe(40);
+});
+
 // The pre-itx-v4 hosted circuit-breaker processor (via the removed
 // StreamProcessorRunner DO) is gone; on itx the pause door is core
 // stream behavior, driven directly through the sidebar's pause/resume gate.
@@ -813,6 +837,9 @@ test("split view disposes a replaced same-stream pane and keeps leadership", asy
 test("large streams stay virtualized and can scroll from tail to earliest rows", async ({
   page,
 }) => {
+  // The narrowest desktop width keeps the sidebar open and puts maximum
+  // wrapping pressure on the virtual row metadata columns.
+  await page.setViewportSize({ width: 761, height: 720 });
   const streamPath = `/e2e/${crypto.randomUUID()}`;
   await page.goto(streamRoute({ path: streamPath }));
   await expect(eventMeta(page, "events.iterate.com/stream/created").first()).toBeVisible();

--- a/apps/streams-example-app/src/routes/-stream-page.tsx
+++ b/apps/streams-example-app/src/routes/-stream-page.tsx
@@ -1072,8 +1072,10 @@ function EventRowWindow({
               onClick={() => onToggleOffset(event.offset)}
             >
               <span>{event.offset}</span>
-              <span>{event.type}</span>
-              <time dateTime={event.created_at}>{event.created_at}</time>
+              <span className="truncate">{event.type}</span>
+              <time className="whitespace-nowrap" dateTime={event.created_at}>
+                {event.created_at}
+              </time>
             </button>
             {isExpanded ? (
               <pre

--- a/tasks/os-custom-domain-provisioning-saga.md
+++ b/tasks/os-custom-domain-provisioning-saga.md
@@ -61,13 +61,13 @@ processor (same architectural bar as project create), with:
 
 ## Current map (do not invent a second path)
 
-| Piece | Location |
-| ----- | -------- |
-| UI add/refresh/remove | `apps/os/src/components/project-custom-domains-settings.tsx` |
-| Events + `ProjectCustomDomain` state | `apps/os/src/domains/projects/project-processor-contract.ts` |
-| Reduce + `blockProcessorWhile` ensure | `apps/os/src/domains/projects/custom-domain-processor.ts` |
-| CF client + KV prime-on-active | `apps/os/src/domains/projects/custom-domains.ts` |
-| Ingress exact + `<app>.<custom>` | `apps/os/src/ingress.ts`, project hostname directory |
+| Piece                                 | Location                                                     |
+| ------------------------------------- | ------------------------------------------------------------ |
+| UI add/refresh/remove                 | `apps/os/src/components/project-custom-domains-settings.tsx` |
+| Events + `ProjectCustomDomain` state  | `apps/os/src/domains/projects/project-processor-contract.ts` |
+| Reduce + `blockProcessorWhile` ensure | `apps/os/src/domains/projects/custom-domain-processor.ts`    |
+| CF client + KV prime-on-active        | `apps/os/src/domains/projects/custom-domains.ts`             |
+| Ingress exact + `<app>.<custom>`      | `apps/os/src/ingress.ts`, project hostname directory         |
 
 Preserve: single project processor ownership, CF as certificate/hostname
 authority, KV hostname directory as routing source of truth when active,
@@ -103,8 +103,8 @@ Names are suggestive; implementer may refine contracts but must keep
   - apex points at SaaS fallback (`cname.<base>` or documented target)
   - `*.hostname` points at same when wildcard cert is requested
   - ownership / ACME TXT present when CF still requires them  
-  Does **not** replace CF as authority for TLS; it explains *why* CF is stuck
-  and why app subdomains 404 DNS.
+    Does **not** replace CF as authority for TLS; it explains _why_ CF is stuck
+    and why app subdomains 404 DNS.
 
 - `…/custom-domain-refresh-requested` (existing)  
   Force re-observation; also emitted by scheduler/alarm while not terminal.
@@ -146,15 +146,15 @@ Names are suggestive; implementer may refine contracts but must keep
 
 ## Tests
 
-1. **Unit / processor harness** (primary):  
-   - add-requested → requested state, ensure called once  
-   - observed pending → pending_validation, no KV prime  
-   - observed active → active + KV prime  
-   - dns-observed missing wildcard → UI-facing state still explains gap  
-   - remove → CF delete + KV clear  
+1. **Unit / processor harness** (primary):
+   - add-requested → requested state, ensure called once
+   - observed pending → pending_validation, no KV prime
+   - observed active → active + KV prime
+   - dns-observed missing wildcard → UI-facing state still explains gap
+   - remove → CF delete + KV clear
    - refresh while pending re-runs observation  
-   Follow `docs/writing-stream-processors.md` and existing
-   `custom-domain` / project-processor tests.
+     Follow `docs/writing-stream-processors.md` and existing
+     `custom-domain` / project-processor tests.
 
 2. **Contract examples** updated for any new events.
 


### PR DESCRIPTION
## Summary

- keep collapsed event metadata on one line so every row matches the virtualizer 40px estimate
- add a focused regression for long event metadata
- run the existing 1,500-row scroll regression at the narrowest desktop breakpoint, where wrapping pressure previously made the flake deterministic

## Root cause

TanStack Virtual estimates collapsed rows at 40px. Event types and timestamps could wrap, so newly realized rows sometimes measured taller and triggered scroll-position compensation while the user was moving upward. That compensation appeared as the intermittent forward jump.

Truncating the variable event type and preventing the timestamp from wrapping restores the existing fixed-height contract without adding scroll machinery or relaxing the assertion.

## CI base repair

`main` currently contains an unrelated `oxfmt` failure in `tasks/os-custom-domain-provisioning-saga.md`. A separate formatter-only commit repairs that inherited file so this PR can have meaningful green CI. It can be dropped once `main` receives the equivalent repair already present in #2033.

## Proof

- before fix: long metadata row measured 88px instead of 40px
- before fix: stressed 1,500-row test reproduced a 20px forward jump with retries disabled
- after fix: both regressions passed 20 times each with 4 workers and no retries (40/40)
- full Streams Playwright suite: 31 passed, 1 intentionally skipped
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (1,811 OS tests plus all other root workspace suites)
- `pnpm format:check`

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +4 -2 | +4 -2 🟩⬜⬜⬜⬜ |
| Tests | +27 -0 | +22 -0 🟩🟩🟩⬜⬜ |
| Docs | +17 -17 | +17 -17 🟩🟩🟩🟥🟥 |
| **Total** | **+48 -19** | **+43 -19** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 8b51afc and ef9dfc3, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-17T11:31:06.610Z",
      "headSha": "ef9dfc3a2945fd9ec0755fd7e2bb005b66d11eca",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/536510939728868",
      "shortSha": "ef9dfc3",
      "cleanupDurationMs": 13191,
      "deployDurationMs": 73568,
      "testDurationMs": 56031,
      "testRetries": "1 retried: stream capnweb protocol > appends events after the stream-created event over capnweb (vitest x1)",
      "workerSizeKib": 5171.9,
      "workerGzipKib": 1471.91,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Streams Example App | released | `ef9dfc3` | [https://streams.iterate-preview-8.com](https://streams.iterate-preview-8.com) | 1.44 MiB | 73.6s | 56.0s | 1 retried: stream capnweb protocol > appends events after the stream-created event over capnweb (vitest x1) | 13.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/536510939728868) | 2026-07-17T11:31:06.610Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->