### PR TITLE
Align preview CI with serialized lanes

### DIFF
--- a/.depot/workflows/cloudflare-previews.yml
+++ b/.depot/workflows/cloudflare-previews.yml
@@ -94,9 +94,10 @@ jobs:
     # Hard backstop on ONE attempt. After the TUI, Vitest, and Playwright
     # lanes were deliberately serialized to cap slot load, measured green
     # runs take ~9m30 end to end (OS e2e alone is 431–441s). Fifteen minutes
-    # leaves room above the measured phase budgets while each remote lane's
-    # own 360s watchdog still fails a wedge first. The outer bound continues
-    # to prevent the historical 31m and ~90m runaway attempts.
+    # leaves room above the measured phase budgets. Each remote lane retains
+    # its own 180–480s watchdog; this outer bound also catches combined lane,
+    # setup, or deploy degeneration and prevents the historical 31m and ~90m
+    # runaway attempts.
     timeout-minutes: 15
     concurrency:
       group: cloudflare-preview-lifecycle-${{ github.event.pull_request.number || inputs.pull-request-number }}

--- a/.depot/workflows/cloudflare-previews.yml
+++ b/.depot/workflows/cloudflare-previews.yml
@@ -91,12 +91,13 @@ jobs:
     # while halving the per-second cost. Re-check with
     # `depot ci metrics --run <id>` before changing.
     runs-on: depot-ubuntu-24.04-8
-    # Hard backstop on ONE attempt: a preview run past 10 minutes IS a flake
-    # (healthy ~4m; slot wait 6m, both e2e sub-lanes 360s watchdogs and
-    # per-test caps all fail loudly before this fires). 2026-07-09 saw 31m
-    # and ~90m attempts (unerasable-slot loops, an unbounded playwright
-    # tail); nothing can stack past this anymore.
-    timeout-minutes: 10
+    # Hard backstop on ONE attempt. After the TUI, Vitest, and Playwright
+    # lanes were deliberately serialized to cap slot load, measured green
+    # runs take ~9m30 end to end (OS e2e alone is 431–441s). Fifteen minutes
+    # leaves room above the measured phase budgets while each remote lane's
+    # own 360s watchdog still fails a wedge first. The outer bound continues
+    # to prevent the historical 31m and ~90m runaway attempts.
+    timeout-minutes: 15
     concurrency:
       group: cloudflare-preview-lifecycle-${{ github.event.pull_request.number || inputs.pull-request-number }}
       cancel-in-progress: false

--- a/apps/os/scripts/erase-data.ts
+++ b/apps/os/scripts/erase-data.ts
@@ -23,8 +23,10 @@
  *     handover leaves the previous branch's classes behind. Killing the
  *     instances also stops orphaned scheduler DOs whose alarms kept running
  *     itx scripts (= real LLM spend) against erased projects. Exception:
- *     container-bearing classes (the sandboxes) survive as unreachable
- *     orphans — recreating them is broken upstream (do-reset.ts explains).
+ *     container-bearing classes still declared by this branch (the
+ *     sandboxes) survive as unreachable orphans — recreating them is broken
+ *     upstream. Container applications/classes left by another branch are
+ *     retired instead (do-reset.ts explains).
  *   - normally, the auth D1 database (identities, orgs, projects — the source
  *     of every project id) and project-directory KV. `--preserve-auth` keeps
  *     both for a planned production recreation: selected OS projects can then
@@ -52,6 +54,10 @@ import {
 } from "../../../scripts/lib/deploy-helpers.ts";
 import { resetWorkerDurableObjects } from "../../../scripts/lib/do-reset.ts";
 import { resolveEnvContext } from "../../../scripts/lib/env-context.ts";
+import {
+  SANDBOX_INSTANCE_TYPE_BINDINGS,
+  SANDBOX_INSTANCE_TYPES,
+} from "../src/domains/sandboxes/instance-types.ts";
 import { COMPATIBILITY_DATE, RETIRED_WORKER_SECRETS } from "./generate-wrangler-config.ts";
 
 /** Erase ALL user data in a deployed environment; infrastructure stays (see file header). */
