### PR TITLE
Surface stale session claims when a forced refresh yields nothing

### DIFF
--- a/apps/auth/src/lib/client.ts
+++ b/apps/auth/src/lib/client.ts
@@ -78,6 +78,16 @@ export function createIterateAuthClient(config: IterateAuthClientConfig = {}) {
 
     if (!response.ok) return { authenticated: false };
 
+    if (response.headers.get("x-iterate-auth-stale-refresh")) {
+      // The server could not mint fresh tokens and served the cookie's old
+      // claims. Minted sessions (auth:mint) can never refresh — anything
+      // created after mint (organizations, projects) stays invisible until a
+      // real sign-in. The server log carries the exact reason.
+      console.warn(
+        "[iterate-auth] session refresh produced no fresh tokens; claims may be stale. Sign in again to pick up new organizations/projects.",
+      );
+    }
+
     return (await response.json()) as SessionResponse;
   }
 

--- a/apps/auth/src/lib/server.ts
+++ b/apps/auth/src/lib/server.ts
@@ -735,6 +735,7 @@ export function createAuthHandler(config: IterateAuthConfig, infra: OAuthInfra) 
     let tokenSet = getTokenSet(c);
     const forceRefresh = c.req.query("refresh") === "force";
     let refreshed = false;
+    let staleRefreshReason: string | null = null;
     if (
       tokenSet &&
       tokenSet.refreshToken &&
@@ -747,12 +748,18 @@ export function createAuthHandler(config: IterateAuthConfig, infra: OAuthInfra) 
           tokenSet = refreshedTokenSet;
           refreshed = true;
         }
-      } catch {
+      } catch (error) {
         if (accessTokenExpired) {
           deleteCookie(c, SESSION_COOKIE, cookieOpts());
           return c.json({ authenticated: false } satisfies SessionResponse, 401);
         }
+        staleRefreshReason = error instanceof Error ? error.message : String(error);
       }
+    } else if (tokenSet && forceRefresh) {
+      // A session cookie without a refresh token (minted sessions —
+      // scripts/auth/mint-session.ts) can never pick up new claims: whatever
+      // orgs/projects it was minted with is all it will ever carry.
+      staleRefreshReason = "session has no refresh token; claims are frozen at mint time";
     }
 
     if (!tokenSet || !tokenSet.idToken) {
@@ -798,6 +805,22 @@ export function createAuthHandler(config: IterateAuthConfig, infra: OAuthInfra) 
       return c.json({ authenticated: false } satisfies SessionResponse, 401);
     }
 
