### PR TITLE
fix(os): exclude ephemeral stream events from PostHog

### DIFF
--- a/apps/os/e2e/vitest/streams.e2e.test.ts
+++ b/apps/os/e2e/vitest/streams.e2e.test.ts
@@ -18,16 +18,16 @@ const CROSS_POST_EVENT_TYPE = "events.iterate.test/minimal-v4/cross-post";
 const POSTHOG_SUBSCRIPTION_KEY = "iterate-platform-posthog";
 const EXPECTED_POSTHOG_SUBSCRIPTION = {
   type: "events.iterate.com/stream/subscription-configured",
-  idempotencyKey: "iterate-platform-posthog-subscription-v1",
+  idempotencyKey: "iterate-platform-posthog-subscription-v2",
   payload: {
     subscriptionKey: POSTHOG_SUBSCRIPTION_KEY,
-    description: "Iterate's first-party, all-event PostHog feed",
+    description: "Iterate's first-party durable-event PostHog feed",
     delivery: {
       mode: "push",
       expression: ["integrations", "posthog", "processEventBatch"],
     },
     deliver: "all",
-    includeEphemeral: true,
+    includeEphemeral: false,
     onPoison: "park",
   },
 } as const;

--- a/apps/os/src/domains/integrations/posthog.test.ts
+++ b/apps/os/src/domains/integrations/posthog.test.ts
@@ -84,20 +84,20 @@ function captureArgs(events: StreamEvent[], workerName = "os-preview-6") {
 }
 
 describe("first-party PostHog stream integration", () => {
-  it("uses an ordinary all-history subscription that explicitly includes ephemeral rows", () => {
+  it("uses an ordinary all-history subscription that excludes ephemeral rows", () => {
     const event = posthogSubscriptionEvent();
     expect(event).toEqual({
       type: "events.iterate.com/stream/subscription-configured",
-      idempotencyKey: "iterate-platform-posthog-subscription-v1",
+      idempotencyKey: "iterate-platform-posthog-subscription-v2",
       payload: {
         subscriptionKey: POSTHOG_SUBSCRIPTION_KEY,
-        description: "Iterate's first-party, all-event PostHog feed",
+        description: "Iterate's first-party durable-event PostHog feed",
         delivery: {
           mode: "push",
           expression: ["integrations", "posthog", "processEventBatch"],
         },
         deliver: "all",
-        includeEphemeral: true,
+        includeEphemeral: false,
         onPoison: "park",
       },
     });
@@ -109,18 +109,12 @@ describe("first-party PostHog stream integration", () => {
     ).not.toThrow();
   });
 
-  it("captures the complete committed event and raw stream path", async () => {
+  it("captures the complete durable committed event and raw stream path", async () => {
     const durable = streamEvent();
-    const ephemeral = streamEvent({
-      type: "events.example.com/progress",
-      offset: 8,
-      ephemeral: true,
-      payload: { token: "full payload retained" },
-    });
     const requests: CapturedRequest[] = [];
     const captureFetch = acceptingFetch(requests);
 
-    await capturePosthogStreamEventBatch(captureArgs([durable, ephemeral]), {
+    await capturePosthogStreamEventBatch(captureArgs([durable]), {
       fetch: captureFetch,
     });
 
@@ -130,7 +124,7 @@ describe("first-party PostHog stream integration", () => {
     expect(init?.method).toBe("POST");
     expect(new Headers(init?.headers).has("Authorization")).toBe(false);
     expect(requests[0]).toMatchObject({ api_key: "phc_test" });
-    expect(requests[0]!.batch).toHaveLength(2);
+    expect(requests[0]!.batch).toHaveLength(1);
     expect(requests[0]!.batch[0]).toMatchObject({
       event: POSTHOG_STREAM_EVENT,
       properties: {
@@ -141,17 +135,43 @@ describe("first-party PostHog stream integration", () => {
         stream_event: durable,
         stream_event_original_json_bytes: jsonBytes(durable),
         stream_event_truncated: false,
+        stream_event_ephemeral: false,
         stream_event_type: durable.type,
         stream_event_uuid: expect.stringMatching(/^[0-9a-f-]{36}$/),
       },
     });
-    expect(requests[0]!.batch[1]).toMatchObject({
+  });
+
+  it("drops ephemeral rows from capture, including all-ephemeral batches", async () => {
+    const durable = streamEvent();
+    const ephemeral = streamEvent({
+      type: "events.example.com/progress",
+      offset: 8,
+      ephemeral: true,
+      payload: { token: "should never reach PostHog" },
+    });
+    const mixed: CapturedRequest[] = [];
+    const mixedFetch = acceptingFetch(mixed);
+    await capturePosthogStreamEventBatch(captureArgs([durable, ephemeral]), {
+      fetch: mixedFetch,
+    });
+    expect(mixedFetch).toHaveBeenCalledOnce();
+    expect(mixed[0]!.batch).toHaveLength(1);
+    expect(mixed[0]!.batch[0]).toMatchObject({
       event: POSTHOG_STREAM_EVENT,
       properties: {
-        stream_event: ephemeral,
-        stream_event_ephemeral: true,
+        stream_event: durable,
+        stream_event_ephemeral: false,
       },
     });
+
+    const onlyEphemeral: CapturedRequest[] = [];
+    const onlyEphemeralFetch = acceptingFetch(onlyEphemeral);
+    await capturePosthogStreamEventBatch(captureArgs([ephemeral]), {
+      fetch: onlyEphemeralFetch,
+    });
+    expect(onlyEphemeralFetch).not.toHaveBeenCalled();
+    expect(onlyEphemeral).toEqual([]);
   });
 
   it("bounds an oversized committed event without filtering its indexed coordinates", async () => {

--- a/apps/os/src/domains/integrations/posthog.ts
+++ b/apps/os/src/domains/integrations/posthog.ts
@@ -19,16 +19,21 @@ const ProjectGroupBirthPayload = z.object({
 export function posthogSubscriptionEvent() {
   return {
     type: "events.iterate.com/stream/subscription-configured",
-    idempotencyKey: "iterate-platform-posthog-subscription-v1",
+    // Bump when the subscription payload changes so new stream births land
+    // the revised config. Existing streams still rely on capture-side filtering
+    // until they are recreated or reconfigured.
+    idempotencyKey: "iterate-platform-posthog-subscription-v2",
     payload: {
       subscriptionKey: "iterate-platform-posthog",
-      description: "Iterate's first-party, all-event PostHog feed",
+      description: "Iterate's first-party durable-event PostHog feed",
       delivery: {
         mode: "push",
         expression: ["integrations", "posthog", "processEventBatch"],
       },
       deliver: "all",
-      includeEphemeral: true,
+      // High-volume transient rows (LLM chunks, progress ticks) stay off the
+      // analytics feed; durable product facts are what PostHog should index.
+      includeEphemeral: false,
       onPoison: "park",
     } satisfies SubscriptionConfiguredPayload,
   };
@@ -137,7 +142,11 @@ function posthogEvents(args: {
     projectId,
   ])}`;
   const streamId = posthogUuid(["stream-v1", workerName, projectId, batch.path]);
-  const occurrences = batch.events.map((event) => {
+  // Capture-side filter is deliberate defense in depth: subscriptions born
+  // before includeEphemeral flipped to false may still deliver ephemeral rows.
+  // Never index those in PostHog.
+  const durableEvents = batch.events.filter((event) => event.ephemeral !== true);
+  const occurrences = durableEvents.map((event) => {
     const createdAt = normalizeEventTimestamp(event.createdAt);
     const streamEvent = truncateJsonToBytes(event, POSTHOG_STREAM_EVENT_MAX_JSON_BYTES);
     const eventUuid = eventIdentity(workerName, projectId, batch.path, {
@@ -216,6 +225,13 @@ export async function capturePosthogStreamEventBatch(
     // keeping it observable prevents a future regression from appearing as
     // unexplained time in the parent Stream.append invocation.
     const events = posthogEvents(args);
+    const durableCount = events.filter((event) => event.event === "stream:append").length;
+    span.setAttribute("iterate.stream.durable_event_count", durableCount);
+    // An all-ephemeral delivery (or one that yields no PostHog rows) is a
+    // successful no-op — do not fail the subscriber or call the capture API.
+    if (events.length === 0) {
+      return;
+    }
 
     const response = await (deps.fetch ?? fetch)("https://eu.i.posthog.com/batch/", {
       // Deliberately omit optional `sent_at`: these are server-authoritative

--- a/apps/os/src/itx/examples-source.ts
+++ b/apps/os/src/itx/examples-source.ts
@@ -151,7 +151,7 @@ return await itx.projects.get(pid).__describe();
     id: "ephemeral-events",
     title: "Ephemeral events: transient signals whose durable truth lands separately",
     description:
-      "append({ ephemeral: true }) commits a second-class product event: live subscribe() connections see it (streaming UI), default getEvents reads skip it unless includeEphemeral: true, and ordinary durable subscribers exclude it by default. A push/webhook can explicitly opt in; Iterate's ordinary PostHog feed does so. Use ephemeral events for high-volume transient signals (LLM streaming chunks, progress ticks); append the durable product fact as its own ordinary event.",
+      "append({ ephemeral: true }) commits a second-class product event: live subscribe() connections see it (streaming UI), default getEvents reads skip it unless includeEphemeral: true, and ordinary durable subscribers exclude it by default. A push/webhook can explicitly opt in; Iterate's ordinary PostHog feed does not. Use ephemeral events for high-volume transient signals (LLM streaming chunks, progress ticks); append the durable product fact as its own ordinary event.",
     runtimes: ALL_RUNTIMES,
     fn: async (itx, vars: { path?: string }) => {
       // Transient signal: live product subscribers see it; product state never will.

--- a/apps/os/src/itx/examples.generated.ts
+++ b/apps/os/src/itx/examples.generated.ts
@@ -122,7 +122,7 @@ return { appended, count: events.length };
     id: "ephemeral-events",
     title: "Ephemeral events: transient signals whose durable truth lands separately",
     description:
-      "append({ ephemeral: true }) commits a second-class product event: live subscribe() connections see it (streaming UI), default getEvents reads skip it unless includeEphemeral: true, and ordinary durable subscribers exclude it by default. A push/webhook can explicitly opt in; Iterate's ordinary PostHog feed does so. Use ephemeral events for high-volume transient signals (LLM streaming chunks, progress ticks); append the durable product fact as its own ordinary event.",
+      "append({ ephemeral: true }) commits a second-class product event: live subscribe() connections see it (streaming UI), default getEvents reads skip it unless includeEphemeral: true, and ordinary durable subscribers exclude it by default. A push/webhook can explicitly opt in; Iterate's ordinary PostHog feed does not. Use ephemeral events for high-volume transient signals (LLM streaming chunks, progress ticks); append the durable product fact as its own ordinary event.",
     context: "project",
     runtimes: ["browser", "node", "cli", "run-script", "project-worker"],
     code: `


### PR DESCRIPTION
## Summary

- Flip the first-party PostHog subscription to `includeEphemeral: false` (subscription key bumped to `v2` for new stream births).
- Filter ephemeral rows on the capture path as defense in depth for streams still configured with the old opt-in.
- All-ephemeral deliveries become a successful no-op (no PostHog batch call).
- Update unit/e2e expectations and the itx ephemeral-events example copy.

## Why

Ephemeral stream events (especially `llm-response-chunk`) dominate `stream:append` volume in PostHog and are second-class product rows. The analytics feed should index durable product facts only.

## Test plan

- [x] `pnpm --dir apps/os exec vitest run src/domains/integrations/posthog.test.ts`
- [x] `pnpm --dir apps/os exec vitest run src/itx/examples.generated.test.ts`
- [ ] Preview/production: after deploy, confirm new `stream:append` traffic is not dominated by chunk types; `stream_event_ephemeral` should stay false / absent for new durable deliveries

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics ingestion behavior only; no auth or durable stream semantics change, with defense-in-depth filtering and tests covering mixed and all-ephemeral batches.
> 
> **Overview**
> Stops high-volume ephemeral stream rows (e.g. LLM chunks) from dominating PostHog analytics by indexing **durable** product events only.
> 
> The first-party PostHog subscription now sets **`includeEphemeral: false`**, bumps the idempotency key to **`iterate-platform-posthog-subscription-v2`**, and updates the description for new stream births. **`capturePosthogStreamEventBatch`** also filters out `ephemeral: true` rows before building the batch (covers streams still on the old subscription) and treats deliveries that produce no PostHog events as a **successful no-op**—no HTTP call and no subscriber failure. Tracing adds **`iterate.stream.durable_event_count`**.
> 
> Unit, e2e, and itx example copy are aligned with the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 994ae43d38543156a99a9b13b2444348f4d9abf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +21 -5 | +11 -5 🟩⬜⬜⬜⬜ |
| Tests | +39 -19 | +37 -19 🟩🟩🟩🟥🟥 |
| Generated | +1 -1 | +1 -1 🟩⬜⬜⬜⬜ |
| **Total** | **+61 -25** | **+49 -25** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between f846445 and 994ae43, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-17T15:05:11.017Z",
      "headSha": "994ae43d38543156a99a9b13b2444348f4d9abf1",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/198574814942989",
      "shortSha": "994ae43",
      "cleanupDurationMs": 2109,
      "deployDurationMs": 19468,
      "testDurationMs": 4093,
      "testRetries": null,
      "workerSizeKib": 4041.39,
      "workerGzipKib": 822.41,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-17T15:05:09.499Z",
      "headSha": "994ae43d38543156a99a9b13b2444348f4d9abf1",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/198574814942989",
      "shortSha": "994ae43",
      "cleanupDurationMs": 589,
      "deployDurationMs": 5734,
      "testDurationMs": 5463,
      "testRetries": null,
      "workerSizeKib": 1139.76,
      "workerGzipKib": 201.7,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-17T15:05:07.907Z",
      "headSha": "994ae43d38543156a99a9b13b2444348f4d9abf1",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/198574814942989",
      "shortSha": "994ae43",
      "cleanupDurationMs": 120432,
      "deployDurationMs": 115046,
      "testDurationMs": 233753,
      "testRetries": "2 retried: explicit child-agent delegation pipelines from an agent scope (relative path + create + message) (vitest x1) · concurrent long-running itx scripts all complete (vitest x1)",
      "workerSizeKib": 16601.05,
      "workerGzipKib": 4477.5,
      "mainWorkerGzipKib": 4477.51
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `994ae43` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 822.4 KiB | 19.5s | 4.1s |  | 2.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/198574814942989) | 2026-07-17T15:05:11.017Z | Preview app released. |
| Dummy Petshop | released | `994ae43` | [https://dummy-petshop.iterate-preview-1.com](https://dummy-petshop.iterate-preview-1.com) | 201.7 KiB | 5.7s | 5.5s |  | 589ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/198574814942989) | 2026-07-17T15:05:09.499Z | Preview app released. |
| OS | released | `994ae43` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 4.37 MiB (-0.0 KiB vs main) | 115.0s | 233.8s | 2 retried: explicit child-agent delegation pipelines from an agent scope (relative path + create + message) (vitest x1) · concurrent long-running itx scripts all complete (vitest x1) | 120.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/198574814942989) | 2026-07-17T15:05:07.907Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->