### PR TITLE
fix(os): bound PostHog JSON truncation work

### DIFF
--- a/apps/os/src/domains/integrations/posthog.ts
+++ b/apps/os/src/domains/integrations/posthog.ts
@@ -203,7 +203,6 @@ export async function capturePosthogStreamEventBatch(
   if (args.batch.events.length === 0) {
     throw new Error("PostHog stream delivery batch must contain an event");
   }
-  const events = posthogEvents(args);
   await tracing.enterSpan("posthog.capture_stream_events", async (span) => {
     const streamId = posthogUuid(["stream-v1", args.workerName, args.projectId, args.batch.path]);
     span.setAttribute("iterate.project.id", args.projectId);
@@ -211,6 +210,12 @@ export async function capturePosthogStreamEventBatch(
     span.setAttribute("iterate.stream.event_count", args.batch.events.length);
     span.setAttribute("iterate.stream.delivery_id", args.batch.deliveryId);
     span.setAttribute("iterate.stream.delivery_attempt", args.batch.attempt);
+
+    // Payload shaping is intentionally inside the span. Oversized stream
+    // events are truncated before egress, and that CPU is part of delivery —
+    // keeping it observable prevents a future regression from appearing as
+    // unexplained time in the parent Stream.append invocation.
+    const events = posthogEvents(args);
 
     const response = await (deps.fetch ?? fetch)("https://eu.i.posthog.com/batch/", {
       // Deliberately omit optional `sent_at`: these are server-authoritative

--- a/apps/os/src/domains/integrations/truncate-json.test.ts
+++ b/apps/os/src/domains/integrations/truncate-json.test.ts
@@ -71,6 +71,71 @@ describe("truncateJsonToBytes", () => {
     expect(compacted.payload).toMatch(/\[truncated from \d+ JSON bytes\]$/);
   });
 
+  it("keeps exact JSON escaping at the truncation boundary", () => {
+    const value = {
+      payload: `line\nquote"slash\\${"😀".repeat(100)}\ud800${"x".repeat(10_000)}`,
+    };
+
+    const result = truncateJsonToBytes(value, 257);
+
+    expect(result.bytes).toBe(jsonBytes(result.value));
+    expect(result.bytes).toBeLessThanOrEqual(257);
+    expect((result.value as typeof value).payload).not.toContain("�");
+  });
+
+  it("matches native byte accounting across normalized JSON shapes and budgets", () => {
+    const values: unknown[] = [
+      `ascii\nquote"slash\\${"é".repeat(20)}${"😀".repeat(20)}\ud800`,
+      [undefined, Number.NaN, Number.POSITIVE_INFINITY, -0, true, "x".repeat(500)],
+      {
+        control: "\u0000\b\t\n\f\r",
+        nested: [{ alpha: "a".repeat(300) }, { omega: "ω".repeat(300) }],
+      },
+      {
+        $iterate_truncated: "occupied",
+        ...Object.fromEntries(
+          Array.from({ length: 100 }, (_, index) => [`field_${index}`, `value_${index}`]),
+        ),
+      },
+      { toJSON: () => ({ normalized: true, payload: "z".repeat(500) }) },
+    ];
+    const budgets = [13, 14, 31, 64, 127, 256, 512, 1_024];
+
+    for (const value of values) {
+      for (const maxBytes of budgets) {
+        const result = truncateJsonToBytes(value, maxBytes);
+        expect(result.originalBytes).toBe(jsonBytes(value));
+        expect(result.bytes).toBe(jsonBytes(result.value));
+        expect(result.bytes).toBeLessThanOrEqual(maxBytes);
+      }
+    }
+  });
+
+  it("bounds a deeply nested 10 MB result without repeatedly copying the discarded tail", () => {
+    const value = {
+      type: "events.iterate.com/capability-host/script-run-settled",
+      payload: {
+        settlement: {
+          status: "succeeded",
+          result: { blob: "x".repeat(10_000_000), marker: "tail" },
+        },
+      },
+    };
+
+    const result = truncateJsonToBytes(value, 100 * 1_024);
+
+    expect(result.originalBytes).toBe(jsonBytes(value));
+    expect(result.bytes).toBe(jsonBytes(result.value));
+    expect(result.bytes).toBe(100 * 1_024);
+    expect(result.value).toMatchObject({
+      type: value.type,
+      payload: { settlement: { status: "succeeded", result: { marker: "tail" } } },
+    });
+    expect((result.value as typeof value).payload.settlement.result.blob).toMatch(
+      /\[truncated from \d+ JSON bytes\]$/,
+    );
+  });
+
   it("chops a wide object when no individual value is large", () => {
     const value = Object.fromEntries(
       Array.from({ length: 1_000 }, (_, index) => [`field_${index}`, index]),

--- a/apps/os/src/domains/integrations/truncate-json.ts
+++ b/apps/os/src/domains/integrations/truncate-json.ts
@@ -1,6 +1,20 @@
 const encoder = new TextEncoder();
 const MINIMUM_TRUNCATED_VALUE = "[truncated]";
 
+type JsonPrimitive = null | boolean | number | string;
+type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
+type MeasuredJson =
+  | { bytes: number; kind: "primitive"; value: Exclude<JsonPrimitive, string> }
+  | { bytes: number; kind: "string"; value: string }
+  | { bytes: number; items: MeasuredJson[]; kind: "array"; value: JsonValue[] }
+  | {
+      bytes: number;
+      entries: { key: string; keyBytes: number; value: MeasuredJson }[];
+      kind: "object";
+      value: { [key: string]: JsonValue };
+    };
+
 function serialize(value: unknown): string {
   const serialized = JSON.stringify(value);
   if (serialized === undefined) {
@@ -9,105 +23,238 @@ function serialize(value: unknown): string {
   return serialized;
 }
 
-function jsonBytes(value: unknown): number {
-  return encoder.encode(serialize(value)).byteLength;
+function serializedBytes(serialized: string): number {
+  return encoder.encode(serialized).byteLength;
 }
 
-const minimumTruncatedBytes = jsonBytes(MINIMUM_TRUNCATED_VALUE);
+function primitiveJsonBytes(value: Exclude<JsonPrimitive, string>): number {
+  if (value === null) return 4;
+  if (typeof value === "boolean") return value ? 4 : 5;
+  // Oversized inputs are measured after a JSON stringify/parse round trip, so
+  // numbers are finite and String(number) is JSON's canonical representation
+  // (including -0 becoming "0").
+  return String(value).length;
+}
 
-function truncateString(value: string, maxBytes: number, originalBytes: number): string {
+/**
+ * Measure normalized JSON once, bottom-up. The previous implementation called
+ * JSON.stringify for every ancestor and every candidate in a binary search;
+ * a 10 MB string nested five levels deep was therefore copied and encoded
+ * dozens of times inside the Stream Durable Object's append CPU budget.
+ */
+function measureJson(value: JsonValue): MeasuredJson {
+  if (typeof value === "string") {
+    return { bytes: jsonStringBytes(value), kind: "string", value };
+  }
+  if (value === null || typeof value !== "object") {
+    return { bytes: primitiveJsonBytes(value), kind: "primitive", value };
+  }
+  if (Array.isArray(value)) {
+    const items = value.map(measureJson);
+    return {
+      // Brackets + commas + each already-measured value.
+      bytes: 2 + Math.max(0, items.length - 1) + items.reduce((sum, item) => sum + item.bytes, 0),
+      items,
+      kind: "array",
+      value,
+    };
+  }
+
+  const entries = Object.entries(value).map(([key, child]) => ({
+    key,
+    keyBytes: jsonStringBytes(key),
+    value: measureJson(child),
+  }));
+  return {
+    // Braces + commas + serialized key + colon + serialized value.
+    bytes:
+      2 +
+      Math.max(0, entries.length - 1) +
+      entries.reduce((sum, entry) => sum + entry.keyBytes + 1 + entry.value.bytes, 0),
+    entries,
+    kind: "object",
+    value,
+  };
+}
+
+/** JSON-string content bytes for one code point, and its UTF-16 width. */
+function encodedStringUnit(value: string, index: number): { bytes: number; width: number } {
+  const unit = value.charCodeAt(index);
+  if (
+    unit === 0x22 ||
+    unit === 0x5c ||
+    unit === 0x08 ||
+    unit === 0x09 ||
+    unit === 0x0a ||
+    unit === 0x0c ||
+    unit === 0x0d
+  ) {
+    return { bytes: 2, width: 1 };
+  }
+  if (unit <= 0x1f) return { bytes: 6, width: 1 };
+  if (unit <= 0x7f) return { bytes: 1, width: 1 };
+  if (unit <= 0x7ff) return { bytes: 2, width: 1 };
+  if (unit >= 0xd800 && unit <= 0xdbff) {
+    const next = value.charCodeAt(index + 1);
+    if (next >= 0xdc00 && next <= 0xdfff) return { bytes: 4, width: 2 };
+    // Well-formed JSON.stringify escapes lone surrogates as \ud800-style text.
+    return { bytes: 6, width: 1 };
+  }
+  if (unit >= 0xdc00 && unit <= 0xdfff) return { bytes: 6, width: 1 };
+  return { bytes: 3, width: 1 };
+}
+
+function jsonStringContentBytes(value: string): number {
+  let bytes = 0;
+  for (let index = 0; index < value.length; ) {
+    const encoded = encodedStringUnit(value, index);
+    bytes += encoded.bytes;
+    index += encoded.width;
+  }
+  return bytes;
+}
+
+function jsonStringBytes(value: string): number {
+  // JSON.stringify adds exactly two ASCII quote bytes around string content.
+  return jsonStringContentBytes(value) + 2;
+}
+
+const minimumTruncatedBytes = jsonStringBytes(MINIMUM_TRUNCATED_VALUE);
+
+function truncateString(value: string, maxBytes: number, originalBytes: number) {
   const marker = `… [truncated from ${originalBytes} JSON bytes]`;
-  if (jsonBytes(marker) > maxBytes) return MINIMUM_TRUNCATED_VALUE;
-
-  const characters = Array.from(value);
-  let low = 0;
-  let high = characters.length;
-  while (low < high) {
-    const middle = Math.ceil((low + high) / 2);
-    const candidate = `${characters.slice(0, middle).join("")}${marker}`;
-    if (jsonBytes(candidate) <= maxBytes) low = middle;
-    else high = middle - 1;
+  const prefixBudget = maxBytes - 2 - jsonStringContentBytes(marker);
+  if (prefixBudget < 0) {
+    return { bytes: minimumTruncatedBytes, value: MINIMUM_TRUNCATED_VALUE };
   }
-  return `${characters.slice(0, low).join("")}${marker}`;
+
+  // Scan only the prefix that can survive (normally <= 100 KiB), regardless
+  // of whether the discarded source string is 10 MB or 10 GB. This follows
+  // JSON.stringify's escaping and never slices a surrogate pair.
+  let bytes = 0;
+  let end = 0;
+  while (end < value.length) {
+    const encoded = encodedStringUnit(value, end);
+    if (bytes + encoded.bytes > prefixBudget) break;
+    bytes += encoded.bytes;
+    end += encoded.width;
+  }
+  const compacted = `${value.slice(0, end)}${marker}`;
+  return { bytes: bytes + jsonStringContentBytes(marker) + 2, value: compacted };
 }
 
-function truncateArray(value: unknown[], maxBytes: number, originalBytes: number): unknown {
-  const makeCandidate = (kept: number) => [
-    ...value.slice(0, kept),
-    `[truncated ${value.length - kept} items; from ${originalBytes} JSON bytes]`,
-  ];
-  if (jsonBytes(makeCandidate(0)) > maxBytes) return MINIMUM_TRUNCATED_VALUE;
-
-  let low = 0;
-  let high = value.length - 1;
-  while (low < high) {
-    const middle = Math.ceil((low + high) / 2);
-    if (jsonBytes(makeCandidate(middle)) <= maxBytes) low = middle;
-    else high = middle - 1;
+function largestChild(node: Extract<MeasuredJson, { kind: "array" | "object" }>): {
+  index: number;
+  value: MeasuredJson;
+} | null {
+  const children = node.kind === "array" ? node.items : node.entries.map((entry) => entry.value);
+  let largest: { index: number; value: MeasuredJson } | null = null;
+  for (const [index, value] of children.entries()) {
+    if (largest === null || value.bytes > largest.value.bytes) largest = { index, value };
   }
-  return makeCandidate(low);
+  return largest;
 }
 
-function truncateObject(
-  value: Record<string, unknown>,
-  maxBytes: number,
-  originalBytes: number,
-): unknown {
-  const entries = Object.entries(value);
+function maximumCandidateLength(args: {
+  length: number;
+  maxBytes: number;
+  candidateBytes(kept: number): number;
+}): number | null {
+  if (args.candidateBytes(0) > args.maxBytes) return null;
+  let low = 0;
+  // Truncation always drops at least one original item/property.
+  let high = args.length - 1;
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    if (args.candidateBytes(middle) <= args.maxBytes) low = middle;
+    else high = middle - 1;
+  }
+  return low;
+}
+
+function truncateArray(node: Extract<MeasuredJson, { kind: "array" }>, maxBytes: number) {
+  const prefixBytes = [0];
+  for (const item of node.items) prefixBytes.push(prefixBytes.at(-1)! + item.bytes);
+  const marker = (kept: number) =>
+    `[truncated ${node.items.length - kept} items; from ${node.bytes} JSON bytes]`;
+  const candidateBytes = (kept: number) =>
+    // Brackets + kept item bytes + marker bytes + one comma per kept item.
+    2 + prefixBytes[kept]! + jsonStringBytes(marker(kept)) + kept;
+  const kept = maximumCandidateLength({
+    candidateBytes,
+    length: node.items.length,
+    maxBytes,
+  });
+  if (kept === null) {
+    return { bytes: minimumTruncatedBytes, value: MINIMUM_TRUNCATED_VALUE };
+  }
+  return {
+    bytes: candidateBytes(kept),
+    value: [...node.items.slice(0, kept).map((item) => item.value), marker(kept)],
+  };
+}
+
+function truncateObject(node: Extract<MeasuredJson, { kind: "object" }>, maxBytes: number) {
   let markerKey = "$iterate_truncated";
-  while (Object.hasOwn(value, markerKey)) markerKey = `$${markerKey}`;
+  while (Object.hasOwn(node.value, markerKey)) markerKey = `$${markerKey}`;
 
-  const makeCandidate = (kept: number) =>
-    Object.fromEntries([
-      ...entries.slice(0, kept),
-      [
-        markerKey,
-        `[truncated ${entries.length - kept} properties; from ${originalBytes} JSON bytes]`,
-      ],
-    ]);
-  if (jsonBytes(makeCandidate(0)) > maxBytes) return MINIMUM_TRUNCATED_VALUE;
-
-  let low = 0;
-  let high = entries.length - 1;
-  while (low < high) {
-    const middle = Math.ceil((low + high) / 2);
-    if (jsonBytes(makeCandidate(middle)) <= maxBytes) low = middle;
-    else high = middle - 1;
+  const prefixBytes = [0];
+  for (const entry of node.entries) {
+    prefixBytes.push(prefixBytes.at(-1)! + entry.keyBytes + 1 + entry.value.bytes);
   }
-  return makeCandidate(low);
+  const marker = (kept: number) =>
+    `[truncated ${node.entries.length - kept} properties; from ${node.bytes} JSON bytes]`;
+  const markerKeyBytes = jsonStringBytes(markerKey);
+  const candidateBytes = (kept: number) =>
+    // Braces + kept entries + marker key/colon/value + one comma per kept entry.
+    2 + prefixBytes[kept]! + markerKeyBytes + 1 + jsonStringBytes(marker(kept)) + kept;
+  const kept = maximumCandidateLength({
+    candidateBytes,
+    length: node.entries.length,
+    maxBytes,
+  });
+  if (kept === null) {
+    return { bytes: minimumTruncatedBytes, value: MINIMUM_TRUNCATED_VALUE };
+  }
+  return {
+    bytes: candidateBytes(kept),
+    value: Object.fromEntries([
+      ...node.entries.slice(0, kept).map((entry) => [entry.key, entry.value.value] as const),
+      [markerKey, marker(kept)],
+    ]),
+  };
 }
 
-function truncateLargestValue(value: unknown, maxBytes: number): unknown {
-  const originalBytes = jsonBytes(value);
-  if (originalBytes <= maxBytes) return value;
-  if (typeof value === "string") return truncateString(value, maxBytes, originalBytes);
-  if (value === null || typeof value !== "object") return MINIMUM_TRUNCATED_VALUE;
-
-  const entries = Array.isArray(value) ? [...value.entries()] : Object.entries(value);
-  let largest: { bytes: number; child: unknown; key: number | string } | undefined;
-  for (const [key, child] of entries) {
-    const bytes = jsonBytes(child);
-    if (largest === undefined || bytes > largest.bytes) largest = { bytes, child, key };
+function truncateMeasuredJson(
+  node: MeasuredJson,
+  maxBytes: number,
+): { bytes: number; value: JsonValue } {
+  if (node.bytes <= maxBytes) return { bytes: node.bytes, value: node.value };
+  if (node.kind === "string") return truncateString(node.value, maxBytes, node.bytes);
+  if (node.kind === "primitive") {
+    return { bytes: minimumTruncatedBytes, value: MINIMUM_TRUNCATED_VALUE };
   }
-  const overflow = originalBytes - maxBytes;
 
-  // Recurse when one child can absorb the whole overflow. Otherwise chopping
-  // the enclosing collection's tail is both deterministic and bounded work.
-  if (largest !== undefined && largest.bytes - minimumTruncatedBytes >= overflow) {
-    const replacement = truncateLargestValue(largest.child, largest.bytes - overflow);
-    if (Array.isArray(value)) {
-      const copy = [...value];
-      copy[largest.key as number] = replacement;
-      return copy;
+  const largest = largestChild(node);
+  const overflow = node.bytes - maxBytes;
+  if (largest !== null && largest.value.bytes - minimumTruncatedBytes >= overflow) {
+    const replacement = truncateMeasuredJson(largest.value, largest.value.bytes - overflow);
+    if (node.kind === "array") {
+      const value = node.items.map((item, index) =>
+        index === largest.index ? replacement.value : item.value,
+      );
+      return { bytes: node.bytes - largest.value.bytes + replacement.bytes, value };
     }
-    return Object.fromEntries(
-      entries.map(([key, child]) => [key, key === largest.key ? replacement : child]),
+    const value = Object.fromEntries(
+      node.entries.map((entry, index) => [
+        entry.key,
+        index === largest.index ? replacement.value : entry.value.value,
+      ]),
     );
+    return { bytes: node.bytes - largest.value.bytes + replacement.bytes, value };
   }
 
-  return Array.isArray(value)
-    ? truncateArray(value, maxBytes, originalBytes)
-    : truncateObject(value as Record<string, unknown>, maxBytes, originalBytes);
+  return node.kind === "array" ? truncateArray(node, maxBytes) : truncateObject(node, maxBytes);
 }
 
 type TruncatedJson = {
@@ -127,17 +274,31 @@ export function truncateJsonToBytes(value: unknown, maxBytes: number): Truncated
     throw new RangeError(`maxBytes must be an integer of at least ${minimumTruncatedBytes}`);
   }
 
+  // Serialize once to apply JSON's toJSON/undefined/NaN semantics. UTF-16
+  // length is a lower bound for UTF-8 JSON length, so only encode the fast
+  // path when it is already bounded by maxBytes. A 10 MB value must not create
+  // a second 10 MB TextEncoder buffer merely to discover that it is oversized.
   const serialized = serialize(value);
-  const originalBytes = encoder.encode(serialized).byteLength;
-  if (originalBytes <= maxBytes) {
-    return { bytes: originalBytes, originalBytes, truncated: false, value };
+  if (serialized.length <= maxBytes) {
+    const originalBytes = serializedBytes(serialized);
+    if (originalBytes <= maxBytes) {
+      return { bytes: originalBytes, originalBytes, truncated: false, value };
+    }
   }
 
-  const compacted = truncateLargestValue(JSON.parse(serialized), maxBytes);
+  const measured = measureJson(JSON.parse(serialized) as JsonValue);
+  const compacted = truncateMeasuredJson(measured, maxBytes);
+  // Verification is intentionally bounded: the compacted representation is
+  // at most maxBytes even when the source was gigabytes. Keep exact accounting
+  // as an asserted invariant without recreating the discarded source tail.
+  const compactedBytes = serializedBytes(serialize(compacted.value));
+  if (compactedBytes !== compacted.bytes || compactedBytes > maxBytes) {
+    throw new Error("truncated JSON byte accounting invariant failed");
+  }
   return {
-    bytes: jsonBytes(compacted),
-    originalBytes,
+    bytes: compactedBytes,
+    originalBytes: measured.bytes,
     truncated: true,
-    value: compacted,
+    value: compacted.value,
   };
 }


### PR DESCRIPTION
## What

- replace recursive repeated `JSON.stringify` / `TextEncoder` truncation with one JSON normalization, exact bottom-up byte measurement, and bounded output construction
- scan only the string prefix that can survive the byte budget while preserving JSON escaping, Unicode, arrays, objects, and sibling fields
- move PostHog payload shaping inside `posthog.capture_stream_events` so its CPU is attributed to the delivery span
- add regression coverage for a deeply nested 10 MB script result and byte-accounting edge cases

## Why

The first-party PostHog stream feed processes `script-run-settled` events inside the Stream Durable Object. A large script result reached `capturePosthogStreamEventBatch`, where `posthogEvents()` called `truncateJsonToBytes()` before the delivery span. The old truncator repeatedly serialized and UTF-8 encoded the full nested value for every ancestor and binary-search candidate, and used `Array.from` over the entire large string. That turned one 10 MB result into repeated large allocations and CPU work, causing the PostHog delivery attempt to consume roughly a second of CPU and the Stream Durable Object to reset/retry.

The new implementation performs linear source measurement, constructs only the bounded compacted representation, and verifies exact byte accounting on that bounded result.

## Impact

Oversized script-result events remain capped at the existing byte budget without repeatedly copying the discarded tail. Normal-sized event behavior and the emitted truncation markers remain unchanged. Payload-shaping latency is now visible in the PostHog child span.

## Checks

- `pnpm --dir apps/os exec vitest run src/domains/integrations/truncate-json.test.ts src/domains/integrations/posthog.test.ts` (16 passed)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm knip`
- `pnpm test` (`apps/os`: 1,782 passed, 1 skipped)

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +248 -82 | +206 -77 🟩🟩🟩🟩🟥 |
| Tests | +65 -0 | +57 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+313 -82** | **+263 -77** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 2ebcadd and ab22972, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

> [!CAUTION]
> All preview slots are leased — this PR is waiting in line for one (since 2026-07-17T13:57:51.256Z).
>   preview-2  leased by pr-2076 until 2026-07-17T16:52:19.488Z (2h54m left) | https://github.com/iterate/iterate/pull/2076
>   preview-3  leased by pr-2039 until 2026-07-17T16:10:55.828Z (2h13m left) | https://github.com/iterate/iterate/pull/2039
>   preview-4  leased by pr-2075 until 2026-07-17T16:39:59.753Z (2h42m left) | https://github.com/iterate/iterate/pull/2075
>   preview-5  leased by pr-2070 until 2026-07-17T16:55:04.420Z (2h57m left) | https://github.com/iterate/iterate/pull/2070
>   preview-6  leased by pr-2072 until 2026-07-17T16:37:19.913Z (2h39m left) | https://github.com/iterate/iterate/pull/2072
>   preview-7  leased by pr-2033 until 2026-07-17T16:56:48.128Z (2h59m left) | https://github.com/iterate/iterate/pull/2033
>   preview-8  leased by pr-2071 until 2026-07-17T16:51:24.917Z (2h54m left) | https://github.com/iterate/iterate/pull/2071
>   preview-9  leased by pr-2071 until 2026-07-17T16:57:00.599Z (2h59m left) | https://github.com/iterate/iterate/pull/2071
>   preview-1  leased by pr-2058 until 2026-07-17T14:15:14.472Z (0h17m left) | https://github.com/iterate/iterate/pull/2058

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": "All preview slots are leased — this PR is waiting in line for one (since 2026-07-17T13:57:51.256Z).\n  preview-2  leased by pr-2076 until 2026-07-17T16:52:19.488Z (2h54m left) | https://github.com/iterate/iterate/pull/2076\n  preview-3  leased by pr-2039 until 2026-07-17T16:10:55.828Z (2h13m left) | https://github.com/iterate/iterate/pull/2039\n  preview-4  leased by pr-2075 until 2026-07-17T16:39:59.753Z (2h42m left) | https://github.com/iterate/iterate/pull/2075\n  preview-5  leased by pr-2070 until 2026-07-17T16:55:04.420Z (2h57m left) | https://github.com/iterate/iterate/pull/2070\n  preview-6  leased by pr-2072 until 2026-07-17T16:37:19.913Z (2h39m left) | https://github.com/iterate/iterate/pull/2072\n  preview-7  leased by pr-2033 until 2026-07-17T16:56:48.128Z (2h59m left) | https://github.com/iterate/iterate/pull/2033\n  preview-8  leased by pr-2071 until 2026-07-17T16:51:24.917Z (2h54m left) | https://github.com/iterate/iterate/pull/2071\n  preview-9  leased by pr-2071 until 2026-07-17T16:57:00.599Z (2h59m left) | https://github.com/iterate/iterate/pull/2071\n  preview-1  leased by pr-2058 until 2026-07-17T14:15:14.472Z (0h17m left) | https://github.com/iterate/iterate/pull/2058"
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large refactor of byte-budget truncation logic used on every PostHog stream event; incorrect accounting could change emitted payloads or still spike DO CPU, though behavior is heavily regression-tested.
> 
> **Overview**
> **Replaces** the PostHog stream JSON truncator so oversized events (e.g. large `script-run-settled` results) no longer burn Stream Durable Object CPU from repeated full-value `JSON.stringify` / UTF-8 encoding during binary search.
> 
> `truncateJsonToBytes` now normalizes once, measures UTF-8 JSON size bottom-up without re-serializing ancestors, truncates strings by scanning only the prefix that can fit the byte budget (with correct escaping/surrogates), and builds array/object tails using precomputed prefix sizes. Oversized inputs skip an eager full `TextEncoder` pass when the serialized string length already exceeds the limit; compacted output is verified with a bounded final stringify.
> 
> **PostHog delivery** runs `posthogEvents()` (and thus truncation) inside the `posthog.capture_stream_events` trace span so payload-shaping CPU shows up on delivery, not as unexplained parent latency.
> 
> Regression tests cover byte accounting edge cases and a deeply nested ~10 MB blob capped at 100 KiB.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab22972f5e04352eadd704a1bad85197f79547f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->