+    if (staleRefreshReason !== null && !refreshed) {
+      // A refresh that produced no fresh tokens is invisible in the 200 body:
+      // the caller asked for current claims and got the cookie's old ones. Say
+      // so — the header lets fetchSession warn in the browser console, the log
+      // makes frozen-claims incidents greppable (a silent variant of this
+      // presented as "created project missing from the project list",
+      // 2026-07-17 prd).
+      console.warn(
+        "[iterate-auth] session refresh produced no fresh tokens; serving existing claims",
+        {
+          forced: forceRefresh,
+          reason: staleRefreshReason,
+        },
+      );
+      c.header("x-iterate-auth-stale-refresh", "1");
+    }
     writeCookie(c, tokenSet);
     return c.json({
       authenticated: true,

--- a/apps/os/src/auth/iterate-auth-login.test.ts
+++ b/apps/os/src/auth/iterate-auth-login.test.ts
@@ -150,12 +150,47 @@ describe("iterate auth login", () => {
 
     expect(doRefresh).toHaveBeenCalledTimes(1);
     expect(response.status).toBe(200);
+    // Served claims are the cookie's old ones — the response says so.
+    expect(response.headers.get("x-iterate-auth-stale-refresh")).toBe("1");
     await expect(response.json()).resolves.toMatchObject({
       authenticated: true,
       user: {
         id: "usr_session",
       },
     });
+  });
+
+  test("flags a forced refresh on a session with no refresh token (minted sessions)", async () => {
+    const signed = await signedTokenSet({
+      accessTokenExpiresAt: Date.now() + 60 * 60 * 1000,
+      refreshToken: undefined,
+    });
+    const doRefresh = vi.fn(async (current: TokenSet) => current);
+    const handler = testAuthHandler(config, {
+      doRefresh,
+      jwks: signed.jwks as never,
+    });
+
+    const forced = await handler(
+      new Request("http://localhost:65455/api/iterate-auth/session?refresh=force", {
+        headers: { cookie: sessionCookie(signed.tokenSet) },
+      }),
+    );
+
+    expect(doRefresh).not.toHaveBeenCalled();
+    expect(forced.status).toBe(200);
+    expect(forced.headers.get("x-iterate-auth-stale-refresh")).toBe("1");
+    await expect(forced.json()).resolves.toMatchObject({ authenticated: true });
+
+    // A plain read is not a refresh request: no flag, no log noise — minted
+    // sessions hit this endpoint constantly.
+    const plain = await handler(
+      new Request("http://localhost:65455/api/iterate-auth/session", {
+        headers: { cookie: sessionCookie(signed.tokenSet) },
+      }),
+    );
+    expect(plain.status).toBe(200);
+    expect(plain.headers.get("x-iterate-auth-stale-refresh")).toBeNull();
   });
 
   test("reports non-fatal refresh failures while returning a valid session", async () => {

--- a/scripts/auth/mint-session.ts
+++ b/scripts/auth/mint-session.ts
@@ -32,6 +32,15 @@ import { forgedSubjectForEmail, mintForgedAccessToken, mintForgedIdToken } from 
 //   2. browserSignInUrl — navigate any browser (Playwright/agent-browser) to
 //      it once; it sets the normal session cookie and redirects
 //   3. as a cookie session via /api/iterate-auth/session-from-token directly
+//
+// LIMITATION — claims are FROZEN at mint time. Minted sessions carry no
+// refresh token, and the auth worker rejects forge-signed tokens at its
+// userinfo/token endpoints (the forge key is not in its JWKS), so the session
+// can never re-mint claims. Anything created after mint (organizations,
+// projects) stays invisible to the session — e.g. a project created through
+// the UI never appears in the minted session's project list — until a real
+// sign-in. `/session?refresh=force` flags this with the
+// `x-iterate-auth-stale-refresh` header and a browser-console warning.
 
 const { values: args } = parseArgs({
   options: {


### PR DESCRIPTION
## What changed

When `/api/iterate-auth/session?refresh=force` cannot produce fresh tokens, it now says so instead of silently returning 200 with the cookie's old claims:

- **Server** (`apps/auth/src/lib/server.ts`): tracks why a refresh produced nothing — `doRefresh` threw while the access token was still valid, or the session has **no refresh token at all** (minted sessions from `scripts/auth/mint-session.ts`, which previously skipped the refresh block without a trace). Both paths log a `console.warn` with the reason and set `x-iterate-auth-stale-refresh: 1` on the 200 response. Plain (non-forced) reads of a no-refresh-token session are deliberately not flagged — minted sessions hit `/session` constantly and that would be pure noise.
- **Client** (`apps/auth/src/lib/client.ts`): `fetchSession` warns in the browser console when the header is present, so "I created a project and it's not in my list" shows its cause right where the user is looking.
- **Docs** (`scripts/auth/mint-session.ts`): header now states the limitation — minted sessions cannot refresh; claims are frozen at mint time; anything created after mint stays invisible to that session until a real sign-in.

## Why

Follow-up to #2100's investigation (2026-07-17 prd): a forge-minted browser session's forced refreshes failed at auth-prd (`JWKSNoMatchingKey`) yet `/session?refresh=force` kept answering 200 with mint-time claims, so newly created projects never appeared in the project list and there was zero signal anywhere. This turns that silent failure mode into a server log line + browser console warning.

## Tests

`apps/os/src/auth/iterate-auth-login.test.ts`:
- extended "keeps a still-valid session when forced refresh fails" to assert the header,
- new "flags a forced refresh on a session with no refresh token (minted sessions)" — asserts the flag on forced reads and its absence on plain reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and response-header signaling on an existing session endpoint; behavior for expired tokens and successful refresh is unchanged.
> 
> **Overview**
> When **`/session?refresh=force`** cannot obtain fresh tokens but still returns **200** with the cookie’s existing JWT claims, the auth handler now records **why** refresh failed (OAuth refresh error while the access token is still valid, or **no refresh token** on minted sessions) and exposes that instead of failing silently.
> 
> The server sets **`x-iterate-auth-stale-refresh: 1`** and **`console.warn`** with the reason only when a refresh was attempted or forced and no new tokens were issued; plain **`/session`** reads on minted sessions stay unflagged to avoid noise. **`fetchSession`** in the auth client logs a matching browser warning when that header is present. **`mint-session.ts`** documents that minted claims are frozen until a real sign-in.
> 
> Tests assert the header on failed forced refresh and on forced refresh without a refresh token, and its absence on non-forced session reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47acd5ef93e466e91ff6d4f5505ca25b88f9a484. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +34 -1 | +20 -1 🟩🟩🟩🟩⬜ |
| Tests | +35 -0 | +28 -0 🟩🟩🟩🟩🟩 |
| CI & scripts | +9 -0 | +0 -0 ⬜⬜⬜⬜⬜ |
| **Total** | **+78 -1** | **+48 -1** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 6c145a7 and 47acd5e, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-17T21:48:46.797Z",
      "headSha": "47acd5ef93e466e91ff6d4f5505ca25b88f9a484",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/459184973470302",
      "shortSha": "47acd5e",
      "cleanupDurationMs": 1921,
      "deployDurationMs": 17501,
      "workerSizeKib": 3949.67,
      "workerGzipKib": 805.08,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-17T21:48:45.322Z",
      "headSha": "47acd5ef93e466e91ff6d4f5505ca25b88f9a484",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/459184973470302",
      "shortSha": "47acd5e",
      "cleanupDurationMs": 444,
      "deployDurationMs": 5596,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `47acd5e` | [https://auth.iterate-preview-4.com](https://auth.iterate-preview-4.com) | 805.1 KiB | 17.5s |  |  | 1.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/459184973470302) | 2026-07-17T21:48:46.797Z | Preview app released. |
| Dummy Petshop | released | `47acd5e` | [https://dummy-petshop.iterate-preview-4.com](https://dummy-petshop.iterate-preview-4.com) | 198.2 KiB | 5.6s |  |  | 444ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/459184973470302) | 2026-07-17T21:48:45.322Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->