### PR TITLE
Capture unresolved OS regressions as expected failures

### DIFF
--- a/apps/os/e2e/vitest/project-create-concurrency.regression.e2e.test.ts
+++ b/apps/os/e2e/vitest/project-create-concurrency.regression.e2e.test.ts
@@ -1,0 +1,24 @@
+import { test } from "vitest";
+import { adminSecret, withItxSession } from "./test-helpers.ts";
+
+test.fails(
+  "DESIRED: concurrent creates of one slug adopt the same project identity",
+  { retry: 0 },
+  async ({ expect }) => {
+    using session = withItxSession({
+      auth: { type: "admin-secret", secret: adminSecret() },
+    });
+    const slug = `project-create-race-${crypto.randomUUID().slice(0, 8)}`;
+
+    using first = session.projects.create({ slug, waitUntilReady: false });
+    using second = session.projects.create({ slug, waitUntilReady: false });
+    const [firstIdentity, secondIdentity] = await Promise.all([
+      first.identity(),
+      second.identity(),
+    ]);
+
+    expect(secondIdentity).toEqual(firstIdentity);
+    expect(firstIdentity).toMatchObject({ organizationId: null, slug });
+    await first.waitUntilReady();
+  },
+);

--- a/apps/os/src/domains/repos/artifact-rpc-ownership.regression.test.ts
+++ b/apps/os/src/domains/repos/artifact-rpc-ownership.regression.test.ts
@@ -1,0 +1,67 @@
+import { expect, test, vi } from "vitest";
+import { replaceArtifactWithEmptyRepo } from "./artifact-replacement.ts";
+
+function artifactsError(code: string): Error & { code: string } {
+  return Object.assign(new Error(code), { code });
+}
+
+test.fails("DESIRED: deletion polling disposes each temporary repository handle", async () => {
+  const calls: string[] = [];
+  const disposeRepo = vi.fn(() => {
+    calls.push("dispose:get:present");
+  });
+  const artifacts = {
+    create: vi.fn(async () => {
+      calls.push("create");
+      return {} as ArtifactsCreateRepoResult;
+    }),
+    delete: vi.fn(async () => {
+      calls.push("delete");
+      return true;
+    }),
+    get: vi
+      .fn<Artifacts["get"]>()
+      .mockImplementationOnce(async () => {
+        calls.push("get:present");
+        return { [Symbol.dispose]: disposeRepo } as unknown as ArtifactsRepo;
+      })
+      .mockImplementationOnce(async () => {
+        calls.push("get:missing");
+        throw artifactsError("NOT_FOUND");
+      }),
+  };
+
+  await replaceArtifactWithEmptyRepo(artifacts, "repo", {
+    pollIntervalMs: 0,
+    sleep: async () => {},
+  });
+
+  expect(calls).toEqual(["delete", "get:present", "dispose:get:present", "get:missing", "create"]);
+  expect(disposeRepo).toHaveBeenCalledOnce();
+});
+
+test.fails("DESIRED: cleanup failure does not masquerade as the repository deletion barrier", async () => {
+  const cleanupError = artifactsError("NOT_FOUND");
+  const disposeRepo = vi.fn(() => {
+    throw cleanupError;
+  });
+  const artifacts = {
+    create: vi.fn(async () => ({}) as ArtifactsCreateRepoResult),
+    delete: vi.fn(async () => true),
+    get: vi
+      .fn<Artifacts["get"]>()
+      .mockResolvedValueOnce({ [Symbol.dispose]: disposeRepo } as unknown as ArtifactsRepo)
+      .mockRejectedValueOnce(artifactsError("NOT_FOUND")),
+  };
+  const sleep = vi.fn(async () => undefined);
+
+  await replaceArtifactWithEmptyRepo(artifacts, "repo", {
+    pollIntervalMs: 17,
+    sleep,
+  });
+
+  expect(disposeRepo).toHaveBeenCalledOnce();
+  expect(artifacts.get).toHaveBeenCalledTimes(2);
+  expect(sleep).toHaveBeenCalledWith(17);
+  expect(artifacts.create).toHaveBeenCalledOnce();
+});

