### PR TITLE
Classify Slack agent cosmetic side effects by conversation type

### DIFF
--- a/.agents/skills/recreate-production/SKILL.md
+++ b/.agents/skills/recreate-production/SKILL.md
@@ -17,12 +17,21 @@ user at consequential forks unless they explicitly waive consultation.
 - Capture ordinary durable event histories only as evidence. Derive the desired
   current domain state, then use normal creation/connection/update APIs. Those
   APIs append new events with new offsets and run current validation.
+- The reconstruction program lives outside deployed OS. It may read the export
+  page files, select the small set of semantic facts named in the reconstruction
+  sheet, and map them to freshly constructed current-version event inputs or
+  public API calls. The export itself is never an executable replay payload.
 - Do not replay stream control facts, processor outputs, old idempotency keys,
   cross-post provenance, or encrypted secret payloads. Recreate subscriptions
   through their owning domain commands.
 - Secret values and integration credentials must come from an authoritative
   external source or a deliberately audited local conversion. Old ciphertext
   is not portable to a new stream offset. Stop if required material is unavailable.
+- Never reconstruct a built-in integration by hand-creating its secret and
+  appending `connected` or directory-claim events. The owning connect command
+  is the atomic invariant boundary: it validates fresh credentials, writes the
+  secret, creates the router/subscription, records lifecycle state, and claims
+  webhook ingress in the supported order.
 - Treat the linked GitHub repository as config authority. Record its connection,
   owner, repo, installation ID, and head before cutover.
 - Discard ordinary streams, schedules, files, workspaces, sandboxes, derived
@@ -47,7 +56,10 @@ user at consequential forks unless they explicitly waive consultation.
 4. Inspect the histories locally and write an explicit reconstruction sheet:
    each desired object, its fresh create/update/connect command, the source of
    any required credential, and what will intentionally be lost. Histories are
-   evidence—not executable restore payloads.
+   evidence—not executable restore payloads. Write the external reconstruction
+   script against the export here: select only the required semantic facts and
+   construct new current-version inputs without copied offsets, timestamps,
+   source/provenance, idempotency keys, or stream-control events.
 5. Call `repo.pushToGithub({})` and require its commit to equal the recorded
    config head. Summarize the reconstruction and intended losses, run
    pre-cutover checks, and obtain destructive-step approval unless already granted.
@@ -68,16 +80,26 @@ user at consequential forks unless they explicitly waive consultation.
    use an admin session for this step: caller-supplied admin projects are
    intentionally organization-less test/operator fixtures. Stop on any mismatch,
    and do not hand-append historical bootstrap events.
-4. Recreate selected secrets through `secrets.get(path).create/update` with
-   freshly supplied material and egress policy. Reconnect integrations through
-   their current connect/OAuth flows. These owning commands must recreate any
-   router subscriptions and deployment-wide directory claims.
+4. Recreate selected non-integration secrets through
+   `secrets.get(path).create/update` with freshly supplied material and egress
+   policy. Reconnect integrations only through their current connect/OAuth
+   flows. Do not seed a Slack connection from
+   `APP_CONFIG_INTEGRATIONS__SLACK.botToken`: that optional deployment fallback
+   may be stale and is not project restoration material. Do not hand-append a
+   provider's `connected`, processor-birth/subscription, or directory-claim
+   events. If interactive OAuth cannot be completed, the reconstruction is
+   incomplete and the maintenance window stays open.
 5. Recreate any other explicitly retained domain object through its current
    public `create`/configuration command. If the domain contract is itself an
-   event API, append a newly constructed current event—not the old envelope.
+   event API, let the external reconstruction script select the relevant old
+   fact and append a newly constructed current event—not the old envelope.
 6. Recreate the erased config repo with `repo.create()`, `repo.linkGithub()` and
-   `repo.syncFromGithub({ force: true })` without a depth limit. Require the
-   local head to equal the recorded GitHub head; GitHub remains authoritative.
+   `repo.syncFromGithub({ force: true })` without a depth limit. `linkGithub()`
+   attempts an initial mirror push, so bracket it with a GitHub ref check: the
+   recorded remote head must still exist, and if the link advanced the default
+   branch, restore that ref to the recorded head before syncing. Require both
+   the remote default branch and local Artifacts head to equal the recorded
+   head; GitHub remains authoritative.
 7. Re-enable automatic deployment if it was disabled.
 
 ## Finish only after proof
