### PR TITLE
Stop preview stream events from consuming PostHog quota

### DIFF
--- a/apps/os/src/domains/integrations/posthog.test.ts
+++ b/apps/os/src/domains/integrations/posthog.test.ts
@@ -74,7 +74,7 @@ function acceptingFetch(requests: CapturedRequest[] = []) {
   });
 }
 
-function captureArgs(events: StreamEvent[], workerName = "os-preview-6") {
+function captureArgs(events: StreamEvent[], workerName = "os-prd") {
   return {
     apiKey: "phc_test",
     batch: batch(events),
@@ -140,6 +140,16 @@ describe("first-party PostHog stream integration", () => {
         stream_event_uuid: expect.stringMatching(/^[0-9a-f-]{36}$/),
       },
     });
+  });
+
+  it("does not export stream events from dev or preview deployments", async () => {
+    for (const workerName of ["os", "os-preview-6"]) {
+      const captureFetch = acceptingFetch();
+      await capturePosthogStreamEventBatch(captureArgs([streamEvent()], workerName), {
+        fetch: captureFetch,
+      });
+      expect(captureFetch).not.toHaveBeenCalled();
+    }
   });
 
   it("drops ephemeral rows from capture, including all-ephemeral batches", async () => {
@@ -265,23 +275,18 @@ describe("first-party PostHog stream integration", () => {
     });
   });
 
