### PR TITLE
Stale tabs resign the stream mirror instead of fighting newer deploys

### DIFF
--- a/apps/os/src/domains/streams/client-libraries/browser/stream-browser-store.ts
+++ b/apps/os/src/domains/streams/client-libraries/browser/stream-browser-store.ts
@@ -380,7 +380,7 @@ function createStreamRuntime(
   let subscriptionHandle: { unsubscribe(): void } | undefined;
   let writerRole: WriterRole | undefined;
   // Set when this tab found a newer-deploy tab's writer lock held and resigned
-  // (see resignToSupersedingWriter): a queued request on that NEWER lock, whose
+  // (see watchSupersedingWriter): a queued request on that NEWER lock, whose
   // grant is exactly the newer writer's death — the wake-up to re-elect.
   let supersededWatch: WriterRole | undefined;
   let connectTimer: ReturnType<typeof setTimeout> | undefined;
@@ -1305,7 +1305,23 @@ function createStreamRuntime(
         });
         if (!ownsRuntime()) return undefined;
         if (supersedingLock !== undefined) {
-          resignToSupersedingWriter(supersedingLock);
+          // Resign: give up writership (keeping the connection — a follower
+          // still appends and reads runtimeState) and let the newer tab own
+          // the shared mirror; its writes reach this tab's reactive queries
+          // through the database change channel like any follower's. Reloading
+          // this tab is the real upgrade; until then the watch below waits for
+          // the newer writer to be truly gone (closed, or rolled back) —
+          // which is when re-electing can win cleanly.
+          console.warn(
+            `[stream ${args.streamPath} ${slug}] a newer app version's tab owns this stream mirror; standing by as a follower (reload this tab to take over)`,
+            { supersedingLock },
+          );
+          writerRole?.release();
+          writerRole = undefined;
+          snapshot = { ...snapshot, subscriptionStatus: "follower" };
+          emitSnapshot();
+          liveAgentStateChannel.request();
+          watchSupersedingWriter(supersedingLock);
           return undefined;
         }
         snapshot = { ...snapshot, subscriptionStatus: "leader" };
@@ -1647,35 +1663,23 @@ function createStreamRuntime(
     }
   }
 
-  // A newer-deploy tab's writer lock is held: this tab's bundle is the stale
-  // one. Give up writership (keeping the connection — a follower still appends
-  // and reads runtimeState) and let the newer tab own the shared mirror; its
-  // writes reach this tab's reactive queries through the database change
-  // channel like any follower's. Reloading this tab is the real upgrade; until
-  // then, a queued request on the newer tab's own lock is a zero-polling death
-  // watch — granted only when that tab is gone (closed, or navigated away),
-  // which is when re-electing can win cleanly (and, if the newer bundle never
-  // comes back — a rollback — legitimately rebuild to our schema).
-  function resignToSupersedingWriter(newerLockName: string) {
-    console.warn(
-      `[stream ${args.streamPath} ${slug}] a newer app version's tab owns this stream mirror; standing by as a follower (reload this tab to take over)`,
-      { newerLockName },
-    );
-    writerRole?.release();
-    writerRole = undefined;
-    snapshot = { ...snapshot, subscriptionStatus: "follower" };
-    emitSnapshot();
-    liveAgentStateChannel.request();
-    watchSupersedingWriter(newerLockName);
-  }
-
   // A grant only proves the newer writer is gone RIGHT NOW — a healthy newer
-  // tab also releases its lock on every routine reconnect (laptop sleep, socket
-  // churn). Debounce the takeover: re-check after a short delay, and only a
-  // writer that STAYED gone triggers re-election. A cycling one re-holds its
-  // lock within its own re-election and this tab just re-arms the watch.
-  const SUPERSEDED_RECHECK_DELAY_MS = 2_000;
+  // tab also releases its lock on every routine reconnect and only re-holds
+  // after its backoff, redial, and re-election complete. That gap can
+  // legitimately reach scheduleReconnect's 30s backoff ceiling (ingest
+  // self-heal, connect failures) plus the 15s dial deadline, so the takeover
+  // re-check must wait it out: only a writer that STAYED gone triggers
+  // re-election; a cycling one re-holds its lock and this tab just re-arms the
+  // watch. The asymmetry is deliberate — a false takeover deletes the newer
+  // tab's projection (the flicker this exists to prevent), while a slow
+  // takeover only delays live updates in a tab that is stale anyway (reads
+  // keep serving the last-written mirror, and reloading is always the fast
+  // path).
+  const SUPERSEDED_RECHECK_DELAY_MS = 60_000;
 