@@ -88,6 +110,15 @@ claims, [Slack webhook delivery](../../../docs/slack-testing.md#post-recreation-
 the complete [GitHub production smoke](../../../docs/github-smoke-testing.md),
 project-worker boot, and AI Search indexing. Add PR-specific checks for whatever
 changed. Do not trigger externally visible provider actions without approval.
+
+For Slack, run
+[`scripts/verify-slack-connection.itx.js`](scripts/verify-slack-connection.itx.js)
+without a project context immediately after OAuth. It requires a successful
+`auth.test`, an exact team-id match, connected lifecycle state, and the matching
+deployment-wide directory claim. Only then send a **new** mention smoke. A
+validly signed webhook delivered before the claim exists is ACKed and ignored
+by design and Slack will not replay it after association, so an earlier message
+is never proof of the re-established path.
 
 Show the evidence and intentional losses to the user and ask whether production
 is done. Continue repairing until they explicitly say yes. Only then delete the

--- a/.agents/skills/recreate-production/scripts/verify-slack-connection.itx.js
+++ b/.agents/skills/recreate-production/scripts/verify-slack-connection.itx.js
@@ -1,0 +1,85 @@
+// Run WITHOUT a project context from apps/os:
+//   pnpm cli itx run --file ../../.agents/skills/recreate-production/scripts/verify-slack-connection.itx.js \
+//     --vars '{"projectId":"prj_...","connection":"workspace","expectedTeamId":"T..."}'
+//
+// Read-only. This proves that the normal Slack OAuth completion installed a
+// usable project token and the deployment-wide webhook directory points at the
+// same project/connection. It deliberately does not accept or repair tokens.
+
+const projectId = String(vars.projectId ?? "").trim();
+const connection = String(vars.connection ?? "").trim();
+const expectedTeamId = String(vars.expectedTeamId ?? "").trim();
+if (!projectId) throw new Error("vars.projectId is required");
+if (!connection) throw new Error("vars.connection is required");
+if (!expectedTeamId) throw new Error("vars.expectedTeamId is required");
+
+const project = itx.projects.get(projectId);
+const status = await project.integrations.getConnection({ provider: "slack", connection });
+let auth;
+try {
+  auth = await project.integrations.slack.get(connection).auth.test();
+} catch (error) {
+  const detail = error instanceof Error ? error.message : String(error);
+  throw new Error(
+    `Slack auth.test failed for ${connection}: ${detail}. Complete Connect Slack OAuth before recreating the association.`,
+  );
+}
+
+if (!status.connected) throw new Error(`Slack connection ${connection} is not connected`);
+if (status.externalId !== expectedTeamId) {
+  throw new Error(
+    `Slack connection external id mismatch: expected ${expectedTeamId}, got ${String(status.externalId)}`,
+  );
+}
+if (auth?.ok !== true) {
+  throw new Error(`Slack auth.test failed: ${String(auth?.error ?? "unknown_error")}`);
+}
+if (auth.team_id !== expectedTeamId) {
+  throw new Error(
+    `Slack token team mismatch: expected ${expectedTeamId}, got ${String(auth.team_id)}`,
+  );
+}
+
+const claimedType = "events.iterate.com/integration/connection-claimed";
+const unclaimedType = "events.iterate.com/integration/connection-unclaimed";
+const stream = itx.streams.get("/integrations/_directory");
+let afterOffset = 0;
+let claim = null;
+let claimOffset = null;
+for (;;) {
+  const events = await stream.getEvents({
+    afterOffset,
+    eventTypes: [claimedType, unclaimedType],
+    limit: 500,
+  });
+  for (const event of events) {
+    afterOffset = event.offset;
+    const payload = event.payload;
+    if (payload?.slug !== "slack" || payload?.externalId !== expectedTeamId) continue;
+    if (event.type === claimedType) {
+      if (claim === null || claim.projectId === payload.projectId) {
+        claim = { connection: payload.connection, projectId: payload.projectId };
+        claimOffset = event.offset;
+      }
+    } else if (claim?.projectId === payload.projectId && claim?.connection === payload.connection) {
+      claim = null;
+      claimOffset = event.offset;
+    }
+  }
+  if (events.length < 500) break;
+}
+
+if (claim?.projectId !== projectId || claim?.connection !== connection) {
+  throw new Error(
+    `Slack directory mismatch: expected ${projectId}/${connection}, got ${JSON.stringify(claim)}`,
+  );
+}
+
+return {
+  ok: true,
+  projectId,
+  connection,
+  teamId: expectedTeamId,
+  botUserId: auth.user_id ?? null,
+  directoryClaimOffset: claimOffset,
+};

--- a/apps/os/docs/integrations.md
+++ b/apps/os/docs/integrations.md
@@ -90,10 +90,18 @@ Slack Web API calls normally never hold material: the request carries a
 `getSecret(path)` placeholder for the connection's token and traverses project
 egress, which substitutes it inside the Secret Durable Object and records
 `secret/used` audit events. If Slack rejects a live connection's token, trusted
-platform code may retry with the deployment Slack app's recovery token only
+platform code may retry with the deployment Slack app's optional fallback token only
 after `auth.test` proves its team id matches the connection journal. A typo'd
 or disconnected connection still errors loudly instead of silently posting
 with a deployment-wide credential.
+
+That deployment token is an optional outbound fallback, not connection state.
+It can be revoked and must never be used to recreate a project association.
+Only OAuth completion owns the sequence “validated token → secret → router
+birth/subscription → connected fact → global team claim.” A validly signed
+webhook that arrives before the final claim is ACKed and ignored; creating a
+claim beside an unvalidated token therefore produces a false-connected project
+and silent inbound loss rather than a partial restoration.
 
 **Status is a journal tail-fold for every provider** — one machine, no
 per-provider mechanism: `getConnection` pages backwards from the journal head

--- a/apps/os/src/domains/agents/agent-durable-object.ts
+++ b/apps/os/src/domains/agents/agent-durable-object.ts
@@ -121,20 +121,15 @@ export class AgentDurableObject extends DurableObject<Env> {
         // itx.integrations.slack in its script, which fails loudly on its
         // own. The facet birth certificate supplies the named connection;
         // the stream path is deliberately unrelated to processor config.
-        try {
-          await callProjectSlackWebApi({
-            body,
-            connection,
-            method,
-            projectId: this.#name.projectId,
-          });
-        } catch (error) {
-          console.error("[slack-agent] Slack side effect failed", {
-            error,
-            method,
-            path: this.#name.path,
-          });
-        }
+        // The processor owns outcome classification: idempotent Slack errors
+        // are quiet no-ops, while unexpected cosmetic failures are reported
+        // once without holding its durable checkpoint forever.
+        await callProjectSlackWebApi({
+          body,
+          connection,
+          method,
+          projectId: this.#name.projectId,
+        });
       },
       fetchSlackChannelName: async ({ channel, connection }) => {
         try {

--- a/apps/os/src/domains/integrations/slack-agent-processor-contract.ts
+++ b/apps/os/src/domains/integrations/slack-agent-processor-contract.ts
@@ -34,7 +34,7 @@ import { SlackAgentBirthCertificate, SlackProcessorContract } from "./slack-proc
  */
 export const SlackAgentProcessorContract = defineProcessorContract({
   slug: "slack-agent",
-  version: "0.5.0",
+  version: "0.6.0",
   description: "Handles Slack-specific behavior for one routed Slack agent stream.",
   stateSchema: z.object({
     birthCertificate: SlackAgentBirthCertificate.nullable().default(null),
@@ -49,6 +49,9 @@ export const SlackAgentProcessorContract = defineProcessorContract({
     botBotId: z.string().optional(),
     botUserId: z.string().optional(),
     channel: z.string().optional(),
+    /** Slack's conversation type from the routed message webhook. Assistant
+     * thread UI methods are valid for app DMs (`im`), not channel mentions. */
+    channelType: z.string().optional(),
     /**
      * True after this thread has seen an @mention / app_mention of our bot.
      * Unlocks follow-up turns without re-mentioning.

--- a/apps/os/src/domains/integrations/slack-agent-processor-implementation.ts
+++ b/apps/os/src/domains/integrations/slack-agent-processor-implementation.ts
@@ -8,9 +8,9 @@
 //   `blockProcessorWhile` so the checkpoint only advances once they finished;
 //   sequences like "commit agent context, then add the eyes reaction" keep their
 //   legacy ordering by sharing one blocking closure.
-// - Replay runs the same idempotency-keyed side effects as live delivery. The
-//   processor checkpoint is the guardrail; failed batches replay from the last
-//   fully processed offset.
+// - Known idempotent Slack outcomes are successful no-ops. Unexpected failures
+//   are reported once and treated as settled because this is a cosmetic lane;
+//   they must not stall the durable message/agent pipeline in a retry loop.
 // - The Slack calls themselves are acknowledgement/cosmetic lanes and must be
 //   REFOLD-SAFE (docs/writing-stream-processors.md, "Refold safety"): the 👀
 //   ack only fires for fresh webhooks (webhookAckIsFresh), and the assistant
@@ -105,12 +105,14 @@ export class SlackAgentProcessor extends StreamProcessor<
         if (target == null) return state;
         const botUserId = state.botUserId ?? botUserIdFromPayload(event.payload);
         const botBotId = state.botBotId ?? botBotIdFromPayload(event.payload);
+        const channelType = slackChannelTypeFromWebhookPayload(event.payload);
         const mentioned = slackWebhookMentionsOurBot(event.payload, botUserId);
         return {
           ...state,
           ...(botBotId == null ? {} : { botBotId }),
           ...(botUserId == null ? {} : { botUserId }),
           channel: target.channel,
+          ...(channelType == null ? {} : { channelType }),
           conversationActive: state.conversationActive || mentioned,
           ...(target.messageTs == null ? {} : { latestMessageTs: target.messageTs }),
           threadTs: target.threadTs,
@@ -142,9 +144,10 @@ export class SlackAgentProcessor extends StreamProcessor<
     // AT-HEAD repaint: `delivery.caughtUp` means `args.state` is the whole
     // observed fold. It rides the last consumed event or the runner's
     // eventless pass. ONE blocking closure — the runner awaits it as this head
-    // event's own work before the frame's deferred commit, so a failed paint
-    // fails the frame and the transport replays it (the memo re-accumulates on
-    // redelivery).
+    // event's own work before the frame's deferred commit. The reconcile owns
+    // Slack's outcome classification: idempotent outcomes are quiet success,
+    // while unexpected cosmetic failures are reported once and settled so
+    // they cannot wedge the durable agent pipeline.
     if (args.delivery.caughtUp) {
       args.blockProcessorWhileCaughtUp(() => this.#reconcileStatus(args));
     }
@@ -385,18 +388,19 @@ export class SlackAgentProcessor extends StreamProcessor<
     if (latest == null) return;
     if (args.state.birthCertificate === null) return;
     const connection = args.state.birthCertificate.config.connection;
-    const { channel, latestMessageTs, status, threadTs } = args.state;
+    const { channel, channelType, latestMessageTs, status, threadTs } = args.state;
     if (channel == null || threadTs == null) return;
     const fresh = webhookAckIsFresh(latest, (this.deps.now ?? Date.now)());
+    const hasAssistantThreadUi = slackConversationHasAssistantThreadUi({ channel, channelType });
 
     // The agent-authored title paints whenever the folded title differs from
     // what this incarnation painted — freshness-gated with everything else,
     // so a refold never replays historical renames. The painted-title record
-    // is written only AFTER the call succeeds: a rejected call fails the
-    // frame, and the redelivered frame must retry the rename instead of
-    // seeing it as already painted.
+    // is written after the Slack outcome has been classified: success and
+    // known idempotent outcomes settle quietly, while an unexpected cosmetic
+    // failure is reported once rather than retried forever.
     const title = args.state.status?.title;
-    if (fresh && title !== undefined && title !== this.#paintedTitle) {
+    if (hasAssistantThreadUi && fresh && title !== undefined && title !== this.#paintedTitle) {
       await this.#callSlackApi(connection, "assistant.threads.setTitle", {
         channel_id: channel,
         thread_ts: threadTs,
@@ -406,7 +410,7 @@ export class SlackAgentProcessor extends StreamProcessor<
     }
 
     if (status?.busy) {
-      if (!fresh) return;
+      if (!fresh || !hasAssistantThreadUi) return;
       // The agent's own words win; otherwise the platform-derived phase says
       // what it is doing ("making an LLM request" / "running a script").
       const text =
@@ -432,12 +436,14 @@ export class SlackAgentProcessor extends StreamProcessor<
     if (status.blocked === true) {
       if (!fresh && !this.#paintedBusyStatus) return;
       const text = status.shortStatus ?? "waiting for input";
-      await this.#callSlackApi(connection, "assistant.threads.setStatus", {
-        channel_id: channel,
-        thread_ts: threadTs,
-        status: `is ${text}...`,
-        loading_messages: [`${text}...`],
-      });
+      if (hasAssistantThreadUi) {
+        await this.#callSlackApi(connection, "assistant.threads.setStatus", {
+          channel_id: channel,
+          thread_ts: threadTs,
+          status: `is ${text}...`,
+          loading_messages: [`${text}...`],
+        });
+      }
       if (latestMessageTs != null) {
         await this.#callSlackApi(connection, "reactions.remove", {
           channel,
@@ -445,7 +451,7 @@ export class SlackAgentProcessor extends StreamProcessor<
           timestamp: latestMessageTs,
         });
       }
-      this.#paintedBusyStatus = true;
+      this.#paintedBusyStatus = hasAssistantThreadUi;
       return;
     }
     if (!fresh && !this.#paintedBusyStatus) return;
@@ -453,6 +459,7 @@ export class SlackAgentProcessor extends StreamProcessor<
       channel,
       connection,
       ...(latestMessageTs == null ? {} : { latestMessageTs }),
+      hasAssistantThreadUi,
       threadTs,
     });
     this.#paintedBusyStatus = false;
@@ -461,14 +468,17 @@ export class SlackAgentProcessor extends StreamProcessor<
   async #clearStatus(target: {
     channel: string;
     connection: string;
+    hasAssistantThreadUi: boolean;
     latestMessageTs?: string;
     threadTs: string;
   }) {
-    await this.#callSlackApi(target.connection, "assistant.threads.setStatus", {
-      channel_id: target.channel,
-      thread_ts: target.threadTs,
-      status: "",
-    });
+    if (target.hasAssistantThreadUi) {
+      await this.#callSlackApi(target.connection, "assistant.threads.setStatus", {
+        channel_id: target.channel,
+        thread_ts: target.threadTs,
+        status: "",
+      });
+    }
     if (target.latestMessageTs != null) {
       await this.#callSlackApi(target.connection, "reactions.remove", {
         channel: target.channel,
@@ -511,7 +521,11 @@ export class SlackAgentProcessor extends StreamProcessor<
         return;
       }
       if (method === "reactions.remove" && message.includes("no_reaction")) return;
-      throw error;
+      console.error("[slack-agent] Slack side effect failed", {
+        error,
+        method,
+        path: this.path,
+      });
     }
   }
 }
@@ -839,6 +853,22 @@ function slackAgentTargetFromWebhookPayload(payload: unknown): SlackAgentTarget 
     ...(messageTs == null ? {} : { messageTs }),
     threadTs,
   };
+}
+
+function slackChannelTypeFromWebhookPayload(payload: unknown): string | undefined {
+  const body = readRecord(readRecord(payload)?.body);
+  return readString(readRecord(body?.event)?.channel_type) ?? undefined;
+}
+
+/** Slack's Assistant thread UI is available on app direct-message threads,
+ * not ordinary channel mentions. Message webhooks name this as `im`; the `D`
+ * fallback covers interactivity payloads and older events without
+ * `channel_type` (Slack reserves D-prefixed conversation IDs for DMs). */
+function slackConversationHasAssistantThreadUi(input: {
+  channel: string;
+  channelType?: string;
+}): boolean {
+  return input.channelType === "im" || (input.channelType == null && input.channel.startsWith("D"));
 }
 
 /**

--- a/apps/os/src/domains/integrations/slack-agent-processor-implementation.ts
+++ b/apps/os/src/domains/integrations/slack-agent-processor-implementation.ts
@@ -361,6 +361,10 @@ export class SlackAgentProcessor extends StreamProcessor<
    * announcement must still clear what we ourselves put up, while a refold
    * (fresh instance, all facts stale) must repaint nothing at all. */
   #paintedBusyStatus = false;
+  /** Whether THIS incarnation acknowledged a fresh message with eyes. Channel
+   * threads have no Assistant busy UI, but a stale completion must still
+   * remove the acknowledgement this incarnation added. */
+  #paintedEyesReaction = false;
   /** The title this incarnation painted, so repeated repaints of an unchanged
    * title cost no Slack calls. */
   #paintedTitle: string | undefined;
@@ -434,7 +438,7 @@ export class SlackAgentProcessor extends StreamProcessor<
     // quiet. The 👀 still comes off — the message was handled — and the
     // next busy flip (the platform clears `blocked` in it) repaints.
     if (status.blocked === true) {
-      if (!fresh && !this.#paintedBusyStatus) return;
+      if (!fresh && !this.#paintedBusyStatus && !this.#paintedEyesReaction) return;
       const text = status.shortStatus ?? "waiting for input";
       if (hasAssistantThreadUi) {
         await this.#callSlackApi(connection, "assistant.threads.setStatus", {
@@ -452,9 +456,10 @@ export class SlackAgentProcessor extends StreamProcessor<
         });
       }
       this.#paintedBusyStatus = hasAssistantThreadUi;
+      this.#paintedEyesReaction = false;
       return;
     }
-    if (!fresh && !this.#paintedBusyStatus) return;
+    if (!fresh && !this.#paintedBusyStatus && !this.#paintedEyesReaction) return;
     await this.#clearStatus({
       channel,
       connection,
@@ -463,6 +468,7 @@ export class SlackAgentProcessor extends StreamProcessor<
       threadTs,
     });
     this.#paintedBusyStatus = false;
+    this.#paintedEyesReaction = false;
   }
 
   async #clearStatus(target: {
@@ -502,6 +508,7 @@ export class SlackAgentProcessor extends StreamProcessor<
       name: "eyes",
       timestamp: target.messageTs,
     });
+    this.#paintedEyesReaction = true;
   }
 
   async #callSlackApi(connection: string, method: string, body: Record<string, unknown>) {

--- a/apps/os/src/domains/integrations/slack-processors.test.ts
+++ b/apps/os/src/domains/integrations/slack-processors.test.ts
@@ -939,6 +939,38 @@ describe("SlackAgentProcessor", () => {
     ]);
   });
 
+  it("clears a channel acknowledgement when completion is delivered stale", async () => {
+    const { clock, deliver, slackCalls, stream } = setup();
+
+    await stream.append({
+      type: "events.iterate.com/slack/webhook-received",
+      payload: humanMessageWebhookPayload({}),
+    });
+    await deliver();
+    slackCalls.length = 0;
+
+    await stream.append({
+      type: "events.iterate.com/agent/status-changed",
+      payload: { busy: true, sinceOffset: 1 },
+    });
+    await deliver();
+    expect(slackCalls).toEqual([]);
+
+    await stream.append({
+      type: "events.iterate.com/agent/status-changed",
+      payload: { busy: false, sinceOffset: 2 },
+    });
+    clock.now += 16 * 60_000;
+    await deliver();
+
+    expect(slackCalls).toEqual([
+      {
+        method: "reactions.remove",
+        body: { channel: "C123", name: "eyes", timestamp: "111.222" },
+      },
+    ]);
+  });
+
   it("treats an already-absent eyes reaction as an idempotent success", async () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
     try {

--- a/apps/os/src/domains/integrations/slack-processors.test.ts
+++ b/apps/os/src/domains/integrations/slack-processors.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { StreamEventInput } from "iterate/processors";
 import { MemoryStreamNetwork, driveProcessor } from "iterate/processors/testing";
 import { StreamProcessorRunner } from "iterate/processors";
@@ -50,6 +50,7 @@ function connectedEvent() {
 
 function humanMessageWebhookPayload(input: {
   channel?: string;
+  channelType?: "channel" | "im" | "mpim";
   eventId?: string;
   /** When true (default), the message @mentions the authorized bot so the
    * mention-gate wakes the LLM. Pass false for ambient channel traffic. */
@@ -74,6 +75,7 @@ function humanMessageWebhookPayload(input: {
       event: {
         type: "message",
         channel: input.channel ?? "C123",
+        channel_type: input.channelType ?? "channel",
         user: "UHUMAN",
         text: input.text ?? defaultText,
         ts: input.ts ?? "111.222",
@@ -82,6 +84,16 @@ function humanMessageWebhookPayload(input: {
       },
     },
   };
+}
+
+function assistantMessageWebhookPayload(
+  input: Parameters<typeof humanMessageWebhookPayload>[0] = {},
+) {
+  return humanMessageWebhookPayload({
+    ...input,
+    channel: input.channel ?? "D123",
+    channelType: "im",
+  });
 }
 
 function botMessageWebhookPayload() {
@@ -850,7 +862,7 @@ describe("SlackAgentProcessor", () => {
     // Establish thread context first.
     await stream.append({
       type: "events.iterate.com/slack/webhook-received",
-      payload: humanMessageWebhookPayload({}),
+      payload: assistantMessageWebhookPayload(),
     });
     await deliver();
     slackCalls.length = 0;
@@ -864,7 +876,7 @@ describe("SlackAgentProcessor", () => {
       {
         method: "assistant.threads.setStatus",
         body: {
-          channel_id: "C123",
+          channel_id: "D123",
           thread_ts: "111.222",
           status: "is making an LLM request...",
           loading_messages: ["making an LLM request..."],
@@ -881,8 +893,45 @@ describe("SlackAgentProcessor", () => {
     expect(slackCalls).toEqual([
       {
         method: "assistant.threads.setStatus",
-        body: { channel_id: "C123", thread_ts: "111.222", status: "" },
+        body: { channel_id: "D123", thread_ts: "111.222", status: "" },
       },
+      {
+        method: "reactions.remove",
+        body: { channel: "D123", name: "eyes", timestamp: "111.222" },
+      },
+    ]);
+  });
+
+  it("keeps Slack Assistant thread APIs out of ordinary channel threads", async () => {
+    const { deliver, slackCalls, stream } = setup();
+
+    await stream.append({
+      type: "events.iterate.com/slack/webhook-received",
+      payload: humanMessageWebhookPayload({}),
+    });
+    await deliver();
+    slackCalls.length = 0;
+
+    await stream.append({
+      type: "events.iterate.com/agent/status-changed",
+      payload: {
+        busy: true,
+        shortStatus: "investigating",
+        sinceOffset: 1,
+        title: "Production incident",
+      },
+    });
+    await deliver();
+
+    expect(slackCalls).toEqual([]);
+
+    await stream.append({
+      type: "events.iterate.com/agent/status-changed",
+      payload: { busy: false, sinceOffset: 2 },
+    });
+    await deliver();
+
+    expect(slackCalls).toEqual([
       {
         method: "reactions.remove",
         body: { channel: "C123", name: "eyes", timestamp: "111.222" },
@@ -890,12 +939,48 @@ describe("SlackAgentProcessor", () => {
     ]);
   });
 
+  it("treats an already-absent eyes reaction as an idempotent success", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    try {
+      const { deliver, slackCalls, stream } = setup({
+        callSlackApi: async ({ method }) => {
+          if (method === "reactions.remove") {
+            throw new Error("Slack Web API reactions.remove failed: no_reaction");
+          }
+        },
+      });
+
+      await stream.append({
+        type: "events.iterate.com/slack/webhook-received",
+        payload: humanMessageWebhookPayload({}),
+      });
+      await deliver();
+      slackCalls.length = 0;
+
+      await stream.append({
+        type: "events.iterate.com/agent/status-changed",
+        payload: { busy: false, sinceOffset: 1 },
+      });
+      await deliver();
+
+      expect(slackCalls).toEqual([
+        {
+          method: "reactions.remove",
+          body: { channel: "C123", name: "eyes", timestamp: "111.222" },
+        },
+      ]);
+      expect(error).not.toHaveBeenCalled();
+    } finally {
+      error.mockRestore();
+    }
+  });
+
   it("repaints the status once per batch — the latest announcement wins", async () => {
     const { deliver, slackCalls, stream } = setup();
 
     await stream.append({
       type: "events.iterate.com/slack/webhook-received",
-      payload: humanMessageWebhookPayload({}),
+      payload: assistantMessageWebhookPayload(),
     });
     await deliver();
     slackCalls.length = 0;
@@ -917,11 +1002,11 @@ describe("SlackAgentProcessor", () => {
     expect(slackCalls).toEqual([
       {
         method: "assistant.threads.setStatus",
-        body: { channel_id: "C123", thread_ts: "111.222", status: "" },
+        body: { channel_id: "D123", thread_ts: "111.222", status: "" },
       },
       {
         method: "reactions.remove",
-        body: { channel: "C123", name: "eyes", timestamp: "111.222" },
+        body: { channel: "D123", name: "eyes", timestamp: "111.222" },
       },
     ]);
   });
@@ -931,7 +1016,7 @@ describe("SlackAgentProcessor", () => {
 
     await stream.append({
       type: "events.iterate.com/slack/webhook-received",
-      payload: humanMessageWebhookPayload({}),
+      payload: assistantMessageWebhookPayload(),
     });
     await deliver();
     slackCalls.length = 0;
@@ -953,12 +1038,12 @@ describe("SlackAgentProcessor", () => {
     expect(slackCalls).toEqual([
       {
         method: "assistant.threads.setTitle",
-        body: { channel_id: "C123", thread_ts: "111.222", title: "Trip planning" },
+        body: { channel_id: "D123", thread_ts: "111.222", title: "Trip planning" },
       },
       {
         method: "assistant.threads.setStatus",
         body: {
-          channel_id: "C123",
+          channel_id: "D123",
           thread_ts: "111.222",
           status: "is comparing flights...",
           loading_messages: ["comparing flights..."],
@@ -977,7 +1062,7 @@ describe("SlackAgentProcessor", () => {
       {
         method: "assistant.threads.setStatus",
         body: {
-          channel_id: "C123",
+          channel_id: "D123",
           thread_ts: "111.222",
           status: "is booking the winner...",
           loading_messages: ["booking the winner..."],
@@ -986,42 +1071,46 @@ describe("SlackAgentProcessor", () => {
     ]);
   });
 
-  it("retries a failed title paint on batch redelivery", async () => {
-    let failNext = true;
-    const { deliver, slackCalls, stream } = setup({
-      callSlackApi: async ({ method }) => {
-        if (method !== "assistant.threads.setTitle" || !failNext) return;
-        failNext = false;
-        throw new Error("slack blew up");
-      },
-    });
+  it("reports an unexpected title-paint failure once without wedging the checkpoint", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    try {
+      const { deliver, runner, slackCalls, stream } = setup({
+        callSlackApi: async ({ method }) => {
+          if (method === "assistant.threads.setTitle") throw new Error("slack blew up");
+        },
+      });
 
-    await stream.append({
-      type: "events.iterate.com/slack/webhook-received",
-      payload: humanMessageWebhookPayload({}),
-    });
-    await deliver();
-    slackCalls.length = 0;
+      await stream.append({
+        type: "events.iterate.com/slack/webhook-received",
+        payload: assistantMessageWebhookPayload(),
+      });
+      await deliver();
+      slackCalls.length = 0;
 
-    await stream.append({
-      type: "events.iterate.com/agent/status-changed",
-      payload: { title: "Trip planning" },
-    });
-    // The failed call fails the frame (cursor held) — the painted-title
-    // record must NOT be written, or the redelivered frame would see the
-    // rename as already painted and skip it forever.
-    await expect(deliver()).rejects.toThrow("slack blew up");
+      await stream.append({
+        type: "events.iterate.com/agent/status-changed",
+        payload: { title: "Trip planning" },
+      });
+      await deliver();
 
-    slackCalls.length = 0;
-    // The runner's cursor never advanced past the failed frame; the next
-    // catch-up redelivers exactly the unacknowledged patch.
-    await deliver();
-    expect(slackCalls).toEqual([
-      {
-        method: "assistant.threads.setTitle",
-        body: { channel_id: "C123", thread_ts: "111.222", title: "Trip planning" },
-      },
-    ]);
+      expect(slackCalls).toEqual([
+        {
+          method: "assistant.threads.setTitle",
+          body: { channel_id: "D123", thread_ts: "111.222", title: "Trip planning" },
+        },
+      ]);
+      expect(runner.currentState.status).toMatchObject({ title: "Trip planning" });
+      expect(error).toHaveBeenCalledWith(
+        "[slack-agent] Slack side effect failed",
+        expect.objectContaining({ method: "assistant.threads.setTitle" }),
+      );
+
+      slackCalls.length = 0;
+      await deliver();
+      expect(slackCalls).toEqual([]);
+    } finally {
+      error.mockRestore();
+    }
   });
 
   it("paints the script phase and a blocked wait in the agent's own words", async () => {
@@ -1029,7 +1118,7 @@ describe("SlackAgentProcessor", () => {
 
     await stream.append({
       type: "events.iterate.com/slack/webhook-received",
-      payload: humanMessageWebhookPayload({}),
+      payload: assistantMessageWebhookPayload(),
     });
     await deliver();
     slackCalls.length = 0;
@@ -1043,7 +1132,7 @@ describe("SlackAgentProcessor", () => {
       {
         method: "assistant.threads.setStatus",
         body: {
-          channel_id: "C123",
+          channel_id: "D123",
           thread_ts: "111.222",
           status: "is running a script...",
           loading_messages: ["running a script..."],
@@ -1069,7 +1158,7 @@ describe("SlackAgentProcessor", () => {
       {
         method: "assistant.threads.setStatus",
         body: {
-          channel_id: "C123",
+          channel_id: "D123",
           thread_ts: "111.222",
           status: "is waiting for your Acme API key...",
           loading_messages: ["waiting for your Acme API key..."],
@@ -1077,7 +1166,7 @@ describe("SlackAgentProcessor", () => {
       },
       {
         method: "reactions.remove",
-        body: { channel: "C123", name: "eyes", timestamp: "111.222" },
+        body: { channel: "D123", name: "eyes", timestamp: "111.222" },
       },
     ]);
   });
@@ -1087,7 +1176,7 @@ describe("SlackAgentProcessor", () => {
 
     await stream.append({
       type: "events.iterate.com/slack/webhook-received",
-      payload: humanMessageWebhookPayload({}),
+      payload: assistantMessageWebhookPayload(),
     });
     await deliver();
     slackCalls.length = 0;
@@ -1103,7 +1192,7 @@ describe("SlackAgentProcessor", () => {
     expect(slackCalls).toEqual([
       {
         method: "assistant.threads.setTitle",
-        body: { channel_id: "C123", thread_ts: "111.222", title: "Trip planning" },
+        body: { channel_id: "D123", thread_ts: "111.222", title: "Trip planning" },
       },
     ]);
   });
@@ -1113,7 +1202,7 @@ describe("SlackAgentProcessor", () => {
 
     await stream.append({
       type: "events.iterate.com/slack/webhook-received",
-      payload: humanMessageWebhookPayload({}),
+      payload: assistantMessageWebhookPayload(),
     });
     await deliver();
     slackCalls.length = 0;
@@ -1140,7 +1229,7 @@ describe("SlackAgentProcessor", () => {
       {
         method: "assistant.threads.setStatus",
         body: {
-          channel_id: "C123",
+          channel_id: "D123",
           thread_ts: "111.222",
           status: "is making an LLM request...",
           loading_messages: ["making an LLM request..."],
@@ -1164,7 +1253,7 @@ describe("SlackAgentProcessor", () => {
 
     await stream.append({
       type: "events.iterate.com/slack/webhook-received",
-      payload: humanMessageWebhookPayload({}),
+      payload: assistantMessageWebhookPayload(),
     });
     await deliver();
     slackCalls.length = 0;
@@ -1185,11 +1274,11 @@ describe("SlackAgentProcessor", () => {
     expect(slackCalls).toEqual([
       {
         method: "assistant.threads.setStatus",
-        body: { channel_id: "C123", thread_ts: "111.222", status: "" },
+        body: { channel_id: "D123", thread_ts: "111.222", status: "" },
       },
       {
         method: "reactions.remove",
-        body: { channel: "C123", name: "eyes", timestamp: "111.222" },
+        body: { channel: "D123", name: "eyes", timestamp: "111.222" },
       },
     ]);
   });
@@ -1199,7 +1288,7 @@ describe("SlackAgentProcessor", () => {
 
     await stream.append({
       type: "events.iterate.com/slack/webhook-received",
-      payload: humanMessageWebhookPayload({}),
+      payload: assistantMessageWebhookPayload(),
     });
     await deliver();
     await stream.append({
@@ -1222,11 +1311,11 @@ describe("SlackAgentProcessor", () => {
     expect(slackCalls).toEqual([
       {
         method: "assistant.threads.setStatus",
-        body: { channel_id: "C123", thread_ts: "111.222", status: "" },
+        body: { channel_id: "D123", thread_ts: "111.222", status: "" },
       },
       {
         method: "reactions.remove",
-        body: { channel: "C123", name: "eyes", timestamp: "111.222" },
+        body: { channel: "D123", name: "eyes", timestamp: "111.222" },
       },
     ]);
   });
@@ -1259,7 +1348,7 @@ describe("SlackAgentProcessor", () => {
 
     await stream.append({
       type: "events.iterate.com/slack/webhook-received",
-      payload: humanMessageWebhookPayload({}),
+      payload: assistantMessageWebhookPayload(),
     });
     await deliver();
     await stream.append({

--- a/docs/slack-bot-token-migration.md
+++ b/docs/slack-bot-token-migration.md
@@ -21,7 +21,10 @@ OS Slack Web API calls use the connected project workspace bot token first. If
 Slack rejects that token, OS verifies that this environment's
 `APP_CONFIG_INTEGRATIONS__SLACK.botToken` belongs to the connection's recorded
 Slack team before retrying with it. Projects without a live Slack connection
-cannot use the recovery token.
+cannot use the fallback token. This token is optional operational fallback,
+not the source of a project's Slack connection and not production-recreation
+material. A configured value can be revoked; validate it with `auth.test`
+against its expected team rather than treating Doppler presence as proof.
 
 `Niterate (CI bot)` is not the production Slack app. The production Slack app
 is `iterate`; `Niterate (CI bot)` is the visible identity associated with the
@@ -49,8 +52,16 @@ preview_8
 preview_9
 ```
 
-Affected workers still need to be redeployed before they can use newly
-uploaded Doppler values.
+This is an inventory of configured values, not a validity statement. During the
+July 17, 2026 production recreation, the configured `prd` value returned
+`invalid_auth`; the normal project OAuth installation was therefore required.
+Affected workers still need to be redeployed before they can use newly uploaded
+Doppler values.
+
+Never restore a project by writing this value into
+`/secrets/integrations/slack/<connection>/bot-token` and manually appending
+connection or directory facts. Complete **Connect Slack** OAuth, then run the
+[post-recreation verifier](slack-testing.md#post-recreation-proof).
 
 ## OAuth pages
 

--- a/docs/slack-testing.md
+++ b/docs/slack-testing.md
@@ -44,8 +44,9 @@ The Doppler secrets are split by purpose:
 
 - `APP_CONFIG_INTEGRATIONS__SLACK` contains the Slack app credentials for the
   OS deployment: OAuth client ID, OAuth client secret, and webhook signing
-  secret. It also contains `botToken`, a recovery credential for that same
-  Slack app.
+  secret. It may also contain `botToken`, an optional app-level outbound
+  fallback for that same Slack app. Presence in Doppler is not proof that the
+  token is live.
 - The OS **Connect Slack** flow stores the workspace bot token for a project at
   `/secrets/integrations/slack/<connection>/bot-token` and claims the Slack
   team in the deployment's `/integrations/_directory` stream.
@@ -53,7 +54,8 @@ The Doppler secrets are split by purpose:
   Slack rejects that token, OS uses `auth.test` to prove that
   `APP_CONFIG_INTEGRATIONS__SLACK.botToken` belongs to the connection's
   journaled team before retrying. A typo'd or disconnected connection never
-  gets the recovery credential.
+  gets the fallback. The fallback is not a substitute for **Connect Slack** and
+  must never be used to reconstruct a project's connection.
 
 ## Trigger actor for smoke tests
 
@@ -79,7 +81,7 @@ smokes (CI notifications and agent smoke posts). It is **not** the product bot:
 |          | Product bot under test                                                                                                                           | Trigger actor                                                        |
 | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
 | Identity | production `iterate`, or `iterate-preview-N`                                                                                                     | `Niterate` / `iterate_ci_preview_bo`                                 |
-| Doppler  | project secret `/secrets/integrations/slack/<connection>/bot-token` (Connect Slack); optional recovery `APP_CONFIG_INTEGRATIONS__SLACK.botToken` | **`SLACK_CI_BOT_TOKEN`** on `os/*` configs **and** `_shared/prd`     |
+| Doppler  | project secret `/secrets/integrations/slack/<connection>/bot-token` (Connect Slack); optional fallback `APP_CONFIG_INTEGRATIONS__SLACK.botToken` | **`SLACK_CI_BOT_TOKEN`** on `os/*` configs **and** `_shared/prd`     |
 | Used for | receiving events, 👀, replies                                                                                                                    | `chat.postMessage` only                                              |
 | Code     | outbound Web API via OS / `itx.integrations.slack`                                                                                               | [`scripts/ci/slack.ts`](../scripts/ci/slack.ts) `getSlackBotToken()` |
 
@@ -120,9 +122,9 @@ doppler run --config prd -- pnpm cli itx run \
   -e 'return await itx.integrations.slack.get().conversations.join({ channel: "C096Q1M4Y86" })'
 ```
 
-`APP_CONFIG_INTEGRATIONS__SLACK.botToken` is only a **recovery** credential for
-the deployment's Slack app and may be `invalid_auth`. Prefer the project secret
-behind `itx.integrations.slack.get()` for join / real outbound API calls.
+`APP_CONFIG_INTEGRATIONS__SLACK.botToken` is only an optional outbound fallback
+for the deployment's Slack app and may be `invalid_auth`. Prefer the project
+secret behind `itx.integrations.slack.get()` for join / real outbound API calls.
 
 ### Production mention-gate smoke
 
@@ -135,6 +137,15 @@ current **slack-agent** mention gate:
 | `<@iterateUserId> …` or Slack `app_mention`          | Product bot wakes and can reply (👀 may appear) |
 | Follow-up in a thread already activated by a mention | Still wakes (no re-mention required)            |
 | `!debug` / bang-commands                             | Still run without a mention                     |
+
+Slack's `assistant.threads.setTitle` and `assistant.threads.setStatus` methods
+belong only to the app's Assistant direct-message surface. The routed webhook's
+`event.channel_type` is the authority: `im` (normally a `D…` conversation) may
+use Assistant thread UI; ordinary `channel`/`group`/`mpim` threads must not.
+Channel mentions still use the 👀 acknowledgement and normal `chat.postMessage`
+reply. Removing an already-absent 👀 returns Slack's `no_reaction`, which is an
+idempotent success and must not appear in error telemetry. In production traces
+for a `C…` or `G…` channel thread, any `assistant.threads.*` call is a defect.
 
 ```bash
 doppler run --project os --config prd -- python3 - <<'PY'
@@ -169,12 +180,36 @@ To confirm membership / reactions from the CI actor:
 
 ### Post-recreation proof
 
-After recreating production, use a real human `@iterate` mention and retain its
-permalink. A product-bot reply in the same thread proves signed webhook ingress,
-the global workspace-to-project claim, the restored project connection and bot
-token, agent routing, and outbound Slack delivery.
+Recreate the association with the normal **Connect Slack** OAuth flow. Never
+hand-create the connection secret or append `slack/connected` / directory-claim
+events: OAuth completion validates and stores the fresh workspace token, creates
+the router and subscription, records the lifecycle fact, and claims webhook
+ingress as one owning operation.
 
-Read the thread back through the restored project connection as a second check.
+Do not use `APP_CONFIG_INTEGRATIONS__SLACK.botToken` as restoration material.
+Before sending any smoke message, prove the project token and directory claim
+with the recreation verifier (run without `--context` so it can read the global
+directory):
+
+```bash
+# from apps/os
+doppler run --config prd -- pnpm cli itx run \
+  --file ../../.agents/skills/recreate-production/scripts/verify-slack-connection.itx.js \
+  --vars '{"projectId":"<iterate-project-id>","connection":"t0675psn873","expectedTeamId":"T0675PSN873"}'
+```
+
+Require `ok: true`, the expected team ID, a bot user ID, and a directory claim
+offset. If `auth.test` reports `invalid_auth`, OAuth has not established a live
+connection—do not append claims around it.
+
+Only after that barrier, send a **new** real-human or CI-actor `@iterate`
+mention and retain its permalink. Slack webhooks received before the directory
+claim exists are validly ACKed and ignored; Slack does not replay them after a
+later association. A product-bot reply in the same thread proves signed webhook
+ingress, the global workspace-to-project claim, the live project connection
+and bot token, agent routing, and outbound Slack delivery.
+
+Read the thread back through the live project connection as a second check.
 Convert the permalink's final `p...` value back to Slack's dotted timestamp and
 use the recorded connection explicitly:
 
@@ -187,9 +222,9 @@ doppler run --config prd -- pnpm cli itx run \
 ```
 
 Require `ok: true`, the human root message, and a reply whose user is the
-recorded product-bot user. Save the permalink, timestamps, and reply text in
-the cutover evidence. A pre-cutover thread is only a baseline; repeat this
-after restore.
+recorded product-bot user. Save the verifier result, permalink, timestamps, and
+reply text in the cutover evidence. A pre-cutover or pre-claim thread is only a
+baseline; repeat the message after reconnecting.
 
 ## Manual preview smoke test
 
@@ -237,9 +272,9 @@ otherwise:
 - The app scope `chat:write.public` lets a Slack app post into public channels,
   so a bot user not appearing as a channel member does not rule out its app
   posting a reply.
-- If production has `APP_CONFIG_INTEGRATIONS__SLACK.botToken`, it can recover
-  outbound Slack Web API calls from a missing, expired, or revoked connection
-  token after verifying the connection's Slack team.
+- If production has `APP_CONFIG_INTEGRATIONS__SLACK.botToken`, it can retry an
+  outbound Slack Web API call after a missing, expired, or revoked connection
+  token, but only after verifying the connection's Slack team.
 
 For a precise diagnosis, inspect the Slack event wrapper and traces:
 


### PR DESCRIPTION
## What changed

- fold Slack's webhook `channel_type` into each routed Slack-agent processor
- call `assistant.threads.setTitle/setStatus` only for app-DM Assistant threads, never ordinary channel mentions
- classify known idempotent reaction outcomes as quiet success
- report an unexpected cosmetic Slack failure once and settle it instead of wedging the durable processor checkpoint
- let the processor own Slack error classification instead of swallowing every error in the agent Durable Object adapter
- add regression coverage for ordinary channels, DMs, `no_reaction`, and unexpected cosmetic failures
- document post-recreation Slack OAuth verification and add a read-only verifier for token, connection, and directory-claim coherence

## Why

Production channel mentions were routed and answered, but the Slack-agent processor treated ordinary channel threads as Assistant DM threads. Slack rejected `assistant.threads.*` with `no_permission`, while a missing eyes reaction produced `no_reaction`; both were emitted as unexplained errors. The adapter also swallowed all Slack failures, so outcome classification was split across layers.

The processor now uses Slack's explicit conversation type, preserves Assistant UI behavior for DMs, and keeps cosmetic failures bounded without hiding unexpected outcomes.

## Impact

Ordinary channel traffic no longer invokes unsupported Assistant APIs or retries cosmetic work indefinitely. DM Assistant status/title behavior remains intact. The production-recreation docs now require normal Slack OAuth plus a read-only end-to-end association check.

## Validation

- `pnpm --dir apps/os generate:itx-api`
- `pnpm --dir apps/os generate:itx-examples`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --dir apps/os exec vitest run src/domains/integrations/slack-processors.test.ts` (54 passed)
- `pnpm test` (OS: 1,819 passed / 1 skipped; workspace green)

Preview and fresh production Slack trace proof will be added before this leaves draft.

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +77 -42 | +53 -33 🟩🟥⬜⬜⬜ |
| Tests | +180 -59 | +163 -54 🟩🟩🟩🟩🟥 |
| Docs | +76 -22 | +69 -22 🟩🟩⬜⬜⬜ |
| Other | +124 -8 | +110 -8 🟩🟩🟩⬜⬜ |
| **Total** | **+457 -131** | **+395 -117** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 35a00b6 and 52bbdb4, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-17T19:35:10.152Z",
      "headSha": "52bbdb42ca2d7e9216f42148a250415070b39587",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/586049881807729",
      "shortSha": "52bbdb4",
      "cleanupDurationMs": 2209,
      "deployDurationMs": 17892,
      "testDurationMs": 12907,
      "testRetries": null,
      "workerSizeKib": 3949.67,
      "workerGzipKib": 804.94,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-17T19:35:08.428Z",
      "headSha": "52bbdb42ca2d7e9216f42148a250415070b39587",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/586049881807729",
      "shortSha": "52bbdb4",
      "cleanupDurationMs": 483,
      "deployDurationMs": 7092,
      "testDurationMs": 6052,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-17T19:35:06.944Z",
      "headSha": "52bbdb42ca2d7e9216f42148a250415070b39587",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/586049881807729",
      "shortSha": "52bbdb4",
      "cleanupDurationMs": 120990,
      "deployDurationMs": 90454,
      "testDurationMs": 245622,
      "testRetries": "2 retried: Top-level RpcTarget live capabilities dispatch by member path (vitest x1) · runs \"describe-project\" through the project REPL (specs x1)",
      "workerSizeKib": 16732.54,
      "workerGzipKib": 4509.14,
      "mainWorkerGzipKib": 4508.82
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `52bbdb4` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 804.9 KiB | 17.9s | 12.9s |  | 2.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/586049881807729) | 2026-07-17T19:35:10.152Z | Preview app released. |
| Dummy Petshop | released | `52bbdb4` | [https://dummy-petshop.iterate-preview-8.com](https://dummy-petshop.iterate-preview-8.com) | 198.2 KiB | 7.1s | 6.1s |  | 483ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/586049881807729) | 2026-07-17T19:35:08.428Z | Preview app released. |
| OS | released | `52bbdb4` | [https://os.iterate-preview-8.com](https://os.iterate-preview-8.com) | 4.40 MiB (+0.3 KiB vs main) | 90.5s | 245.6s | 2 retried: Top-level RpcTarget live capabilities dispatch by member path (vitest x1) · runs "describe-project" through the project REPL (specs x1) | 121.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/586049881807729) | 2026-07-17T19:35:06.944Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes durable slack-agent processor behavior and checkpoint policy on a hot integration path, though limited to cosmetic Slack APIs and reactions rather than message delivery or auth.
> 
> **Overview**
> Fixes production noise where **channel @mentions** still routed and replied but the slack-agent processor called unsupported `assistant.threads.*` APIs (`no_permission`) and treated benign reaction outcomes as hard failures.
> 
> The processor now **folds webhook `channel_type`** (contract **0.6.0**) and only paints Assistant title/status in **app DM** threads (`im` / `D…` fallback). **Ordinary channels** keep 👀 ack/clear via reactions only—no Assistant UI calls. **Cosmetic Slack errors** are classified in the processor: known idempotent reaction outcomes are quiet successes; unexpected cosmetic failures are **logged once and settled** so the durable checkpoint does not retry forever (the agent DO adapter no longer swallows all Slack errors).
> 
> **Docs and ops**: production-recreation guidance requires **Connect Slack OAuth** (not deployment `botToken` or hand-appended connection/claim events), documents optional fallback vs real connection state, and adds a read-only **`verify-slack-connection.itx.js`** plus updated post-recreation Slack proof steps. Regression tests cover channel vs DM, stale channel ack cleanup, `no_reaction`, and non-wedging title failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52bbdb42ca2d7e9216f42148a250415070b39587. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->