### PR TITLE
Warm the typechecker and capability scope at host boot

### DIFF
--- a/apps/os/src/domains/capability-host/capability-host-durable-object.ts
+++ b/apps/os/src/domains/capability-host/capability-host-durable-object.ts
@@ -90,6 +90,30 @@ export class CapabilityHostDurableObject extends DurableObject<Env> {
   // reads via #processorReads) goes through the runner's committed progress.
   readonly #reads = this.#registry.reads(this.#capabilityHostProcessor);
 
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    this.#warmBoot();
+  }
+
+  /**
+   * Overlap this scope's cold activation with whatever woke the object: warm
+   * the typechecker sidecar's wasm compiler, and pre-read this scope's
+   * capability descriptions — journal catch-up plus the one fallback-host
+   * dial, exactly the data the first script's typecheck gate needs.
+   * DELIBERATELY fire-and-forget: no verb awaits it and a failure only logs.
+   * Consumers re-do this work on demand and merely pay the cold cost warmup
+   * failed to hide; gating verbs on a cached warmup rejection would let one
+   * transient sidecar error brick the whole incarnation.
+   */
+  #warmBoot(): void {
+    this.env.TYPECHECKER.warm().catch((error: unknown) => {
+      console.warn("[capability-host] typechecker warmup failed", { error });
+    });
+    this.#capabilityHostProcessor.describeCapabilities().catch((error: unknown) => {
+      console.warn("[capability-host] capability description warmup failed", { error });
+    });
+  }
+
   /** The processor's runner-backed fold reads — lazy closures because #reads
    * is built from the registered processor above; the explicit return type
    * breaks the field-initializer inference cycle. */

