### PR TITLE
Preserve non-streamed completion text across an interrupt race

### DIFF
--- a/apps/os/src/domains/agents/agent-processor-implementation.ts
+++ b/apps/os/src/domains/agents/agent-processor-implementation.ts
@@ -621,6 +621,14 @@ export class AgentProcessor extends StreamProcessor<AgentProcessorContract, Agen
               .catch(() => undefined);
           },
         });
+        // A non-streaming transport reports no chunks, so its text exists
+        // only in this closure until the success batch commits. Record it as
+        // the in-flight partial BEFORE awaiting that append: an interrupt
+        // racing the append settles cancelled with whatever partial is
+        // recorded, and must not drop a response already delivered whole.
+        if (!inFlight.controller.signal.aborted) {
+          inFlight.partialText = completion.text;
+        }
         const usage = completion.usage;
         await this.#appendUnlessLostIdempotencyRace(args.append, [
           {

--- a/apps/os/src/domains/agents/agent-processor.test.ts
+++ b/apps/os/src/domains/agents/agent-processor.test.ts
@@ -306,6 +306,63 @@ describe("AgentProcessor turn lifecycle", () => {
     expect(h.events(REQUESTED)).toHaveLength(2);
   });
 
+  it("interrupt racing a NON-streamed completion: the cancelled settlement still carries the full text", async () => {
+    const h = makeAgentHarness();
+    await h.play(["append", ...NEW_AGENT_EVENTS, userMessage("Hello")], ["advanceTime", 10_000]);
+    expect(h.llm.calls).toHaveLength(1);
+
+    // Park the success batch at the substrate door: the completion resolves
+    // with its full text (no chunks ever streamed — the unified transport's
+    // non-ReadableStream fallback), but the assistant+settled append has not
+    // committed. This is the window an interrupt races into and wins the
+    // settle key.
+    const realAppend = h.stream.append.bind(h.stream);
+    let releaseSuccessBatch = () => {};
+    const successBatchHeld = new Promise<void>((resolve) => {
+      releaseSuccessBatch = resolve;
+    });
+    h.stream.append = async (...inputs) => {
+      if (inputs.some((input) => input.idempotencyKey?.includes("assistant-context@"))) {
+        await successBatchHeld;
+      }
+      return realAppend(...inputs);
+    };
+
+    await h.play(
+      () => h.llm.respond("The complete non-streamed answer."),
+      ["append", userMessage("actually stop", { behaviour: "interrupt-current-request" })],
+      () => releaseSuccessBatch(),
+    );
+
+    // The interrupt won the settle key, and the dropped success batch took
+    // `completion.text` with it — but the text survives because the resolved
+    // completion is recorded as the in-flight partial BEFORE the success
+    // append is awaited. (Chunk accumulation alone left partialText empty
+    // here: nothing streamed, so the whole response used to vanish.)
+    expect(h.events(SETTLED)).toMatchObject([
+      {
+        payload: {
+          result: {
+            status: "cancelled",
+            reason: "interrupted-by-user-input",
+            partialText: "The complete non-streamed answer.",
+          },
+        },
+      },
+    ]);
+    const preserved = h
+      .state()
+      .contextItems.find((item) => item.payload.content.includes("partial output follows"));
+    expect(preserved!.payload.content).toContain("The complete non-streamed answer.");
+
+    // The interrupting message's own turn sees what the user never saw lost.
+    await h.play(["advanceTime", 10_000]);
+    expect(h.llm.calls).toHaveLength(2);
+    expect(h.llm.calls[1]!.messages.map((message) => message.content).join("\n")).toContain(
+      "The complete non-streamed answer.",
+    );
+  });
+
   it("mirrors a visible web message into assistant history so the model sees what it sent", async () => {
     const h = makeAgentHarness();
     const files = [


### PR DESCRIPTION
## What

Fixes the Bugbot finding on #2162 ("Interrupt can drop non-streamed text"): `partialText` only accumulated through streamed `onChunk` calls, but a transport that answers without streaming — the unified lane's non-`ReadableStream` fallback, or a custom `callLlm` host — returns its full text without ever calling `onChunk`. An interrupt racing the success append then won the shared `settle/<offset>` idempotency key with **no** partial recorded, the atomic success batch (assistant context + settled + token usage) was dropped by the lost-race guard, and the response text vanished: absent from the next turn's prompt and from durable UI rebuilds.

The fix records the resolved completion as the in-flight partial **before** the success append is awaited, so an interrupt landing in that window settles cancelled carrying the whole text — same preservation path the streamed case already had.

## Regression test

`agent-processor.test.ts` "interrupt racing a NON-streamed completion": parks the success batch at the substrate door (append gate on the `assistant-context@` idempotency key), resolves the scripted transport with full text and no chunks, delivers the interrupt into exactly that window, then releases the batch to lose the settle race. Asserts the cancelled settlement and preserved context item carry the full text and that the next turn's prompt sees it. Bite-verified: fails on the pre-fix implementation, passes with the fix.

## Context

Follow-up to the prd erase + rebuild (prd was erased and redeployed from `main` at cd8598d63; auth + os smoke green, fresh project + live agent turn verified at 7.5s). No other breakage surfaced during the rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to interrupt/cancel handling timing in the agent LLM path; regression test covers the race. No auth or data-model changes.
> 
> **Overview**
> Fixes **lost assistant text** when a user interrupt races the success append after a **non-streaming** LLM completion (unified transport fallback or custom `callLlm`). `partialText` used to come only from streamed `onChunk` calls, so an interrupt that won `settle/<offset>` could drop the atomic success batch and leave **no** partial for cancelled settlement or the next turn.
> 
> The processor now assigns **`completion.text` to the in-flight partial immediately after the attempt resolves and before awaiting the assistant-context + settled append**, so cancelled settlements and interrupted-partial context items still carry the full response.
> 
> Adds a harness regression test that holds the success batch on `assistant-context@`, resolves a chunkless completion, interrupts in that window, and asserts `partialText`, preserved context, and the following prompt all include the answer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b16268332472143630042ae2896d100c13d0fc1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-20T22:52:16.108Z",
      "headSha": "b16268332472143630042ae2896d100c13d0fc1a",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/342357175150317",
      "shortSha": "b162683",
      "cleanupDurationMs": 1782,
      "deployDurationMs": 20072,
      "testDurationMs": 11618,
      "testRetries": null,
      "workerSizeKib": 3958.36,
      "workerGzipKib": 808.17,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-20T22:52:14.952Z",
      "headSha": "b16268332472143630042ae2896d100c13d0fc1a",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/342357175150317",
      "shortSha": "b162683",
      "cleanupDurationMs": 622,
      "deployDurationMs": 5948,
      "testDurationMs": 11132,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-20T22:52:13.299Z",
      "headSha": "b16268332472143630042ae2896d100c13d0fc1a",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/342357175150317",
      "shortSha": "b162683",
      "cleanupDurationMs": 18993,
      "deployDurationMs": 107435,
      "testDurationMs": 477837,
      "testRetries": null,
      "workerSizeKib": 17313.88,
      "workerGzipKib": 4633.27,
      "mainWorkerGzipKib": 4633.26
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `b162683` | [https://auth.iterate-preview-5.com](https://auth.iterate-preview-5.com) | 808.2 KiB | 20.1s | 11.6s |  | 1.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/342357175150317) | 2026-07-20T22:52:16.108Z | Preview app released. |
| Dummy Petshop | released | `b162683` | [https://dummy-petshop.iterate-preview-5.com](https://dummy-petshop.iterate-preview-5.com) | 198.2 KiB | 5.9s | 11.1s |  | 622ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/342357175150317) | 2026-07-20T22:52:14.952Z | Preview app released. |
| OS | released | `b162683` | [https://os.iterate-preview-5.com](https://os.iterate-preview-5.com) | 4.52 MiB (+0.0 KiB vs main) | 107.4s | 477.8s |  | 19.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/342357175150317) | 2026-07-20T22:52:13.299Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +8 -0 | +3 -0 🟩⬜⬜⬜⬜ |
| Tests | +57 -0 | +41 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+65 -0** | **+44 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between cd8598d and b162683, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->