-  it("keeps source identity stable on retry and distinct between deployments", async () => {
+  it("keeps source identity stable on retry", async () => {
     const first: CapturedRequest[] = [];
     const retry: CapturedRequest[] = [];
-    const production: CapturedRequest[] = [];
     await capturePosthogStreamEventBatch(captureArgs([streamEvent()]), {
       fetch: acceptingFetch(first),
     });
     await capturePosthogStreamEventBatch(captureArgs([streamEvent()]), {
       fetch: acceptingFetch(retry),
     });
-    await capturePosthogStreamEventBatch(captureArgs([streamEvent()], "os"), {
-      fetch: acceptingFetch(production),
-    });
 
     expect(first[0]!.batch[0]!.uuid).toBe(retry[0]!.batch[0]!.uuid);
     expect(first[0]!.batch[0]!.timestamp).toBe(retry[0]!.batch[0]!.timestamp);
-    expect(first[0]!.batch[0]!.uuid).not.toBe(production[0]!.batch[0]!.uuid);
   });
 
   it("rejects malformed source timestamps and non-2xx capture responses", async () => {

--- a/apps/os/src/domains/integrations/posthog.ts
+++ b/apps/os/src/domains/integrations/posthog.ts
@@ -7,6 +7,7 @@ import type { SubscriptionConfiguredPayload } from "../streams/core-processor-co
 import { truncateJsonToBytes } from "./truncate-json.ts";
 
 export const POSTHOG_STREAM_EVENT_MAX_JSON_BYTES = 100 * 1_024;
+const POSTHOG_STREAM_FEED_WORKER_NAME = "os-prd";
 
 const StreamEventTimestamp = z.iso.datetime({ offset: true });
 const ProjectGroupBirthPayload = z.object({
@@ -209,6 +210,11 @@ export async function capturePosthogStreamEventBatch(
   },
   deps: { fetch?: typeof fetch } = {},
 ): Promise<void> {
+  // The complete durable feed is a production observability surface. Preview
+  // and local deployments generate synthetic projects and streams at CI scale;
+  // exporting those facts adds no production signal and can dominate PostHog
+  // usage. WORKER_SELF is the reviewed deployment identity from envs.ts.
+  if (args.workerName !== POSTHOG_STREAM_FEED_WORKER_NAME) return;
   if (args.batch.events.length === 0) {
     throw new Error("PostHog stream delivery batch must contain an event");
   }


### PR DESCRIPTION
## Why

The durable stream feed rollout exposed a staging/preview cost fire: the staging PostHog project stored 2,800,084 `stream:append` events in the trailing 24 hours, across all nine preview workers. That is real CI fan-out rather than a duplicate-ingestion loop, but it is far above the requested $20/day intervention threshold. Production is only about 41k stream events/day and must keep the complete durable feed.

## What changed

- Export durable stream events only when `WORKER_SELF` is the reviewed production identity, `os-prd`.
- Let local and preview deliveries return successfully without calling PostHog, so their already-configured subscriptions do not retry or park.
- Cover local/preview suppression and keep production capture/retry behavior covered.

As an immediate reversible control while existing preview versions update, I also enabled staging-only PostHog transformation `019f741a-2dd8-0000-61e9-73abda6505fe` (`Emergency: drop preview stream:append`). Staging has stored zero matching events after 2026-07-18 07:21:43 UTC; production remained live and exclusively sourced from `os-prd`.

## Verification

- `pnpm format`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (all workspaces; apps/os: 1,942 passed, 1 skipped)
- PostHog staging: zero `stream:append` rows after the cutoff and zero in the subsequent five-minute window
- PostHog production: continued ingestion after the cutoff, exclusively from `os-prd`

The full attribution, payload-size analysis, rollout timeline, error classification, and long-term recommendations will follow in a documentation PR so this emergency change can land independently.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow observability gate with no auth or data-path changes; production capture behavior is unchanged for `os-prd`.
> 
> **Overview**
> **PostHog durable stream export is limited to production** (`os-prd`). `capturePosthogStreamEventBatch` returns immediately when `workerName` is not `os-prd`, so local (`os`) and preview workers do not call the PostHog batch API. Deliveries still succeed without retries.
> 
> Tests now default to `os-prd`, assert no fetch for `os` and `os-preview-6`, and drop the cross-deployment UUID distinction case because non-production paths no longer capture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3602df08d819a32616184087d918df443ac3090. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +6 -0 | +2 -0 🟩⬜⬜⬜⬜ |
| Tests | +12 -7 | +11 -7 🟩🟩🟩🟥🟥 |
| **Total** | **+18 -7** | **+13 -7** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 177628b and f3602df, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-18T08:06:46.439Z",
      "headSha": "f3602df08d819a32616184087d918df443ac3090",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/195701979246696",
      "shortSha": "f3602df",
      "cleanupDurationMs": 2531,
      "deployDurationMs": 16614,
      "testDurationMs": 10654,
      "testRetries": null,
      "workerSizeKib": 3949.67,
      "workerGzipKib": 805.03,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-18T08:06:44.671Z",
      "headSha": "f3602df08d819a32616184087d918df443ac3090",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/195701979246696",
      "shortSha": "f3602df",
      "cleanupDurationMs": 761,
      "deployDurationMs": 6285,
      "testDurationMs": 8994,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-18T08:06:42.988Z",
      "headSha": "f3602df08d819a32616184087d918df443ac3090",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/195701979246696",
      "shortSha": "f3602df",
      "cleanupDurationMs": 110853,
      "deployDurationMs": 85703,
      "testDurationMs": 390421,
      "testRetries": "1 retried: the seeded internal app authenticates a real project member (specs x1)",
      "workerSizeKib": 17008.26,
      "workerGzipKib": 4576.09,
      "mainWorkerGzipKib": 4576.2
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `f3602df` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 805.0 KiB | 16.6s | 10.7s |  | 2.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/195701979246696) | 2026-07-18T08:06:46.439Z | Preview app released. |
| Dummy Petshop | released | `f3602df` | [https://dummy-petshop.iterate-preview-3.com](https://dummy-petshop.iterate-preview-3.com) | 198.2 KiB | 6.3s | 9.0s |  | 761ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/195701979246696) | 2026-07-18T08:06:44.671Z | Preview app released. |
| OS | released | `f3602df` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 4.47 MiB (-0.1 KiB vs main) | 85.7s | 390.4s | 1 retried: the seeded internal app authenticates a real project member (specs x1) | 110.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/195701979246696) | 2026-07-18T08:06:42.988Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->