### PR TITLE
Route Gmail and GitHub through project egress

### DIFF
--- a/apps/os/docs/integrations-and-secrets-design.md
+++ b/apps/os/docs/integrations-and-secrets-design.md
@@ -130,9 +130,10 @@ Google accounts / GitHub installations, each at
   connected fact, arm the router subscription, claim the directory entry).
 - **Outbound calls**: the itx caller surface replays dotted paths onto real
   vendor SDK instances — a real `@slack/web-api` WebClient, the all-in-one
-  `octokit` SDK — whose transport carries a `getSecret(...)`
-  placeholder through the connection secret's `fetch()`. Full SDK surface for
-  free; tokens never leave the DO.
+  `octokit` SDK — whose transport carries a `getSecret(...)` placeholder
+  through project egress. Project policy runs first; the connection Secret DO
+  then substitutes, refreshes, pins, and audits. Full SDK surface for free;
+  tokens never leave the DO.
 - **Inbound webhooks** (`integration-webhook-api.ts` + per-provider
   handlers): a tiny chain of imperative `fetch` handlers. Each verifies
   however its provider requires (plain WebCrypto in platform code), extracts

--- a/apps/os/docs/integrations.md
+++ b/apps/os/docs/integrations.md
@@ -85,6 +85,9 @@ pick the right bot token, and how **multiple Slack workspaces in one project
 just work**. Google connections are named from the account email; tokens live
 in the connection secret, refreshed on 401 by the Secret DO's shared
 `oauth-refresh-token` strategy (nothing token-shaped ever lands on a journal).
+Gmail REST calls carry that connection's access-token placeholder through
+project egress before the Secret DO substitutes it, so the same interceptors
+and approval rules apply to reads and sends.
 
 Slack Web API calls normally never hold material: the request carries a
 `getSecret(path)` placeholder for the connection's token and traverses project