@@ -94,6 +100,9 @@ export default async function eraseData(options: {
       CLOUDFLARE_ACCOUNT_ID: env.cloudflareAccountId,
     },
     compatibilityDate: COMPATIBILITY_DATE,
+    containerClassNames: SANDBOX_INSTANCE_TYPES.map(
+      (instanceType) => SANDBOX_INSTANCE_TYPE_BINDINGS[instanceType].className,
+    ),
   });
 
   if (options.preserveAuth) {

--- a/apps/os/scripts/erase-data.ts
+++ b/apps/os/scripts/erase-data.ts
@@ -119,7 +119,7 @@ export default async function eraseData(options: {
   }
 
   // Delete a batch of items with bounded concurrency and a deadline: this
-  // script runs inside the preview-slot cleanup job's 10-MINUTE ceiling, and
+  // script runs inside the preview-slot cleanup job's 15-MINUTE ceiling, and
   // an e2e-churned search-index bucket holds thousands of objects —
   // one-at-a-time REST deletes blew the ceiling on the first live run
   // (preview_6, 2026-07-14). The API's global rate limit (~1200 req/5min)
@@ -253,7 +253,7 @@ export default async function eraseData(options: {
   for (const bucket of bucketsToWalk) {
     // Per-bucket budget: a churn-refilled search-index must not starve the
     // files pass (Bugbot). 90s each + 90s instances stays well inside the
-    // cleanup job's 10-minute ceiling alongside the DO/D1/KV work.
+    // cleanup job's 15-minute ceiling alongside the DO/D1/KV work.
     const bucketDeadline = Date.now() + 90_000;
     try {
       let objectsDeleted = 0;

--- a/apps/streams-example-app/scripts/erase-data.ts
+++ b/apps/streams-example-app/scripts/erase-data.ts
@@ -36,6 +36,7 @@ export default async function eraseData(options: {
       CLOUDFLARE_ACCOUNT_ID: ctx.env.cloudflareAccountId,
     },
     compatibilityDate: COMPATIBILITY_DATE,
+    containerClassNames: [],
   });
   console.log(`✅ ${ctx.name} streams playground data erased; worker and infrastructure remain.`);
 }

--- a/docs/ci-preview-performance.md
+++ b/docs/ci-preview-performance.md
@@ -21,8 +21,8 @@ and cost.
 
 The OS deploy and the OS e2e lane are the long poles; the other apps finish in
 seconds and run alongside OS. The 15-minute workflow watchdog is an outer
-backstop, not the expected duration: each remote OS sub-lane retains its own
-360-second watchdog.
+backstop, not the expected duration: the onboarding, TUI, Vitest, and
+Playwright lanes retain their dedicated 180–480-second watchdogs.
 
 ## The optimizations (and why each one is load-bearing)
 

--- a/docs/ci-preview-performance.md
+++ b/docs/ci-preview-performance.md
@@ -1,10 +1,10 @@
 # Preview CI performance
 
-The **Cloudflare Previews** check (deploy every app to a leased preview slot,
-then run the full e2e suite against it) is the slowest thing that runs on every
-PR push, so it gets a dedicated performance budget. As of 2026-07-02 it lands
-in **~2m30s** end-to-end. This doc explains how, and — more importantly — how
-to keep it there.
+The **Cloudflare Previews** check (deploy every affected app to a leased preview
+slot, then run its full e2e suite) is the slowest thing that runs on every PR
+push, so it gets a dedicated performance budget. As of 2026-07-18 an OS run
+lands in **~9m30s** end-to-end. This doc explains how, and — more importantly —
+how to keep it there.
 
 For the mechanics (where the workflows live, how to run them locally, the
 Doppler wiring), see [Depot CI](depot-ci.md). This doc is about speed
@@ -12,15 +12,17 @@ and cost.
 
 ## Where the time goes
 
-| Phase  | Budget   | Typical | What it is                              |
-| ------ | -------- | ------- | --------------------------------------- |
-| Pickup | —        | ~7s     | Depot CI assigns a runner               |
-| Setup  | —        | ~20s    | checkout + `pnpm install` + Doppler CLI |
-| Deploy | 55s (OS) | ~40s    | all apps deploy in parallel to the slot |
-| Tests  | 80s (OS) | ~60s    | full e2e against the deployed slot      |
+| Phase  | Budget    | Typical | What it is                                         |
+| ------ | --------- | ------- | -------------------------------------------------- |
+| Pickup | —         | ~7s     | Depot CI assigns a runner                          |
+| Setup  | —         | ~20s    | checkout + `pnpm install` + Doppler CLI            |
+| Deploy | 115s (OS) | ~90s    | affected apps deploy in dependency-ordered batches |
+| Tests  | 560s (OS) | ~7m20s  | smoke, TUI, Vitest, then Playwright                |
 
 The OS deploy and the OS e2e lane are the long poles; the other apps finish in
-seconds and run alongside OS.
+seconds and run alongside OS. The 15-minute workflow watchdog is an outer
+backstop, not the expected duration: each remote OS sub-lane retains its own
+360-second watchdog.
 
 ## The optimizations (and why each one is load-bearing)
 
@@ -32,17 +34,17 @@ seconds and run alongside OS.
   the PR-close cleanup — lives in one Depot workflow
   (`.depot/workflows/cloudflare-previews.yml`); there is no GitHub Actions
   preview workflow (see [Depot CI](depot-ci.md)).
-- **Deploys run in one parallel batch.** OS bakes the auth JWKS at deploy time,
-  but instead of waiting for auth to finish first, the OS deploy _polls_ the
-  slot's auth worker for JWKS (`bakeStaticAuthJwks` in `apps/os/scripts/deploy.ts`). All
-  apps deploy at once.
+- **Deploy dependencies are explicit.** Auth and Dummy Petshop deploy in
+  parallel, then OS deploys with Auth's JWKS and Petshop's preview URL. Apps
+  without an OS dependency continue in parallel; the ordering lives in
+  `scripts/preview/preview.ts` and is covered by its dependency-expansion tests.
 - **Parallelism is capped per deployed slot, not per runner process.** The OS
   Vitest catalogue uses four workers with at most two concurrent tests each;
   Playwright uses eight fully-parallel workers. Each suite therefore peaks at
   eight remote tests. The TUI, Vitest, and Playwright suites run sequentially
   against one OS preview slot: overlapping the two eight-wide worker pools
   produced project-processor self-pull timeouts even though each suite was
-  clean in isolation. The four apps' independent preview suites may still run
+  clean in isolation. The other apps' independent preview suites may still run
   concurrently (`scripts/preview/preview.ts`).
 - **File-level parallelism plus bounded intra-file concurrency.** Every Vitest
   test provisions its own project, so files are independent (`fileParallelism`,
@@ -98,8 +100,10 @@ creep visible. If you see one:
 - **Prefer test-level parallelism over adding lanes.** A new check that runs
   _after_ the existing lanes adds its whole duration to the critical path. If
   you must add coverage, fold it into an existing concurrent lane.
-- **Never serialize what can self-provision.** The apps' suites and the vitest
-  lanes run concurrently on purpose; keep it that way.
+- **Serialize only at the real contention boundary.** Different deployed apps'
+  suites run concurrently. OS's TUI, Vitest, and Playwright lanes stay
+  sequential because their independent fixtures still contend on one deployed
+  worker; restoring overlap requires evidence that the aggregate load is clean.
 - **Keep the create-saga smoke.** Removing it brings back the rotating
   "saw 0 events" cold-start flakes across the concurrent suites, which fail or
   retry and make runs _slower_, not faster.

--- a/docs/preview-resource-gc.md
+++ b/docs/preview-resource-gc.md
@@ -10,9 +10,11 @@ There are nine preview **slots**. Each is a fixed shell of Cloudflare
 resources — a Worker, its hostname/DNS, a D1 database, KV namespaces, R2
 buckets, an AI Search namespace — created once by `ensure-resources` and
 **never deleted** (Workers especially: recreating a container-bearing Durable
-Object class is broken upstream). A slot is leased to one PR at a time through
-the [semaphore](../apps/semaphore); a PR's deploy and e2e renew the lease, and
-closing the PR releases it.
+Object class is broken upstream). Erase preserves container classes declared
+by the incoming branch, but deletes any retired container application before
+tombstoning a class left by another branch. A slot is leased to one PR at a
+time through the [semaphore](../apps/semaphore); a PR's deploy and e2e renew
+the lease, and closing the PR releases it.
 
 The bug this design fixes: teardown used to be **on the critical path of
 releasing the slot**. Cleanup erased the slot's data, and only then released

--- a/scripts/lib/do-reset.test.ts
+++ b/scripts/lib/do-reset.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi } from "vitest";
-import { detachExternalDurableObjectBindings } from "./do-reset.ts";
+import { detachExternalDurableObjectBindings, resetWorkerDurableObjects } from "./do-reset.ts";
 
 type Settings = {
   annotations?: Record<string, unknown>;
@@ -135,5 +135,87 @@ describe("detachExternalDurableObjectBindings", () => {
         workerNames: ["os-preview-4", "sidecar"],
       }),
     ).rejects.toThrow("settings readback did not preserve");
+  });
+});
+
+describe("resetWorkerDurableObjects", () => {
+  test("deletes a retired container application before tombstoning its class", async () => {
+    const applications = [
+      {
+        id: "sandbox-app",
+        name: "os-preview-4-SandboxBasicDurableObject",
+        durable_objects: { namespace_id: "sandbox-namespace" },
+      },
+      {
+        id: "retired-builder-app",
+        name: "os-preview-4-WorkerBuilderDurableObject",
+        durable_objects: { namespace_id: "retired-builder-namespace" },
+      },
+    ];
+    let deployedMetadata: Record<string, unknown> | undefined;
+    const cf = vi.fn(async (path: string, init?: RequestInit) => {
+      if (path === "/workers/scripts") return [{ id: "os-preview-4" }];
+      if (path.startsWith("/workers/durable_objects/namespaces?")) {
+        return [
+          {
+            id: "sandbox-namespace",
+            script: "os-preview-4",
+            class: "SandboxBasicDurableObject",
+          },
+          {
+            id: "retired-builder-namespace",
+            script: "os-preview-4",
+            class: "WorkerBuilderDurableObject",
+          },
+        ];
+      }
+      if (path === "/containers/applications") return structuredClone(applications);
+      if (path === "/containers/applications/retired-builder-app") {
+        expect(init?.method).toBe("DELETE");
+        applications.splice(
+          applications.findIndex((application) => application.id === "retired-builder-app"),
+          1,
+        );
+        return undefined;
+      }
+      if (path === "/workers/scripts/os-preview-4") {
+        expect(init?.method).toBe("PUT");
+        const body = init?.body;
+        expect(body).toBeInstanceOf(FormData);
+        if (!(body instanceof FormData)) throw new Error("expected a FormData worker upload");
+        const metadata = body.get("metadata");
+        expect(typeof metadata).toBe("string");
+        deployedMetadata = JSON.parse(metadata as string) as Record<string, unknown>;
+        return undefined;
+      }
+      throw new Error(`unexpected Cloudflare request: ${path}`);
+    });
+
+    await expect(
+      resetWorkerDurableObjects({
+        ctx: { cf } as never,
+        workerName: "os-preview-4",
+        cwd: "/tmp/os",
+        credentials: {},
+        compatibilityDate: "2026-07-01",
+        containerClassNames: ["SandboxBasicDurableObject"],
+      }),
+    ).resolves.toEqual({
+      action: "reset",
+      deletedClasses: ["WorkerBuilderDurableObject"],
+      keptContainerClasses: ["SandboxBasicDurableObject"],
+    });
+
+    expect(deployedMetadata).toMatchObject({
+      containers: [{ class_name: "SandboxBasicDurableObject" }],
+      migrations: { steps: [{ deleted_classes: ["WorkerBuilderDurableObject"] }] },
+    });
+    expect(applications).toEqual([
+      {
+        id: "sandbox-app",
+        name: "os-preview-4-SandboxBasicDurableObject",
+        durable_objects: { namespace_id: "sandbox-namespace" },
+      },
+    ]);
   });
 });