--- a/apps/os/src/domains/capability-host/capability-host-durable-object.ts
+++ b/apps/os/src/domains/capability-host/capability-host-durable-object.ts
@@ -98,12 +98,12 @@ export class CapabilityHostDurableObject extends DurableObject<Env> {
   /**
    * Overlap this scope's cold activation with whatever woke the object: warm
    * the typechecker sidecar's wasm compiler, and pre-read this scope's
-   * capability descriptions — journal catch-up plus the one fallback-host
-   * dial, exactly the data the first script's typecheck gate needs.
-   * DELIBERATELY fire-and-forget: no verb awaits it and a failure only logs.
-   * Consumers re-do this work on demand and merely pay the cold cost warmup
-   * failed to hide; gating verbs on a cached warmup rejection would let one
-   * transient sidecar error brick the whole incarnation.
+   * capability descriptions — the runner's load (refold if stale) plus, once
+   * born, the one fallback-host dial: the exact read the first script's
+   * typecheck gate performs. DELIBERATELY fire-and-forget: no verb awaits it
+   * and a failure only logs. Consumers re-do this work on demand and merely
+   * pay the cold cost warmup failed to hide; gating verbs on a cached warmup
+   * rejection would let one transient sidecar error brick the incarnation.
    */
   #warmBoot(): void {
     this.env.TYPECHECKER.warm().catch((error: unknown) => {

--- a/apps/os/src/domains/typecheck/run-typecheck.ts
+++ b/apps/os/src/domains/typecheck/run-typecheck.ts
@@ -12,6 +12,16 @@ import { listOpenApiOperations } from "../itx/openapi-types.ts";
 /** One compiler diagnostic — tswasm's own shape (aliased so nothing drifts). */
 export type TypecheckDiagnostic = import("tswasm").Diagnostic;
 
+/**
+ * The `warm()` probe: one trivial file that must compile clean with ZERO
+ * network fetches — warmup fires on every capability-host wake, so an import
+ * sneaking in here would turn fleet-wide wakes into registry traffic. That
+ * invariant is pinned by a test in virtual-project.test.ts.
+ */
+export const TYPECHECKER_WARMUP_FILES: Record<string, string> = {
+  "/warmup.ts": "export const warm: number = 1;\n",
+};
+
 /** What a check returns: diagnostics plus acquisition notes (npm budget
  * trips, download failures) — without the notes, a budget-tripped package
  * reads as a plain "Cannot find module" typo. */

--- a/apps/os/src/domains/typecheck/typechecker-entrypoint.ts
+++ b/apps/os/src/domains/typecheck/typechecker-entrypoint.ts
@@ -8,7 +8,7 @@ import { createCachedFetch } from "@iterate-com/typm/cached-fetch";
 // CANNOT be one: esbuild-wasm + tswasm gzip to ~11 MiB, over Cloudflare's
 // 10 MiB compressed script limit (upload rejected, error 10027).
 import typescriptWasm from "tswasm/tswasm.wasm";
-import { runTypecheck, type TypecheckResult } from "./run-typecheck.ts";
+import { runTypecheck, TYPECHECKER_WARMUP_FILES, type TypecheckResult } from "./run-typecheck.ts";
 import { createCompilerCache } from "./compiler-cache.ts";
 
 /** The whole input is inert data: a virtual file map. The checker holds no
@@ -62,7 +62,7 @@ export class TypecheckerEntrypoint extends WorkerEntrypoint {
    * otherwise land inside a user's first script.
    */
   async warm(): Promise<void> {
-    await this.check({ files: { "/warmup.ts": "export const warm: number = 1;\n" } });
+    await this.check({ files: TYPECHECKER_WARMUP_FILES });
   }
 
   async check(input: {

--- a/apps/os/src/domains/typecheck/typechecker-entrypoint.ts
+++ b/apps/os/src/domains/typecheck/typechecker-entrypoint.ts
@@ -54,6 +54,17 @@ export class TypecheckerEntrypoint extends WorkerEntrypoint {
     return Response.json({ worker: "os-typechecker" }, { status: 404 });
   }
 
+  /**
+   * Idempotently pre-pay this isolate's cold cost: instantiate the shared
+   * wasm compiler and push one trivial no-network file through the same lane
+   * real checks use, crash-reset included. On a warm isolate this is ~free;
+   * on a cold one it absorbs the multi-hundred-ms wasm activation that would
+   * otherwise land inside a user's first script.
+   */
+  async warm(): Promise<void> {
+    await this.check({ files: { "/warmup.ts": "export const warm: number = 1;\n" } });
+  }
+
   async check(input: {
     files: Record<string, string>;
     entrypoint?: string;

--- a/apps/os/src/domains/typecheck/virtual-project.test.ts
+++ b/apps/os/src/domains/typecheck/virtual-project.test.ts
@@ -12,7 +12,7 @@ import { beforeAll, expect, test } from "vitest";
 import type { CapabilityDescription } from "../itx/describe.ts";
 import { openApiCapabilityTypeReference } from "../itx/capability-type-declarations.ts";
 import type { CompileFn } from "./run-typecheck.ts";
-import { runTypecheck, npmPackagesMentioned } from "./run-typecheck.ts";
+import { runTypecheck, npmPackagesMentioned, TYPECHECKER_WARMUP_FILES } from "./run-typecheck.ts";
 import {
   checkCapabilityTypes,
   checkItxScript,
@@ -126,6 +126,15 @@ const WEATHER_MOUNT: CapabilityDescription = {
   instructions: "Three-day forecasts.",
   types: "export type Forecast = { forecast(input: { city: string }): Promise<string> };",
 };
+
+test("the warmup probe compiles clean with zero network fetches", async () => {
+  // warm() fires on every capability-host wake; an import creeping into the
+  // probe would turn fleet-wide wakes into registry traffic.
+  fetchedUrls = [];
+  const result = await typechecker.check({ files: TYPECHECKER_WARMUP_FILES });
+  expect(result.diagnostics).toEqual([]);
+  expect(fetchedUrls).toEqual([]);
+});
 
 test("the platform surface compiles clean without eagerly loading Octokit's package graph", async () => {
   fetchedUrls = [];

--- a/apps/os/src/env.ts
+++ b/apps/os/src/env.ts
@@ -63,9 +63,10 @@ export interface Env {
   /**
    * The typechecker sidecar (src/typechecker.ts): compiles virtual TypeScript
    * projects and returns diagnostics, behind provide-time capability-types
-   * validation and `itx.docs.typecheck`. The only script carrying the
-   * TypeScript compiler (tswasm, ~30MB wasm) — same quarantine story as
-   * BUILDER.
+   * validation and `itx.docs.typecheck`; `warm()` idempotently pre-pays the
+   * isolate's wasm activation (capability hosts fire it at boot). The only
+   * script carrying the TypeScript compiler (tswasm, ~30MB wasm) — same
+   * quarantine story as BUILDER.
    */
   TYPECHECKER: Service<
     import("./domains/typecheck/typechecker-entrypoint.ts").TypecheckerEntrypoint


### PR DESCRIPTION
## What / why

Mini-PR 2 from the #2039 drawing-board series (after #2107). The `runScript` cold column on prd is ~1.5–2s, and a large serial chunk of it is pure activation, not work: the typechecker sidecar's ~30MB tswasm compiler instantiates inside the first script's typecheck gate, and the scope's first capability read pays journal catch-up plus the fallback-host dial at the same moment.

## Fix

- `TypecheckerEntrypoint.warm()`: idempotently pre-pays the isolate's cold cost by pushing one trivial no-network file through the exact `check()` lane (crash-reset semantics included, no new machinery). Warm calls are ~free.
- The capability host DO constructor fires `warm()` and a `describeCapabilities()` pre-read **fire-and-forget**, overlapping cold activation with whatever woke the object (stream delivery, a first RPC).
- **Deliberately not a gate.** No verb awaits warmup; failures only log. This is the explicit lesson from the #2039 review: gating verbs on a cached warmup rejection lets one transient sidecar error brick the whole incarnation. Consumers simply re-do the work on demand and pay the cold cost warmup failed to hide.

+39/−3 across 3 files. No contract or behavior change — a pure latency overlay.

## Validation

- `pnpm typecheck`, `pnpm lint`, `pnpm format`, `pnpm knip`: clean.
- `pnpm test`: all workspaces green (os: 196 files).
- A same-slot preview A/B benchmark (old vs new deploy, cold `runScript`) will be posted on this PR before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure latency overlay with no gating on warmup failures; only adds background RPC and a documented no-network warmup probe.
> 
> **Overview**
> **Overlaps cold `runScript` latency** by kicking off work as soon as a capability-host durable object wakes, without changing any verb contracts.
> 
> On boot, `CapabilityHostDurableObject` now runs **`#warmBoot()`** (fire-and-forget): RPC to **`TYPECHECKER.warm()`** and a **`describeCapabilities()`** pre-read so wasm compiler activation and journal/fallback-host reads can finish in parallel with the request that woke the DO. Failures only log; nothing awaits warmup so a flaky sidecar cannot brick the incarnation.
> 
> The typechecker sidecar adds **`warm()`**, which runs the same **`check()`** path as real typechecks using shared **`TYPECHECKER_WARMUP_FILES`** (a trivial `/warmup.ts` with **no imports**). A test locks in **zero network fetches** for that probe so fleet-wide wakes do not hit the npm registry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3cd57e9435d208304ff797dd1a90a97aa0d759b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +39 -3 | +15 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+39 -3** | **+15 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 29c130e and 6588749, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-18T06:59:41.394Z",
      "headSha": "f3cd57e9435d208304ff797dd1a90a97aa0d759b",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/402799039639180",
      "shortSha": "f3cd57e",
      "cleanupDurationMs": 2209,
      "deployDurationMs": 17938,
      "testDurationMs": 11556,
      "testRetries": null,
      "workerSizeKib": 3949.67,
      "workerGzipKib": 804.92,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-18T06:59:39.640Z",
      "headSha": "f3cd57e9435d208304ff797dd1a90a97aa0d759b",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/402799039639180",
      "shortSha": "f3cd57e",
      "cleanupDurationMs": 453,
      "deployDurationMs": 5870,
      "testDurationMs": 5391,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-18T06:59:37.988Z",
      "headSha": "f3cd57e9435d208304ff797dd1a90a97aa0d759b",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/402799039639180",
      "shortSha": "f3cd57e",
      "cleanupDurationMs": 117876,
      "deployDurationMs": 80311,
      "testDurationMs": 409277,
      "testRetries": null,
      "workerSizeKib": 17008.55,
      "workerGzipKib": 4576.37,
      "mainWorkerGzipKib": 4576.01
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `f3cd57e` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 804.9 KiB | 17.9s | 11.6s |  | 2.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/402799039639180) | 2026-07-18T06:59:41.394Z | Preview app released. |
| Dummy Petshop | released | `f3cd57e` | [https://dummy-petshop.iterate-preview-2.com](https://dummy-petshop.iterate-preview-2.com) | 198.2 KiB | 5.9s | 5.4s |  | 453ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/402799039639180) | 2026-07-18T06:59:39.640Z | Preview app released. |
| OS | released | `f3cd57e` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 4.47 MiB (+0.4 KiB vs main) | 80.3s | 409.3s |  | 117.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/402799039639180) | 2026-07-18T06:59:37.988Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->