### PR TITLE
Restrict Semaphore acquisition to allowed slugs

### DIFF
--- a/apps/semaphore/e2e/vitest/live.e2e.test.ts
+++ b/apps/semaphore/e2e/vitest/live.e2e.test.ts
@@ -263,6 +263,71 @@ describe.sequential("live semaphore E2E", () => {
     expect(waitingLease.slug).toBe("only");
   }, 120_000);
 
+  test("a waiter does not block capacity allowed for a later waiter", async () => {
+    const type = uniqueType();
+    for (const slug of ["alpha", "beta"]) {
+      await semaphore.resources.add({ type, slug, data: { token: `secret-${slug}` } });
+      createdResources.push({ type, slug });
+    }
+
+    const alphaLease = await semaphore.resources.acquireSpecific({
+      type,
+      slug: "alpha",
+      leaseMs: 60_000,
+    });
+    const betaLease = await semaphore.resources.acquireSpecific({
+      type,
+      slug: "beta",
+      leaseMs: 60_000,
+    });
+    expect(alphaLease).not.toBeNull();
+    expect(betaLease).not.toBeNull();
+    leasedResources.push(
+      { type, slug: "alpha", leaseId: alphaLease!.leaseId },
+      { type, slug: "beta", leaseId: betaLease!.leaseId },
+    );
+
+    const waitingForAlpha = semaphore.resources.acquire({
+      type,
+      leaseMs: 60_000,
+      waitMs: 5_000,
+      allowedSlugs: ["alpha"],
+    });
+    const waitingForBeta = semaphore.resources.acquire({
+      type,
+      leaseMs: 60_000,
+      waitMs: 5_000,
+      allowedSlugs: ["beta"],
+    });
+    await sleep(250);
+
+    await semaphore.resources.release({
+      type,
+      slug: "beta",
+      leaseId: betaLease!.leaseId,
+    });
+    leasedResources.splice(
+      leasedResources.findIndex((lease) => lease.leaseId === betaLease!.leaseId),
+      1,
+    );
+    const reassignedBeta = await waitingForBeta;
+    leasedResources.push({ type, slug: "beta", leaseId: reassignedBeta.leaseId });
+    expect(reassignedBeta.slug).toBe("beta");
+
+    await semaphore.resources.release({
+      type,
+      slug: "alpha",
+      leaseId: alphaLease!.leaseId,
+    });
+    leasedResources.splice(
+      leasedResources.findIndex((lease) => lease.leaseId === alphaLease!.leaseId),
+      1,
+    );
+    const reassignedAlpha = await waitingForAlpha;
+    leasedResources.push({ type, slug: "alpha", leaseId: reassignedAlpha.leaseId });
+    expect(reassignedAlpha.slug).toBe("alpha");
+  }, 120_000);
+
   test("records the lease holder and honors force acquire/release", async () => {
     const type = uniqueType();
     const created = await semaphore.resources.add({

--- a/apps/semaphore/e2e/vitest/live.e2e.test.ts
+++ b/apps/semaphore/e2e/vitest/live.e2e.test.ts
@@ -319,6 +319,32 @@ describe.sequential("live semaphore E2E", () => {
     expect(releasedList[0]).toMatchObject({ leaseState: "available", holder: null });
   }, 120_000);
 
+  test("specific acquisition stays inside the caller's allowed slugs", async () => {
+    const type = uniqueType();
+    for (const slug of ["alpha", "beta"]) {
+      await semaphore.resources.add({ type, slug, data: { token: `secret-${slug}` } });
+      createdResources.push({ type, slug });
+    }
+
+    expect(
+      await semaphore.resources.acquireSpecific({
+        type,
+        slug: "beta",
+        leaseMs: 60_000,
+        allowedSlugs: ["alpha"],
+      }),
+    ).toBeNull();
+
+    const lease = await semaphore.resources.acquireSpecific({
+      type,
+      slug: "beta",
+      leaseMs: 60_000,
+      allowedSlugs: ["beta"],
+    });
+    expect(lease).not.toBeNull();
+    leasedResources.push({ type, slug: lease!.slug, leaseId: lease!.leaseId });
+  }, 120_000);
+
   test("hands out the least recently released resource first", async () => {
     const type = uniqueType();
     for (const slug of ["alpha", "beta"]) {
@@ -347,6 +373,23 @@ describe.sequential("live semaphore E2E", () => {
     const fourth = await semaphore.resources.acquire({ type, leaseMs: 60_000 });
     leasedResources.push({ type, slug: fourth.slug, leaseId: fourth.leaseId });
     expect(fourth.slug).toBe("beta");
+  }, 120_000);
+
+  test("acquires only from the caller's allowed slugs", async () => {
+    const type = uniqueType();
+    for (const slug of ["alpha", "beta", "gamma"]) {
+      await semaphore.resources.add({ type, slug, data: { token: `secret-${slug}` } });
+      createdResources.push({ type, slug });
+    }
+
+    const lease = await semaphore.resources.acquire({
+      type,
+      leaseMs: 60_000,
+      allowedSlugs: ["beta", "gamma"],
+    });
+    leasedResources.push({ type, slug: lease.slug, leaseId: lease.leaseId });
+
+    expect(lease.slug).toBe("beta");
   }, 120_000);
 
   test("supports the contract client against the live worker", async () => {

--- a/apps/semaphore/package.json
+++ b/apps/semaphore/package.json
@@ -17,7 +17,7 @@
     "seed:environment-config-leases": "pnpm cli seed-environment-config-leases",
     "sync-auth-client": "tsx ./scripts/sync-auth-client.ts",
     "typecheck": "pnpm gen:wrangler && tsc --noEmit",
-    "test": "pnpm typecheck",
+    "test": "pnpm typecheck && vitest run src",
     "test:e2e": "node -e \"if (!process.env.SEMAPHORE_BASE_URL) { console.error('SEMAPHORE_BASE_URL is required for semaphore e2e tests'); process.exit(1); }\" && vitest run --config ./e2e/vitest.config.ts",
     "test:all": "pnpm run test && pnpm run test:e2e",
     "test:quick": "pnpm test:e2e",

--- a/apps/semaphore/src/contract.test.ts
+++ b/apps/semaphore/src/contract.test.ts
@@ -1,0 +1,52 @@
+import { expect, it } from "vitest";
+import { AcquireResourceInput } from "./contract.ts";
+
+it("keeps older preview clients inside the original nine slots", () => {
+  expect(
+    AcquireResourceInput.parse({
+      type: "environment-config-lease",
+      leaseMs: 60_000,
+    }),
+  ).toMatchObject({
+    allowedSlugs: [
+      "preview-1",
+      "preview-2",
+      "preview-3",
+      "preview-4",
+      "preview-5",
+      "preview-6",
+      "preview-7",
+      "preview-8",
+      "preview-9",
+    ],
+  });
+});
+
+it("rejects duplicate allowed slugs", () => {
+  expect(
+    AcquireResourceInput.safeParse({
+      type: "environment-config-lease",
+      leaseMs: 60_000,
+      allowedSlugs: ["preview-2", "preview-2"],
+    }),
+  ).toMatchObject({ success: false });
+});
+
+it("preserves an explicit preview allow-list", () => {
+  expect(
+    AcquireResourceInput.parse({
+      type: "environment-config-lease",
+      leaseMs: 60_000,
+      allowedSlugs: ["preview-17"],
+    }),
+  ).toMatchObject({ allowedSlugs: ["preview-17"] });
+});
+
+it("leaves unrelated resource types unrestricted when allowedSlugs is omitted", () => {
+  expect(
+    AcquireResourceInput.parse({
+      type: "browser-lease",
+      leaseMs: 60_000,
+    }),
+  ).not.toHaveProperty("allowedSlugs");
+});

--- a/apps/semaphore/src/contract.ts
+++ b/apps/semaphore/src/contract.ts
@@ -74,6 +74,10 @@ const semaphoreWaitMsSchema = z
   .int()
   .nonnegative()
   .max(MAX_WAIT_MS, `waitMs must be <= ${MAX_WAIT_MS}`);
+const allowedSlugsSchema = z
+  .array(semaphoreKeySchema)
+  .min(1)
+  .refine((slugs) => new Set(slugs).size === slugs.length, "allowedSlugs must be unique");
 
 export const SemaphoreResourceRecord = z.object({
   type: semaphoreKeySchema,
@@ -117,31 +121,47 @@ export const FindResourceInput = z.object({
   slug: semaphoreKeySchema,
 });
 
-export const AcquireResourceInput = z.object({
+const legacyPreviewAllowedSlugs = Array.from({ length: 9 }, (_, index) => `preview-${index + 1}`);
+
+function applyLegacyPreviewAllowedSlugs<T extends { type: string; allowedSlugs?: string[] }>(
+  input: T,
+): T {
+  if (input.type !== "environment-config-lease" || input.allowedSlugs) return input;
+  return { ...input, allowedSlugs: [...legacyPreviewAllowedSlugs] };
+}
+
+const AcquireResourceInputBase = z.object({
   type: semaphoreKeySchema,
   leaseMs: semaphoreLeaseMsSchema,
   waitMs: semaphoreWaitMsSchema.optional(),
   holder: semaphoreHolderSchema.optional(),
+  allowedSlugs: allowedSlugsSchema.optional(),
 });
+export const AcquireResourceInput = AcquireResourceInputBase.transform(
+  applyLegacyPreviewAllowedSlugs,
+);
 
-export const AcquireSpecificResourceInput = z.object({
-  type: semaphoreKeySchema,
-  slug: semaphoreKeySchema,
-  leaseMs: semaphoreLeaseMsSchema,
-  holder: semaphoreHolderSchema.optional(),
-  /**
-   * Evict any active lease on the slug before acquiring. The eviction is
-   * recorded (event `evicted`, with the previous holder). Only pass this on an
-   * explicit human `--force`; automation must never steal a held resource.
-   */
-  force: z.boolean().optional(),
-});
+export const AcquireSpecificResourceInput = z
+  .object({
+    type: semaphoreKeySchema,
+    slug: semaphoreKeySchema,
+    leaseMs: semaphoreLeaseMsSchema,
+    holder: semaphoreHolderSchema.optional(),
+    allowedSlugs: allowedSlugsSchema.optional(),
+    /**
+     * Evict any active lease on the slug before acquiring. The eviction is
+     * recorded (event `evicted`, with the previous holder). Only pass this on an
+     * explicit human `--force`; automation must never steal a held resource.
+     */
+    force: z.boolean().optional(),
+  })
+  .transform(applyLegacyPreviewAllowedSlugs);
 
-const RenewResourceLeaseInput = z.object({
-  type: semaphoreKeySchema,
+export const RenewResourceLeaseInput = z.object({
+  type: AcquireResourceInputBase.shape.type,
   slug: semaphoreKeySchema,
   leaseId: z.uuid(),
-  leaseMs: semaphoreLeaseMsSchema,
+  leaseMs: AcquireResourceInputBase.shape.leaseMs,
 });
 
 export const ReleaseResourceInput = z

--- a/apps/semaphore/src/durable-objects/resource-coordinator.ts
+++ b/apps/semaphore/src/durable-objects/resource-coordinator.ts
@@ -407,45 +407,54 @@ export class ResourceCoordinator extends DurableObject<Env> {
   }
 
   private async dispatchWaiters(): Promise<void> {
-    const queued = this.waiters;
-    const deferred: Waiter[] = [];
-    this.waiters = [];
-    for (const waiter of queued) {
-      if (waiter.settled) {
-        continue;
-      }
-
-      const lease = await this.tryAcquire(
-        waiter.type,
-        waiter.leaseMs,
-        waiter.holder,
-        waiter.allowedSlugs,
-      );
-      if (!lease) {
-        if (!waiter.settled) {
-          deferred.push(waiter);
+    for (;;) {
+      const queued = this.waiters;
+      const deferred: Waiter[] = [];
+      let capacityFreedDuringPass = false;
+      this.waiters = [];
+      for (const waiter of queued) {
+        if (waiter.settled) {
+          continue;
         }
-        continue;
-      }
 
-      if (waiter.settled) {
-        await this.releaseLease(
+        const lease = await this.tryAcquire(
           waiter.type,
-          lease.slug,
-          lease.leaseId,
-          "timed-out-before-delivery",
-          {
-            releasedAt: null,
-          },
+          waiter.leaseMs,
+          waiter.holder,
+          waiter.allowedSlugs,
         );
-        continue;
+        if (!lease) {
+          if (!waiter.settled) {
+            deferred.push(waiter);
+          }
+          continue;
+        }
+
+        if (waiter.settled) {
+          await this.releaseLease(
+            waiter.type,
+            lease.slug,
+            lease.leaseId,
+            "timed-out-before-delivery",
+            {
+              releasedAt: null,
+            },
+          );
+          capacityFreedDuringPass = true;
+          continue;
+        }
+
+        waiter.settled = true;
+        clearTimeout(waiter.timeoutHandle);
+        waiter.resolve(lease);
       }
 
-      waiter.settled = true;
-      clearTimeout(waiter.timeoutHandle);
-      waiter.resolve(lease);
+      const arrivals = this.waiters;
+      this.waiters = [...deferred.filter((waiter) => !waiter.settled), ...arrivals];
+      if (!capacityFreedDuringPass && arrivals.length === 0) {
+        return;
+      }
     }
-    this.waiters = [...deferred.filter((waiter) => !waiter.settled), ...this.waiters];
   }
 
   private async releaseLease(

--- a/apps/semaphore/src/durable-objects/resource-coordinator.ts
+++ b/apps/semaphore/src/durable-objects/resource-coordinator.ts
@@ -1,9 +1,9 @@
 import { DurableObject } from "cloudflare:workers";
-import { z } from "zod";
 import {
   AcquireResourceInput,
   AcquireSpecificResourceInput,
   DeleteResourceInput,
+  RenewResourceLeaseInput,
   ReleaseResourceInput,
   type SemaphoreJsonObject,
   type SemaphoreLeaseRecord,
@@ -21,6 +21,7 @@ type Waiter = {
   type: string;
   leaseMs: number;
   holder: string | null;
+  allowedSlugs: string[] | undefined;
   timeoutHandle: ReturnType<typeof setTimeout>;
   settled: boolean;
   resolve: (value: SemaphoreLeaseRecord | null) => void;
@@ -44,10 +45,11 @@ export class ResourceCoordinator extends DurableObject<Env> {
     leaseMs: number;
     waitMs?: number;
     holder?: string;
+    allowedSlugs?: string[];
   }): Promise<SemaphoreLeaseRecord | null> {
-    const { type, leaseMs, waitMs = 0, holder } = AcquireResourceInput.parse(params);
+    const { type, leaseMs, waitMs = 0, holder, allowedSlugs } = AcquireResourceInput.parse(params);
     this.rememberCoordinatorType(type);
-    const immediate = await this.tryAcquire(type, leaseMs, holder ?? null);
+    const immediate = await this.tryAcquire(type, leaseMs, holder ?? null, allowedSlugs);
     if (immediate) {
       return immediate;
     }
@@ -62,6 +64,7 @@ export class ResourceCoordinator extends DurableObject<Env> {
         type,
         leaseMs,
         holder: holder ?? null,
+        allowedSlugs,
         timeoutHandle: setTimeout(() => {
           if (waiter.settled) {
             return;
@@ -145,10 +148,14 @@ export class ResourceCoordinator extends DurableObject<Env> {
     leaseMs: number;
     holder?: string;
     force?: boolean;
+    allowedSlugs?: string[];
   }) {
     const parsed = AcquireSpecificResourceInput.parse(params);
 
     this.rememberCoordinatorType(parsed.type);
+    if (parsed.allowedSlugs && !parsed.allowedSlugs.includes(parsed.slug)) {
+      return null;
+    }
     await this.reapExpiredLeases(parsed.type);
     const activeLease = this.ctx.storage.sql
       .exec<{ lease_id: string; holder: string | null }>(
@@ -182,14 +189,7 @@ export class ResourceCoordinator extends DurableObject<Env> {
   }
 
   async renew(params: { type: string; slug: string; leaseId: string; leaseMs: number }) {
-    const parsed = z
-      .object({
-        type: AcquireResourceInput.shape.type,
-        slug: DeleteResourceInput.shape.slug,
-        leaseId: z.uuid(),
-        leaseMs: AcquireResourceInput.shape.leaseMs,
-      })
-      .parse(params);
+    const parsed = RenewResourceLeaseInput.parse(params);
 
     this.rememberCoordinatorType(parsed.type);
     await this.reapExpiredLeases(parsed.type);
@@ -337,6 +337,7 @@ export class ResourceCoordinator extends DurableObject<Env> {
     type: string,
     leaseMs: number,
     holder: string | null,
+    allowedSlugs: string[] | undefined,
   ): Promise<SemaphoreLeaseRecord | null> {
     await this.reapExpiredLeases();
 
@@ -356,8 +357,13 @@ export class ResourceCoordinator extends DurableObject<Env> {
     // freed slot often still carries its previous holder's deployment; resting
     // it as long as possible maximizes the chance that holder retakes its own
     // slot before anyone else lands on it.
+    const allowedSlugSet = allowedSlugs ? new Set(allowedSlugs) : null;
     const candidates = inventory
-      .filter((resource) => !activeLeases.has(resource.slug))
+      .filter(
+        (resource) =>
+          !activeLeases.has(resource.slug) &&
+          (allowedSlugSet === null || allowedSlugSet.has(resource.slug)),
+      )
       .sort((left, right) => (left.lastReleasedAt ?? 0) - (right.lastReleasedAt ?? 0));
     if (candidates.length === 0) {
       return null;
@@ -411,7 +417,12 @@ export class ResourceCoordinator extends DurableObject<Env> {
         continue;
       }
 
-      const lease = await this.tryAcquire(waiter.type, waiter.leaseMs, waiter.holder);
+      const lease = await this.tryAcquire(
+        waiter.type,
+        waiter.leaseMs,
+        waiter.holder,
+        waiter.allowedSlugs,
+      );
       if (!lease) {
         if (!waiter.settled) {
           this.waiters.unshift(waiter);

--- a/apps/semaphore/src/durable-objects/resource-coordinator.ts
+++ b/apps/semaphore/src/durable-objects/resource-coordinator.ts
@@ -407,12 +407,10 @@ export class ResourceCoordinator extends DurableObject<Env> {
   }
 
   private async dispatchWaiters(): Promise<void> {
-    while (this.waiters.length > 0) {
-      const waiter = this.waiters.shift();
-      if (!waiter) {
-        return;
-      }
-
+    const queued = this.waiters;
+    const deferred: Waiter[] = [];
+    this.waiters = [];
+    for (const waiter of queued) {
       if (waiter.settled) {
         continue;
       }
@@ -425,9 +423,9 @@ export class ResourceCoordinator extends DurableObject<Env> {
       );
       if (!lease) {
         if (!waiter.settled) {
-          this.waiters.unshift(waiter);
+          deferred.push(waiter);
         }
-        return;
+        continue;
       }
 
       if (waiter.settled) {
@@ -447,6 +445,7 @@ export class ResourceCoordinator extends DurableObject<Env> {
       clearTimeout(waiter.timeoutHandle);
       waiter.resolve(lease);
     }
+    this.waiters = [...deferred.filter((waiter) => !waiter.settled), ...this.waiters];
   }
 
   private async releaseLease(

--- a/apps/semaphore/src/orpc/root.ts
+++ b/apps/semaphore/src/orpc/root.ts
@@ -134,7 +134,7 @@ const acquireResourceProcedure = semaphore.resources.acquire
   .use(requireAuth)
   .use(mapResourceErrors)
   .handler(async ({ input }) => {
-    const { type, leaseMs, waitMs = 0, holder } = input;
+    const { type, leaseMs, waitMs = 0, holder, allowedSlugs } = input;
     const hasInventory = await hasInventoryForType(env.DB, type);
     if (!hasInventory) {
       throw new ORPCError("NOT_FOUND", {
@@ -142,7 +142,13 @@ const acquireResourceProcedure = semaphore.resources.acquire
       });
     }
 
-    const lease = await getCoordinator(type).acquire({ type, leaseMs, waitMs, holder });
+    const lease = await getCoordinator(type).acquire({
+      type,
+      leaseMs,
+      waitMs,
+      holder,
+      allowedSlugs,
+    });
     if (!lease) {
       throw new ORPCError("CONFLICT", {
         message:
@@ -159,7 +165,7 @@ const acquireSpecificResourceProcedure = semaphore.resources.acquireSpecific
   .use(requireAuth)
   .use(mapResourceErrors)
   .handler(async ({ input }) => {
-    const { type, slug, leaseMs, holder, force } = input;
+    const { type, slug, leaseMs, holder, force, allowedSlugs } = input;
     const hasInventory = await hasInventoryForType(env.DB, type);
     if (!hasInventory) {
       throw new ORPCError("NOT_FOUND", {
@@ -167,7 +173,14 @@ const acquireSpecificResourceProcedure = semaphore.resources.acquireSpecific
       });
     }
 
-    return await getCoordinator(type).acquireSpecific({ type, slug, leaseMs, holder, force });
+    return await getCoordinator(type).acquireSpecific({
+      type,
+      slug,
+      leaseMs,
+      holder,
+      force,
+      allowedSlugs,
+    });
   });
 
 const renewResourceLeaseProcedure = semaphore.resources.renew

--- a/apps/semaphore/vitest.config.ts
+++ b/apps/semaphore/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/tasks/semaphore-allowed-slugs.md
+++ b/tasks/semaphore-allowed-slugs.md
@@ -38,3 +38,4 @@ Let callers constrain generic Semaphore acquisition to an explicit set of resour
 
 - 2026-07-20: Split from preview-slot expansion so the server can accept the new field before PR #2161 starts sending it.
 - 2026-07-20: Followed red→green slices for generic selection, specific selection, legacy fallback, and duplicate validation.
+- 2026-07-20: PR preview review exposed head-of-line blocking between disjoint allow-lists. A live API test reproduced the timeout; dispatch now scans one FIFO pass and preserves unmatched waiter order.

--- a/tasks/semaphore-allowed-slugs.md
+++ b/tasks/semaphore-allowed-slugs.md
@@ -5,7 +5,7 @@ size: medium
 
 # Restrict Semaphore acquisition to allowed slugs
 
-Status: Specified; implementation has not started. This prerequisite must land and deploy before preview slots 10–19 enter production inventory.
+Status: Implementation complete locally. Contract/unit/type checks pass; the public HTTP/DO behavior still needs its PR preview deployment before production rollout.
 
 ## Goal
 
@@ -22,13 +22,18 @@ Let callers constrain generic Semaphore acquisition to an explicit set of resour
 
 ## Checklist
 
-- [ ] Specify the public acquisition behavior with failing integration-style tests.
-- [ ] Add `allowedSlugs` to the public contract and Resource Coordinator inputs.
-- [ ] Filter generic and specific acquisition atomically.
-- [ ] Preserve the legacy-safe preview fallback for omitted input.
+- [x] Specify the public acquisition behavior with failing integration-style tests.  
+  _Added live API coverage for generic and specific acquisition plus contract fallback tests._
+- [x] Add `allowedSlugs` to the public contract and Resource Coordinator inputs.  
+  _Both acquisition endpoints accept a validated, unique, non-empty slug list._
+- [x] Filter generic and specific acquisition atomically.  
+  _The Resource Coordinator filters immediate/waiting candidates and rejects disallowed specific acquisition before eviction._
+- [x] Preserve the legacy-safe preview fallback for omitted input.  
+  _Omitted input resolves to preview-1 through preview-9 only for environment-config leases; other resource types remain unrestricted._
 - [ ] Verify focused tests, typecheck, lint, and formatting.
 - [ ] Deploy Semaphore production before any client requires the new input.
 
 ## Implementation log
 
 - 2026-07-20: Split from preview-slot expansion so the server can accept the new field before PR #2161 starts sending it.
+- 2026-07-20: Followed red→green slices for generic selection, specific selection, legacy fallback, and duplicate validation.

--- a/tasks/semaphore-allowed-slugs.md
+++ b/tasks/semaphore-allowed-slugs.md
@@ -39,3 +39,4 @@ Let callers constrain generic Semaphore acquisition to an explicit set of resour
 - 2026-07-20: Split from preview-slot expansion so the server can accept the new field before PR #2161 starts sending it.
 - 2026-07-20: Followed red→green slices for generic selection, specific selection, legacy fallback, and duplicate validation.
 - 2026-07-20: PR preview review exposed head-of-line blocking between disjoint allow-lists. A live API test reproduced the timeout; dispatch now scans one FIFO pass and preserves unmatched waiter order.
+- 2026-07-20: Refreshed review identified capacity freed by a waiter timing out during delivery. Dispatch now performs another bounded FIFO pass only when it freed capacity or received arrivals while scanning.

--- a/tasks/semaphore-allowed-slugs.md
+++ b/tasks/semaphore-allowed-slugs.md
@@ -22,15 +22,16 @@ Let callers constrain generic Semaphore acquisition to an explicit set of resour
 
 ## Checklist
 
-- [x] Specify the public acquisition behavior with failing integration-style tests.  
+- [x] Specify the public acquisition behavior with failing integration-style tests.
   _Added live API coverage for generic and specific acquisition plus contract fallback tests._
-- [x] Add `allowedSlugs` to the public contract and Resource Coordinator inputs.  
+- [x] Add `allowedSlugs` to the public contract and Resource Coordinator inputs.
   _Both acquisition endpoints accept a validated, unique, non-empty slug list._
-- [x] Filter generic and specific acquisition atomically.  
+- [x] Filter generic and specific acquisition atomically.
   _The Resource Coordinator filters immediate/waiting candidates and rejects disallowed specific acquisition before eviction._
-- [x] Preserve the legacy-safe preview fallback for omitted input.  
+- [x] Preserve the legacy-safe preview fallback for omitted input.
   _Omitted input resolves to preview-1 through preview-9 only for environment-config leases; other resource types remain unrestricted._
-- [ ] Verify focused tests, typecheck, lint, and formatting.
+- [x] Verify focused tests, typecheck, lint, and formatting.
+  _Four unit tests, Semaphore typecheck, repository lint, and formatting pass locally; live E2E is delegated to the PR preview deployment._
 - [ ] Deploy Semaphore production before any client requires the new input.
 
 ## Implementation log

--- a/tasks/semaphore-allowed-slugs.md
+++ b/tasks/semaphore-allowed-slugs.md
@@ -1,0 +1,34 @@
+---
+status: ready
+size: medium
+---
+
+# Restrict Semaphore acquisition to allowed slugs
+
+Status: Specified; implementation has not started. This prerequisite must land and deploy before preview slots 10–19 enter production inventory.
+
+## Goal
+
+Let callers constrain generic Semaphore acquisition to an explicit set of resource slugs, while keeping older preview clients safely limited to the original nine slots during the rollout.
+
+## Decisions and assumptions
+
+- Add optional `allowedSlugs` to both `acquire` and `acquireSpecific`; filtering happens atomically inside the Resource Coordinator.
+- Omitted `allowedSlugs` preserves generic behavior for every resource type except `environment-config-lease`.
+- For `environment-config-lease`, omission temporarily defaults to `preview-1` through `preview-9`, so older clients cannot acquire newly seeded slots.
+- A supplied list must be non-empty and contain unique, valid slugs.
+- Waiting, least-recently-used selection, lease renewal, and force semantics operate only within the allowed set.
+- This PR does not seed inventory or deploy preview applications.
+
+## Checklist
+
+- [ ] Specify the public acquisition behavior with failing integration-style tests.
+- [ ] Add `allowedSlugs` to the public contract and Resource Coordinator inputs.
+- [ ] Filter generic and specific acquisition atomically.
+- [ ] Preserve the legacy-safe preview fallback for omitted input.
+- [ ] Verify focused tests, typecheck, lint, and formatting.
+- [ ] Deploy Semaphore production before any client requires the new input.
+
+## Implementation log
+
+- 2026-07-20: Split from preview-slot expansion so the server can accept the new field before PR #2161 starts sending it.


### PR DESCRIPTION
## Summary

- Add an optional `allowedSlugs` constraint to Semaphore acquisition.
- Keep older preview clients limited to `preview-1` through `preview-9` while the fleet expands.
- Filter inside the coordinator so selection and waiting remain atomic.

## Usage

```ts
const lease = await semaphore.resources.acquire({
  type: "environment-config-lease",
  leaseMs: 3 * 60 * 60 * 1000,
  allowedSlugs: ["preview-1", "preview-2", "preview-17"],
});
```

During the fleet rollout, older clients that omit `allowedSlugs` remain limited to `preview-1` through `preview-9`. Omission remains unrestricted for other resource types.

This is the backwards-compatible server prerequisite for PR #2161. It does not seed inventory or deploy preview applications.

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +120 -60 | +110 -53 🟩🟩🟩🟥🟥 |
| Tests | +160 -0 | +145 -0 🟩🟩🟩🟩⬜ |
| Config | +1 -1 | +1 -1 🟩⬜⬜⬜⬜ |
| Docs | +42 -0 | +32 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+323 -61** | **+288 -54** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 6667101 and 4019145, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-20T22:47:54.025Z",
      "headSha": "401914590b37e2e34247640f37ad9813f983313d",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/365481023665730",
      "shortSha": "4019145",
      "cleanupDurationMs": 2080,
      "deployDurationMs": 18050,
      "testDurationMs": 12104,
      "testRetries": null,
      "workerSizeKib": 3958.36,
      "workerGzipKib": 808.32,
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-20T22:47:51.117Z",
      "headSha": "401914590b37e2e34247640f37ad9813f983313d",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/365481023665730",
      "shortSha": "4019145",
      "cleanupDurationMs": 393,
      "deployDurationMs": 13446,
      "testDurationMs": 27416,
      "testRetries": null,
      "workerSizeKib": 1920.24,
      "workerGzipKib": 442.1,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `4019145` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 808.3 KiB | 18.1s | 12.1s |  | 2.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/365481023665730) | 2026-07-20T22:47:54.025Z | Preview app released. |
| Semaphore | released | `4019145` | [https://semaphore.iterate-preview-7.com](https://semaphore.iterate-preview-7.com) | 442.1 KiB | 13.4s | 27.4s |  | 393ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/365481023665730) | 2026-07-20T22:47:51.117Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Durable Object lease scheduling and default preview-slot policy during fleet expansion; mistakes could mis-route leases or starve waiters, though behavior is heavily covered by new E2E and contract tests.
> 
> **Overview**
> Adds optional **`allowedSlugs`** on generic and specific Semaphore **`acquire`** so callers only receive leases from named inventory slugs. The Resource Coordinator applies that filter for immediate picks, LRU ordering, and queued waiters; **`acquireSpecific`** returns null when the requested slug is outside the list.
> 
> For **`environment-config-lease`**, omitting **`allowedSlugs`** now defaults to **`preview-1`…`preview-9`** so legacy clients cannot take newly added preview slots; other resource types stay unrestricted when the field is omitted. Contract parsing rejects duplicate entries in the list.
> 
> **Waiter dispatch** no longer stops at the first waiter who cannot be satisfied: one FIFO pass tries every waiter against its allow-list, and the loop repeats only when a pass frees capacity (e.g. delivery after timeout) or new waiters arrive—fixing head-of-line blocking between disjoint allow-lists.
> 
> Unit tests cover the Zod transform and legacy fallback; live E2E covers slug filtering and the cross-waiter scenario. The **`test`** script also runs Vitest on **`src/**`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 401914590b37e2e34247640f37ad9813f983313d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

