### PR TITLE
Expire a worker's cannot-accept-identity verdict with the build that earned it

### DIFF
--- a/apps/os/src/domains/workers/stateful-worker-durable-object.ts
+++ b/apps/os/src/domains/workers/stateful-worker-durable-object.ts
@@ -176,22 +176,27 @@ export class StatefulWorkerDurableObject extends DurableObject<Env> {
     this.ctx.abort("kill requested");
   }
 
-  /** The one ref whose identity this incarnation already delivered (JSON) —
-   * re-delivered when the caller's ref changes so a stashed inline recipe
-   * converges on current source. */
+  /** The (build version, ref) whose identity this incarnation already
+   * delivered — re-delivered when either changes, so a stashed inline recipe
+   * converges on current source and a rebuilt class that newly accepts
+   * identity gets it without waiting for an eviction. */
   #identityDelivered: string | undefined;
 
   async #facet(ref: StatefulDynamicWorkerRef, buildBudgetMs?: number): Promise<unknown> {
     const facet = await this.#resolveFacet(ref, buildBudgetMs);
     // A facet cannot learn its own identity (ctx.facets.get has no props
     // channel, worker env is per-isolate) — deliver its ref before any
-    // traffic, once per incarnation per ref. The stash is what lets the
-    // worker's own code address itself (the SDK's alarm shim dials
+    // traffic, once per incarnation per ref AND BUILD. The stash is what
+    // lets the worker's own code address itself (the SDK's alarm shim dials
     // `itx.workers.get(ref)`, which resolves back to this DO). Marked
     // delivered only on success (or on a class that structurally cannot
     // accept identity), so a TRANSIENT failure retries on the next call
-    // instead of silently disabling self-alarms for the incarnation.
-    const identity = JSON.stringify(ref);
+    // instead of silently disabling self-alarms for the incarnation. The
+    // version marker in the key is what makes a "cannot accept" verdict
+    // expire with the build that earned it: a repo-backed ref's JSON never
+    // changes, but a rebuilt source that newly extends IterateDurableObject
+    // must get its identity without waiting for this DO's eviction.
+    const identity = `${this.ctx.storage.kv.get<string>(VERSION_STORAGE_KEY) ?? ""}\n${JSON.stringify(ref)}`;
     if (this.#identityDelivered !== identity) {
       try {
         await invokeFlattenedPath({ args: [ref], path: ["__stashSelfRef"], target: facet });


### PR DESCRIPTION
Follow-up to #2108, addressing the Bugbot thread that landed as it merged: the identity-delivery skip was keyed on ref JSON alone, which never changes for repo-backed refs — so a worker class that upgraded to `IterateDurableObject` after a warm host marked it "cannot accept identity" stayed skipped (self-alarms dead) until the hosting DO happened to be evicted. Same trap via stale-while-rebuild when an old facet answers first.

Fix: fold the parent's facet **version marker** (which moves exactly when the source does) into the delivery key, so a rebuild re-offers identity. One line plus comments; alarm e2e green locally (24.7s), full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to identity-delivery deduplication in the stateful worker host; improves alarm/self-address correctness without touching auth or data paths.
> 
> **Overview**
> Fixes a bug where **self-ref identity** (`__stashSelfRef`) was only retried when the worker **ref** JSON changed. Repo-backed refs stay constant, so a warm hosting DO could permanently skip identity delivery after an old build failed or was deemed unable to accept it—breaking **self-alarms** until the outer DO was evicted (including under **stale-while-rebuild** when an old facet answered first).
> 
> The delivery dedupe key in `#facet` now combines the durable **facet version marker** (`VERSION_STORAGE_KEY`) with the ref JSON, so any source rebuild changes the key and **re-offers** identity. A class that upgrades to `IterateDurableObject` on a new build gets its ref stashed without waiting for eviction. Comments on `#identityDelivered` and `#facet` document the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f1f5d093951d33cf0b0bb4c75a20f4ee38804a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +12 -7 | +1 -1 🟩🟩🟩🟥🟥 |
| **Total** | **+12 -7** | **+1 -1** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between e1c2306 and 3f1f5d0, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-17T23:16:17.492Z",
      "headSha": "3f1f5d093951d33cf0b0bb4c75a20f4ee38804a7",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/433515971482630",
      "shortSha": "3f1f5d0",
      "cleanupDurationMs": 2424,
      "deployDurationMs": 22446,
      "testDurationMs": 11909,
      "testRetries": null,
      "workerSizeKib": 3949.67,
      "workerGzipKib": 804.98,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-17T23:16:15.612Z",
      "headSha": "3f1f5d093951d33cf0b0bb4c75a20f4ee38804a7",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/433515971482630",
      "shortSha": "3f1f5d0",
      "cleanupDurationMs": 541,
      "deployDurationMs": 7306,
      "testDurationMs": 5970,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-17T23:16:14.113Z",
      "headSha": "3f1f5d093951d33cf0b0bb4c75a20f4ee38804a7",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/433515971482630",
      "shortSha": "3f1f5d0",
      "cleanupDurationMs": 122170,
      "deployDurationMs": 91441,
      "testDurationMs": 216688,
      "testRetries": "5 retried: catalogue example \"scheduler-basics\" runs identically across runtimes (vitest x1) · Agent scripts can send web-chat messages (with file attachments) and call project tools (vitest x1) · runScript caps an in-script sandbox timeout to its absolute deadline and kills the process group (vitest x1) · a lost ancestor announcement heals on the stream's next wake (vitest x1) · the seeded internal app authenticates a real project member (specs x1)",
      "workerSizeKib": 16752.19,
      "workerGzipKib": 4514.95,
      "mainWorkerGzipKib": 4514.88
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `3f1f5d0` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 805.0 KiB | 22.4s | 11.9s |  | 2.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/433515971482630) | 2026-07-17T23:16:17.492Z | Preview app released. |
| Dummy Petshop | released | `3f1f5d0` | [https://dummy-petshop.iterate-preview-7.com](https://dummy-petshop.iterate-preview-7.com) | 198.2 KiB | 7.3s | 6.0s |  | 541ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/433515971482630) | 2026-07-17T23:16:15.612Z | Preview app released. |
| OS | released | `3f1f5d0` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 4.41 MiB (+0.1 KiB vs main) | 91.4s | 216.7s | 5 retried: catalogue example "scheduler-basics" runs identically across runtimes (vitest x1) · Agent scripts can send web-chat messages (with file attachments) and call project tools (vitest x1) · runScript caps an in-script sandbox timeout to its absolute deadline and kills the process group (vitest x1) · a lost ancestor announcement heals on the stream's next wake (vitest x1) · the seeded internal app authenticates a real project member (specs x1) | 122.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/433515971482630) | 2026-07-17T23:16:14.113Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->