### PR TITLE
Guard userinfo requests by token audience

### DIFF
--- a/apps/auth/src/lib/relying-party.test.ts
+++ b/apps/auth/src/lib/relying-party.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { exportJWK, generateKeyPair, SignJWT } from "jose";
+import { sessionCookie, signedTokenSet } from "./relying-party-test-support.ts";
 import { createIterateAuth, withAuthenticationResponseHeaders } from "./server.ts";
 
 const auth = createIterateAuth({
@@ -76,6 +77,81 @@ describe("relying-party credential resolution", () => {
       projects: [],
     });
     assert.deepEqual(errors, []);
+  });
+
+  it("sends an access token to userinfo only when userinfo is its audience", async (t) => {
+    const issuer = "https://auth.example.test/api/auth";
+    const resource = "https://app.example.test";
+    const userInfoEndpoint = `${issuer}/oauth2/userinfo`;
+    const baseConfig = {
+      clientId: "relying-party-session-test",
+      clientSecret: "secret",
+      issuer,
+      redirectURI: `${resource}/api/iterate-auth/callback`,
+    };
+    const discoveryUrl = `${issuer}/.well-known/openid-configuration`;
+    const fetchedUrls: string[] = [];
+
+    t.mock.method(globalThis, "fetch", async (input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : input.toString();
+      fetchedUrls.push(url);
+      if (url === discoveryUrl) {
+        return Response.json({
+          issuer,
+          authorization_endpoint: `${issuer}/oauth2/authorize`,
+          token_endpoint: `${issuer}/oauth2/token`,
+          jwks_uri: `${issuer}/jwks`,
+          userinfo_endpoint: userInfoEndpoint,
+        });
+      }
+      assert.equal(url, userInfoEndpoint);
+      return Response.json({
+        sub: "usr_session",
+        "https://iterate.com/claims/active_organization_id": "org_iterate",
+        "https://iterate.com/claims/organizations": [
+          { id: "org_iterate", name: "Iterate", role: "owner", slug: "iterate" },
+        ],
+      });
+    });
+
+    async function fetchSession(audience: string | string[]) {
+      const config = { ...baseConfig, resource: audience };
+      const signed = await signedTokenSet(config);
+      const publicJwk = await exportJWK(signed.jwks as CryptoKey);
+      const sessionAuth = createIterateAuth({
+        ...config,
+        jwks: { keys: [publicJwk] },
+      });
+      return sessionAuth.fetch(
+        new Request(`${resource}/api/iterate-auth/session`, {
+          headers: { cookie: sessionCookie(signed.tokenSet) },
+        }),
+      );
+    }
+
+    const response = await fetchSession(resource);
+
+    assert.ok(response);
+    assert.equal(response.status, 200);
+    assert.partialDeepStrictEqual(await response.json(), {
+      authenticated: true,
+      user: { id: "usr_session" },
+    });
+    assert.deepEqual(fetchedUrls, [discoveryUrl]);
+
+    fetchedUrls.length = 0;
+    const responseWithUserInfo = await fetchSession([resource, userInfoEndpoint]);
+
+    assert.ok(responseWithUserInfo);
+    assert.equal(responseWithUserInfo.status, 200);
+    assert.partialDeepStrictEqual(await responseWithUserInfo.json(), {
+      authenticated: true,
+      session: {
+        activeOrganizationId: "org_iterate",
+        organizations: [{ id: "org_iterate", name: "Iterate", role: "owner", slug: "iterate" }],
+      },
+    });
+    assert.deepEqual(fetchedUrls, [discoveryUrl, userInfoEndpoint]);
   });
 });
 

--- a/apps/auth/src/lib/server.ts
+++ b/apps/auth/src/lib/server.ts
@@ -66,7 +66,10 @@ export type OAuthInfra = {
   httpOptions: () => { [oauth.allowInsecureRequests]: true } | undefined;
   toTokenSet: (token: oauth.TokenEndpointResponse, existing?: TokenSet | null) => TokenSet;
   doRefresh: (tokenSet: TokenSet) => Promise<TokenSet | null>;
-  getUserInfo: (accessToken: string) => Promise<UserInfoClaims | null>;
+  getUserInfo: (
+    accessToken: string,
+    accessTokenClaims: AccessTokenClaims,
+  ) => Promise<UserInfoClaims | null>;
   cookieOpts: () => { httpOnly: true; path: string; sameSite: "Lax"; secure: boolean };
   resource: () => string;
   audiences: () => string[];
@@ -214,9 +217,19 @@ function createOAuthInfra(config: IterateAuthConfig, jwks: JWKS): OAuthInfra {
     });
   }
 
