### PR TITLE
fix(auth): project creation slug snap-back, homepage nowrap, OAuth org name

### DIFF
--- a/apps/auth/src/routes/_auth/project-access.tsx
+++ b/apps/auth/src/routes/_auth/project-access.tsx
@@ -29,7 +29,7 @@ import { createServerFn } from "@tanstack/react-start";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { slugify } from "@iterate-com/shared/slug";
-import { suggestOrganizationNameFromEmail } from "@iterate-com/shared/name-suggestions";
+import { suggestOrganizationName } from "@iterate-com/shared/name-suggestions";
 import {
   Field,
   FieldDescription,
@@ -96,10 +96,14 @@ function RouteComponent() {
   const session = useSession();
   const [selectedProjectIds, setSelectedProjectIds] = useState<string[] | null>(null);
   const [organizationName, setOrganizationName] = useState(() =>
-    suggestOrganizationNameFromEmail(session.user.email ?? ""),
+    suggestOrganizationName({
+      name: session.user.name,
+      email: session.user.email,
+    }),
   );
-  // null = keep deriving the first project's slug from the organization name;
-  // a string means the user took over. Clearing the field hands control back.
+  // null = still deriving the first project's slug from the organization name.
+  // Once the user edits the field (including clearing it), we keep their
+  // value — empty string stays empty and does not snap back to the suggestion.
   const [projectSlugOverride, setProjectSlugOverride] = useState<string | null>(null);
   const [projectSlug, setProjectSlug] = useState("");
   const [selectedOrganizationSlug, setSelectedOrganizationSlug] = useState("");
@@ -420,13 +424,13 @@ function RouteComponent() {
                     name="first-project-slug"
                     placeholder="acme"
                     value={firstProjectSlug}
-                    onChange={(event) => setProjectSlugOverride(event.target.value || null)}
+                    onChange={(event) => setProjectSlugOverride(event.target.value)}
                     aria-invalid={firstProjectSlugIssues.length > 0}
                     disabled={isSubmitting}
                   />
                   <FieldDescription>
                     Your project homepage will be under{" "}
-                    <span className="font-medium text-foreground">
+                    <span className="whitespace-nowrap font-medium text-foreground">
                       {firstProjectSlug || "your-project"}.{projectHostnameBase}
                     </span>
                   </FieldDescription>
@@ -794,7 +798,7 @@ function CreateProjectForm(props: {
           />
           <FieldDescription>
             Your project homepage will be under{" "}
-            <span className="font-medium text-foreground">
+            <span className="whitespace-nowrap font-medium text-foreground">
               {props.projectSlug || "your-project"}.{props.projectHostnameBase}
             </span>
           </FieldDescription>

--- a/packages/shared/src/name-suggestions.test.ts
+++ b/packages/shared/src/name-suggestions.test.ts
@@ -1,5 +1,28 @@
 import { describe, expect, it } from "vitest";
-import { suggestOrganizationNameFromEmail } from "./name-suggestions.ts";
+import { suggestOrganizationName, suggestOrganizationNameFromEmail } from "./name-suggestions.ts";
+
+describe("suggestOrganizationName", () => {
+  it("prefers the OAuth display name over the email local part", () => {
+    expect(
+      suggestOrganizationName({
+        name: "Jonas Templestein",
+        email: "jonas.huckestein@gmail.com",
+      }),
+    ).toBe("Jonas Templestein's Organization");
+  });
+
+  it("trims the display name before appending the possessive", () => {
+    expect(suggestOrganizationName({ name: "  Ada Lovelace  " })).toBe(
+      "Ada Lovelace's Organization",
+    );
+  });
+
+  it("falls back to the email heuristic when name is missing", () => {
+    expect(suggestOrganizationName({ email: "jonas@nustom.com" })).toBe("Nustom");
+    expect(suggestOrganizationName({ name: "   ", email: "jane.doe@gmail.com" })).toBe("Jane Doe");
+    expect(suggestOrganizationName({})).toBe("");
+  });
+});
 
 describe("suggestOrganizationNameFromEmail", () => {
   it("uses the company domain's first label", () => {

--- a/packages/shared/src/name-suggestions.ts
+++ b/packages/shared/src/name-suggestions.ts
@@ -28,6 +28,24 @@ const GENERIC_EMAIL_DOMAINS = new Set([
 ]);
 
 /**
+ * Proposes an organization name for first-run onboarding.
+ *
+ * Prefer the OAuth display name when the provider gave us one
+ * ("Jonas Templestein" → "Jonas Templestein's Organization"). Fall back to
+ * the email-only heuristic when name is missing.
+ */
+export function suggestOrganizationName(input: {
+  name?: string | null;
+  email?: string | null;
+}): string {
+  const displayName = input.name?.trim();
+  if (displayName) {
+    return `${displayName}'s Organization`;
+  }
+  return suggestOrganizationNameFromEmail(input.email ?? "");
+}
+
+/**
  * Proposes an organization name from an email address: the company domain's
  * first label when the domain looks like a company ("jonas@nustom.com" →
  * "Nustom"), otherwise the local part ("jane.doe+work@gmail.com" → "Jane

--- a/packages/shared/src/name-suggestions.ts
+++ b/packages/shared/src/name-suggestions.ts
@@ -34,10 +34,7 @@ const GENERIC_EMAIL_DOMAINS = new Set([
  * ("Jonas Templestein" → "Jonas Templestein's Organization"). Fall back to
  * the email-only heuristic when name is missing.
  */
-export function suggestOrganizationName(input: {
-  name?: string | null;
-  email?: string | null;
-}): string {
+export function suggestOrganizationName(input: { name?: string | null; email?: string | null }) {
   const displayName = input.name?.trim();
   if (displayName) {
     return `${displayName}'s Organization`;


### PR DESCRIPTION
## Summary

- **Slug snap-back:** clearing the first-project slug no longer resets `projectSlugOverride` to `null`, so backspacing the field empty no longer re-fills it from the org-name suggestion.
- **Homepage URL:** wrap the preview host in `whitespace-nowrap` so long slugs stay on one line in the field description.
- **Org name heuristic:** prefer the OAuth display name (`Jonas Templestein` → `Jonas Templestein's Organization`) over guessing from the email local part (`jonas.huckestein@gmail.com` → `Jonas Huckestein`). Email-only suggestion remains the fallback when name is missing.

## Test plan

- [x] `pnpm --dir packages/shared test` (includes new `suggestOrganizationName` cases)
- [x] `pnpm --dir packages/shared typecheck`
- [x] `pnpm --dir apps/auth typecheck`
- [ ] On `/project-access` first-run form: type a slug, backspace it fully — field stays empty
- [ ] Suggested org name uses Google display name when present
- [ ] Homepage URL preview does not wrap mid-hostname

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small onboarding UX and naming heuristics only; no auth, persistence, or API contract changes beyond default form values.
> 
> **Overview**
> Improves first-run **project-access** onboarding with three small UX fixes.
> 
> **Organization name** now comes from a new `suggestOrganizationName` helper that prefers the OAuth **display name** (e.g. `Jonas Templestein's Organization`) and only falls back to the existing email heuristic when name is missing. The create-org form seeds its default from `session.user.name` and email.
> 
> **First-project slug** no longer snaps back after the user clears the field: `projectSlugOverride` stores the raw input (including `""`) instead of resetting to `null`, so an empty slug stays empty until the user types again.
> 
> The **homepage URL** preview in field descriptions uses `whitespace-nowrap` so long `slug.hostname` strings don’t break across lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dc4c00d9d206bf6d45d67a5468a7ffc05920c30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +26 -7 | +15 -5 🟩🟩🟩🟩🟥 |
| Tests | +24 -1 | +21 -1 🟩🟩🟩🟩🟩 |
| **Total** | **+50 -8** | **+36 -6** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 49df341 and 2dc4c00, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-18T14:33:16.146Z",
      "headSha": "2dc4c00d9d206bf6d45d67a5468a7ffc05920c30",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/40665017664634",
      "shortSha": "2dc4c00",
      "cleanupDurationMs": 2692,
      "deployDurationMs": 15683,
      "testDurationMs": 11269,
      "testRetries": null,
      "workerSizeKib": 3950.18,
      "workerGzipKib": 805.13,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-18T14:33:22.741Z",
      "headSha": "2dc4c00d9d206bf6d45d67a5468a7ffc05920c30",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/40665017664634",
      "shortSha": "2dc4c00",
      "cleanupDurationMs": 9285,
      "deployDurationMs": 12472,
      "testDurationMs": 53633,
      "testRetries": null,
      "workerSizeKib": 5323.1,
      "workerGzipKib": 1517.09,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-18T14:33:14.203Z",
      "headSha": "2dc4c00d9d206bf6d45d67a5468a7ffc05920c30",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/40665017664634",
      "shortSha": "2dc4c00",
      "cleanupDurationMs": 744,
      "deployDurationMs": 5645,
      "testDurationMs": 5669,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-18T14:33:12.394Z",
      "headSha": "2dc4c00d9d206bf6d45d67a5468a7ffc05920c30",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/40665017664634",
      "shortSha": "2dc4c00",
      "cleanupDurationMs": 104185,
      "deployDurationMs": 80178,
      "testDurationMs": 407100,
      "testRetries": "1 retried: the seeded internal app authenticates a real project member (specs x1)",
      "workerSizeKib": 17017.68,
      "workerGzipKib": 4578.72,
      "mainWorkerGzipKib": 4578.72
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-18T14:31:28.783Z",
      "headSha": "2dc4c00d9d206bf6d45d67a5468a7ffc05920c30",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/40665017664634",
      "shortSha": "2dc4c00",
      "cleanupDurationMs": 570,
      "deployDurationMs": 11414,
      "testDurationMs": 18416,
      "testRetries": null,
      "workerSizeKib": 1915.43,
      "workerGzipKib": 441,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `2dc4c00` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 805.1 KiB | 15.7s | 11.3s |  | 2.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/40665017664634) | 2026-07-18T14:33:16.146Z | Preview app released. |
| Dummy Petshop | released | `2dc4c00` | [https://dummy-petshop.iterate-preview-7.com](https://dummy-petshop.iterate-preview-7.com) | 198.2 KiB | 5.6s | 5.7s |  | 744ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/40665017664634) | 2026-07-18T14:33:14.203Z | Preview app released. |
| OS | released | `2dc4c00` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 4.47 MiB (±0 vs main) | 80.2s | 407.1s | 1 retried: the seeded internal app authenticates a real project member (specs x1) | 104.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/40665017664634) | 2026-07-18T14:33:12.394Z | Preview app released. |
| Semaphore | released | `2dc4c00` | [https://semaphore.iterate-preview-7.com](https://semaphore.iterate-preview-7.com) | 441.0 KiB | 11.4s | 18.4s |  | 570ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/40665017664634) | 2026-07-18T14:31:28.783Z | Preview app released. |
| Streams Example App | released | `2dc4c00` | [https://streams.iterate-preview-7.com](https://streams.iterate-preview-7.com) | 1.48 MiB | 12.5s | 53.6s |  | 9.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/40665017664634) | 2026-07-18T14:33:22.741Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->