### PR TITLE
fix(os): make event inspector arrow keys work inside sheet

### DIFF
--- a/apps/os/src/components/raw-event-inspector-panel.test.tsx
+++ b/apps/os/src/components/raw-event-inspector-panel.test.tsx
@@ -68,13 +68,59 @@ test("retained exit content cannot navigate and reopen the raw-event inspector",
   };
 
   await render(true);
-  window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight" }));
+  window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
   expect(onNavigate).toHaveBeenCalledWith(3);
 
   onNavigate.mockClear();
   await render(false);
-  window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight" }));
+  window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
   host.querySelectorAll("button")[1]?.click();
   expect(onNavigate).not.toHaveBeenCalled();
   expect([...host.querySelectorAll("button")].every((button) => button.disabled)).toBe(true);
+});
+
+test("arrow keys still page when a Base UI sheet would stopPropagation on bubble", async () => {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  mountedRoots.push(root);
+  const onNavigate = vi.fn();
+
+  await act(async () => {
+    root.render(
+      <RawEventInspectorContent
+        database={{} as never}
+        navigationEnabled
+        offset={2}
+        onNavigate={onNavigate}
+      />,
+    );
+  });
+
+  // Mimic @base-ui/react DialogPopup: composite keys are stopPropagated on the
+  // popup so nested composites do not leak. A bubble-only window listener never
+  // sees the event; capture-phase is required.
+  const stopCompositeKeys = (event: KeyboardEvent) => {
+    if (event.key === "ArrowLeft" || event.key === "ArrowRight") event.stopPropagation();
+  };
+  host.addEventListener("keydown", stopCompositeKeys);
+
+  const nextButton = host.querySelectorAll("button")[1];
+  expect(nextButton).toBeTruthy();
+  nextButton?.focus();
+  nextButton?.dispatchEvent(
+    new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true, cancelable: true }),
+  );
+  expect(onNavigate).toHaveBeenCalledWith(3);
+
+  onNavigate.mockClear();
+  const prevButton = host.querySelectorAll("button")[0];
+  prevButton?.focus();
+  prevButton?.dispatchEvent(
+    new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true, cancelable: true }),
+  );
+  expect(onNavigate).toHaveBeenCalledWith(1);
+
+  host.removeEventListener("keydown", stopCompositeKeys);
+  host.remove();
 });