+  // The zero-polling death watch on the newer tab's own writer lock: a
+  // queued request granted only when that tab is gone (closed, navigated
+  // away, or rolled back).
   function watchSupersedingWriter(newerLockName: string) {
     supersededWatch?.release();
     // SHARED mode: granted only once the exclusive holder is gone, and other

--- a/apps/os/src/domains/streams/client-libraries/browser/stream-browser-store.ts
+++ b/apps/os/src/domains/streams/client-libraries/browser/stream-browser-store.ts
@@ -50,6 +50,7 @@ import {
 import type { BrowserProjectionWriteBuffer } from "./projection-write-buffer.ts";
 import {
   acquireWriterRole,
+  findSupersedingMirrorWriterLock,
   mirrorLockVersionVector,
   streamMirrorWriterLockName,
   type WriterRole,
@@ -378,10 +379,15 @@ function createStreamRuntime(
   let stream: BrowserStreamClient | undefined;
   let subscriptionHandle: { unsubscribe(): void } | undefined;
   let writerRole: WriterRole | undefined;
+  // Set when this tab found a newer-deploy tab's writer lock held and resigned
+  // (see resignToSupersedingWriter): a queued request on that NEWER lock, whose
+  // grant is exactly the newer writer's death — the wake-up to re-elect.
+  let supersededWatch: WriterRole | undefined;
   let connectTimer: ReturnType<typeof setTimeout> | undefined;
   let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
   let databaseInfoTimer: ReturnType<typeof setTimeout> | undefined;
   let databaseChangeTimer: ReturnType<typeof setTimeout> | undefined;
+  let supersededRecheckTimer: ReturnType<typeof setTimeout> | undefined;
   let disposeTimer: ReturnType<typeof setTimeout> | undefined;
   let livenessTimer: ReturnType<typeof setInterval> | undefined;
   let disposed = false;
@@ -1283,6 +1289,25 @@ function createStreamRuntime(
       .then(async () => {
         clearTimeout(followerTimeout);
         if (!ownsRuntime()) return undefined;
+        // Winning OUR lock is not enough: the lock name is version-vectored, so
+        // a tab from a different deploy holds a DIFFERENT lock over the same
+        // shared OPFS file. If a strictly newer vector's lock is held, a
+        // fresh-deploy tab owns this mirror right now — proceeding would
+        // rebuild its tables down to our older schema and rewind its cursors,
+        // and the two writers would fence each other's commits forever (each
+        // ingest self-heal deleting the other's projection: the deploy-boundary
+        // livelock). Resign BEFORE touching the database and stand by as a
+        // follower on the mirror the newer tab maintains.
+        const supersedingLock = await findSupersedingMirrorWriterLock({
+          projectId: args.projectId,
+          streamPath: args.streamPath,
+          versionVector: mirrorVersionVector,
+        });
+        if (!ownsRuntime()) return undefined;
+        if (supersedingLock !== undefined) {
+          resignToSupersedingWriter(supersedingLock);
+          return undefined;
+        }
         snapshot = { ...snapshot, subscriptionStatus: "leader" };
         emitSnapshot();
         // Build every canonical member over the shared connection + db: the
@@ -1622,12 +1647,82 @@ function createStreamRuntime(
     }
   }
 
+  // A newer-deploy tab's writer lock is held: this tab's bundle is the stale
+  // one. Give up writership (keeping the connection — a follower still appends
+  // and reads runtimeState) and let the newer tab own the shared mirror; its
+  // writes reach this tab's reactive queries through the database change
+  // channel like any follower's. Reloading this tab is the real upgrade; until
+  // then, a queued request on the newer tab's own lock is a zero-polling death
+  // watch — granted only when that tab is gone (closed, or navigated away),
+  // which is when re-electing can win cleanly (and, if the newer bundle never
+  // comes back — a rollback — legitimately rebuild to our schema).
+  function resignToSupersedingWriter(newerLockName: string) {
+    console.warn(
+      `[stream ${args.streamPath} ${slug}] a newer app version's tab owns this stream mirror; standing by as a follower (reload this tab to take over)`,
+      { newerLockName },
+    );
+    writerRole?.release();
+    writerRole = undefined;
+    snapshot = { ...snapshot, subscriptionStatus: "follower" };
+    emitSnapshot();
+    liveAgentStateChannel.request();
+    watchSupersedingWriter(newerLockName);
+  }
+
+  // A grant only proves the newer writer is gone RIGHT NOW — a healthy newer
+  // tab also releases its lock on every routine reconnect (laptop sleep, socket
+  // churn). Debounce the takeover: re-check after a short delay, and only a
+  // writer that STAYED gone triggers re-election. A cycling one re-holds its
+  // lock within its own re-election and this tab just re-arms the watch.
+  const SUPERSEDED_RECHECK_DELAY_MS = 2_000;
+
+  function watchSupersedingWriter(newerLockName: string) {
+    supersededWatch?.release();
+    // SHARED mode: granted only once the exclusive holder is gone, and other
+    // resigned tabs' watches neither queue behind this one nor read as live
+    // writers (findSupersedingMirrorWriterLock ignores shared holders).
+    const watch = acquireWriterRole({ lockName: newerLockName, mode: "shared" });
+    supersededWatch = watch;
+    void watch.whenWriter.then(() => {
+      // Never HOLD the newer generation's lock — a fresh tab of that version
+      // must stay able to elect. The grant was only the death notification.
+      watch.release();
+      // whenWriter also settles on release() (teardown, or a later resign
+      // replacing the watch); only the still-current watch proceeds. The
+      // released watch stays in `supersededWatch` as the "still resigned"
+      // marker until the recheck below decides.
+      if (disposed || supersededWatch !== watch) return;
+      supersededRecheckTimer = setTimeout(() => {
+        supersededRecheckTimer = undefined;
+        void findSupersedingMirrorWriterLock({
+          projectId: args.projectId,
+          streamPath: args.streamPath,
+          versionVector: mirrorVersionVector,
+        }).then((stillSuperseding) => {
+          if (disposed || supersededWatch !== watch) return;
+          supersededWatch = undefined;
+          if (stillSuperseding !== undefined) {
+            watchSupersedingWriter(stillSuperseding);
+            return;
+          }
+          scheduleReconnect("superseding mirror writer gone; re-electing", 0);
+        });
+      }, SUPERSEDED_RECHECK_DELAY_MS);
+    });
+  }
+
   function stopSubscriptionElection() {
     fireAndForgetUnsubscribe(subscriptionHandle);
     subscriptionHandle = undefined;
     liveAgentStateChannel.release();
     writerRole?.release();
     writerRole = undefined;
+    supersededWatch?.release();
+    supersededWatch = undefined;
+    if (supersededRecheckTimer !== undefined) {
+      clearTimeout(supersededRecheckTimer);
+      supersededRecheckTimer = undefined;
+    }
     // Dispose the election's member runners so queued frames (and their
     // trailing self-pulls) reject at their turn instead of racing the next
     // election's drive over the shared mirror. A frame already PAST the

--- a/apps/os/src/domains/streams/client-libraries/browser/stream-leader.test.ts
+++ b/apps/os/src/domains/streams/client-libraries/browser/stream-leader.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import {
+  findSupersedingMirrorWriterLock,
+  mirrorLockVersionVector,
+  parseLockVersionVector,
+  streamMirrorWriterLockName,
+  vectorSupersedes,
+} from "./stream-leader.ts";
+
+describe("mirrorLockVersionVector", () => {
+  it("is deterministic regardless of member order", () => {
+    const forward = mirrorLockVersionVector([
+      { slug: "browser-raw-events", schemaVersion: 2 },
+      { slug: "browser-feed", schemaVersion: 6 },
+    ]);
+    const reversed = mirrorLockVersionVector([
+      { slug: "browser-feed", schemaVersion: 6 },
+      { slug: "browser-raw-events", schemaVersion: 2 },
+    ]);
+    expect(forward).toBe("browser-feed@6|browser-raw-events@2");
+    expect(reversed).toBe(forward);
+  });
+});
+
+describe("parseLockVersionVector", () => {
+  it("round-trips a built vector", () => {
+    const vector = mirrorLockVersionVector([
+      { slug: "browser-feed", schemaVersion: 6 },
+      { slug: "browser-raw-events", schemaVersion: 2 },
+    ]);
+    expect(parseLockVersionVector(vector)).toEqual(
+      new Map([
+        ["browser-feed", 6],
+        ["browser-raw-events", 2],
+      ]),
+    );
+  });
+
+  it("skips malformed entries instead of poisoning the comparison", () => {
+    expect(parseLockVersionVector("browser-feed@6|garbage|@3|no-version@x")).toEqual(
+      new Map([["browser-feed", 6]]),
+    );
+  });
+});
+
+describe("vectorSupersedes", () => {
+  const v5 = "browser-feed@5|browser-raw-events@2";
+  const v6 = "browser-feed@6|browser-raw-events@2";
+
+  it("a bumped shared member supersedes (the deploy-boundary case)", () => {
+    expect(vectorSupersedes(v6, v5)).toBe(true);
+  });
+
+  it("never supersedes in the other direction (the stale tab must lose)", () => {
+    expect(vectorSupersedes(v5, v6)).toBe(false);
+  });
+
+  it("an identical vector never supersedes", () => {
+    expect(vectorSupersedes(v6, v6)).toBe(false);
+  });
+
+  it("mixed vectors (one member ahead, one behind) supersede in neither direction", () => {
+    const mixedA = "browser-feed@6|browser-raw-events@1";
+    const mixedB = "browser-feed@5|browser-raw-events@2";
+    expect(vectorSupersedes(mixedA, mixedB)).toBe(false);
+    expect(vectorSupersedes(mixedB, mixedA)).toBe(false);
+  });
+
+  it("disjoint member sets are incomparable", () => {
+    expect(vectorSupersedes("other-member@9", v5)).toBe(false);
+  });
+
+  it("an added member alone does not supersede; an added member plus a shared bump does", () => {
+    const withExtraSameVersions = "browser-feed@5|browser-raw-events@2|new-member@1";
+    const withExtraAndBump = "browser-feed@6|browser-raw-events@2|new-member@1";
+    expect(vectorSupersedes(withExtraSameVersions, v5)).toBe(false);
+    expect(vectorSupersedes(withExtraAndBump, v5)).toBe(true);
+  });
+});
+
+describe("findSupersedingMirrorWriterLock", () => {
+  const stream = { projectId: "prj_1", streamPath: "/agents/onboarding" };
+  const oldVector = "browser-feed@5|browser-raw-events@2";
+  const newVector = "browser-feed@6|browser-raw-events@2";
+  const lockName = (versionVector: string) =>
+    streamMirrorWriterLockName({ ...stream, versionVector });
+
+  it("finds a live newer-deploy writer from the stale tab's point of view", async () => {
+    await expect(
+      findSupersedingMirrorWriterLock({
+        ...stream,
+        versionVector: oldVector,
+        queryLocks: async () => ({
+          held: [
+            { name: lockName(oldVector), mode: "exclusive" },
+            { name: lockName(newVector), mode: "exclusive" },
+          ],
+        }),
+      }),
+    ).resolves.toBe(lockName(newVector));
+  });
+
+  it("the fresh tab does not resign to the stale tab's lock", async () => {
+    await expect(
+      findSupersedingMirrorWriterLock({
+        ...stream,
+        versionVector: newVector,
+        queryLocks: async () => ({
+          held: [
+            { name: lockName(oldVector), mode: "exclusive" },
+            { name: lockName(newVector), mode: "exclusive" },
+          ],
+        }),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("ignores our own lock and other streams' locks", async () => {
+    await expect(
+      findSupersedingMirrorWriterLock({
+        ...stream,
+        versionVector: oldVector,
+        queryLocks: async () => ({
+          held: [
+            { name: lockName(oldVector), mode: "exclusive" },
+            {
+              name: streamMirrorWriterLockName({
+                projectId: "prj_1",
+                streamPath: "/agents/another",
+                versionVector: newVector,
+              }),
+              mode: "exclusive",
+            },
+            { name: "some-unrelated-lock", mode: "exclusive" },
+          ],
+        }),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("ignores shared holders — a resigned tab's death watch must not read as a live writer", async () => {
+    await expect(
+      findSupersedingMirrorWriterLock({
+        ...stream,
+        versionVector: oldVector,
+        queryLocks: async () => ({
+          held: [{ name: lockName(newVector), mode: "shared" }],
+        }),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("answers undefined when the query fails (no evidence ⇒ keep today's rebuild behavior)", async () => {
+    await expect(
+      findSupersedingMirrorWriterLock({
+        ...stream,
+        versionVector: oldVector,
+        queryLocks: async () => {
+          throw new Error("locks API unavailable");
+        },
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/os/src/domains/streams/client-libraries/browser/stream-leader.ts
+++ b/apps/os/src/domains/streams/client-libraries/browser/stream-leader.ts
@@ -160,7 +160,7 @@ export function vectorSupersedes(other: string, ours: string): boolean {
 }
 
 /** The subset of `navigator.locks.query()` this module reads, injectable for tests. */
-export type LocksQuerySnapshot = {
+type LocksQuerySnapshot = {
   held?: readonly { name?: string | null; mode?: string | null }[] | null;
 };
 

--- a/apps/os/src/domains/streams/client-libraries/browser/stream-leader.ts
+++ b/apps/os/src/domains/streams/client-libraries/browser/stream-leader.ts
@@ -26,7 +26,17 @@ export type WriterRole = {
   release(): void;
 };
 
-export function acquireWriterRole(args: { lockName: string }): WriterRole {
+export function acquireWriterRole(args: {
+  lockName: string;
+  /**
+   * "exclusive" (the default) is the writer election. "shared" is a WATCH on
+   * someone else's exclusive lock: granted only once the holder is gone, and
+   * multiple watchers coexist without queueing behind each other — see
+   * {@link findSupersedingMirrorWriterLock}, which deliberately ignores shared
+   * holders so a watch never reads as a live writer.
+   */
+  mode?: "exclusive" | "shared";
+}): WriterRole {
   let release = () => {};
   // The lock is held until this promise resolves; resolving it === resigning.
   const held = new Promise<void>((resolve) => {
@@ -43,10 +53,14 @@ export function acquireWriterRole(args: { lockName: string }): WriterRole {
   // `await held` returns and the held lock is freed.
   const abortController = new AbortController();
   navigator.locks
-    .request(args.lockName, { mode: "exclusive", signal: abortController.signal }, async () => {
-      signalWriter();
-      await held;
-    })
+    .request(
+      args.lockName,
+      { mode: args.mode ?? "exclusive", signal: abortController.signal },
+      async () => {
+        signalWriter();
+        await held;
+      },
+    )
     .catch((error: unknown) => {
       // AbortError is the expected outcome of release()-before-grant; anything else is a
       // genuine failure to acquire the lock and must not be swallowed silently.
@@ -85,17 +99,111 @@ export function mirrorLockVersionVector(
  * The Web Lock name electing the single writer for one stream MIRROR (the
  * runtime that downloads once and fans out to the canonical processor set).
  * Versioned by {@link mirrorLockVersionVector}, so a deploy that migrates any
- * member's projection lets a fresh tab take over instead of waiting behind an
- * old tab's lock — the same failover a per-processor lock gave, now per mirror.
+ * member's projection lets a fresh tab re-elect immediately instead of waiting
+ * behind an old tab's lock — the same failover a per-processor lock gave, now
+ * per mirror.
  *
- * A deploy that changes the lock briefly lets an old tab and a fresh tab write
- * concurrently — the same window a schema migration already accepts by design:
- * the fresh tab takes over, and the mirror self-heals on reload.
+ * The versioned name means cross-deploy tabs hold DIFFERENT locks over the
+ * SAME shared OPFS file, so the lock alone cannot arbitrate between them.
+ * {@link findSupersedingMirrorWriterLock} is the other half of the contract:
+ * a tab that finds a strictly-newer vector's lock held must resign as writer
+ * instead of rebuilding the mirror down to its own older schema (two writers
+ * rebuilding in opposite directions fence each other's cursors forever — the
+ * deploy-boundary livelock).
  */
 export function streamMirrorWriterLockName(args: {
   projectId: string;
   streamPath: string;
   versionVector: string;
 }): string {
-  return `stream-writer:${args.projectId}:${args.streamPath}:browser-stream-mirror:${args.versionVector}`;
+  return streamMirrorWriterLockPrefix(args) + args.versionVector;
+}
+
+/** Shared name prefix for every version vector's writer lock on one stream mirror. */
+function streamMirrorWriterLockPrefix(args: { projectId: string; streamPath: string }): string {
+  return `stream-writer:${args.projectId}:${args.streamPath}:browser-stream-mirror:`;
+}
+
+/** Parse a {@link mirrorLockVersionVector} string back into per-member schema versions. */
+export function parseLockVersionVector(vector: string): Map<string, number> {
+  const versions = new Map<string, number>();
+  for (const entry of vector.split("|")) {
+    const at = entry.lastIndexOf("@");
+    if (at <= 0) continue;
+    const version = Number(entry.slice(at + 1));
+    if (!Number.isFinite(version)) continue;
+    versions.set(entry.slice(0, at), version);
+  }
+  return versions;
+}
+
+/**
+ * Whether `other` is a strictly NEWER compatibility vector than `ours`: every
+ * member both vectors share is at least our version, and at least one shared
+ * member is ahead. Members only one side has are ignored — deploys add and
+ * remove members, and an unshared member carries no before/after ordering.
+ * Incomparable or equal vectors answer false: when in doubt, contend as usual
+ * rather than resign (a wrong "not newer" costs one bounded fence/re-elect
+ * cycle; a wrong "newer" would park a healthy writer forever).
+ */
+export function vectorSupersedes(other: string, ours: string): boolean {
+  if (other === ours) return false;
+  const otherVersions = parseLockVersionVector(other);
+  let strictlyNewer = false;
+  for (const [member, ourVersion] of parseLockVersionVector(ours)) {
+    const otherVersion = otherVersions.get(member);
+    if (otherVersion === undefined) continue;
+    if (otherVersion < ourVersion) return false;
+    if (otherVersion > ourVersion) strictlyNewer = true;
+  }
+  return strictlyNewer;
+}
+
+/** The subset of `navigator.locks.query()` this module reads, injectable for tests. */
+export type LocksQuerySnapshot = {
+  held?: readonly { name?: string | null; mode?: string | null }[] | null;
+};
+
+/**
+ * The name of a HELD EXCLUSIVE writer lock for this stream mirror whose
+ * version vector {@link vectorSupersedes} ours — proof a newer-deploy tab is
+ * ALIVE and owns the shared mirror right now — or undefined when no such tab
+ * exists. Undefined is also the answer when the Locks API is unavailable or
+ * the query fails: without evidence of a live newer writer we keep today's
+ * behavior (rebuild to our own schema), which is what heals a rollback or an
+ * abandoned upgrade.
+ *
+ * Only held exclusive locks count. A writer always holds its lock exclusively,
+ * while a resigned tab's death WATCH rides the same name in shared mode — if
+ * shared holders or pending requests counted, two resigned stale tabs would
+ * each read the other's watch as a live newer writer and neither would ever
+ * take over.
+ */
+export async function findSupersedingMirrorWriterLock(args: {
+  projectId: string;
+  streamPath: string;
+  versionVector: string;
+  queryLocks?: () => Promise<LocksQuerySnapshot>;
+}): Promise<string | undefined> {
+  const queryLocks =
+    args.queryLocks ??
+    (typeof navigator !== "undefined" && typeof navigator.locks?.query === "function"
+      ? () => navigator.locks.query()
+      : undefined);
+  if (queryLocks === undefined) return undefined;
+  let state: LocksQuerySnapshot;
+  try {
+    state = await queryLocks();
+  } catch {
+    return undefined;
+  }
+  const prefix = streamMirrorWriterLockPrefix(args);
+  const ourName = streamMirrorWriterLockName(args);
+  for (const lock of state.held ?? []) {
+    const name = lock?.name;
+    if (name == null || name === ourName || !name.startsWith(prefix)) continue;
+    if (lock.mode === "shared") continue;
+    if (vectorSupersedes(name.slice(prefix.length), args.versionVector)) return name;
+  }
+  return undefined;
 }


### PR DESCRIPTION
## Symptom (live on prd today)

https://os.iterate.com/projects/jeeves/agents/streams/agents/onboarding (and the same page on the `iterate` project) alternates between showing the stream and **"Nothing here yet"**, with the console looping forever:

```
[stream /agents/onboarding browser-feed] local schema version changed; rebuilding member mirror.
stream processor "browser-feed" reduction cache is stale (persisted reducerVersion "", current "0.4.0", ...)
[stream /agents/onboarding browser-stream-mirror] local mirror write failed Error: stream processor progress
  commit fenced: expectedCursorRevision does not match the persisted cursorRevision ...
[stream /agents/onboarding browser-stream-mirror] local mirror ingest failed (attempt 1); resubscribing ...
```

## Root cause: a deploy-boundary livelock between two of your own tabs

The mirror writer lock deliberately embeds a version vector (`stream-leader.ts`), so after a deploy that bumps any member's `schemaVersion` (#2089 bumped browser-feed 4→5, #2121 bumped 5→6 the same day), a still-open pre-deploy tab and a fresh tab hold **different locks over the same shared OPFS database** — both are permanent writers. Then, symmetrically and forever:

1. The fresh tab reads the old tab's recorded schema version → "schema version changed" → `DELETE` the projection (**the "Nothing here yet" flash**) + cursor rewind (which **fences the old tab's in-flight commit**) → records its version.
2. The fenced old tab self-heals, re-elects, reads the *newer* recorded version → also "changed" → deletes + rewinds **downgrade-wards** → records its older version back.
3. Now the fresh tab is fenced. Repeat.

Neither side ever resigns; the old tab never reloads itself. **Erasing prd does not help** — the state lives in browser OPFS and both tabs repopulate it instantly. Closing the stale tab fixes one incident, but it recurs on every schema-bumping deploy.

## Fix: staleness loses deterministically

- At election time, **before touching the database**, the winner queries `navigator.locks.query()` for a **held exclusive** mirror lock for this stream whose version vector **strictly supersedes** its own (every shared member ≥, at least one >). Finding one proves a newer-deploy tab owns the mirror *right now*.
- The stale tab then **resigns**: releases its writer lock and stands by as a follower on the mirror the newer tab maintains (reads keep refreshing via the existing database change channel; appends/runtimeState keep working — same contract as any follower). One console warning suggests reloading.
- A **shared-mode** lock request on the newer tab's own lock name is a zero-polling death watch. Its grant is debounced 2s and re-checked, because a *healthy* newer tab also releases its lock on every routine reconnect — only a writer that *stayed* gone triggers re-election.
- **No evidence of a live newer writer ⇒ behavior unchanged** (rebuild to own schema). That is exactly what heals a prd rollback or a closed newer tab, so rollbacks cannot strand mirrors.

Shared mode on the watch is load-bearing: watches must neither queue behind each other nor read as live writers, otherwise two resigned stale tabs would each mistake the other's watch for a newer writer and neither would ever take over. `findSupersedingMirrorWriterLock` therefore counts held **exclusive** locks only.

The race where both tabs pass the check simultaneously (new tab hasn't started its election yet) still costs one bounded fence/re-elect cycle — the same window the version-vectored lock already accepts by design — and then converges permanently.

## Testing

- New `stream-leader.test.ts` (14 tests): vector build/parse round-trip, the supersedes matrix (including mixed/disjoint vectors answering "not newer" in both directions), and the finder against injected lock snapshots — including the exact #2121 shape (`browser-feed@5` vs `@6`) from both tabs' points of view, and the shared-holder/watch exclusion.
- `pnpm typecheck`, `pnpm lint`, `pnpm format`, full `pnpm test` (200 files / 1960 tests in apps/os) all green.
- Cross-version two-tab behavior is not covered by e2e (previews run one bundle); verified by reasoning through every entry path (fresh election, fence self-heal, resume, rollback, 3-generation tabs) documented in the code comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multi-tab writer election and OPFS mirror coordination at deploy boundaries; mistakes could stall live updates or allow brief dual-writer races, though conservative fallbacks and tests limit blast radius.
> 
> **Overview**
> Fixes a **deploy-boundary livelock** where a pre-deploy tab and a fresh tab each hold a **different version-vectored Web Lock** on the same OPFS mirror and alternately rebuild projections, fence commits, and resubscribe forever.
> 
> After winning its own writer election, a tab now calls **`findSupersedingMirrorWriterLock`** (via `navigator.locks.query()`, **exclusive** holders only) **before** reconcile/DB writes. If another tab holds a lock whose schema vector **strictly supersedes** this bundle, the stale tab **releases writership**, stays connected as a **follower**, and warns to reload.
> 
> **`stream-leader`** adds vector parse/compare (`vectorSupersedes`), the superseding-lock finder, and optional **`shared`** lock mode on `acquireWriterRole` for a **death watch** on the newer writer’s lock. When that watch fires, a **60s** recheck avoids false takeover during the newer tab’s routine reconnect gaps; only if no live newer writer remains does the stale tab **re-elect**.
> 
> If lock query fails or finds nothing, behavior is unchanged (rebuild to own schema). New **`stream-leader.test.ts`** covers the vector matrix and finder edge cases (shared holders ignored, query failures).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ffebc5d0e5288a5fd375c4d5ebb2e20a4b00160. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +214 -11 | +127 -6 🟩🟩🟩🟩⬜ |
| Tests | +164 -0 | +148 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+378 -11** | **+275 -6** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 0d99ae1 and 1473511, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-18T17:46:10.149Z",
      "headSha": "0ffebc5d0e5288a5fd375c4d5ebb2e20a4b00160",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/205288281740957",
      "shortSha": "0ffebc5",
      "cleanupDurationMs": 2473,
      "deployDurationMs": 15223,
      "testDurationMs": 4063,
      "testRetries": null,
      "workerSizeKib": 3950.2,
      "workerGzipKib": 805.28,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-18T17:46:16.715Z",
      "headSha": "0ffebc5d0e5288a5fd375c4d5ebb2e20a4b00160",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/205288281740957",
      "shortSha": "0ffebc5",
      "cleanupDurationMs": 9038,
      "deployDurationMs": 15118,
      "testDurationMs": 55561,
      "testRetries": null,
      "workerSizeKib": 5345.14,
      "workerGzipKib": 1522.12,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-18T17:46:08.276Z",
      "headSha": "0ffebc5d0e5288a5fd375c4d5ebb2e20a4b00160",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/205288281740957",
      "shortSha": "0ffebc5",
      "cleanupDurationMs": 598,
      "deployDurationMs": 5815,
      "testDurationMs": 5093,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-18T17:46:06.657Z",
      "headSha": "0ffebc5d0e5288a5fd375c4d5ebb2e20a4b00160",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/205288281740957",
      "shortSha": "0ffebc5",
      "cleanupDurationMs": 110247,
      "deployDurationMs": 85725,
      "testDurationMs": 470039,
      "testRetries": "3 retried: Agent scripts can send web-chat messages (with file attachments) and call project tools (vitest x1) · a stateful dynamic worker's alarm fires into its own alarm() method, with native retry (vitest x1) · discarding a new file confirms before permanently removing it (specs x1)",
      "workerSizeKib": 17037.1,
      "workerGzipKib": 4582.23,
      "mainWorkerGzipKib": 4582.24
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `0ffebc5` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 805.3 KiB | 15.2s | 4.1s |  | 2.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/205288281740957) | 2026-07-18T17:46:10.149Z | Preview app released. |
| Dummy Petshop | released | `0ffebc5` | [https://dummy-petshop.iterate-preview-1.com](https://dummy-petshop.iterate-preview-1.com) | 198.2 KiB | 5.8s | 5.1s |  | 598ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/205288281740957) | 2026-07-18T17:46:08.276Z | Preview app released. |
| OS | released | `0ffebc5` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 4.47 MiB (-0.0 KiB vs main) | 85.7s | 470.0s | 3 retried: Agent scripts can send web-chat messages (with file attachments) and call project tools (vitest x1) · a stateful dynamic worker's alarm fires into its own alarm() method, with native retry (vitest x1) · discarding a new file confirms before permanently removing it (specs x1) | 110.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/205288281740957) | 2026-07-18T17:46:06.657Z | Preview app released. |
| Streams Example App | released | `0ffebc5` | [https://streams.iterate-preview-1.com](https://streams.iterate-preview-1.com) | 1.49 MiB | 15.1s | 55.6s |  | 9.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/205288281740957) | 2026-07-18T17:46:16.715Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->