### PR TITLE
feat(os): show project creation saga ASAP from a deep-linkable sheet

### DIFF
--- a/apps/os/src/components/app-sidebar.tsx
+++ b/apps/os/src/components/app-sidebar.tsx
@@ -30,7 +30,6 @@ import type { PublicAppConfig } from "@iterate-com/shared/config";
 import { useAuthClient } from "@iterate-com/auth/client";
 import { useConfig } from "@iterate-com/ui/apps/config";
 import { Avatar, AvatarFallback } from "@iterate-com/ui/components/avatar";
-import { Button } from "@iterate-com/ui/components/button";
 import { IterateLogo } from "@iterate-com/ui/components/iterate-logo";
 import {
   DropdownMenu,
@@ -154,16 +153,8 @@ function AppSidebarHeader({ projects }: { projects: ProjectListEntry[] }) {
             className="min-w-56 rounded-lg"
           >
             <DropdownMenuGroup>
-              <DropdownMenuLabel className="flex items-center justify-between pr-1 text-xs text-muted-foreground">
+              <DropdownMenuLabel className="text-xs text-muted-foreground">
                 Projects
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  aria-label="New project"
-                  render={<Link to="/new-project" />}
-                >
-                  <Plus />
-                </Button>
               </DropdownMenuLabel>
               {projects.length > 0 ? (
                 projects.map((project) => (
@@ -192,6 +183,10 @@ function AppSidebarHeader({ projects }: { projects: ProjectListEntry[] }) {
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
             <DropdownMenuGroup>
+              <DropdownMenuItem render={<Link to="/new-project" />}>
+                <Plus />
+                <span>Create project</span>
+              </DropdownMenuItem>
               <DropdownMenuItem render={<Link to="/projects" />}>
                 <ArrowLeft />
                 <span>View all projects</span>

--- a/apps/os/src/components/create-project-form.tsx
+++ b/apps/os/src/components/create-project-form.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
@@ -45,6 +45,10 @@ export function CreateProjectForm({
   const queryClient = useQueryClient();
   const { refresh, session } = useAuthClient();
   const organizations = session?.authenticated ? session.session.organizations : [];
+  // Stays true from mutation success until this form unmounts after navigate —
+  // `isPending` alone drops false before router.navigate settles, which would
+  // briefly re-enable sheet dismiss and race the welcome redirect.
+  const [navigatingAway, setNavigatingAway] = useState(false);
   const createProject = useMutation({
     mutationFn: async (input: { slug: string; organizationSlug: string }) => {
       // Straight through the itx session: create registers the project with
@@ -71,6 +75,7 @@ export function CreateProjectForm({
       return { id: description.projectId, slug: input.slug };
     },
     onSuccess: (project) => {
+      setNavigatingAway(true);
       // Onto the project home immediately with `welcome` so the creation
       // checklist paints while the bootstrap saga runs. The project route
       // resolves without the refreshed session: create primes the
@@ -130,12 +135,14 @@ export function CreateProjectForm({
     },
   });
 
+  const createPending = createProject.isPending || navigatingAway;
+
   // Host sheet (and any other shell) must not dismiss while create is in
-  // flight: onSuccess navigates into the new project, and a mid-flight
+  // flight or while we are navigating into the new project: a mid-flight
   // close would race that navigation with a /projects bounce.
   useEffect(() => {
-    onPendingChange?.(createProject.isPending);
-  }, [createProject.isPending, onPendingChange]);
+    onPendingChange?.(createPending);
+  }, [createPending, onPendingChange]);
 
   return (
     <form
@@ -197,8 +204,8 @@ export function CreateProjectForm({
       </FieldGroup>
       <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting] as const}>
         {([canSubmit, isSubmitting]) => (
-          <Button type="submit" disabled={!canSubmit || isSubmitting || createProject.isPending}>
-            {isSubmitting || createProject.isPending ? "Creating..." : "Create project"}
+          <Button type="submit" disabled={!canSubmit || isSubmitting || createPending}>
+            {isSubmitting || createPending ? "Creating..." : "Create project"}
           </Button>
         )}
       </form.Subscribe>

--- a/apps/os/src/components/create-project-form.tsx
+++ b/apps/os/src/components/create-project-form.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
@@ -34,7 +35,12 @@ const CreateProjectInput = z.object({
   organizationSlug: z.string(),
 });
 
-export function CreateProjectForm() {
+export function CreateProjectForm({
+  onPendingChange,
+}: {
+  /** Fired when create submit starts/ends so a host sheet can block dismiss. */
+  onPendingChange?: (pending: boolean) => void;
+} = {}) {
   const router = useRouter();
   const queryClient = useQueryClient();
   const { refresh, session } = useAuthClient();
@@ -123,6 +129,13 @@ export function CreateProjectForm() {
       form.reset();
     },
   });
+
+  // Host sheet (and any other shell) must not dismiss while create is in
+  // flight: onSuccess navigates into the new project, and a mid-flight
+  // close would race that navigation with a /projects bounce.
+  useEffect(() => {
+    onPendingChange?.(createProject.isPending);
+  }, [createProject.isPending, onPendingChange]);
 
   return (
     <form

--- a/apps/os/src/components/create-project-form.tsx
+++ b/apps/os/src/components/create-project-form.tsx
@@ -21,7 +21,6 @@ import {
 import { toast } from "@iterate-com/ui/components/sonner";
 import { z } from "zod";
 import { connectIterateSession, reconnectIterateSession } from "iterate/react";
-import { ONBOARDING_AGENT_PATH } from "~/lib/onboarding-agent.ts";
 import { projectsListQueryKey } from "~/lib/projects-query.ts";
 
 const PROJECT_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
@@ -43,12 +42,12 @@ export function CreateProjectForm() {
   const createProject = useMutation({
     mutationFn: async (input: { slug: string; organizationSlug: string }) => {
       // Straight through the itx session: create registers the project with
-      // the auth worker (org grant -> claims) and runs the engine bootstrap
+      // the auth worker (org grant -> claims) and starts the engine bootstrap
       // saga, then widens THIS socket's access to the new project.
       const session = await connectIterateSession();
       // Fast path: resolve as soon as the project EXISTS — the bootstrap saga
       // keeps running behind the handle, and the project home page plays its
-      // progress live from processor pushes until `state.created` flips.
+      // progress live from processor pushes until `state.ready` flips.
       const project = session.projects.create({
         slug: input.slug,
         waitUntilReady: false,
@@ -56,9 +55,9 @@ export function CreateProjectForm() {
       });
       // ONE pipelined round trip, then navigate: __describe() rides the create
       // pipeline, so the only wait is create itself (auth registration +
-      // bootstrap appends). Deliberately NOT awaited here: projects.list() —
-      // it probes engine existence for every project the caller owns, which
-      // costs whole seconds and is exactly the "weird delay" this path had.
+      // birth). Deliberately NOT awaited here: projects.list() — it probes
+      // engine existence for every project the caller owns, which costs whole
+      // seconds and is exactly the "weird delay" this path had.
       const description = await project.__describe();
       // The form validates strict kebab-case, so the auth worker's slug
       // normalization is an identity for UI creates; the background task
@@ -66,15 +65,16 @@ export function CreateProjectForm() {
       return { id: description.projectId, slug: input.slug };
     },
     onSuccess: (project) => {
-      // Onto the onboarding agent URL immediately. The stream page can render
-      // while the bootstrap saga and onboarding agent birth catch up behind it.
-      // The project route resolves without the refreshed session: create primes
-      // the server-side project directory, which is the auth fallback for
-      // exactly this claims-lag window.
+      // Onto the project home immediately with `welcome` so the creation
+      // checklist paints while the bootstrap saga runs. The project route
+      // resolves without the refreshed session: create primes the
+      // server-side project directory, which is the auth fallback for exactly
+      // this claims-lag window. Once `state.ready` flips, the home page
+      // hands off to the onboarding agent.
       void router.navigate({
-        to: "/projects/$projectSlug/agents/streams/$",
-        params: { projectSlug: project.slug, _splat: ONBOARDING_AGENT_PATH },
-        search: {},
+        to: "/projects/$projectSlug",
+        params: { projectSlug: project.slug },
+        search: { welcome: true },
       });
       // Session catch-up runs BEHIND the navigation: refresh the browser auth
       // session so its claims carry the new project, reconnect the one itx
@@ -94,9 +94,9 @@ export function CreateProjectForm() {
         );
         if (entry != null && entry.slug !== project.slug) {
           void router.navigate({
-            to: "/projects/$projectSlug/agents/streams/$",
-            params: { projectSlug: entry.slug, _splat: ONBOARDING_AGENT_PATH },
-            search: {},
+            to: "/projects/$projectSlug",
+            params: { projectSlug: entry.slug },
+            search: { welcome: true },
             replace: true,
           });
         }
@@ -126,7 +126,7 @@ export function CreateProjectForm() {
 
   return (
     <form
-      className="max-w-sm space-y-4"
+      className="space-y-4"
       onSubmit={(event) => {
         event.preventDefault();
         event.stopPropagation();

--- a/apps/os/src/routes/_app/new-project.tsx
+++ b/apps/os/src/routes/_app/new-project.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import {
   Sheet,
@@ -18,21 +19,30 @@ export const Route = createFileRoute("/_app/new-project")({
  * Deep-linkable create-project form (`/new-project`). Opens as a right-edge
  * sheet so the same entry works from the sidebar switcher, the projects list,
  * and a shared URL. Closing returns to the projects list (create itself
- * navigates into the new project home).
+ * navigates into the new project home). While create is in flight the sheet
+ * refuses dismiss so Escape/overlay cannot race the success navigation.
  */
 function NewProjectPage() {
   const navigate = useNavigate();
+  const [creating, setCreating] = useState(false);
 
   return (
     <Sheet
       open
       onOpenChange={(open) => {
         if (!open) {
+          // Controlled open stays true when we ignore dismiss, so the sheet
+          // remains visible until create finishes and navigates away.
+          if (creating) return;
           void navigate({ to: "/projects" });
         }
       }}
     >
-      <SheetContent side="right" className="overflow-y-auto data-[side=right]:sm:max-w-md">
+      <SheetContent
+        side="right"
+        showCloseButton={!creating}
+        className="overflow-y-auto data-[side=right]:sm:max-w-md"
+      >
         <SheetHeader className="border-b">
           <SheetTitle>Create project</SheetTitle>
           <SheetDescription>
@@ -40,7 +50,7 @@ function NewProjectPage() {
           </SheetDescription>
         </SheetHeader>
         <div className="p-4">
-          <CreateProjectForm />
+          <CreateProjectForm onPendingChange={setCreating} />
         </div>
       </SheetContent>
     </Sheet>

--- a/apps/os/src/routes/_app/new-project.tsx
+++ b/apps/os/src/routes/_app/new-project.tsx
@@ -1,4 +1,11 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@iterate-com/ui/components/sheet";
 import { CreateProjectForm } from "~/components/create-project-form.tsx";
 import { breadcrumbStaticData } from "~/lib/route-breadcrumbs.ts";
 
@@ -7,16 +14,35 @@ export const Route = createFileRoute("/_app/new-project")({
   component: NewProjectPage,
 });
 
+/**
+ * Deep-linkable create-project form (`/new-project`). Opens as a right-edge
+ * sheet so the same entry works from the sidebar switcher, the projects list,
+ * and a shared URL. Closing returns to the projects list (create itself
+ * navigates into the new project home).
+ */
 function NewProjectPage() {
+  const navigate = useNavigate();
+
   return (
-    <section className="space-y-4 p-4">
-      <div className="space-y-1">
-        <h2 className="text-sm font-semibold">New project</h2>
-        <p className="text-sm text-muted-foreground">
-          Pick a slug for your project. You can configure hostnames later.
-        </p>
-      </div>
-      <CreateProjectForm />
-    </section>
+    <Sheet
+      open
+      onOpenChange={(open) => {
+        if (!open) {
+          void navigate({ to: "/projects" });
+        }
+      }}
+    >
+      <SheetContent side="right" className="overflow-y-auto data-[side=right]:sm:max-w-md">
+        <SheetHeader className="border-b">
+          <SheetTitle>Create project</SheetTitle>
+          <SheetDescription>
+            Pick a slug for your project. You can configure hostnames later.
+          </SheetDescription>
+        </SheetHeader>
+        <div className="p-4">
+          <CreateProjectForm />
+        </div>
+      </SheetContent>
+    </Sheet>
   );
 }

--- a/apps/os/src/routes/_app/projects/$projectSlug/index.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/index.tsx
@@ -18,8 +18,8 @@ import {
 import { StreamViewSearch } from "~/lib/stream-view-search.ts";
 
 const HomeSearch = StreamViewSearch.extend({
-  /** Set by the create form: play the creation checklist, then hand over to
-   * the onboarding agent if this route is reached before the direct agent URL. */
+  /** Set by the create form: play the creation checklist until `ready`, then
+   * hand over to the onboarding agent. */
   welcome: z.boolean().optional().catch(undefined),
 });
 
@@ -62,11 +62,12 @@ function ProjectHomePage() {
   // Onboarding phase: the completion event has not been appended yet. This
   // keys off the explicit project phase marker, independently of agent state.
   const inOnboarding = lifecycle.value === undefined ? false : isOnboardingActive(lifecycle.value);
-  const handOffToOnboarding = welcome === true && inOnboarding;
+  // Create lands here with `welcome` as soon as the project exists. Stay on
+  // the checklist until bootstrap flips `ready`, then hand off to the
+  // onboarding agent so the user watches the saga rather than waiting on the
+  // create button.
+  const handOffToOnboarding = welcome === true && ready && inOnboarding;
 
-  // The welcome handoff: arrived here from an older create/root redirect, so
-  // as soon as the state confirms the onboarding phase, continue into the
-  // agent page.
   useEffect(() => {
     if (!handOffToOnboarding) return;
     void navigate({
@@ -107,8 +108,8 @@ function ProjectHomePage() {
         />
       </>
     ) : (
-      // Creating, or the welcome handoff is in flight (the effect above is
-      // navigating): keep showing the checklist rather than flashing settings.
+      // Creating (including welcome), or the welcome handoff is in flight:
+      // keep showing the checklist rather than flashing settings.
       <ProjectCreationProgress state={lifecycle.value} />
     );
 

--- a/apps/os/src/routes/_app/projects/index.tsx
+++ b/apps/os/src/routes/_app/projects/index.tsx
@@ -144,7 +144,7 @@ function ProjectsIndexPage() {
               size="sm"
               render={<Link to="/new-project" />}
             >
-              New project
+              Create project
             </Button>
           ) : null}
         </div>
@@ -172,7 +172,7 @@ function ProjectsIndexPage() {
               size="sm"
               render={<Link to="/new-project" />}
             >
-              Create new project
+              Create project
             </Button>
           </div>
         </div>

--- a/specs/create-project.spec.ts
+++ b/specs/create-project.spec.ts
@@ -40,20 +40,22 @@ test("a new user can create a project through the UI form", async ({ page }) => 
   expect(page.url()).toContain(`/projects/${firstSlug}/agents/streams/agents/onboarding`);
 
   await spinnerWaiter.settings.run({ disabled: true }, async () => {
-    // /projects is the home of SUBSEQUENT projects: the header's "New project"
-    // and the sidebar's icon both link here, but share an accessible name, so
-    // navigate directly instead of picking one with a strict-mode locator.
+    // /new-project is the deep-linked create sheet (sidebar + projects list
+    // both link here). Navigate directly so strict-mode locators don't have
+    // to disambiguate multiple "Create project" controls.
     await page.goto("/new-project");
 
     await page.getByLabel("Slug").fill(slug, { timeout: 15_000 });
-    // Create resolves as soon as the project identity and bootstrap events
-    // exist, then redirects straight to the onboarding agent stream; repo and
-    // worker readiness continue behind that route. The composer is the
-    // destination's structural chrome; 60s covers the redirect plus the
-    // bootstrap still catching up behind it.
+    // Create resolves as soon as the project identity exists
+    // (`waitUntilReady: false`), then lands on the project home checklist so
+    // the bootstrap saga is visible. Once `state.ready` flips, the home page
+    // hands off to the onboarding agent. The composer is that destination's
+    // structural chrome; 60s covers birth + saga + handoff.
     await page.getByRole("button", { name: "Create project" }).click({ timeout: 15_000 });
+    await page.getByTestId("project-creation-progress").waitFor({ timeout: 30_000 });
+    expect(page.url()).toContain(`/projects/${slug}`);
     await page.getByPlaceholder("Message this agent").waitFor({ timeout: 60_000 });
   });
-  // Same reasoning as above, now for the project created through the form.
+  // After the checklist completes, welcome handoff lands on onboarding.
   expect(page.url()).toContain(`/projects/${slug}/agents/streams/agents/onboarding`);
 });

--- a/specs/create-project.spec.ts
+++ b/specs/create-project.spec.ts
@@ -52,8 +52,9 @@ test("a new user can create a project through the UI form", async ({ page }) => 
     // hands off to the onboarding agent. The composer is that destination's
     // structural chrome; 60s covers birth + saga + handoff.
     await page.getByRole("button", { name: "Create project" }).click({ timeout: 15_000 });
+    // Checklist is the early-land destination (project home while bootstrap
+    // runs). Locator wait only — no expect() under this outer await (lint).
     await page.getByTestId("project-creation-progress").waitFor({ timeout: 30_000 });
-    expect(page.url()).toContain(`/projects/${slug}`);
     await page.getByPlaceholder("Message this agent").waitFor({ timeout: 60_000 });
   });
   // After the checklist completes, welcome handoff lands on onboarding.


### PR DESCRIPTION
## Summary

- Create navigates to the project home **as soon as the project exists** (`waitUntilReady: false`) with `?welcome=true`, so users see the live creation checklist (register → integrations → repo → ready) instead of spinning on the create button until bootstrap finishes.
- After `state.ready` flips, welcome hands off to the onboarding agent.
- `/new-project` is a deep-linkable right-edge **sheet** (sidebar + projects list both open it).
- Sidebar project switcher has an explicit **Create project** menu item.

## Test plan

- [ ] Open `/new-project` (or Create project from the sidebar switcher / projects list) and confirm the form opens in a sheet
- [ ] Create a project and confirm the create button only waits for identity/birth, then lands on the project home checklist
- [ ] Confirm checklist steps tick live while bootstrap runs
- [ ] Confirm welcome handoff to `/agents/onboarding` after ready
- [ ] Close the sheet without creating and land on `/projects`
- [ ] `specs/create-project.spec.ts` covers checklist then onboarding handoff

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core post-create navigation and welcome handoff timing; mitigated by dismiss guards and updated E2E, but onboarding routing regressions are possible.
> 
> **Overview**
> Project creation no longer blocks on bootstrap finish or jumps straight to the onboarding agent. After identity exists (`waitUntilReady: false`), the app navigates to **project home** with `?welcome=true` so users see the live **creation checklist** while the saga runs; once `state.ready` flips, welcome flow **hands off** to the onboarding agent.
> 
> **`/new-project`** is a deep-linkable **right-edge sheet** (sidebar and projects list both open it). Dismiss is blocked while create or post-success navigation is in flight so Escape/overlay cannot race the redirect. The sidebar switcher adds an explicit **Create project** menu item (replacing the header plus icon).
> 
> E2E coverage now waits for `project-creation-progress` before the onboarding composer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a71d1d4a6ebe912d577cccf86fa1ab229f3aacc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +57 -20 | +39 -13 🟩🟩🟩🟩🟥 |
| UI components | +46 -31 | +26 -21 🟩🟩🟩🟥🟥 |
| Tests | +12 -9 | +1 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+115 -60** | **+66 -34** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 35a00b6 and 2a71d1d, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-17T19:58:19.780Z",
      "headSha": "2a71d1d4a6ebe912d577cccf86fa1ab229f3aacc",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/497530641823276",
      "shortSha": "2a71d1d",
      "cleanupDurationMs": 4132,
      "deployDurationMs": 19735,
      "testDurationMs": 11651,
      "testRetries": null,
      "workerSizeKib": 3949.67,
      "workerGzipKib": 804.86,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-17T19:58:16.048Z",
      "headSha": "2a71d1d4a6ebe912d577cccf86fa1ab229f3aacc",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/497530641823276",
      "shortSha": "2a71d1d",
      "cleanupDurationMs": 398,
      "deployDurationMs": 5864,
      "testDurationMs": 8370,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-17T19:58:14.767Z",
      "headSha": "2a71d1d4a6ebe912d577cccf86fa1ab229f3aacc",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/497530641823276",
      "shortSha": "2a71d1d",
      "cleanupDurationMs": 124423,
      "deployDurationMs": 88539,
      "testDurationMs": 225182,
      "testRetries": "2 retried: stream-tui.spec.ts:32:82 › Agent chat TUI connects, renders the feed, and sends (tui x1) · the seeded hello and counter apps work after creating a project (specs x1)",
      "workerSizeKib": 16730.69,
      "workerGzipKib": 4508.69,
      "mainWorkerGzipKib": 4508.91
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `2a71d1d` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 804.9 KiB | 19.7s | 11.7s |  | 4.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/497530641823276) | 2026-07-17T19:58:19.780Z | Preview app released. |
| Dummy Petshop | released | `2a71d1d` | [https://dummy-petshop.iterate-preview-7.com](https://dummy-petshop.iterate-preview-7.com) | 198.2 KiB | 5.9s | 8.4s |  | 398ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/497530641823276) | 2026-07-17T19:58:16.048Z | Preview app released. |
| OS | released | `2a71d1d` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 4.40 MiB (-0.2 KiB vs main) | 88.5s | 225.2s | 2 retried: stream-tui.spec.ts:32:82 › Agent chat TUI connects, renders the feed, and sends (tui x1) · the seeded hello and counter apps work after creating a project (specs x1) | 124.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/497530641823276) | 2026-07-17T19:58:14.767Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->