--- a/apps/os/src/components/raw-event-inspector-panel.test.tsx
+++ b/apps/os/src/components/raw-event-inspector-panel.test.tsx
@@ -81,7 +81,7 @@ test("retained exit content cannot navigate and reopen the raw-event inspector",
 
 test("arrow keys still page when a Base UI sheet would stopPropagation on bubble", async () => {
   const host = document.createElement("div");
-  document.body.append(host);
+  document.body.appendChild(host);
   const root = createRoot(host);
   mountedRoots.push(root);
   const onNavigate = vi.fn();

--- a/apps/os/src/components/raw-event-inspector-panel.tsx
+++ b/apps/os/src/components/raw-event-inspector-panel.tsx
@@ -85,8 +85,12 @@ export function RawEventInspectorContent({
         navigate(nextOffset);
       }
     };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
+    // Capture phase: Base UI's DialogPopup (our Sheet) stopPropagates composite
+    // keys (← → ↑ ↓ Home End) on the popup so nested composites stay isolated.
+    // A bubble-only window listener never sees those keydowns while the sheet
+    // is open — which is exactly when this inspector is mounted.
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
   }, [navigationEnabled]);
 
   // Parse + reorder only when the underlying row changes, not on every render:


### PR DESCRIPTION
## Summary

- Left/right arrow keys on the raw event details sheet did nothing (Prev/Next buttons still worked).
- Root cause: Base UI `DialogPopup` (our `Sheet`) `stopPropagation()`s composite keys (`← → ↑ ↓ Home End`) so nested composites do not leak. The inspector only listened on `window` in the **bubble** phase, so those keydowns never arrived.
- Fix: register the key handler in the **capture** phase. Editable inputs/textareas are still skipped via `isTypingTarget`.

## Repro (prod)

1. Open https://os.iterate.com/projects/iterate/agents/streams/agents/repos/config/pr/10?mode=pretty-raw&event=17
2. With the sheet open (focus on Close / header is fine), press `→` or `←`
3. **Before:** URL stays on the same `event=`; **After:** pages to the neighbour offset
4. Prev/Next buttons already worked; they remain unchanged

## Test plan

- [x] Unit test: arrows still navigate when an ancestor stops composite-key propagation (Base UI sheet behaviour)
- [x] Unit test: retained exit content still cannot navigate
- [ ] Manually verify on preview or local: open `?event=N`, press `←`/`→`, confirm URL and payload update

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small event-listener phase change in the OS raw event inspector with unit coverage; no auth, data, or API surface changes.
> 
> **Overview**
> **Fixes left/right arrow paging** on the raw event details sheet when it is open inside Base UI’s `Sheet` (`DialogPopup`), where composite keys are `stopPropagation()`’d on the popup so bubble-phase listeners never see them.
> 
> The inspector’s window `keydown` handler is registered in the **capture** phase instead of bubble, so `←`/`→` still call `onNavigate` for prev/next offsets. Existing guards remain: modifier keys and typing targets (`isTypingTarget`) are ignored; Prev/Next buttons are unchanged.
> 
> Tests now dispatch bubbling key events and add a case that simulates an ancestor stopping arrow-key propagation, asserting navigation still works.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daf0912761d96f8d619211aa141ecddf1aa490d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| UI components | +6 -2 | +2 -2 🟩⬜⬜⬜⬜ |
| Tests | +48 -2 | +39 -2 🟩🟩🟩🟩🟩 |
| **Total** | **+54 -4** | **+41 -4** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between c8025c1 and daf0912, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-17T21:13:28.164Z",
      "headSha": "daf0912761d96f8d619211aa141ecddf1aa490d7",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/557590520470179",
      "shortSha": "daf0912",
      "cleanupDurationMs": 2160,
      "deployDurationMs": 17107,
      "testDurationMs": 4688,
      "testRetries": null,
      "workerSizeKib": 3949.67,
      "workerGzipKib": 804.89,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-17T21:13:26.619Z",
      "headSha": "daf0912761d96f8d619211aa141ecddf1aa490d7",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/557590520470179",
      "shortSha": "daf0912",
      "cleanupDurationMs": 614,
      "deployDurationMs": 6034,
      "testDurationMs": 5212,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-17T21:13:24.965Z",
      "headSha": "daf0912761d96f8d619211aa141ecddf1aa490d7",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/557590520470179",
      "shortSha": "daf0912",
      "cleanupDurationMs": 139201,
      "deployDurationMs": 90582,
      "testDurationMs": 215151,
      "testRetries": "2 retried: stream-tui.spec.ts:32:82 › Agent chat TUI connects, renders the feed, and sends (tui x1, still failed) · a new user can create a project through the UI form (specs x1, still failed)",
      "workerSizeKib": 16732.04,
      "workerGzipKib": 4509.15,
      "mainWorkerGzipKib": 4509.18
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `daf0912` | [https://auth.iterate-preview-4.com](https://auth.iterate-preview-4.com) | 804.9 KiB | 17.1s | 4.7s |  | 2.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/557590520470179) | 2026-07-17T21:13:28.164Z | Preview app released. |
| Dummy Petshop | released | `daf0912` | [https://dummy-petshop.iterate-preview-4.com](https://dummy-petshop.iterate-preview-4.com) | 198.2 KiB | 6.0s | 5.2s |  | 614ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/557590520470179) | 2026-07-17T21:13:26.619Z | Preview app released. |
| OS | released | `daf0912` | [https://os.iterate-preview-4.com](https://os.iterate-preview-4.com) | 4.40 MiB (-0.0 KiB vs main) | 90.6s | 215.2s | 2 retried: stream-tui.spec.ts:32:82 › Agent chat TUI connects, renders the feed, and sends (tui x1, still failed) · a new user can create a project through the UI form (specs x1, still failed) | 139.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/557590520470179) | 2026-07-17T21:13:24.965Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->