-  async function getUserInfo(accessToken: string): Promise<UserInfoClaims | null> {
+  async function getUserInfo(
+    accessToken: string,
+    accessTokenClaims: AccessTokenClaims,
+  ): Promise<UserInfoClaims | null> {
     const as = await getAuthorizationServer();
     if (!as.userinfo_endpoint) {
+      return null;
+    }
+
+    const accessTokenAudiences = Array.isArray(accessTokenClaims.aud)
+      ? accessTokenClaims.aud
+      : [accessTokenClaims.aud];
+    if (!accessTokenAudiences.includes(as.userinfo_endpoint)) {
       return null;
     }
 
@@ -417,7 +430,9 @@ export function createAuthMiddleware(config: IterateAuthConfig, infra: OAuthInfr
       }
 
       try {
-        const userInfo = includeUserInfo ? await getUserInfo(tokenSet.accessToken) : null;
+        const userInfo = includeUserInfo
+          ? await getUserInfo(tokenSet.accessToken, verification.accessToken)
+          : null;
 
         return {
           session: buildAuthenticatedSession(
@@ -674,7 +689,7 @@ export function createAuthHandler(config: IterateAuthConfig, infra: OAuthInfra) 
 
     let userInfo: UserInfoClaims | null;
     try {
-      userInfo = await getUserInfo(tokenSet.accessToken);
+      userInfo = await getUserInfo(tokenSet.accessToken, verification.accessToken);
     } catch {
       deleteCookie(c, SESSION_COOKIE, cookieOpts());
       return c.json({ authenticated: false } satisfies SessionResponse, 401);


### PR DESCRIPTION
## What changed

The shared Iterate relying-party auth client now forwards an access token to the OIDC `userinfo_endpoint` only when that exact endpoint is present in the already-verified token's `aud` claim.

Both `authenticateSession()` and `/api/iterate-auth/session` use the same guarded `getUserInfo()` path. Tokens with scalar or array audiences are handled without decoding the JWT a second time.

## Why

Production verification of #2127 exposed one Auth `500`: a forge-minted test token was valid for OS but intentionally not for Auth's userinfo resource. The shared client nevertheless sent it to userinfo. OAuth resource servers should not receive bearer tokens outside their declared audience.

This keeps forge/programmatic OS sessions authenticated from their verified token claims without making an invalid userinfo request. Normal OAuth sessions are unchanged because Auth-issued OpenID access tokens include the userinfo endpoint in their audience.

## Proof

The integration regression uses real signed JWTs and mocked OIDC discovery to prove both sides:

- OS-only scalar audience: no userinfo request; the session remains authenticated.
- Normal array audience `[resource, userinfo_endpoint]`: userinfo is fetched and its organization claims are merged.

Checks completed locally:

- `pnpm --dir apps/auth test`
- `pnpm --dir apps/auth typecheck`
- `pnpm format:check`
- `pnpm lint`
- Full OS unit suite: 202 files / 1,943 tests passed
- Two independent strict reviews approved; no package/export/legacy-gunk findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session enrichment and userinfo behavior on an auth-critical path; scope is narrow and covered by tests, with standard OAuth sessions unchanged when userinfo is in `aud`.
> 
> **Overview**
> The shared relying-party client **stops calling OIDC userinfo** unless the verified access token’s `aud` includes the discovery `userinfo_endpoint`. Audience is read from already-verified claims (scalar or array), not by decoding the JWT again.
> 
> `getUserInfo` now takes those claims; **`authenticateSession`** (when `includeUserInfo` is set) and **`/api/iterate-auth/session`** both use the same guard. If userinfo isn’t in `aud`, the call is skipped and the session stays authenticated from JWT claims only—fixing invalid userinfo calls for resource-only tokens (e.g. forge-minted OS sessions) that previously could trigger Auth `500`s.
> 
> A regression test mocks discovery and asserts: OS-only audience → no userinfo fetch, still `200`; audience including userinfo → userinfo is fetched and org claims appear in the session response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a6b4460a2d4dfeac9a3f75a7c6b1f70cee5d2e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +19 -4 | +18 -4 🟩🟩⬜⬜⬜ |
| Tests | +76 -0 | +69 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+95 -4** | **+87 -4** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between fd6024a and 6a6b446, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-18T20:15:21.709Z",
      "headSha": "6a6b4460a2d4dfeac9a3f75a7c6b1f70cee5d2e3",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/264267072538920",
      "shortSha": "6a6b446",
      "cleanupDurationMs": 2052,
      "deployDurationMs": 23180,
      "testDurationMs": 10616,
      "testRetries": null,
      "workerSizeKib": 3950.2,
      "workerGzipKib": 804.87,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-18T20:15:20.090Z",
      "headSha": "6a6b4460a2d4dfeac9a3f75a7c6b1f70cee5d2e3",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/264267072538920",
      "shortSha": "6a6b446",
      "cleanupDurationMs": 432,
      "deployDurationMs": 6126,
      "testDurationMs": 6028,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-18T20:15:18.387Z",
      "headSha": "6a6b4460a2d4dfeac9a3f75a7c6b1f70cee5d2e3",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/264267072538920",
      "shortSha": "6a6b446",
      "cleanupDurationMs": 140545,
      "deployDurationMs": 102945,
      "testDurationMs": 683801,
      "testRetries": "4 retried: catalogue example \"repo-edit-file\" runs identically across runtimes (vitest x1) · catalogue example \"secrets-lifecycle\" runs identically across runtimes (vitest x1) · catalogue example \"agent-send-message\" runs identically across runtimes (vitest x1) · project host serves the previous build through a broken commit, with serve info and overlay (vitest x1)",
      "workerSizeKib": 17075.16,
      "workerGzipKib": 4594.76,
      "mainWorkerGzipKib": 4595.25
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `6a6b446` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 804.9 KiB | 23.2s | 10.6s |  | 2.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/264267072538920) | 2026-07-18T20:15:21.709Z | Preview app released. |
| Dummy Petshop | released | `6a6b446` | [https://dummy-petshop.iterate-preview-7.com](https://dummy-petshop.iterate-preview-7.com) | 198.2 KiB | 6.1s | 6.0s |  | 432ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/264267072538920) | 2026-07-18T20:15:20.090Z | Preview app released. |
| OS | released | `6a6b446` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 4.49 MiB (-0.5 KiB vs main) | 102.9s | 683.8s | 4 retried: catalogue example "repo-edit-file" runs identically across runtimes (vitest x1) · catalogue example "secrets-lifecycle" runs identically across runtimes (vitest x1) · catalogue example "agent-send-message" runs identically across runtimes (vitest x1) · project host serves the previous build through a broken commit, with serve info and overlay (vitest x1) | 140.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/264267072538920) | 2026-07-18T20:15:18.387Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->