--- a/scripts/lib/do-reset.test.ts
+++ b/scripts/lib/do-reset.test.ts
@@ -152,7 +152,7 @@ describe("resetWorkerDurableObjects", () => {
         durable_objects: { namespace_id: "retired-builder-namespace" },
       },
     ];
-    let deployedMetadata: Record<string, unknown> | undefined;
+    let deployedMetadata: unknown;
     const cf = vi.fn(async (path: string, init?: RequestInit) => {
       if (path === "/workers/scripts") return [{ id: "os-preview-4" }];
       if (path.startsWith("/workers/durable_objects/namespaces?")) {
@@ -185,7 +185,8 @@ describe("resetWorkerDurableObjects", () => {
         if (!(body instanceof FormData)) throw new Error("expected a FormData worker upload");
         const metadata = body.get("metadata");
         expect(typeof metadata).toBe("string");
-        deployedMetadata = JSON.parse(metadata as string) as Record<string, unknown>;
+        if (typeof metadata !== "string") throw new Error("expected string worker metadata");
+        deployedMetadata = JSON.parse(metadata);
         return undefined;
       }
       throw new Error(`unexpected Cloudflare request: ${path}`);

--- a/scripts/lib/do-reset.ts
+++ b/scripts/lib/do-reset.ts
@@ -6,10 +6,12 @@
  * that retires their classes, so the reset deploys the checked-in parked
  * worker (parked-worker/worker.js — 503 + queue ack) with a `state:
  * "deleted"` tombstone for every class that exists on the worker — except
- * container-bearing classes, which are kept alive (see the inline comment
- * for the upstream Cloudflare gap that forces this). Plain `wrangler
- * deploy`; the tombstone map is the only generated content, and it is a
- * readback of live reality — no checked-in file can know what a previous
+ * container-bearing classes still declared by the incoming branch, which
+ * are kept alive (see the inline comment for the upstream Cloudflare gap
+ * that forces this). Retired container applications are deleted first so
+ * their classes can be tombstoned too. Plain `wrangler deploy`; the tombstone
+ * map is generated from live reality plus the incoming branch's current
+ * container classes — no checked-in tombstone can know what a previous
  * branch left on a shared slot.
  *
  * The worker script and its routes stay (deleting a script cascades its
@@ -223,6 +225,8 @@ export async function resetWorkerDurableObjects(input: {
   credentials: Record<string, string>;
   /** The worker's compatibility date — reuse the app's own so the parked module never trails it. */
   compatibilityDate: string;
+  /** Container-bearing classes declared by the branch that will deploy next. */
+  containerClassNames: readonly string[];
 }): Promise<
   | { action: "skipped"; reason: string }
   | { action: "reset"; deletedClasses: string[]; keptContainerClasses: string[] }
@@ -246,8 +250,8 @@ export async function resetWorkerDurableObjects(input: {
     return { action: "skipped", reason: "no Durable Object classes" };
   }
 
-  // Container-bearing classes are KEPT, not destroyed. Cloudflare's exports
-  // reconciliation cannot container-enable a namespace it creates (upstream
+  // CURRENT container-bearing classes are KEPT, not destroyed. Cloudflare's
+  // exports reconciliation cannot container-enable a namespace it creates (upstream
   // gap, verified live 2026-07-08: recreating a container class under
   // `exports` fails its container application with
   // DURABLE_OBJECT_NOT_CONTAINER_ENABLED, and exports is one-way — error
@@ -256,10 +260,52 @@ export async function resetWorkerDurableObjects(input: {
   // unreachable orphans like every pre-teardown DO did (D1/KV are wiped;
   // running containers are reaped by the sandbox destroy-on-idle sweeper),
   // and their container applications stay attached to the live namespaces.
-  const applications =
+  let applications =
     await input.ctx.cf<{ id: string; name: string; durable_objects?: { namespace_id?: string } }[]>(
       `/containers/applications`,
     );
+  const namespaceById = new Map(
+    namespaces.map((namespace) => [namespace.namespaceId, namespace] as const),
+  );
+  const currentContainerClasses = new Set(input.containerClassNames);
+  const retiredApplications = applications.filter((application) => {
+    const namespaceId = application.durable_objects?.namespace_id;
+    const namespace = namespaceId ? namespaceById.get(namespaceId) : undefined;
+    return namespace !== undefined && !currentContainerClasses.has(namespace.className);
+  });
+  for (const application of retiredApplications) {
+    const namespaceId = application.durable_objects?.namespace_id;
+    const namespace = namespaceId ? namespaceById.get(namespaceId) : undefined;
+    await input.ctx.cf(`/containers/applications/${encodeURIComponent(application.id)}`, {
+      method: "DELETE",
+    });
+    console.log(
+      `DO reset: deleted retired container application ${application.name} ` +
+        `(class ${namespace?.className ?? "unknown"})`,
+    );
+  }
+  if (retiredApplications.length > 0) {
+    applications =
+      await input.ctx.cf<
+        { id: string; name: string; durable_objects?: { namespace_id?: string } }[]
+      >(`/containers/applications`);
+    const retiredNamespaceIds = new Set(
+      retiredApplications.flatMap((application) => {
+        const namespaceId = application.durable_objects?.namespace_id;
+        return namespaceId ? [namespaceId] : [];
+      }),
+    );
+    const lingering = applications.filter((application) => {
+      const namespaceId = application.durable_objects?.namespace_id;
+      return namespaceId !== undefined && retiredNamespaceIds.has(namespaceId);
+    });
+    if (lingering.length > 0) {
+      throw new Error(
+        `DO reset: Cloudflare kept retired container applications ` +
+          `${lingering.map((application) => application.name).join(", ")}; refusing to park ${input.workerName}`,
+      );
+    }
+  }
   const containerNamespaceIds = new Set(
     applications
       .map((application) => application.durable_objects?.namespace_id)

--- a/scripts/lib/do-reset.ts
+++ b/scripts/lib/do-reset.ts
@@ -264,9 +264,8 @@ export async function resetWorkerDurableObjects(input: {
     await input.ctx.cf<{ id: string; name: string; durable_objects?: { namespace_id?: string } }[]>(
       `/containers/applications`,
     );
-  const namespaceById = new Map(
-    namespaces.map((namespace) => [namespace.namespaceId, namespace] as const),
-  );
+  const namespaceById = new Map<string, (typeof namespaces)[number]>();
+  for (const namespace of namespaces) namespaceById.set(namespace.namespaceId, namespace);
   const currentContainerClasses = new Set(input.containerClassNames);
   const retiredApplications = applications.filter((application) => {
     const namespaceId = application.durable_objects?.namespace_id;

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -475,6 +475,18 @@ describe("preview test commands", () => {
     expect(script.indexOf(tuiLane)).toBeLessThan(script.indexOf(playwrightSpec));
     expect(script.indexOf(e2eLane)).toBeLessThan(script.indexOf(playwrightSpec));
   });
+
+  test("budgets the serialized OS preview lane from its measured green floor", () => {
+    expect(cloudflarePreviewApps.os).toMatchObject({
+      previewDeployBudgetMs: 115_000,
+      previewTestBudgetMs: 560_000,
+    });
+
+    const workflow = parseYaml(
+      readFileSync(resolve(repoRoot, ".depot/workflows/cloudflare-previews.yml"), "utf8"),
+    ) as { jobs: { preview: { "timeout-minutes": number } } };
+    expect(workflow.jobs.preview["timeout-minutes"]).toBe(15);
+  });
 });
 
 describe("preview readiness URLs", () => {

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -1546,10 +1546,12 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
     // integration e2e talks to the slot's deployed dummy Petshop. Both must
     // finish deploying before OS starts.
     previewDependencies: ["auth", "dummy-petshop"],
-    // Budgets sit ~25% above the observed green floor (deploy ~40s, e2e lane
-    // ~60s as of 2026-07-02). Crossing them warns, never fails.
-    previewDeployBudgetMs: 55_000,
-    previewTestBudgetMs: 80_000,
+    // Budgets sit ~25% above the observed green floor after the TUI, Vitest,
+    // and Playwright lanes became sequential to cap deployed-slot load
+    // (deploy 89–92s, e2e 431–441s as of 2026-07-18). Crossing them warns,
+    // never fails.
+    previewDeployBudgetMs: 115_000,
+    previewTestBudgetMs: 560_000,
     previewTestBaseUrlEnvVar: "OS_BASE_URL",
     previewTestDependencyBaseUrlEnvVars: {
       "dummy-petshop": "PETSHOP_BASE_URL",

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -3655,7 +3655,7 @@ function isNoSlotAvailableError(error: unknown) {
 // worse, stealing a slot), the deploy waits its turn and logs who holds what
 // while it waits. Override with PREVIEW_SLOT_WAIT_MS=0 to fail fast.
 // Bounded so a slotless (or broken-slot) run fails LOUDLY inside the job's
-// 10-minute ceiling instead of being killed silently by it: 2026-07-09's
+// 15-minute ceiling instead of being killed silently by it: 2026-07-09's
 // unerasable-slot loop burned this entire budget per attempt, and external
 // retries stacked those into 15-30 minute walls. 6 minutes still rides out
 // a normal handover (cleanup of a closing PR takes ~2m); a genuinely full


### PR DESCRIPTION
## What changed

- raise the OS preview deploy and test warning budgets to 115s and 560s
- raise the preview job's hard watchdog from 10 to 15 minutes
- lock the budgets and watchdog together with a regression test
- update the performance guide for the intentionally serialized TUI, Vitest, and Playwright lanes
- retire container applications/classes left on a shared slot by a branch that no longer declares them

## Why

The OS preview lanes were deliberately serialized in #2089 to stop overlapping eight-wide test pools from timing out the deployed project processor. That changed the measured green floor without updating the old 10-minute outer watchdog: recent healthy runs take about 9m30 end to end, with deploy at 89–92s and OS e2e at 431–441s. The old watchdog can therefore cancel a healthy run near the end of Playwright.

A rerun also exposed a stale `WorkerBuilderDurableObject` container left by a different branch on the shared slot. Reset previously preserved every container-backed class, so the next exports deploy could neither declare nor delete it. Erase now preserves only container classes declared by the incoming branch, deletes retired applications, verifies their removal, and tombstones the retired classes. This is roll-forward cleanup; it adds no compatibility export or alias.

This keeps the load-safe serialization and gives it bounded headroom. Individual remote lanes retain dedicated 180–480-second watchdogs; the 15-minute outer backstop bounds combined lane, setup, and deploy degeneration.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test`
- `pnpm --dir scripts test --run preview/preview.test.ts ci/depot-workflows.test.ts` (124 tests)
- `pnpm --dir scripts test -- lib/do-reset.test.ts` (175 tests)
- `git diff --check`

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +96 -1 | +91 -1 🟩🟩🟩🟩🟩 |
| CI & scripts | +81 -22 | +61 -9 🟩🟩🟩🟥⬜ |
| Docs | +28 -22 | +28 -22 🟩🟩🟥⬜⬜ |
| **Total** | **+205 -45** | **+180 -32** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 0d99ae1 and 62843eb, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes destructive preview teardown (container app deletion + DO tombstoning) on shared slots; mistakes could wedge handover, though lingering apps are explicitly detected and the change is covered by tests.
> 
> **Overview**
> Raises preview CI limits to match **serialized** OS deploy/e2e timing (~9m30 green): the Depot preview job watchdog goes from **10 → 15 minutes**, OS warning budgets move to **115s deploy / 560s tests**, and a regression test keeps those budgets aligned with the workflow timeout. Docs and inline comments reflect the new floor and serialized TUI → Vitest → Playwright lanes.
> 
> **Preview slot handover** no longer keeps every container-backed Durable Object class. `resetWorkerDurableObjects` takes **`containerClassNames` from the branch that will deploy next**; it **deletes retired Cloudflare container applications** (and verifies they are gone) so classes left by another branch—e.g. `WorkerBuilderDurableObject`—can be tombstoned. OS `erase-data` passes current sandbox class names; streams-example passes an empty list. A unit test covers delete-then-tombstone behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62843eb63e5fd12f5e970e3b019fb41a908074fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-18T17:40:19.064Z",
      "headSha": "62843eb63e5fd12f5e970e3b019fb41a908074fc",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/258522406528443",
      "shortSha": "62843eb",
      "cleanupDurationMs": 2561,
      "deployDurationMs": 20415,
      "testDurationMs": 10914,
      "testRetries": null,
      "workerSizeKib": 3950.2,
      "workerGzipKib": 805.33,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-18T17:40:25.330Z",
      "headSha": "62843eb63e5fd12f5e970e3b019fb41a908074fc",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/258522406528443",
      "shortSha": "62843eb",
      "cleanupDurationMs": 8825,
      "deployDurationMs": 14746,
      "testDurationMs": 57361,
      "testRetries": null,
      "workerSizeKib": 5345.14,
      "workerGzipKib": 1522.13,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-18T17:40:17.160Z",
      "headSha": "62843eb63e5fd12f5e970e3b019fb41a908074fc",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/258522406528443",
      "shortSha": "62843eb",
      "cleanupDurationMs": 653,
      "deployDurationMs": 6310,
      "testDurationMs": 8893,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-18T17:40:15.497Z",
      "headSha": "62843eb63e5fd12f5e970e3b019fb41a908074fc",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/258522406528443",
      "shortSha": "62843eb",
      "cleanupDurationMs": 120553,
      "deployDurationMs": 90074,
      "testDurationMs": 456001,
      "testRetries": null,
      "workerSizeKib": 17037.1,
      "workerGzipKib": 4582.24,
      "mainWorkerGzipKib": 4582.24
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-18T17:38:15.726Z",
      "headSha": "62843eb63e5fd12f5e970e3b019fb41a908074fc",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/258522406528443",
      "shortSha": "62843eb",
      "cleanupDurationMs": 778,
      "deployDurationMs": 13319,
      "testDurationMs": 15123,
      "testRetries": null,
      "workerSizeKib": 1915.43,
      "workerGzipKib": 441,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `62843eb` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 805.3 KiB | 20.4s | 10.9s |  | 2.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/258522406528443) | 2026-07-18T17:40:19.064Z | Preview app released. |
| Dummy Petshop | released | `62843eb` | [https://dummy-petshop.iterate-preview-3.com](https://dummy-petshop.iterate-preview-3.com) | 198.2 KiB | 6.3s | 8.9s |  | 653ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/258522406528443) | 2026-07-18T17:40:17.160Z | Preview app released. |
| OS | released | `62843eb` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 4.47 MiB (±0 vs main) | 90.1s | 456.0s |  | 120.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/258522406528443) | 2026-07-18T17:40:15.497Z | Preview app released. |
| Semaphore | released | `62843eb` | [https://semaphore.iterate-preview-3.com](https://semaphore.iterate-preview-3.com) | 441.0 KiB | 13.3s | 15.1s |  | 778ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/258522406528443) | 2026-07-18T17:38:15.726Z | Preview app released. |
| Streams Example App | released | `62843eb` | [https://streams.iterate-preview-3.com](https://streams.iterate-preview-3.com) | 1.49 MiB | 14.7s | 57.4s |  | 8.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/258522406528443) | 2026-07-18T17:40:25.330Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->