### PR TITLE
Add locator-driven Playwright screenshots

### DIFF
--- a/specs/AGENTS.md
+++ b/specs/AGENTS.md
@@ -24,6 +24,10 @@ If you've really come up against a case where you truly think it's better to add
 
 For common developer pitfalls, instead of littering your test code with defensive try/catch statements and custom selectors for app error UI, just add the `data-type="error"` attribute to relevant UI elements. Then, the `ui-error-reporter` plugin will pick up any errors on screen automatically (including toasts rendered using the `sonner` library). The plugin will find elements annotated in this way and include their text content in error reports, so agents and humans will quickly be able to get an indication of what went wrong.
 
+## Videos
+
+When features are exercised by playwright specs, you can capture videos of them simply by running `VIDEO_MODE=1 pnpm spec -g whichever-test`. This will capture a video annotated with mouse movements, click pointers, dead-air speedup, and brief pauses for meaningful actions. It uses [middlewright](https://github.com/iterate/middlewright).
+
 ## Screenshots
 
 Set `PLAYWRIGHT_SCREENSHOT` to semicolon-separated regular expressions matched

--- a/specs/AGENTS.md
+++ b/specs/AGENTS.md
@@ -23,3 +23,15 @@ If you've really come up against a case where you truly think it's better to add
 ## Error UI
 
 For common developer pitfalls, instead of littering your test code with defensive try/catch statements and custom selectors for app error UI, just add the `data-type="error"` attribute to relevant UI elements. Then, the `ui-error-reporter` plugin will pick up any errors on screen automatically (including toasts rendered using the `sonner` library). The plugin will find elements annotated in this way and include their text content in error reports, so agents and humans will quickly be able to get an indication of what went wrong.
+
+## Screenshots
+
+Set `PLAYWRIGHT_SCREENSHOT` to semicolon-separated regular expressions matched
+against `locator.toString()`. Every matching successful locator action saves a
+full-page PNG under a readable locator-derived name and attaches it to the
+Playwright report. For example, capture the complete locator-driven flow for
+the dashboard spec with:
+
+```sh
+PLAYWRIGHT_SCREENSHOT='.*' pnpm spec dashboard
+```

--- a/specs/test-support/screenshot.spec.ts
+++ b/specs/test-support/screenshot.spec.ts
@@ -1,0 +1,45 @@
+import { statSync } from "node:fs";
+import { test, expect } from "@playwright/test";
+import { addPlugins } from "middlewright";
+import { screenshot } from "./screenshot.ts";
+
+test("saves a successful locator screenshot under its readable locator slug", async ({
+  page,
+}, testInfo) => {
+  using _environment = environmentVariable("PLAYWRIGHT_SCREENSHOT", ".*");
+  await using plugged = await addPlugins({ page, testInfo, plugins: [screenshot()] });
+  await plugged.setContent(`<a href="#dashboard">dynamic-project-slug</a>`);
+
+  await plugged.getByRole("link", { name: "dynamic-project-slug" }).waitFor();
+  await plugged.getByRole("link", { name: "dynamic-project-slug" }).waitFor();
+
+  expect(testInfo.attachments).toMatchObject([
+    {
+      contentType: "image/png",
+      name: "getbyrole-link-name-dynamic-project-slug",
+      path: expect.any(String),
+    },
+    {
+      contentType: "image/png",
+      name: "getbyrole-link-name-dynamic-project-slug-2",
+      path: expect.any(String),
+    },
+  ]);
+  expect(
+    statSync(testInfo.outputPath("getbyrole-link-name-dynamic-project-slug.png")).size,
+  ).toBeGreaterThan(0);
+  expect(
+    statSync(testInfo.outputPath("getbyrole-link-name-dynamic-project-slug-2.png")).size,
+  ).toBeGreaterThan(0);
+});
+
+const environmentVariable = (name: string, value: string) => {
+  const previous = process.env[name];
+  process.env[name] = value;
+  return {
+    [Symbol.dispose]: () => {
+      if (previous === undefined) delete process.env[name];
+      else process.env[name] = previous;
+    },
+  };
+};

--- a/specs/test-support/screenshot.spec.ts
+++ b/specs/test-support/screenshot.spec.ts
@@ -33,6 +33,29 @@ test("saves a successful locator screenshot under its readable locator slug", as
   ).toBeGreaterThan(0);
 });
 
