### PR TITLE
Seed the tasks app proxy into new project config repos

### DIFF
--- a/apps/os/config-repo-template/worker.ts
+++ b/apps/os/config-repo-template/worker.ts
@@ -153,6 +153,32 @@ export default class ProjectWorker extends IterateWorkerEntrypoint {
     if (app === "guestbook") {
       return this.fetchDynamicWorker(req, guestbookAppRef);
     }
+    if (app === "tasks") {
+      // A collaborative Kanban board over this repo's tasks/ markdown
+      // (github.com/iterate/tasks): project-member gate, then a transparent
+      // reverse proxy — pages, assets, and WebSocket upgrades — to the
+      // deployed vessel. The ingress already stamps x-itx-project-id and the
+      // platform session cookie rides along, so the vessel authenticates
+      // every connection back to os.iterate.com as the visiting user; no
+      // secrets or state live in the vessel. The kv knob points the proxy at
+      // a dev tunnel while developing the tasks app itself (see its README);
+      // absent knob means the deployed vessel.
+      using itx = await this.env.ITX.get();
+      const denied = await itx.auth.get({ policy: "project-member" }).fetch(req);
+      if (denied) return denied;
+      const url = new URL(req.url);
+      url.protocol = "https:";
+      const origin = await itx.kv.get("tasks-app-origin");
+      url.host = typeof origin === "string" && origin !== "" ? origin : "tasks.iterate.workers.dev";
+      return fetch(
+        new Request(url, {
+          method: req.method,
+          headers: req.headers,
+          body: req.body,
+          redirect: "manual",
+        }),
+      );
+    }
     if (app) return new Response(`unknown app: ${app}`, { status: 404 });
 
     const url = new URL(req.url);
@@ -171,6 +197,7 @@ export default class ProjectWorker extends IterateWorkerEntrypoint {
                 <li><a href="${appUrl("todo")}">todo</a> (basic React + SQLite Durable Object, project members only)</li>
                 <li><a href="${appUrl("counter")}">counter</a> (stateful)</li>
                 <li><a href="${appUrl("guestbook")}">guestbook</a> (basic React + SQLite Durable Object, public)</li>
+                <li><a href="${appUrl("tasks")}">tasks</a> (collaborative task board over tasks/, project members only)</li>
               </ul>
               <p>Edit worker.ts in the project repo to change this.</p>
             </main>

--- a/apps/os/src/domains/repos/config-repo-template.generated.ts
+++ b/apps/os/src/domains/repos/config-repo-template.generated.ts
@@ -848,6 +848,32 @@ export const PROJECT_REPO_INITIAL_FILES: Array<{ content: string; path: string }
       "    if (app === \"guestbook\") {\n" +
       "      return this.fetchDynamicWorker(req, guestbookAppRef);\n" +
       "    }\n" +
+      "    if (app === \"tasks\") {\n" +
+      "      // A collaborative Kanban board over this repo's tasks/ markdown\n" +
+      "      // (github.com/iterate/tasks): project-member gate, then a transparent\n" +
+      "      // reverse proxy — pages, assets, and WebSocket upgrades — to the\n" +
+      "      // deployed vessel. The ingress already stamps x-itx-project-id and the\n" +
+      "      // platform session cookie rides along, so the vessel authenticates\n" +
+      "      // every connection back to os.iterate.com as the visiting user; no\n" +
+      "      // secrets or state live in the vessel. The kv knob points the proxy at\n" +
+      "      // a dev tunnel while developing the tasks app itself (see its README);\n" +
+      "      // absent knob means the deployed vessel.\n" +
+      "      using itx = await this.env.ITX.get();\n" +
+      "      const denied = await itx.auth.get({ policy: \"project-member\" }).fetch(req);\n" +
+      "      if (denied) return denied;\n" +
+      "      const url = new URL(req.url);\n" +
+      "      url.protocol = \"https:\";\n" +
+      "      const origin = await itx.kv.get(\"tasks-app-origin\");\n" +
+      "      url.host = typeof origin === \"string\" && origin !== \"\" ? origin : \"tasks.iterate.workers.dev\";\n" +
+      "      return fetch(\n" +
+      "        new Request(url, {\n" +
+      "          method: req.method,\n" +
+      "          headers: req.headers,\n" +
+      "          body: req.body,\n" +
+      "          redirect: \"manual\",\n" +
+      "        }),\n" +
+      "      );\n" +
+      "    }\n" +
       "    if (app) return new Response(`unknown app: ${app}`, { status: 404 });\n" +
       "\n" +
       "    const url = new URL(req.url);\n" +
@@ -866,6 +892,7 @@ export const PROJECT_REPO_INITIAL_FILES: Array<{ content: string; path: string }
       "                <li><a href=\"${appUrl(\"todo\")}\">todo</a> (basic React + SQLite Durable Object, project members only)</li>\n" +
       "                <li><a href=\"${appUrl(\"counter\")}\">counter</a> (stateful)</li>\n" +
       "                <li><a href=\"${appUrl(\"guestbook\")}\">guestbook</a> (basic React + SQLite Durable Object, public)</li>\n" +
+      "                <li><a href=\"${appUrl(\"tasks\")}\">tasks</a> (collaborative task board over tasks/, project members only)</li>\n" +
       "              </ul>\n" +
       "              <p>Edit worker.ts in the project repo to change this.</p>\n" +
       "            </main>\n" +


### PR DESCRIPTION
Every new project's config worker now ships a `tasks` app branch, so `tasks--<slug>.iterate.app` serves the collaborative task board (github.com/iterate/tasks) out of the box: a project-member gate followed by a transparent reverse proxy — pages, assets, and WebSocket upgrades — to the stateless vessel at `tasks.iterate.workers.dev`.

The vessel holds no secrets or sessions: the ingress-stamped `x-itx-project-id` header and the platform session cookie ride through untouched, and the vessel authenticates each connection back to `os.iterate.com` (`project-app-session`) as the visiting user. The board itself is a collaborative checkout — a y-partyserver Yjs Durable Object over the repo's `tasks/` markdown with live presence/cursors, committing batched diffs back via `commitFiles`.

An `itx.kv` `tasks-app-origin` knob points the proxy at a dev tunnel while developing the tasks app itself (documented in that repo's README); absent knob means the deployed vessel. This is the same wiring that has been running on the `tasks-dev` project (`prj_736db70de19a4d06861107eedd7522d8`) — this PR just seeds it for every new project.

Testing: `config-repo-template.test.ts` + `project-repo-seed.test.ts` pass, lint codegen regenerated (`config-repo-template.generated.ts`), and `tsc` reports no errors in the template (pre-existing unrelated `packages/ui` React-type errors exist on main locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds auth-gated outbound proxying for all new projects; misconfiguration of `tasks-app-origin` or upstream availability would break the tasks app route, but scope is limited to the seeded template and mirrors existing production wiring.
> 
> **Overview**
> New projects get a **`tasks`** app route on the seeded config worker so `tasks--<project-host>` can serve the collaborative task board without per-project setup.
> 
> When ingress selects **`tasks`**, the worker enforces **`project-member`** auth (same pattern as **`todo`**), then **transparently proxies** the request—including WebSocket upgrades—to **`tasks.iterate.workers.dev`**, forwarding method, headers, and body. Optional **`itx.kv`** key **`tasks-app-origin`** overrides the upstream host for local/tunnel development.
> 
> The default project index HTML gains a **tasks** link. **`config-repo-template.generated.ts`** is regenerated from the template so newly seeded repos include the same wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a58cede58d56621c664e8902d8e0d6ce6689a41a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-20T22:53:14.152Z",
      "headSha": "a58cede58d56621c664e8902d8e0d6ce6689a41a",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/141086906682065",
      "shortSha": "a58cede",
      "cleanupDurationMs": 1727,
      "deployDurationMs": 19526,
      "testDurationMs": 11078,
      "testRetries": null,
      "workerSizeKib": 3958.36,
      "workerGzipKib": 808.3,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-20T22:53:12.834Z",
      "headSha": "a58cede58d56621c664e8902d8e0d6ce6689a41a",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/141086906682065",
      "shortSha": "a58cede",
      "cleanupDurationMs": 407,
      "deployDurationMs": 5636,
      "testDurationMs": 9074,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    },
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-20T22:53:11.545Z",
      "headSha": "a58cede58d56621c664e8902d8e0d6ce6689a41a",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/141086906682065",
      "shortSha": "a58cede",
      "cleanupDurationMs": 13532,
      "deployDurationMs": 114674,
      "testDurationMs": 474761,
      "testRetries": "2 retried: catalogue example \"scheduler-basics\" runs identically across runtimes (vitest x1) · agent runs an itx script that appends a proof event, then replies (vitest x1)",
      "workerSizeKib": 17315.2,
      "workerGzipKib": 4633.47,
      "mainWorkerGzipKib": 4633.26
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `a58cede` | [https://auth.iterate-preview-9.com](https://auth.iterate-preview-9.com) | 808.3 KiB | 19.5s | 11.1s |  | 1.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/141086906682065) | 2026-07-20T22:53:14.152Z | Preview app released. |
| Dummy Petshop | released | `a58cede` | [https://dummy-petshop.iterate-preview-9.com](https://dummy-petshop.iterate-preview-9.com) | 198.2 KiB | 5.6s | 9.1s |  | 407ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/141086906682065) | 2026-07-20T22:53:12.834Z | Preview app released. |
| OS | released | `a58cede` | [https://os.iterate-preview-9.com](https://os.iterate-preview-9.com) | 4.52 MiB (+0.2 KiB vs main) | 114.7s | 474.8s | 2 retried: catalogue example "scheduler-basics" runs identically across runtimes (vitest x1) · agent runs an itx script that appends a proof event, then replies (vitest x1) | 13.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/141086906682065) | 2026-07-20T22:53:11.545Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +27 -0 | +18 -0 🟩🟩🟩⬜⬜ |
| Generated | +27 -0 | +27 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+54 -0** | **+45 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between cd8598d and a58cede, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->