--- a/apps/os/src/domains/scheduler/scheduler-rpc-ownership.regression.test.ts
+++ b/apps/os/src/domains/scheduler/scheduler-rpc-ownership.regression.test.ts
@@ -1,0 +1,149 @@
+import { expect, test, vi } from "vitest";
+import {
+  StreamProcessorRunner,
+  type ProcessorProgress,
+  type ProcessorProgressStore,
+} from "iterate/processors";
+import { MemoryStream } from "iterate/processors/testing";
+import {
+  SchedulerProcessor,
+  type SchedulerProcessorDeps,
+} from "./scheduler-processor-implementation.ts";
+import {
+  SchedulerProcessorContract,
+  type SchedulerProcessorState,
+} from "./scheduler-processor-contract.ts";
+
+const T0 = Date.parse("2026-01-15T12:00:00Z");
+const COMPLETED_TYPE = "events.iterate.com/scheduler/trigger-completed";
+
+function makeProgressStore(): ProcessorProgressStore<SchedulerProcessorState> {
+  let record: ProcessorProgress<SchedulerProcessorState> | undefined;
+  return {
+    read: () => (record === undefined ? undefined : structuredClone(record)),
+    commit: (progress, options) => {
+      const persistedRevision = record?.processing.cursorRevision ?? 0;
+      if (options.expectedCursorRevision !== persistedRevision) {
+        throw new Error(
+          `progress commit fenced: expected ${options.expectedCursorRevision}, persisted ${persistedRevision}`,
+        );
+      }
+      record = structuredClone(progress);
+    },
+  };
+}
+
+function makeHarness(
+  invokeCapability: SchedulerProcessorDeps["dynamicWorkers"]["invokeCapability"],
+) {
+  const clock = { now: T0 };
+  const stream = new MemoryStream("/scheduler/primary");
+  stream.now = () => clock.now;
+  stream.events.push({
+    type: "events.iterate.com/scheduler/created",
+    idempotencyKey: "scheduler/created:rpc-ownership-regression",
+    payload: { config: {} },
+    createdAt: new Date(clock.now).toISOString(),
+    offset: 1,
+    path: stream.path,
+  });
+
+  let runner!: StreamProcessorRunner<typeof SchedulerProcessorContract, SchedulerProcessorDeps>;
+  const processor = new SchedulerProcessor({
+    stream,
+    path: stream.path,
+    projectId: null,
+    dynamicWorkers: { invokeCapability },
+    now: () => clock.now,
+    readAlarm: async () => null,
+    repointAlarm: async () => {},
+    reads: {
+      snapshot: () => runner.snapshot(),
+      waitUntilEvent: (input) => runner.waitUntilEvent(input),
+    },
+  });
+  runner = new StreamProcessorRunner({
+    processor,
+    stream,
+    durability: { progress: makeProgressStore() },
+    now: () => clock.now,
+  });
+
+  const deliver = async () => {
+    for (;;) {
+      const head = stream.events.at(-1)?.offset ?? 0;
+      const { offset } = await runner.snapshot();
+      if (offset >= head) return;
+      await runner.catchUp();
+    }
+  };
+
+  return { clock, deliver, processor, stream };
+}
+
+function setEvent() {
+  return {
+    type: "events.iterate.com/scheduler/schedule-set",
+    payload: {
+      action: { kind: "itx-script", script: "async () => ({ made: 'cat-image' })" },
+      key: "report",
+      recurrence: { every: 60 },
+    },
+  };
+}
+
+async function runOneAction(
+  invokeCapability: SchedulerProcessorDeps["dynamicWorkers"]["invokeCapability"],
+) {
+  const harness = makeHarness(invokeCapability);
+  await harness.stream.append(setEvent());
+  await harness.deliver();
+  harness.clock.now = T0 + 61_000;
+  await harness.processor.triggerDue();
+  await harness.deliver();
+  await vi.waitFor(() => {
+    expect(harness.stream.events.some((event) => event.type === COMPLETED_TYPE)).toBe(true);
+  });
+  await harness.deliver();
+  return harness.stream.events.find((event) => event.type === COMPLETED_TYPE)!;
+}
+
+test.fails("DESIRED: a scheduler action disposes its RPC result after detaching the JSON value", async () => {
+  const dispose = vi.fn();
+  const result = Object.assign({ made: "cat-image" }, { [Symbol.dispose]: dispose });
+
+  const completed = await runOneAction(async () => result);
+
+  expect(completed.payload).toMatchObject({
+    outcome: "succeeded",
+    result: { made: "cat-image" },
+  });
+  expect(dispose).toHaveBeenCalledOnce();
+});
+
+test.fails("DESIRED: RPC result cleanup failure does not replace a successful scheduler action", async () => {
+  const cleanupError = new Error("dispose failed");
+  const dispose = vi.fn(() => {
+    throw cleanupError;
+  });
+  const result = Object.assign({ made: "cat-image" }, { [Symbol.dispose]: dispose });
+
+  const completed = await runOneAction(async () => result);
+
+  expect(completed.payload).toMatchObject({
+    outcome: "succeeded",
+    result: { made: "cat-image" },
+  });
+  expect(dispose).toHaveBeenCalledOnce();
+});
+
+test.fails("DESIRED: a scheduler disposes its RPC result even when JSON detachment fails", async () => {
+  const dispose = vi.fn();
+  const result: Record<string | symbol, unknown> = { [Symbol.dispose]: dispose };
+  result.self = result;
+
+  const completed = await runOneAction(async () => result);
+
+  expect(completed.payload).toMatchObject({ outcome: "failed" });
+  expect(dispose).toHaveBeenCalledOnce();
+});

