### PR TITLE
Route admin-user project creates through the org lane

### DIFF
--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -4967,6 +4967,14 @@ export class ProjectCollectionRpcTarget extends IterateRpcTarget<"ProjectCollect
    * project into the user's claims); the admin lane only needs an id. Admin
    * callers may bring their own id (test fixtures); we never mint prj_ ids
    * locally when the directory is configured.
+   *
+   * EVERY user principal takes the user lane, including platform-admin users
+   * creating from the dashboard. Admin-ness must not reroute a human create
+   * into the fixture lane: that lane mints a bare id with no org-owned
+   * directory row, so the project would never enter the creator's claims
+   * (project list, slug routes) and org members could never find it. The
+   * mint-only lane is for principal-less admin credentials (admin API secret,
+   * trusted-internal) whose fixtures live outside any customer organization.
    */
   async #registerProject(args: {
     organizationSlug?: string;
@@ -4975,7 +4983,7 @@ export class ProjectCollectionRpcTarget extends IterateRpcTarget<"ProjectCollect
   }): Promise<{ organizationId: string | null; projectId: string; slug: string }> {
     const userPrincipal = userPrincipalOf(this.props.auth);
 
-    if (userPrincipal && !this.props.auth.isAdmin()) {
+    if (userPrincipal) {
       const organizationSlug = resolveOrganizationSlugForCreate(
         userPrincipal,
         args.organizationSlug,

--- a/specs/create-project.spec.ts
+++ b/specs/create-project.spec.ts
@@ -52,9 +52,18 @@ test("a new user can create a project through the UI form", async ({ page }) => 
     // hands off to the onboarding agent. The composer is that destination's
     // structural chrome; 60s covers birth + saga + handoff.
     await page.getByRole("button", { name: "Create project" }).click({ timeout: 15_000 });
-    // Checklist is the early-land destination (project home while bootstrap
-    // runs). Locator wait only — no expect() under this outer await (lint).
-    await page.getByTestId("project-creation-progress").waitFor({ timeout: 30_000 });
+    // The checklist (project home while bootstrap runs) is the usual early-land
+    // destination — but it is TRANSIENT: `project/ready` often commits within a
+    // second of create resolving, and when the browser's navigation loses that
+    // race the home page mounts already-ready and hands off to the onboarding
+    // agent without ever painting the checklist. Accept either landing: the
+    // checklist, or the composer of the onboarding agent it hands off to.
+    // Locator wait only — no expect() under this outer await (lint).
+    await page
+      .getByTestId("project-creation-progress")
+      .or(page.getByPlaceholder("Message this agent"))
+      .first()
+      .waitFor({ timeout: 60_000 });
     await page.getByPlaceholder("Message this agent").waitFor({ timeout: 60_000 });
   });
   // After the checklist completes, welcome handoff lands on onboarding.


### PR DESCRIPTION
## What changed

`ProjectCollectionRpcTarget.#registerProject` routed on `userPrincipal && !auth.isAdmin()`, so a **signed-in platform-admin user** creating a project from the dashboard fell into the admin fixture lane: the auth worker only minted a bare `prj_` id, with `organizationId: null` and **no org-owned directory row**.

Such a project never enters anyone's claims:

- it never shows up in the creator's project list (`projects.list({scope: "mine"})` is claims-driven, and `listAccessibleProjects()` is deliberately empty for admin contexts),
- `listProjectsForUser` can't return it (it joins `member` on `project.organization_id`, which is null),
- org members can't discover it either — the KV directory prime is its only record.

The fix: **every user principal takes the user lane** (`AUTH.createProjectForOrganization`, org resolved from the explicit `organizationSlug` or the sole membership). The mint-only lane remains for principal-less admin credentials (admin API secret, trusted-internal), whose fixtures live outside any customer organization.

## Why this is safe

- The user lane is idempotent for the explicit-`projectId` path (`createProject` returns `existing` for same id+slug+org), so `getRootProjectRedirectServerFn`'s signup-bootstrap auto-create is unaffected.
- E2E fixtures create via the admin API secret (no user principal) — unchanged.
- Operator sessions: admin-kind grants resolve to the principal-less `adminPrincipal` (unchanged, mint lane); project-kind grants were already non-admin user principals (unchanged, user lane).
- An admin *user* with zero org memberships now gets the explicit "Project creation requires organization membership." error instead of silently creating an invisible project.

## How this was found

Debugging "project doesn't show up in my project list" + "Project testtesttest not found" on prd (2026-07-17 ~18:33 UTC). That incident's proximate cause was a forge-minted browser session whose claims can never refresh (auth-prd rejects forge-signed tokens with `JWKSNoMatchingKey`, and `/api/iterate-auth/session?refresh=force` returns 200 with the frozen claims). The created projects themselves were healthy and org-owned — the create had taken the user lane precisely because the minted session was *not* admin-flagged. A real session for the same user carries `role: "admin"` claims and would have hit this fixture-lane bug instead, producing a genuinely invisible project.

Follow-ups deliberately not in this PR:

- surface `/session?refresh=force` refresh/userinfo failures instead of silently returning stale claims,
- document in `scripts/auth/mint-session.ts` that minted sessions cannot refresh claims (anything created after mint stays out of the list until a real re-sign-in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes project registration routing for platform-admin dashboard creates (fixes invisible projects); behavior for principal-less admin fixtures is unchanged but the auth/create boundary is security-sensitive.
> 
> **Overview**
> **Signed-in users (including platform admins) always register new projects via the org-owned auth path** instead of skipping that when `auth.isAdmin()` is true.
> 
> `ProjectCollectionRpcTarget.#registerProject` no longer gates the user lane on `!isAdmin()`. Any human session now calls `AUTH.createProjectForOrganization`, so the directory row and claims stay aligned with the creator’s org and the project shows up in lists and slug routes. **Principal-less admin credentials** (API secret, trusted-internal) still use the mint-only fixture lane with `organizationId: null`.
> 
> Docs in the method comment spell out why admin flag must not send dashboard creates down the fixture path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82a0619dbdf6c67e8cc03eb23545fecf30045d71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +9 -1 | +1 -1 🟩🟩🟩🟥🟥 |
| **Total** | **+9 -1** | **+1 -1** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between ea13593 and 82a0619, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-17T21:17:59.162Z",
      "headSha": "82a0619dbdf6c67e8cc03eb23545fecf30045d71",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/301559681621137",
      "shortSha": "82a0619",
      "cleanupDurationMs": 2380,
      "deployDurationMs": 26773,
      "workerSizeKib": 3949.67,
      "workerGzipKib": 804.99,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-17T21:17:57.355Z",
      "headSha": "82a0619dbdf6c67e8cc03eb23545fecf30045d71",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/301559681621137",
      "shortSha": "82a0619",
      "cleanupDurationMs": 570,
      "deployDurationMs": 6230,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-17T21:17:55.677Z",
      "headSha": "b2e75603dcb75215eff0aef88bc3d54e27447545",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/239511745125719",
      "shortSha": "b2e7560",
      "cleanupDurationMs": 69654,
      "deployDurationMs": 96830,
      "testDurationMs": 227945,
      "testRetries": "5 retried: ephemeral events are raw-readable and delivered live, but never replayed to a later subscription (vitest x1) · stream-tui.spec.ts:32:82 › Agent chat TUI connects, renders the feed, and sends (tui x1, still failed) · a new user can create a project through the UI form (specs x1, still failed) · reactivity page appends a batch and renders every delivered marker (specs x1) · the seeded hello and counter apps work after creating a project (specs x1)",
      "workerSizeKib": 16732.52,
      "workerGzipKib": 4509.29,
      "mainWorkerGzipKib": 4509.14
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-17T21:18:13.480Z",
      "headSha": "82a0619dbdf6c67e8cc03eb23545fecf30045d71",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/301559681621137",
      "shortSha": "82a0619",
      "cleanupDurationMs": 16694,
      "deployDurationMs": 32585,
      "workerSizeKib": 5295.88,
      "workerGzipKib": 1509.87,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `82a0619` | [https://auth.iterate-preview-6.com](https://auth.iterate-preview-6.com) | 805.0 KiB | 26.8s |  |  | 2.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/301559681621137) | 2026-07-17T21:17:59.162Z | Preview app released. |
| Dummy Petshop | released | `82a0619` | [https://dummy-petshop.iterate-preview-6.com](https://dummy-petshop.iterate-preview-6.com) | 198.2 KiB | 6.2s |  |  | 570ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/301559681621137) | 2026-07-17T21:17:57.355Z | Preview app released. |
| OS | released | `b2e7560` | [https://os.iterate-preview-6.com](https://os.iterate-preview-6.com) | 4.40 MiB (+0.1 KiB vs main) | 96.8s | 227.9s | 5 retried: ephemeral events are raw-readable and delivered live, but never replayed to a later subscription (vitest x1) · stream-tui.spec.ts:32:82 › Agent chat TUI connects, renders the feed, and sends (tui x1, still failed) · a new user can create a project through the UI form (specs x1, still failed) · reactivity page appends a batch and renders every delivered marker (specs x1) · the seeded hello and counter apps work after creating a project (specs x1) | 69.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/239511745125719) | 2026-07-17T21:17:55.677Z | Preview app released. |
| Streams Example App | released | `82a0619` | [https://streams.iterate-preview-6.com](https://streams.iterate-preview-6.com) | 1.47 MiB | 32.6s |  |  | 16.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/301559681621137) | 2026-07-17T21:18:13.480Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->