+test("does not overwrite a screenshot from another page in the same test", async ({
+  context,
+  page,
+}, testInfo) => {
+  using _environment = environmentVariable("PLAYWRIGHT_SCREENSHOT", ".*");
+  await using firstPage = await addPlugins({ page, testInfo, plugins: [screenshot()] });
+  await using secondPage = await addPlugins({
+    page: await context.newPage(),
+    testInfo,
+    plugins: [screenshot()],
+  });
+  await firstPage.setContent(`<button>Save</button>`);
+  await secondPage.setContent(`<button>Save</button>`);
+
+  await firstPage.getByRole("button", { name: "Save" }).waitFor();
+  await secondPage.getByRole("button", { name: "Save" }).waitFor();
+
+  expect(testInfo.attachments).toMatchObject([
+    { name: "getbyrole-button-name-save" },
+    { name: "getbyrole-button-name-save-2" },
+  ]);
+});
+
 const environmentVariable = (name: string, value: string) => {
   const previous = process.env[name];
   process.env[name] = value;

--- a/specs/test-support/screenshot.ts
+++ b/specs/test-support/screenshot.ts
@@ -1,0 +1,48 @@
+import { slugify } from "@iterate-com/shared/slugify";
+import type { Plugin } from "middlewright";
+
+const ENVIRONMENT_VARIABLE = "PLAYWRIGHT_SCREENSHOT";
+
+export const screenshot = (): Plugin => {
+  const matchers = parseMatchers(process.env[ENVIRONMENT_VARIABLE] || "");
+  const occurrences = new Map<string, number>();
+
+  if (matchers.length === 0 || process.env.PWDEBUG) return { name: "screenshot" };
+
+  return {
+    name: "screenshot",
+    middleware: async (context, next) => {
+      const locatorDescription = context.locator.toString();
+      const matches = matchers.some((matcher) => matcher.test(locatorDescription));
+      const result = await next();
+
+      if (matches) {
+        const locatorSlug = slugify(locatorDescription, { maxLength: 160 });
+        const occurrence = (occurrences.get(locatorSlug) || 0) + 1;
+        occurrences.set(locatorSlug, occurrence);
+        const screenshotSlug = occurrence === 1 ? locatorSlug : `${locatorSlug}-${occurrence}`;
+        const path = context.testInfo.outputPath(`${screenshotSlug}.png`);
+        await context.page.screenshot({ fullPage: true, path });
+        await context.testInfo.attach(screenshotSlug, { contentType: "image/png", path });
+      }
+
+      return result;
+    },
+  };
+};
+
+const parseMatchers = (value: string) =>
+  value
+    .split(";")
+    .map((pattern) => pattern.trim())
+    .filter(Boolean)
+    .map((pattern, index) => {
+      try {
+        return new RegExp(pattern);
+      } catch (error) {
+        throw new Error(
+          `Invalid ${ENVIRONMENT_VARIABLE} regex at position ${index + 1}: ${pattern}`,
+          { cause: error },
+        );
+      }
+    });

--- a/specs/test-support/screenshot.ts
+++ b/specs/test-support/screenshot.ts
@@ -1,11 +1,12 @@
 import { slugify } from "@iterate-com/shared/slugify";
+import type { TestInfo } from "@playwright/test";
 import type { Plugin } from "middlewright";
 
 const ENVIRONMENT_VARIABLE = "PLAYWRIGHT_SCREENSHOT";
+const occurrencesByTest = new WeakMap<TestInfo, Map<string, number>>();
 
 export const screenshot = (): Plugin => {
   const matchers = parseMatchers(process.env[ENVIRONMENT_VARIABLE] || "");
-  const occurrences = new Map<string, number>();
 
   if (matchers.length === 0 || process.env.PWDEBUG) return { name: "screenshot" };
 
@@ -17,6 +18,8 @@ export const screenshot = (): Plugin => {
       const result = await next();
 
       if (matches) {
+        const occurrences = occurrencesByTest.get(context.testInfo) || new Map<string, number>();
+        occurrencesByTest.set(context.testInfo, occurrences);
         const locatorSlug = slugify(locatorDescription, { maxLength: 160 });
         const occurrence = (occurrences.get(locatorSlug) || 0) + 1;
         occurrences.set(locatorSlug, occurrence);

--- a/specs/test-support/test.ts
+++ b/specs/test-support/test.ts
@@ -7,6 +7,7 @@ import {
   videoMode,
 } from "middlewright";
 import { createProjectFixture as createForgedProjectFixture } from "./forged-session.ts";
+import { screenshot } from "./screenshot.ts";
 
 type ForgedProjectFixture = Awaited<ReturnType<typeof createForgedProjectFixture>>;
 
@@ -18,6 +19,7 @@ const addPagePlugins = (page: Page, testInfo: TestInfo) =>
       hydrationWaiter({ timeout: 30_000 }),
       uiErrorReporter(),
       spinnerWaiter({ spinnerTimeout: 30_000 }),
+      screenshot(),
       process.env.VIDEO_MODE === "1" &&
         videoMode({
           skipStackFrames: ["test-support/test.ts"],


### PR DESCRIPTION
## What this adds

Playwright product specs can now capture full-page screenshots after selected successful locator actions without changing the spec itself. Set `PLAYWRIGHT_SCREENSHOT` to one or more semicolon-separated regular expressions matched against `locator.toString()`.

```sh
PLAYWRIGHT_SCREENSHOT='.*' pnpm spec dashboard
```

For example, a dynamic role locator is saved with a readable artifact name like:

```text
getbyrole-link-name-dashboard-mrp1gnsb-80397e5a.png
```

## Proof from the real dashboard spec

Generated by `PLAYWRIGHT_SCREENSHOT='.*' pnpm spec dashboard`:

<img width="1280" height="900" alt="Screenshot generated after the dashboard project-link locator succeeded" src="https://github.com/user-attachments/assets/b3900ee8-c3d0-4b36-858f-edb65531c262" />

Screenshots are saved in the test output directory and attached to the Playwright report. Repeated matching locators receive `-2`, `-3`, and so on rather than overwriting earlier states. Failed actions do not produce misleading screenshots.

## Verification

- `PLAYWRIGHT_SCREENSHOT='.*' pnpm spec dashboard`
- focused screenshot plugin spec
- `pnpm lint`
- `pnpm format:check`
- GitHub CI: lint/typecheck and tests passing

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +68 -0 | +61 -0 🟩🟩🟩🟩🟩 |
| Docs | +16 -0 | +11 -0 🟩⬜⬜⬜⬜ |
| Other | +53 -0 | +46 -0 🟩🟩🟩🟩⬜ |
| **Total** | **+137 -0** | **+118 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between e53af01 and 7e769d0, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only, opt-in infrastructure with no production or auth paths touched; default runs behave unchanged when `PLAYWRIGHT_SCREENSHOT` is unset.
> 
> **Overview**
> Product specs can now capture **full-page screenshots** after successful locator actions without changing spec code. Opt in with `PLAYWRIGHT_SCREENSHOT` set to semicolon-separated regexes matched against `locator.toString()` (e.g. `PLAYWRIGHT_SCREENSHOT='.*' pnpm spec dashboard`).
> 
> A new **middlewright `screenshot()` plugin** runs the locator action first, then saves a slugified PNG to the test output dir and attaches it to the Playwright report. Repeated hits on the same locator get `-2`, `-3`, … suffixes; the plugin is a no-op when the env var is unset or `PWDEBUG` is on. It is registered in the shared `test.ts` page plugin stack next to spinner/error/video helpers.
> 
> **`specs/AGENTS.md`** documents screenshot (and video) capture for agents and humans. **`screenshot.spec.ts`** covers readable artifact names and non-colliding names across two pages in one test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e769d0dbaec07e611e67f56f1dc5d834d1c3fe2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->