--- a/apps/os/src/domains/streams/stream-delivery-recovery.regression.test.ts
+++ b/apps/os/src/domains/streams/stream-delivery-recovery.regression.test.ts
@@ -171,7 +171,7 @@ test.fails("DESIRED: a post-delivery cursor failure schedules durable redelivery
     expect(pushes).toHaveLength(1);
     expect(failed).toMatchObject({
       ackedOffset: 0,
-      attempt: 0,
+      attempt: 1,
       lastError: "sqlite write failed",
     });
     expect(failed?.nextAttemptAt).not.toBeNull();

--- a/apps/os/src/domains/streams/stream-delivery-recovery.regression.test.ts
+++ b/apps/os/src/domains/streams/stream-delivery-recovery.regression.test.ts
@@ -1,0 +1,193 @@
+import { expect, test, vi } from "vitest";
+import type {
+  StreamEvent,
+  StreamEventInput,
+  StreamPushEventBatch,
+  StreamSubscriberWakeRequest,
+  StreamWebhookDelivery,
+} from "iterate/processors";
+import type { ItxExpression } from "../../itx/expression.ts";
+import type {
+  CoreProcessorState,
+  SubscriptionConfiguredPayload,
+} from "./core-processor-contract.ts";
+import { CoreProcessorContract } from "./core-processor-contract.ts";
+import type { SubscriptionCursorRow, SubscriptionCursorStore } from "./stream-storage.ts";
+import { StreamSubscribers, type SubscriberDial } from "./stream-subscribers.ts";
+
+class FailingAckCursorStore implements SubscriptionCursorStore {
+  readonly rows = new Map<string, SubscriptionCursorRow>();
+  failNextAck = true;
+
+  get(subscriptionKey: string): SubscriptionCursorRow | undefined {
+    const row = this.rows.get(subscriptionKey);
+    return row === undefined ? undefined : { ...row };
+  }
+
+  list(): SubscriptionCursorRow[] {
+    return [...this.rows.values()].map((row) => ({ ...row }));
+  }
+
+  ensure(subscriptionKey: string, ackedOffset: number): void {
+    if (this.rows.has(subscriptionKey)) return;
+    this.rows.set(subscriptionKey, {
+      subscriptionKey,
+      ackedOffset,
+      attempt: 0,
+      nextAttemptAt: null,
+      lastError: null,
+      epoch: 1,
+    });
+  }
+
+  ack(subscriptionKey: string, ackedOffset: number, epoch?: number): void {
+    if (this.failNextAck) {
+      this.failNextAck = false;
+      throw new Error("sqlite write failed");
+    }
+    const row = this.rows.get(subscriptionKey);
+    if (row === undefined || (epoch !== undefined && row.epoch !== epoch)) return;
+    row.ackedOffset = Math.max(row.ackedOffset, ackedOffset);
+    row.attempt = 0;
+    row.nextAttemptAt = null;
+    row.lastError = null;
+  }
+
+  advanceWatermark(subscriptionKey: string, ackedOffset: number): void {
+    const row = this.rows.get(subscriptionKey);
+    if (row === undefined) return;
+    row.ackedOffset = Math.max(row.ackedOffset, ackedOffset);
+    row.nextAttemptAt = null;
+  }
+
+  nack(
+    subscriptionKey: string,
+    args: { attempt: number; nextAttemptAt: number; error: string },
+  ): void {
+    const row = this.rows.get(subscriptionKey);
+    if (row === undefined) return;
+    row.attempt = args.attempt;
+    row.nextAttemptAt = args.nextAttemptAt;
+    row.lastError = args.error;
+  }
+
+  setCursor(subscriptionKey: string, ackedOffset: number): void {
+    const row = this.rows.get(subscriptionKey);
+    if (row === undefined) return;
+    row.ackedOffset = ackedOffset;
+    row.attempt = 0;
+    row.nextAttemptAt = null;
+    row.lastError = null;
+    row.epoch += 1;
+  }
+
+  delete(subscriptionKey: string): void {
+    this.rows.delete(subscriptionKey);
+  }
+
+  minNextAttemptAt(): number | null {
+    let next: number | null = null;
+    for (const row of this.rows.values()) {
+      if (row.nextAttemptAt !== null && (next === null || row.nextAttemptAt < next)) {
+        next = row.nextAttemptAt;
+      }
+    }
+    return next;
+  }
+}
+
+test.fails("DESIRED: a post-delivery cursor failure schedules durable redelivery", async () => {
+  let now = 0;
+  const event: StreamEvent = {
+    type: "events.example.com/message",
+    offset: 1,
+    createdAt: new Date(1).toISOString(),
+    path: "/t",
+  };
+  const config: SubscriptionConfiguredPayload = {
+    subscriptionKey: "k",
+    delivery: { mode: "push", expression: ["worker", "processEventBatch"] },
+    deliver: "all",
+  };
+  const configured = {
+    k: {
+      latestConfiguredEvent: {
+        offset: 0,
+        type: "events.iterate.com/stream/subscription-configured" as const,
+        payload: config,
+        createdAt: new Date(0).toISOString(),
+      },
+    },
+  };
+  const store = new FailingAckCursorStore();
+  const pushes: StreamPushEventBatch[] = [];
+  const armedAlarms: number[] = [];
+  const kept: Promise<unknown>[] = [];
+  const dial: SubscriberDial = {
+    poke: async (_expression: ItxExpression, _request: StreamSubscriberWakeRequest) => {
+      throw new Error("wake lane is not used by this regression");
+    },
+    push: async (_expression, batch) => {
+      pushes.push(batch);
+    },
+    webhook: async (_url: string, _delivery: StreamWebhookDelivery) => {},
+  };
+  const hooks: ConstructorParameters<typeof StreamSubscribers>[0]["hooks"] = {
+    readEvents: ({ afterOffset }) =>
+      afterOffset < event.offset ? [{ event, byteLength: JSON.stringify(event).length }] : [],
+    coreState: (): CoreProcessorState =>
+      CoreProcessorContract.stateSchema.parse({
+        projectId: "p1",
+        path: "/t",
+        createdAt: "stream-v1",
+        maxOffset: event.offset,
+        configuredSubscribersByKey: configured,
+      }),
+    store,
+    dial,
+    appendFact: (_event: StreamEventInput) => {},
+    recordEgress: () => {},
+    now: () => now,
+    random: () => 0.5,
+    armAlarm: (atMs) => armedAlarms.push(atMs),
+    keepAlive: (promise) => kept.push(promise),
+  };
+  const createSubscribers = () => new StreamSubscribers({ idleTeardownMs: 60_000, hooks });
+  const settle = async () => {
+    let seen = -1;
+    while (seen !== kept.length) {
+      seen = kept.length;
+      await Promise.allSettled([...kept]);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  };
+  const errorLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+  try {
+    createSubscribers().wake();
+    await settle();
+
+    const failed = store.get("k");
+    expect(pushes).toHaveLength(1);
+    expect(failed).toMatchObject({
+      ackedOffset: 0,
+      attempt: 0,
+      lastError: "sqlite write failed",
+    });
+    expect(failed?.nextAttemptAt).not.toBeNull();
+    expect(armedAlarms).toContain(failed!.nextAttemptAt!);
+
+    now = failed!.nextAttemptAt! + 1;
+    createSubscribers().onAlarm();
+    await settle();
+
+    expect(pushes).toHaveLength(2);
+    expect(store.get("k")).toMatchObject({
+      ackedOffset: 1,
+      attempt: 0,
+      nextAttemptAt: null,
+    });
+  } finally {
+    errorLog.mockRestore();
+  }
+});


### PR DESCRIPTION
## Summary

- Adds seven expected-failure regression specs for behavior that is currently broken on main.
- Isolates them in four new files, including exactly one e2e test file.
- Changes no production code and no existing tests.

## Regressions captured

- Concurrent public project creation for one slug should converge on one project identity.
- A successful stream push followed by cursor persistence failure should schedule durable redelivery.
- Temporary Artifacts repository handles should be disposed without cleanup failures replacing the primary deletion outcome.
- Scheduler action RPC results should be disposed after detachment, including success, cleanup-failure, and detachment-failure paths.

## Red proof

Before converting these to test.fails, all seven failed on current main:

- Six unit specs failed at the intended missing cleanup or recovery assertions.
- The public-API e2e returned two different project IDs for two concurrent creates of the same slug.

Each test now uses test.fails so CI stays green while preserving an executable statement of the desired behavior. A fix should turn its corresponding expected failure into a normal passing test.

## Verification

- pnpm format
- pnpm typecheck
- pnpm lint
- pnpm test: 202 OS test files passed; 1,946 normal tests passed; 6 expected failures; 1 skipped
- Focused e2e: 1 expected failure passed against the local OS deployment

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +433 -0 | +391 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+433 -0** | **+391 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 240e3e9 and c1a4052, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-18T18:52:25.329Z",
      "headSha": "c1a40529f8cdea5deb4c42d64ccce5b5b0e5e4b1",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/400311423847057",
      "shortSha": "c1a4052",
      "cleanupDurationMs": 2817,
      "deployDurationMs": 15455,
      "testDurationMs": 12376,
      "testRetries": null,
      "workerSizeKib": 3950.2,
      "workerGzipKib": 805.16,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-18T18:52:31.088Z",
      "headSha": "c1a40529f8cdea5deb4c42d64ccce5b5b0e5e4b1",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/400311423847057",
      "shortSha": "c1a4052",
      "cleanupDurationMs": 8575,
      "deployDurationMs": 12775,
      "testDurationMs": 59122,
      "testRetries": null,
      "workerSizeKib": 5345.14,
      "workerGzipKib": 1522.12,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-18T18:52:23.304Z",
      "headSha": "c1a40529f8cdea5deb4c42d64ccce5b5b0e5e4b1",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/400311423847057",
      "shortSha": "c1a4052",
      "cleanupDurationMs": 789,
      "deployDurationMs": 5851,
      "testDurationMs": 5328,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-18T18:52:21.577Z",
      "headSha": "c1a40529f8cdea5deb4c42d64ccce5b5b0e5e4b1",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/400311423847057",
      "shortSha": "c1a4052",
      "cleanupDurationMs": 108085,
      "deployDurationMs": 81299,
      "testDurationMs": 581138,
      "testRetries": "2 retried: public secret events can change egress but copied ciphertext cannot follow (vitest x1) · reactivity page processor panel goes live and repaints from a server push (specs x1)",
      "workerSizeKib": 17037.1,
      "workerGzipKib": 4582.23,
      "mainWorkerGzipKib": 4580.68
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `c1a4052` | [https://auth.iterate-preview-6.com](https://auth.iterate-preview-6.com) | 805.2 KiB | 15.5s | 12.4s |  | 2.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/400311423847057) | 2026-07-18T18:52:25.329Z | Preview app released. |
| Dummy Petshop | released | `c1a4052` | [https://dummy-petshop.iterate-preview-6.com](https://dummy-petshop.iterate-preview-6.com) | 198.2 KiB | 5.9s | 5.3s |  | 789ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/400311423847057) | 2026-07-18T18:52:23.304Z | Preview app released. |
| OS | released | `c1a4052` | [https://os.iterate-preview-6.com](https://os.iterate-preview-6.com) | 4.47 MiB (+1.5 KiB vs main) | 81.3s | 581.1s | 2 retried: public secret events can change egress but copied ciphertext cannot follow (vitest x1) · reactivity page processor panel goes live and repaints from a server push (specs x1) | 108.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/400311423847057) | 2026-07-18T18:52:21.577Z | Preview app released. |
| Streams Example App | released | `c1a4052` | [https://streams.iterate-preview-6.com](https://streams.iterate-preview-6.com) | 1.49 MiB | 12.8s | 59.1s |  | 8.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/400311423847057) | 2026-07-18T18:52:31.088Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions using Vitest expected failures; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **seven `test.fails` regression specs** in four new files so known-broken behavior stays documented and CI stays green until fixes land. **No production or existing test changes.**
> 
> **Project creation (e2e):** concurrent `projects.create` calls with the same slug should resolve to **one** project identity; today they can diverge.
> 
> **Stream delivery:** after a successful push, a **cursor ack failure** should nack, arm a retry alarm, and **redeliver** on the next wake—not leave the subscription stuck.
> 
> **Artifacts replacement:** polling during `replaceArtifactWithEmptyRepo` should **`Symbol.dispose` temporary repo handles**; dispose errors must not be confused with the deletion barrier or block recreate.
> 
> **Scheduler actions:** RPC results with `[Symbol.dispose]` should be disposed after JSON detachment, including when the action **succeeds**, when **dispose throws**, and when **detachment fails** (cyclic values).
> 
> Each spec is labeled **DESIRED** and is meant to flip to a normal passing test when the corresponding fix ships.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1a40529f8cdea5deb4c42d64ccce5b5b0e5e4b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->