@@ -221,9 +224,9 @@ GitHub connects as a **GitHub App installation** (deep-link to
   wrapped Octokit (`rest.*`, `request(...)`, `graphql(...)`, `paginate(...)`).
   The `.octokit` namespace is mandatory: it makes the SDK boundary explicit
   and a direct `.rest` on the connection is rejected. Its transport carries a
-  `getSecret` placeholder through the connection secret's fetch. The Secret
-  DO mints the installation token on first use and re-mints on 401 — trusted
-  DO code signing the App JWT, no worker, no jail.
+  `getSecret` placeholder through project egress, so interceptors and approval
+  rules run before the Secret DO mints the installation token on first use or
+  re-mints it on 401 — trusted DO code signing the App JWT, no worker, no jail.
 - **Inbound App webhooks** land on the door, verify `x-hub-signature-256`
   with plain WebCrypto, and route on `installation_id`. Each delivery is
   appended once to `/integrations/github/<connection>` with its complete

--- a/apps/os/src/domains/integrations/github-api.test.ts
+++ b/apps/os/src/domains/integrations/github-api.test.ts
@@ -1,19 +1,25 @@
-// connectionOctokit: the wrapped Octokit's transport must ride the connection
-// secret's fetch with an access-token PLACEHOLDER (never a real token), so the
+// connectionOctokit: the wrapped Octokit's transport must ride project egress
+// with an access-token PLACEHOLDER (never a real token), so the
 // itx caller surface (github.get("<conn>").octokit.rest.* / .octokit.graphql()
-// / .octokit.request()) keeps the token in its Secret DO. Only the secret stub
+// / .octokit.request()) keeps the token in its Secret DO. Only project egress
 // is mocked; the all-in-one Octokit is real.
 
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-const captured: { request?: Request; requestCount: number; responseStatus?: number } = {
+const captured: {
+  projectDurableObjectName?: string;
+  request?: Request;
+  requestCount: number;
+  responseStatus?: number;
+} = {
   requestCount: 0,
 };
 vi.mock("../../env.ts", () => ({
   itxEnv: {
-    SECRET: {
-      getByName: () => ({
+    PROJECT: {
+      getByName: (name: string) => ({
         fetch: async (request: Request) => {
+          captured.projectDurableObjectName = name;
           captured.request = request;
           captured.requestCount += 1;
           if (captured.responseStatus !== undefined) {
@@ -39,6 +45,7 @@ const { connectionOctokit, normalizeGithubError, GITHUB_CALL_GRAMMAR } =
   await import("./github-api.ts");
 
 beforeEach(() => {
+  captured.projectDurableObjectName = undefined;
   captured.request = undefined;
   captured.requestCount = 0;
   captured.responseStatus = undefined;
@@ -91,7 +98,7 @@ describe("normalizeGithubError", () => {
 });
 
 describe("connectionOctokit", () => {
-  test(".request() rides the connection secret's fetch with a placeholder auth header", async () => {
+  test(".request() rides project egress with a placeholder auth header", async () => {
     const octokit = connectionOctokit({ connection: "acme", projectId: "prj_1" });
     const response = await octokit.request("GET /user");
 
@@ -102,6 +109,7 @@ describe("connectionOctokit", () => {
     expect(request.headers.get("authorization")).toBe(
       'Bearer getSecret("/secrets/integrations/github/acme", { field: "accessToken" })',
     );
+    expect(captured.projectDurableObjectName).toContain("prj_1");
   });
 
   test("rest.* namespaced methods hit the right path over the same jailed transport", async () => {

--- a/apps/os/src/domains/integrations/github-api.ts
+++ b/apps/os/src/domains/integrations/github-api.ts
@@ -1,8 +1,8 @@
 // GitHub Web API access for itx — a real Octokit, wrapped so its transport
-// rides one named connection's secret. The installation token never leaves its
+// rides project egress with one named connection's secret placeholder. The installation token never leaves its
 // Secret Durable Object: every request Octokit makes carries a
 // `getSecret(path, { field: "accessToken" })` placeholder Authorization header and is
-// dispatched through the connection secret's own `fetch()`, whose
+// dispatched through project policy before the connection secret's `fetch()`, whose
 // github-app-installation strategy mints the installation token on first use,
 // re-mints on 401, substitutes the placeholder, and pins the host — all in
 // trusted DO code. The caller's mandatory `.octokit` namespace
@@ -14,13 +14,14 @@
 import { Octokit } from "octokit";
 import { itxEnv } from "../../env.ts";
 import { isPathMissMessage } from "../../itx/path-proxy.ts";
-import { DurableObjectNameCodec } from "../durable-object-names.ts";
-import { githubAccessTokenPlaceholder, githubConnectionSecretPath } from "./utils.ts";
+import { projectStub } from "../projects/egress.ts";
+import { githubAccessTokenPlaceholder } from "./utils.ts";
 
 /**
  * A connection-scoped Octokit whose every request is routed through the GitHub
- * connection secret's `fetch()` with the access-token placeholder — the token
- * never leaves the Secret DO, and every call lands on the secret's audit trail.
+ * project egress with the access-token placeholder — project policy runs
+ * before the token is substituted in the Secret DO, and every permitted call
+ * lands on the secret's audit trail.
  *
  * `baseUrl` overrides the GitHub API origin (a petshop stand-in in e2e);
  * omitted, Octokit uses `https://api.github.com`.
@@ -30,11 +31,8 @@ export function connectionOctokit(input: {
   connection: string;
   projectId: string;
 }): Octokit {
-  const secretPath = githubConnectionSecretPath(input.connection);
   const placeholder = `Bearer ${githubAccessTokenPlaceholder(input.connection)}`;
-  const stub = itxEnv.SECRET.getByName(
-    DurableObjectNameCodec.stringify({ path: secretPath, projectId: input.projectId }),
-  );
+  const egress = projectStub(itxEnv.PROJECT, input.projectId);
   return new Octokit({
     ...(input.baseUrl ? { baseUrl: input.baseUrl } : {}),
     // Disable Octokit's own retry paths: replaying an opaque write after a
@@ -50,7 +48,7 @@ export function connectionOctokit(input: {
       fetch: (url: string, init: RequestInit = {}) => {
         const headers = new Headers(init.headers);
         headers.set("authorization", placeholder);
-        return stub.fetch(new Request(url, { ...init, headers }));
+        return egress.fetch(new Request(url, { ...init, headers }));
       },
     },
   });

--- a/apps/os/src/domains/integrations/gmail-api.test.ts
+++ b/apps/os/src/domains/integrations/gmail-api.test.ts
@@ -1,0 +1,41 @@
+import { expect, test, vi } from "vitest";
+
+const captured: { projectDurableObjectName?: string; request?: Request } = {};
+
+vi.mock("../../env.ts", () => ({
+  itxEnv: {
+    PROJECT: {
+      getByName: (name: string) => ({
+        fetch: async (request: Request) => {
+          captured.projectDurableObjectName = name;
+          captured.request = request;
+          return Response.json({ id: "message-123" });
+        },
+      }),
+    },
+  },
+}));
+
+const { callGmailApi } = await import("./gmail-api.ts");
+
+test("a Gmail API request enters project egress with its access-token placeholder", async () => {
+  const response = await callGmailApi({
+    authorization:
+      'Bearer getSecret("/secrets/integrations/google/alice", { field: "accessToken" })',
+    projectId: "prj_1",
+    request: {
+      body: { raw: "base64url-mime" },
+      method: "POST",
+      path: "/users/me/messages/send",
+    },
+  });
+
+  expect(response).toMatchObject({ data: { id: "message-123" }, status: 200 });
+  expect(captured.projectDurableObjectName).toContain("prj_1");
+  expect(captured.request).toMatchObject({
+    method: "POST",
+    url: "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
+  });
+  expect(captured.request!.headers.get("authorization")).toContain('getSecret("/secrets/');
+  await expect(captured.request!.clone().json()).resolves.toEqual({ raw: "base64url-mime" });
+});

--- a/apps/os/src/domains/integrations/gmail-api.ts
+++ b/apps/os/src/domains/integrations/gmail-api.ts
@@ -1,23 +1,23 @@
-// Gmail REST proxy: the request goes through the connection secret's fetch
+// Gmail REST proxy: the request goes through project egress
 // carrying a `getSecret(...)` Authorization placeholder — the Secret DO
 // substitutes the fresh access token and its oauth-refresh-token strategy
 // refreshes on 401. No token bytes ever reach this code.
 
+import { itxEnv } from "../../env.ts";
+import { projectStub } from "../projects/egress.ts";
 import type { GmailRequestInput } from "./types.ts";
 
 export async function callGmailApi(input: {
   /** The Gmail REST call. */
   request: GmailRequestInput;
+  projectId: string;
   /** The Authorization header VALUE — a `Bearer getSecret(...)` placeholder the
    * connection secret substitutes; never a raw token. */
   authorization: string;
-  /** Sends the composed request through the connection secret's fetch (the DO
-   * stub): substitute + 401→refresh→retry, all in trusted DO code. */
-  send: (request: Request) => Promise<Response>;
 }) {
   const method = (input.request.method ?? "GET").trim().toUpperCase();
   const url = gmailUrl(input.request);
-  const response = await input.send(
+  const response = await projectStub(itxEnv.PROJECT, input.projectId).fetch(
     new Request(url, {
       method,
       headers: {

--- a/apps/os/src/domains/integrations/slack-api.ts
+++ b/apps/os/src/domains/integrations/slack-api.ts
@@ -118,8 +118,8 @@ function slackEgressAdapter(input: {
 export function connectionSlackClient(input: { connection: string; projectId: string }): WebClient {
   const placeholder = `getSecret("${slackBotTokenSecretPath(input.connection)}")`;
   return new WebClient(placeholder, {
-    // Dials the project egress door (not the Secret DO directly, unlike
-    // github/gmail) so project egress interceptors observe Slack calls.
+    // Dials the project egress door so project interceptors and approval rules
+    // observe Slack calls before the Secret DO substitutes the token.
     adapter: slackEgressAdapter({
       connection: input.connection,
       projectId: input.projectId,

--- a/apps/os/src/domains/repos/github-link.test.ts
+++ b/apps/os/src/domains/repos/github-link.test.ts
@@ -1,6 +1,6 @@
 // Unit tests for linkRepoToGithub / unlinkRepoFromGithub — the itx-side flow
 // behind repo.linkGithub(). There is NO network: the connection stream, the
-// connection secret's fetch (which is how the wrapped Octokit reaches
+// project egress fetch (which is how the wrapped Octokit reaches
 // "GitHub"), and the Repo Durable Object are all in-memory fakes on the same
 // itxEnv seam the connect-flow tests use. The GitHub-touching push/sync
 // mechanics live on the Repo DO and are proven against real GitHub in
@@ -50,11 +50,10 @@ const network = await vi.hoisted(async () => {
       state.subscriptionRemoveAppendShouldFail = false;
     },
     state,
-    // The connection secret's fetch IS the fake GitHub API: the wrapped
-    // Octokit dispatches every request through it. (The shared seam's SECRET
-    // is a store of update()d records; this suite needs the other half of
-    // the Secret DO — its egress fetch — so it stays bespoke.)
-    SECRET: {
+    // Project egress IS the fake GitHub API: wrapped Octokit dispatches every
+    // placeholder-bearing request through this outer policy boundary. The
+    // shared seam's SECRET remains the connection-record store.
+    PROJECT: {
       getByName(_name: string) {
         return {
           async fetch(request: Request) {
@@ -151,6 +150,7 @@ vi.mock("../integrations/telegram-api.ts", () => ({
 
 vi.mock("../../env.ts", () => ({
   itxEnv: {
+    PROJECT: network.PROJECT,
     REPO: network.REPO,
     SECRET: network.SECRET,
     STREAM: network.STREAM,

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -2977,21 +2977,14 @@ class ProjectIntegrationsRpcTarget extends IterateRpcTarget<"ProjectIntegrations
           `itx.integrations.gmail.get(${JSON.stringify(connection)}) exposes request(...); got "${method.join(".")}".`,
         );
       }
-      // No in-process token fetch — the Gmail call goes through the connection
-      // secret's fetch with a placeholder Authorization header; the Secret DO
-      // substitutes the access token and its oauth-refresh-token strategy
-      // refreshes on 401.
+      // No in-process token fetch — the Gmail call goes through project egress
+      // with a placeholder Authorization header; after project policy permits
+      // it, the Secret DO substitutes the access token and refreshes on 401.
       const connectionPath = googleConnectionSecretPath(connection);
       return await callGmailApi({
         authorization: `Bearer getSecret("${connectionPath}", { field: "accessToken" })`,
+        projectId: this.props.projectId,
         request: args[0] as GmailRequestInput,
-        send: (request) =>
-          env.SECRET.getByName(
-            DurableObjectNameCodec.stringify({
-              path: connectionPath,
-              projectId: this.props.projectId,
-            }),
-          ).fetch(request),
       });
     }
 

--- a/tasks/complete/2026-07-20-gmail-github-project-egress.md
+++ b/tasks/complete/2026-07-20-gmail-github-project-egress.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: complete
 size: small
 priority: high
 tags: [egress, approvals, integrations, gmail, github, secrets]
@@ -7,7 +7,7 @@ tags: [egress, approvals, integrations, gmail, github, secrets]
 
 # Route Gmail and GitHub through project egress
 
-**Status summary:** Implementation and local verification are complete. Gmail and GitHub data calls now enter project egress with credential placeholders intact; focused and full workspace checks pass. Missing: preview CI evidence and review feedback.
+**Status summary:** Complete. Gmail and GitHub data calls now enter project egress with credential placeholders intact; focused tests, full workspace checks, and preview deployment/e2e pass. No implementation pieces remain.
 
 Gmail and GitHub currently dispatch credential-bearing requests directly through their connection Secret Durable Objects. That preserves secret confinement and origin pinning, but skips the Project Durable Object's egress policy boundary. Consequently, project egress interceptors and human-approval `hold` rules cannot observe these built-in integration calls.
 
@@ -19,7 +19,7 @@ Gmail and GitHub currently dispatch credential-bearing requests directly through
 - [x] Existing Gmail request composition and GitHub Octokit behavior remain unchanged, including GitHub's no-retry-on-5xx policy and the Secret DO's one refresh-and-retry on 401. _Focused transport/repo-link tests and the full OS suite pass._
 - [x] Documentation no longer describes Gmail or GitHub as intentionally bypassing project egress. _Updated both integration guides and stale source/test comments._
 - [x] Focused tests, typecheck, lint, and formatting pass. _24 focused tests plus full `pnpm typecheck`, `pnpm lint`, `pnpm format`, and `pnpm test` are green._
-- [ ] Preview CI confirms the integration transports cross the production-shaped project egress boundary without new trace or test errors.
+- [x] Preview CI confirms the integration transports cross the production-shaped project egress boundary without new trace or test errors. _PR #2159 deployed preview-4 and passed its full production-shaped e2e suite (56 browser specs; 15m53s job)._
 
 ## Scope
 
@@ -38,3 +38,4 @@ This task changes the two built-in integration transports only. It does not remo
 - Retargeted `callGmailApi` to own project-egress dispatch; the RPC layer can no longer inject the inner Secret DO fetcher.
 - Updated the repo-link fake to preserve its public behavior at the new project-egress seam.
 - Local verification: 24 focused tests; full workspace typecheck, lint, format, and tests; OS reports 2,055 passed, 6 expected failures, and 1 skip.
+- Preview verification: preview-4 deployed auth, dummy-petshop, and OS successfully; all preview e2e checks passed, including 56 OS browser specs.

--- a/tasks/gmail-github-project-egress.md
+++ b/tasks/gmail-github-project-egress.md
@@ -7,18 +7,19 @@ tags: [egress, approvals, integrations, gmail, github, secrets]
 
 # Route Gmail and GitHub through project egress
 
-**Status summary:** Specified; implementation has not started. The intended change is limited to the built-in Gmail and GitHub data-call transports. Missing: regression coverage, transport changes, and verification.
+**Status summary:** Implementation and local verification are complete. Gmail and GitHub data calls now enter project egress with credential placeholders intact; focused and full workspace checks pass. Missing: preview CI evidence and review feedback.
 
 Gmail and GitHub currently dispatch credential-bearing requests directly through their connection Secret Durable Objects. That preserves secret confinement and origin pinning, but skips the Project Durable Object's egress policy boundary. Consequently, project egress interceptors and human-approval `hold` rules cannot observe these built-in integration calls.
 
 ## Acceptance criteria
 
-- [ ] A Gmail `gmail.request(...)` call enters project egress with its Google connection-secret placeholder intact before any secret substitution.
-- [ ] Every wrapped Octokit request enters project egress with its GitHub connection-secret placeholder intact before any secret substitution.
-- [ ] The existing Secret Durable Object remains the sole substitution, refresh, origin-pin, and credential-audit authority after project policy permits the request.
-- [ ] Existing Gmail request composition and GitHub Octokit behavior remain unchanged, including GitHub's no-retry-on-5xx policy and the Secret DO's one refresh-and-retry on 401.
-- [ ] Documentation no longer describes Gmail or GitHub as intentionally bypassing project egress.
-- [ ] Focused tests, typecheck, lint, and formatting pass.
+- [x] A Gmail `gmail.request(...)` call enters project egress with its Google connection-secret placeholder intact before any secret substitution. _`gmail-api.test.ts` drives the real request composer against the root project fetcher._
+- [x] Every wrapped Octokit request enters project egress with its GitHub connection-secret placeholder intact before any secret substitution. _`github-api.test.ts` drives real Octokit request, REST, GraphQL, pagination, and write-failure paths._
+- [x] The existing Secret Durable Object remains the sole substitution, refresh, origin-pin, and credential-audit authority after project policy permits the request. _Only the outer transport changed; project egress's existing secret-reference lane still delegates to the Secret DO._
+- [x] Existing Gmail request composition and GitHub Octokit behavior remain unchanged, including GitHub's no-retry-on-5xx policy and the Secret DO's one refresh-and-retry on 401. _Focused transport/repo-link tests and the full OS suite pass._
+- [x] Documentation no longer describes Gmail or GitHub as intentionally bypassing project egress. _Updated both integration guides and stale source/test comments._
+- [x] Focused tests, typecheck, lint, and formatting pass. _24 focused tests plus full `pnpm typecheck`, `pnpm lint`, `pnpm format`, and `pnpm test` are green._
+- [ ] Preview CI confirms the integration transports cross the production-shaped project egress boundary without new trace or test errors.
 
 ## Scope
 
@@ -29,3 +30,11 @@ This task changes the two built-in integration transports only. It does not remo
 - Assumption: `ProjectDurableObject.fetch()` remains the single outer policy door. After approval/interception, its existing egress implementation selects the referenced Secret Durable Object, which performs substitution and the real outbound request. The Secret DO must not call back into project egress.
 - Assumption: existing integration call syntax and return values are public API and must not change.
 - Test behavior at the transport boundary: the observable outbound request must arrive at the project fetcher, addressed by project ID, with the expected `getSecret(...)` placeholder. Do not expose or seed private secret storage in tests.
+
+## Implementation log
+
+- Added a Gmail transport spec proving the composed `messages/send` request reaches the root project fetcher with its Google access-token placeholder.
+- Retargeted wrapped Octokit from the connection Secret namespace to the root Project namespace and updated its real-Octokit transport coverage.
+- Retargeted `callGmailApi` to own project-egress dispatch; the RPC layer can no longer inject the inner Secret DO fetcher.
+- Updated the repo-link fake to preserve its public behavior at the new project-egress seam.
+- Local verification: 24 focused tests; full workspace typecheck, lint, format, and tests; OS reports 2,055 passed, 6 expected failures, and 1 skip.

--- a/tasks/gmail-github-project-egress.md
+++ b/tasks/gmail-github-project-egress.md
@@ -1,0 +1,31 @@
+---
+status: in-progress
+size: small
+priority: high
+tags: [egress, approvals, integrations, gmail, github, secrets]
+---
+
+# Route Gmail and GitHub through project egress
+
+**Status summary:** Specified; implementation has not started. The intended change is limited to the built-in Gmail and GitHub data-call transports. Missing: regression coverage, transport changes, and verification.
+
+Gmail and GitHub currently dispatch credential-bearing requests directly through their connection Secret Durable Objects. That preserves secret confinement and origin pinning, but skips the Project Durable Object's egress policy boundary. Consequently, project egress interceptors and human-approval `hold` rules cannot observe these built-in integration calls.
+
+## Acceptance criteria
+
+- [ ] A Gmail `gmail.request(...)` call enters project egress with its Google connection-secret placeholder intact before any secret substitution.
+- [ ] Every wrapped Octokit request enters project egress with its GitHub connection-secret placeholder intact before any secret substitution.
+- [ ] The existing Secret Durable Object remains the sole substitution, refresh, origin-pin, and credential-audit authority after project policy permits the request.
+- [ ] Existing Gmail request composition and GitHub Octokit behavior remain unchanged, including GitHub's no-retry-on-5xx policy and the Secret DO's one refresh-and-retry on 401.
+- [ ] Documentation no longer describes Gmail or GitHub as intentionally bypassing project egress.
+- [ ] Focused tests, typecheck, lint, and formatting pass.
+
+## Scope
+
+This task changes the two built-in integration transports only. It does not remove or redesign the public `itx.secrets.get(path).fetch(...)` surface, generalize approvals beyond HTTP, add semantic email approval rendering, or change OAuth/connect-time provider calls.
+
+## Implementation notes
+
+- Assumption: `ProjectDurableObject.fetch()` remains the single outer policy door. After approval/interception, its existing egress implementation selects the referenced Secret Durable Object, which performs substitution and the real outbound request. The Secret DO must not call back into project egress.
+- Assumption: existing integration call syntax and return values are public API and must not change.
+- Test behavior at the transport boundary: the observable outbound request must arrive at the project fetcher, addressed by project ID, with the expected `getSecret(...)` placeholder. Do not expose or seed private secret storage in tests.


### PR DESCRIPTION
## Summary

Make built-in Gmail and GitHub API calls obey the same project egress policy as ordinary agent `fetch()` calls.

After this change, a project can hold or deny Gmail/GitHub requests with its existing egress rules while OAuth and installation tokens remain confined to their Secret Durable Objects:

```ts
await project.streams.get("/").append({
  type: "events.iterate.com/project/egress-rules-configured",
  payload: {
    rules: [
      {
        ruleKey: "approve-outgoing-email",
        match: {
          hosts: ["gmail.googleapis.com"],
          methods: ["POST"],
          pathPrefix: "/gmail/v1/users/me/messages/send",
        },
        verdict: "hold",
      },
    ],
  },
});
```

The integration APIs do not change. Project egress sees only `getSecret(...)` placeholders; the Secret DO still owns origin pinning, substitution, refresh, and audit.

## Scope

- Route built-in `gmail.request(...)` data calls through project egress.
- Route wrapped Octokit requests through project egress.
- Preserve existing request composition and retry behavior.
- Leave the broader public `secret.fetch(...)` redesign and semantic email approval UI to follow-up work.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm test` — OS: 2,055 passed, 6 expected failures, 1 skipped
- Focused Gmail/GitHub/repo-link tests: 24 passed
- Preview-4 deploy/e2e: green across auth, dummy-petshop, and OS (56 browser specs)
- Retry audit: the unrelated userspace-integration test needed one bounded retry in the full run, then passed a targeted zero-retry rerun against the same preview in 24.1s

Task: `tasks/complete/2026-07-20-gmail-github-project-egress.md`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

> [!CAUTION]
> Preview e2e skipped for head a035066: no app is recorded at this head — nothing app-affecting changed since the last fully tested deploy, so the recorded results below still stand. If this PR has never deployed for this head, run preview deploy first.

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-21T12:20:11.370Z",
      "headSha": "684f99deb06cfce11a696193660b0a564179edb0",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/353060495553843",
      "shortSha": "684f99d",
      "cleanupDurationMs": 2899,
      "deployDurationMs": 87651,
      "testDurationMs": 3805,
      "testRetries": null,
      "workerSizeKib": 3958.36,
      "workerGzipKib": 808.08,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-21T12:20:09.082Z",
      "headSha": "684f99deb06cfce11a696193660b0a564179edb0",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/353060495553843",
      "shortSha": "684f99d",
      "cleanupDurationMs": 608,
      "deployDurationMs": 9078,
      "testDurationMs": 5985,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-21T12:20:22.085Z",
      "headSha": "684f99deb06cfce11a696193660b0a564179edb0",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/353060495553843",
      "shortSha": "684f99d",
      "cleanupDurationMs": 13610,
      "deployDurationMs": 160581,
      "testDurationMs": 627652,
      "testRetries": "1 retried: a project mounts ocado into the collection; connections + secret confinement hold (vitest x1)",
      "workerSizeKib": 17390.02,
      "workerGzipKib": 4656.39,
      "mainWorkerGzipKib": 4656.25
    }
  },
  "environmentConfigLease": null,
  "notice": "Preview e2e skipped for head a035066: no app is recorded at this head — nothing app-affecting changed since the last fully tested deploy, so the recorded results below still stand. If this PR has never deployed for this head, run preview deploy first."
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `684f99d` | [https://auth.iterate-preview-4.com](https://auth.iterate-preview-4.com) | 808.1 KiB | 87.7s | 3.8s |  | 2.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/353060495553843) | 2026-07-21T12:20:11.370Z | Preview app released. |
| Dummy Petshop | released | `684f99d` | [https://dummy-petshop.iterate-preview-4.com](https://dummy-petshop.iterate-preview-4.com) | 198.2 KiB | 9.1s | 6.0s |  | 608ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/353060495553843) | 2026-07-21T12:20:09.082Z | Preview app released. |
| OS | released | `684f99d` | [https://os.iterate-preview-4.com](https://os.iterate-preview-4.com) | 4.55 MiB (+0.1 KiB vs main) | 160.6s | 627.7s | 1 retried: a project mounts ocado into the collection; connections + secret confinement hold (vitest x1) | 13.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/353060495553843) | 2026-07-21T12:20:22.085Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +20 -29 | +9 -16 🟩🟥⬜⬜⬜ |
| Tests | +62 -13 | +50 -5 🟩🟩🟩🟩🟩 |
| Docs | +51 -6 | +40 -6 🟩🟩🟩🟥⬜ |
| **Total** | **+133 -48** | **+99 -27** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between af4d2ae and a035066, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the outbound path for built-in Gmail/GitHub calls (policy ordering) while keeping tokens in Secret DOs; behavior is covered by focused transport tests and full suite, but any project-egress edge case could affect integration traffic.
> 
> **Overview**
> Built-in **Gmail** and **GitHub** outbound calls now hit the **Project Durable Object** egress door first, with `getSecret(...)` placeholders unchanged—same public `itx.integrations` APIs, but project **egress rules**, interceptors, and **hold** approvals can observe those requests before the Secret DO substitutes tokens, refreshes on 401, and audits.
> 
> **GitHub** wrapped Octokit transport switches from `SECRET.getByName(...).fetch` to `projectStub(PROJECT, projectId).fetch`. **Gmail** `callGmailApi` owns project-egress dispatch (RPC no longer injects the inner Secret fetcher); it takes `projectId`. Repo-link and integration tests mock **PROJECT** instead of **SECRET** for the outer hop.
> 
> Docs and comments state Gmail/GitHub align with Slack: policy at the project boundary, secrets still confined to the Secret DO.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a035066f044355776aab9f3371c9b63ec9a9cf21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->