### PR TITLE
Fix public config extraction through defaults

### DIFF
--- a/packages/shared/src/config.test.ts
+++ b/packages/shared/src/config.test.ts
@@ -415,6 +415,16 @@ describe("public config helpers", () => {
     });
   });
 
+  it("extracts public fields from objects with defaults", () => {
+    const schema = z.object({
+      deployment: z
+        .object({ stage: publicValue(z.string()), privateToken: z.string() })
+        .default({ stage: "local", privateToken: "hidden" }),
+    });
+
+    expect(getPublicConfig(schema.parse({}), schema)).toEqual({ deployment: { stage: "local" } });
+  });
+
   it("exposes the correct public config types", () => {
     const config = Config.parse({
       pirateSecret: "ahoy",

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -202,6 +202,10 @@ function extractPublicConfigSchemaInternal(schema: z.ZodTypeAny): z.ZodTypeAny |
     return publicInnerSchema ? publicInnerSchema.optional() : null;
   }
 
+  if (schema instanceof z.ZodDefault) {
+    return extractPublicConfigSchemaInternal(schema.unwrap() as z.ZodTypeAny);
+  }
+
   if (schema instanceof z.ZodArray) {
     const publicElementSchema = extractPublicConfigSchemaInternal(schema.element as z.ZodTypeAny);
     if (!publicElementSchema) {


### PR DESCRIPTION
## What

- unwrap Zod default wrappers while projecting explicitly public config fields
- retain the rebuilt public-only schema so private defaulted fields cannot leak
- restore `cloudflare.workerName` in the browser bootstrap, allowing frontend PostHog events to carry `$environment: os-prd`

## Verification

- `pnpm install && pnpm typecheck && pnpm lint && pnpm format && pnpm test`
- `pnpm --dir packages/shared test` (46/46)
- `pnpm --dir packages/shared typecheck`
- real `AppConfig` probe returns `{ "workerName": "os-prd" }` from `getPublicConfig()`
- three independent architecture/cleanliness/TanStack audits: approved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to shared config projection with a focused unit test; no auth or data-path changes beyond what is already marked public.
> 
> **Overview**
> **Fixes public config projection when schema nodes use `.default()`.** `extractPublicConfigSchemaInternal` now unwraps `ZodDefault` the same way it already does for `ZodOptional`, so nested objects with defaults still contribute their `publicValue` fields to the rebuilt public-only schema instead of being dropped entirely.
> 
> A regression test covers a defaulted object that mixes a public `stage` field with a private `privateToken`, asserting `getPublicConfig` returns only `{ deployment: { stage: "local" } }` when parsing `{}`. That keeps private defaulted siblings out of the browser bootstrap payload (e.g. restoring public `cloudflare.workerName` for PostHog `$environment` tagging).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62d3264930472dc6b5fe6a620b022bf0be7e8b29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +4 -0 | +3 -0 🟩🟩⬜⬜⬜ |
| Tests | +10 -0 | +8 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+14 -0** | **+11 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between e8c95a5 and 62d3264, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-19T01:25:22.503Z",
      "headSha": "62d3264930472dc6b5fe6a620b022bf0be7e8b29",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/248934890444447",
      "shortSha": "62d3264",
      "cleanupDurationMs": 2622,
      "deployDurationMs": 20558,
      "testDurationMs": 11774,
      "testRetries": null,
      "workerSizeKib": 3950.2,
      "workerGzipKib": 804.9,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-19T01:25:30.297Z",
      "headSha": "62d3264930472dc6b5fe6a620b022bf0be7e8b29",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/248934890444447",
      "shortSha": "62d3264",
      "cleanupDurationMs": 10414,
      "deployDurationMs": 41780,
      "testDurationMs": 56091,
      "testRetries": null,
      "workerSizeKib": 5525.26,
      "workerGzipKib": 1570.45,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-19T01:25:20.575Z",
      "headSha": "62d3264930472dc6b5fe6a620b022bf0be7e8b29",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/248934890444447",
      "shortSha": "62d3264",
      "cleanupDurationMs": 691,
      "deployDurationMs": 6954,
      "testDurationMs": 9915,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-19T01:25:18.979Z",
      "headSha": "62d3264930472dc6b5fe6a620b022bf0be7e8b29",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/248934890444447",
      "shortSha": "62d3264",
      "cleanupDurationMs": 91004,
      "deployDurationMs": 168757,
      "testDurationMs": 493296,
      "testRetries": "2 retried: explicit child-agent delegation pipelines from an agent scope (relative path + create + message) (vitest x1) · runs \"workspace-files-transfer\" through the project REPL (specs x1)",
      "workerSizeKib": 17357.48,
      "workerGzipKib": 4655.96,
      "mainWorkerGzipKib": 4656.19
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-19T01:23:48.502Z",
      "headSha": "62d3264930472dc6b5fe6a620b022bf0be7e8b29",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/248934890444447",
      "shortSha": "62d3264",
      "cleanupDurationMs": 525,
      "deployDurationMs": 14294,
      "testDurationMs": 15808,
      "testRetries": null,
      "workerSizeKib": 1919.02,
      "workerGzipKib": 441.77,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `62d3264` | [https://auth.iterate-preview-9.com](https://auth.iterate-preview-9.com) | 804.9 KiB | 20.6s | 11.8s |  | 2.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/248934890444447) | 2026-07-19T01:25:22.503Z | Preview app released. |
| Dummy Petshop | released | `62d3264` | [https://dummy-petshop.iterate-preview-9.com](https://dummy-petshop.iterate-preview-9.com) | 198.2 KiB | 7.0s | 9.9s |  | 691ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/248934890444447) | 2026-07-19T01:25:20.575Z | Preview app released. |
| OS | released | `62d3264` | [https://os.iterate-preview-9.com](https://os.iterate-preview-9.com) | 4.55 MiB (-0.2 KiB vs main) | 168.8s | 493.3s | 2 retried: explicit child-agent delegation pipelines from an agent scope (relative path + create + message) (vitest x1) · runs "workspace-files-transfer" through the project REPL (specs x1) | 91.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/248934890444447) | 2026-07-19T01:25:18.979Z | Preview app released. |
| Semaphore | released | `62d3264` | [https://semaphore.iterate-preview-9.com](https://semaphore.iterate-preview-9.com) | 441.8 KiB | 14.3s | 15.8s |  | 525ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/248934890444447) | 2026-07-19T01:23:48.502Z | Preview app released. |
| Streams Example App | released | `62d3264` | [https://streams.iterate-preview-9.com](https://streams.iterate-preview-9.com) | 1.53 MiB | 41.8s | 56.1s |  | 10.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/248934890444447) | 2026-07-19T01:25:30.297Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->