### PR TITLE
Preserve later LLM explanations in mobile activity cards

### DIFF
--- a/apps/mobile/src/components/activity-card.tsx
+++ b/apps/mobile/src/components/activity-card.tsx
@@ -16,7 +16,6 @@ import CodeEditor from "./code-editor.tsx";
 export function ActivityCard({ activity }: { activity: AgentUiActivity }) {
   const isLive = activity.status !== "done";
   const [toggled, setToggled] = useState<boolean | null>(null);
-  const hasParsedCode = activity.steps.some((step) => step.kind === "code");
   // Live activities stream open so you can watch the code being written;
   // settled ones collapse to their summary until tapped.
   const expanded = toggled ?? isLive;
@@ -34,8 +33,8 @@ export function ActivityCard({ activity }: { activity: AgentUiActivity }) {
         </Text>
       </Pressable>
       {expanded
-        ? activity.steps.map((step) => (
-            <StepView hasParsedCode={hasParsedCode} key={step.id} step={step} />
+        ? activity.steps.map((step, index) => (
+            <StepView key={step.id} nextStep={activity.steps[index + 1]} step={step} />
           ))
         : null}
     </View>
@@ -52,9 +51,14 @@ function liveSummary(activity: AgentUiActivity): string {
   return "working…";
 }
 
-function StepView({ hasParsedCode, step }: { hasParsedCode: boolean; step: AgentUiStep }) {
+function StepView({ nextStep, step }: { nextStep: AgentUiStep | undefined; step: AgentUiStep }) {
   const responseText =
-    step.kind === "llm" ? llmResponseForDisplay(step.responseText, hasParsedCode) : "";
+    step.kind === "llm"
+      ? llmResponseForDisplay(
+          step.responseText,
+          nextStep?.kind === "code" ? nextStep.code : undefined,
+        )
+      : "";
   return (
     <View style={styles.step}>
       <Text style={styles.stepLabel}>

--- a/apps/mobile/src/lib/activity-display.test.ts
+++ b/apps/mobile/src/lib/activity-display.test.ts
@@ -1,12 +1,18 @@
 import { expect, test } from "vitest";
 import { llmResponseForDisplay } from "./activity-display.ts";
 
-test("hides the internal model response whenever the activity has parsed execution code", () => {
-  expect(llmResponseForDisplay("```ts\nconst generated = true;\n```", true)).toBe("");
+test("hides a fenced model response duplicated by the following execution step", () => {
+  expect(
+    llmResponseForDisplay("```ts\nconst generated = true;\n```", "const generated = true;"),
+  ).toBe("");
 });
 
-test("keeps the model response while no execution step exists", () => {
-  expect(llmResponseForDisplay("```ts\nconst answer = 42;\n```", false)).toBe(
+test("keeps a later model explanation after code has run", () => {
+  expect(llmResponseForDisplay("The request succeeded.", undefined)).toBe("The request succeeded.");
+});
+
+test("keeps a model response that differs from the following execution step", () => {
+  expect(llmResponseForDisplay("```ts\nconst answer = 42;\n```", "const answer = 43;")).toBe(
     "```ts\nconst answer = 42;\n```",
   );
 });

--- a/apps/mobile/src/lib/activity-display.ts
+++ b/apps/mobile/src/lib/activity-display.ts
@@ -1,3 +1,7 @@
-export function llmResponseForDisplay(responseText: string, hasParsedCode: boolean): string {
-  return hasParsedCode ? "" : responseText;
+export function llmResponseForDisplay(responseText: string, followingCode: string | undefined) {
+  if (followingCode === undefined) return responseText;
+  const response = responseText.trim();
+  const fenced = /^```(?:typescript|ts|javascript|js)?\s*\n([\s\S]*?)\n```$/.exec(response)?.[1];
+  const generatedCode = fenced || response;
+  return generatedCode.trim() === followingCode.trim() ? "" : responseText;
 }


### PR DESCRIPTION
Follow-up to #2143 after its auto-merge raced the final review comment.

Mobile activity cards now suppress an LLM response only when it duplicates the immediately following executable code. Explanations emitted after code runs, and responses that differ from the executable step, remain visible.

Tests cover the duplicated-code, later-explanation, and differing-code cases.

## Verification

- `pnpm --dir apps/mobile test` (47 tests)
- `pnpm --dir apps/mobile typecheck`
- `pnpm lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only logic in the mobile activity feed with unit tests; no auth, data, or API changes.
> 
> **Overview**
> Mobile activity cards no longer blank every LLM step once the activity includes code. **`llmResponseForDisplay`** now takes the **next step’s executable code** (if any) instead of a whole-activity `hasParsedCode` flag, and hides the LLM body only when that response duplicates what runs immediately after (including fenced `ts`/`js` blocks).
> 
> **`StepView`** receives `nextStep` so each LLM row is judged against its successor; explanations with no following code step, or text that doesn’t match the next run, stay visible. Tests cover duplicate hide, post-code explanations, and mismatched code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3897651a8b88a1395e5ac37c839333b47e1e52af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Mobile | +25 -11 | +24 -11 🟩🟩🟩🟥🟥 |
| **Total** | **+25 -11** | **+24 -11** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between a0accb9 and 3897651, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->