### PR TITLE
Classify stream background deployment resets

### DIFF
--- a/apps/os/src/domains/streams/stream-durable-object-background-work.test.ts
+++ b/apps/os/src/domains/streams/stream-durable-object-background-work.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { settleStreamCoreBackgroundWork } from "./stream-durable-object.ts";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("settleStreamCoreBackgroundWork", () => {
+  it("settles a deployment reset as an observed lifecycle interruption", async () => {
+    const reset = Object.assign(new Error("Durable Object reset because its code was updated."), {
+      durableObjectReset: true,
+    });
+    const info = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(
+      settleStreamCoreBackgroundWork(() => Promise.reject(reset)),
+    ).resolves.toBeUndefined();
+
+    expect(info).toHaveBeenCalledWith(
+      "stream core background work interrupted by durable object lifecycle",
+      { message: reset.message },
+    );
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it("reports an application failure exactly once while settling the waitUntil promise", async () => {
+    const failure = new Error("ancestor append rejected");
+    const info = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(
+      settleStreamCoreBackgroundWork(() => Promise.reject(failure)),
+    ).resolves.toBeUndefined();
+
+    expect(info).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledOnce();
+    expect(error).toHaveBeenCalledWith("stream core background work failed", failure);
+  });
+
+  it("also observes a synchronous application failure", async () => {
+    const failure = new Error("background work did not start");
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(
+      settleStreamCoreBackgroundWork(() => {
+        throw failure;
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(error).toHaveBeenCalledOnce();
+    expect(error).toHaveBeenCalledWith("stream core background work failed", failure);
+  });
+});

--- a/apps/os/src/domains/streams/stream-durable-object.ts
+++ b/apps/os/src/domains/streams/stream-durable-object.ts
@@ -27,7 +27,10 @@ import {
   type SubscriptionRuntimeState,
 } from "./stream-subscribers.ts";
 import { createSubscriberDial } from "./subscriber-sinks.ts";
-import { STREAM_WAIT_TIMEOUT_MESSAGE_PREFIX } from "./stream-unavailable.ts";
+import {
+  isDurableObjectLifecycleError,
+  STREAM_WAIT_TIMEOUT_MESSAGE_PREFIX,
+} from "./stream-unavailable.ts";
 import {
   CORE_STATE_VERSION,
   CoreProcessorContract,
@@ -38,6 +41,26 @@ import {
 
 const DEFAULT_GET_EVENTS_LIMIT = 500;
 const MAX_GET_EVENTS_LIMIT = 500;
+
+/**
+ * Observe fire-and-forget stream-core work without handing a rejected promise
+ * to `waitUntil`. A deployment replaces the current Durable Object
+ * incarnation and rejects its in-flight stub calls; that is a lifecycle
+ * interruption, while an application rejection remains an error.
+ */
+export async function settleStreamCoreBackgroundWork(work: () => Promise<unknown>): Promise<void> {
+  try {
+    await work();
+  } catch (error) {
+    if (isDurableObjectLifecycleError(error)) {
+      console.info("stream core background work interrupted by durable object lifecycle", {
+        message: error instanceof Error ? error.message : String(error),
+      });
+      return;
+    }
+    console.error("stream core background work failed", error);
+  }
+}
 
 /**
  * The subscription key of the birth-certificate worker feed every
@@ -893,17 +916,7 @@ export class StreamDurableObject extends DurableObject<Env> {
   }
 
   #runInBackground(work: () => Promise<unknown>): void {
-    let promise: Promise<unknown>;
-    try {
-      promise = work();
-    } catch (error) {
-      console.error("stream core background work failed", error);
-      return;
-    }
-    this.ctx.waitUntil(promise);
-    void promise.catch((error: unknown) => {
-      console.error("stream core background work failed", error);
-    });
+    this.ctx.waitUntil(settleStreamCoreBackgroundWork(work));
   }
 
   // ===========================================================================


### PR DESCRIPTION
## Why

The 2026-07-17 production cutover exposed a false error at the deployment boundary. A stream core background ancestor announcement was interrupted by a Durable Object code reset. The triggering append had already committed, and the next `stream/woken` announcement healed the idempotent ancestor fact, but `#runInBackground` handed the original rejected promise to `ctx.waitUntil` and separately observed it. Cloudflare therefore recorded both a native invocation error and our application error for an expected lifecycle interruption.

Request evidence: `HKK6A5PJDT2JTHAH`. The affected Stream Durable Object recovered on the next wake; no post-cutover stream reset errors recurred.

## What changed

- Hand `ctx.waitUntil` a promise that has already classified and observed its rejection.
- Record workerd lifecycle-flagged resets as informational interruptions.
- Continue recording application failures as errors, exactly once.
- Keep the existing idempotent next-wake healing behavior. This adds no retry, restore, backup upload, or recovery machinery.
- Leave agent crash cancellation classification unchanged so genuine agent crashes are not hidden.

## Verification

- Regression test first failed because the settling function did not exist.
- Focused stream tests: 19 passed.
- OS unit suite: 1,827 passed, 1 skipped.
- Full monorepo tests: green.
- Full monorepo typecheck: green.
- Lint: green.
- Format check: green.

## Preview acceptance

- Deploy the preview and exercise stream creation/ancestor announcement across a code deployment.
- Confirm lifecycle interruptions do not enter error telemetry.
- Confirm a synthetic application rejection remains one error.
- Confirm stream ancestry and processor progress remain coherent after the cutover.

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +25 -12 | +18 -12 🟩🟩🟥🟥⬜ |
| Tests | +52 -0 | +42 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+77 -12** | **+60 -12** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between b818642 and 1ee4e8e, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-17T21:34:21.175Z",
      "headSha": "1ee4e8ea0fd5a6845a40731d9cc1dcfbd0a97ce0",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/452755208319959",
      "shortSha": "1ee4e8e",
      "cleanupDurationMs": 2566,
      "deployDurationMs": 19895,
      "testDurationMs": 12171,
      "testRetries": null,
      "workerSizeKib": 3949.67,
      "workerGzipKib": 804.98,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-17T21:34:30.196Z",
      "headSha": "1ee4e8ea0fd5a6845a40731d9cc1dcfbd0a97ce0",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/452755208319959",
      "shortSha": "1ee4e8e",
      "cleanupDurationMs": 11585,
      "deployDurationMs": 13728,
      "testDurationMs": 58110,
      "testRetries": null,
      "workerSizeKib": 5295.85,
      "workerGzipKib": 1509.84,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-17T21:34:19.196Z",
      "headSha": "1ee4e8ea0fd5a6845a40731d9cc1dcfbd0a97ce0",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/452755208319959",
      "shortSha": "1ee4e8e",
      "cleanupDurationMs": 583,
      "deployDurationMs": 6297,
      "testDurationMs": 5814,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-17T21:34:17.668Z",
      "headSha": "1ee4e8ea0fd5a6845a40731d9cc1dcfbd0a97ce0",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/452755208319959",
      "shortSha": "1ee4e8e",
      "cleanupDurationMs": 115659,
      "deployDurationMs": 90144,
      "testDurationMs": 275469,
      "testRetries": "4 retried: Top-level RpcTarget live capabilities dispatch by member path (vitest x1) · Flattened live capabilities receive the remaining member path (vitest x1) · Worker capabilities cover project/agent, stateful/stateless, repo/inline refs and env.ITX cross-calls (vitest x1) · concurrent long-running itx scripts all complete (vitest x1)",
      "workerSizeKib": 16732.53,
      "workerGzipKib": 4509.36,
      "mainWorkerGzipKib": 4509.18
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `1ee4e8e` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 805.0 KiB | 19.9s | 12.2s |  | 2.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/452755208319959) | 2026-07-17T21:34:21.175Z | Preview app released. |
| Dummy Petshop | released | `1ee4e8e` | [https://dummy-petshop.iterate-preview-8.com](https://dummy-petshop.iterate-preview-8.com) | 198.2 KiB | 6.3s | 5.8s |  | 583ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/452755208319959) | 2026-07-17T21:34:19.196Z | Preview app released. |
| OS | released | `1ee4e8e` | [https://os.iterate-preview-8.com](https://os.iterate-preview-8.com) | 4.40 MiB (+0.2 KiB vs main) | 90.1s | 275.5s | 4 retried: Top-level RpcTarget live capabilities dispatch by member path (vitest x1) · Flattened live capabilities receive the remaining member path (vitest x1) · Worker capabilities cover project/agent, stateful/stateless, repo/inline refs and env.ITX cross-calls (vitest x1) · concurrent long-running itx scripts all complete (vitest x1) | 115.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/452755208319959) | 2026-07-17T21:34:17.668Z | Preview app released. |
| Streams Example App | released | `1ee4e8e` | [https://streams.iterate-preview-8.com](https://streams.iterate-preview-8.com) | 1.47 MiB | 13.7s | 58.1s |  | 11.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/452755208319959) | 2026-07-17T21:34:30.196Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to background error handling and logging on the Stream DO; no new retry or recovery paths, with regression tests covering the main branches.
> 
> **Overview**
> Stream core **fire-and-forget** work now goes through **`settleStreamCoreBackgroundWork`** before **`ctx.waitUntil`**, so Cloudflare never sees an unsettled rejection when a deploy resets the Durable Object mid-flight.
> 
> **Durable Object lifecycle** failures (via existing **`isDurableObjectLifecycleError`**) are logged at **info** as an expected interruption; real application failures still log **once** at **error**, including synchronous throws. **`#runInBackground`** no longer registers a separate `.catch` on the raw promise (which duplicated errors and treated deploy resets as failures).
> 
> Unit tests cover lifecycle reset vs async/sync application failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ee4e8ea0fd5a6845a40731d9cc1dcfbd0a97ce0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->