### PR TITLE
Cache fingerprinted OS assets immutably

### DIFF
--- a/apps/os/public/_headers
+++ b/apps/os/public/_headers
@@ -1,0 +1,2 @@
+/assets/*
+  Cache-Control: public, max-age=31556952, immutable

--- a/apps/os/src/static-asset-cache-policy.test.ts
+++ b/apps/os/src/static-asset-cache-policy.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const headersFile = fileURLToPath(new URL("../public/_headers", import.meta.url));
+
+describe("static asset browser caching", () => {
+  it("caches fingerprinted Vite assets immutably without caching SSR documents", () => {
+    expect(readFileSync(headersFile, "utf8").trim()).toBe(
+      ["/assets/*", "  Cache-Control: public, max-age=31556952, immutable"].join("\n"),
+    );
+  });
+});


### PR DESCRIPTION
## What changed

- add a Workers Static Assets `_headers` rule that gives content-hashed `/assets/*` files a one-year immutable browser cache
- add a regression test that keeps the cache policy scoped to fingerprinted assets rather than SSR documents

## Root cause

Cloudflare's default browser-facing header for static assets was `public, max-age=0, must-revalidate`. A normal OS page loads roughly 136 Vite modules, so returning visitors still paid a network revalidation round trip for every module even when Cloudflare answered each request from its edge cache.

## Impact

On the preview deployment, the first integrations load transferred 934 KB across 136 assets. The repeat load served all 136 assets directly from the browser cache with 0 bytes transferred:

- FCP: 468 ms cold → 188 ms warm
- load: 578 ms cold → 180 ms warm
- LCP: 2,468 ms cold → 1,556 ms warm

The built asset inventory contained 1,225 content-hashed files and no unhashed files under `/assets`.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm test` (OS: 222 files passed; 2,109 tests passed, 6 expected failures, 1 skipped)
- `pnpm --dir apps/os build`
- preview deployment browser validation
- preview Cloudflare telemetry: cold/warm HTML requests completed normally, no warning/error logs, and static assets bypassed the Worker

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +2 -0 | +2 -0 🟩⬜⬜⬜⬜ |
| Tests | +13 -0 | +11 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+15 -0** | **+13 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 2c250cf and 76bbbd6, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-21T10:22:41.826Z",
      "headSha": "76bbbd694af6104980d41b737cfdd4d5f85cf3da",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/68502548864541",
      "shortSha": "76bbbd6",
      "cleanupDurationMs": 14229,
      "deployDurationMs": 139111,
      "testDurationMs": 145335,
      "testRetries": null,
      "workerSizeKib": 17354.93,
      "workerGzipKib": 4652.9,
      "mainWorkerGzipKib": 4663.53
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-21T10:22:33.735Z",
      "headSha": "76bbbd694af6104980d41b737cfdd4d5f85cf3da",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/68502548864541",
      "shortSha": "76bbbd6",
      "cleanupDurationMs": 6136,
      "deployDurationMs": 17312,
      "testDurationMs": 3312,
      "testRetries": null,
      "workerSizeKib": 3960.4,
      "workerGzipKib": 808.81,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-21T10:22:28.389Z",
      "headSha": "76bbbd694af6104980d41b737cfdd4d5f85cf3da",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/68502548864541",
      "shortSha": "76bbbd6",
      "cleanupDurationMs": 783,
      "deployDurationMs": 6130,
      "testDurationMs": 5182,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `76bbbd6` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 808.8 KiB | 17.3s | 3.3s |  | 6.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/68502548864541) | 2026-07-21T10:22:33.735Z | Preview app released. |
| Dummy Petshop | released | `76bbbd6` | [https://dummy-petshop.iterate-preview-1.com](https://dummy-petshop.iterate-preview-1.com) | 198.2 KiB | 6.1s | 5.2s |  | 783ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/68502548864541) | 2026-07-21T10:22:28.389Z | Preview app released. |
| OS | released | `76bbbd6` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 4.54 MiB (-10.6 KiB vs main) | 139.1s | 145.3s |  | 14.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/68502548864541) | 2026-07-21T10:22:41.826Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static delivery headers only, scoped to hashed assets; no auth, data, or application logic changes.
> 
> **Overview**
> Adds a Cloudflare Static Assets **`_headers`** rule so only **`/assets/*`** responses get **`Cache-Control: public, max-age=31556952, immutable`**, replacing the default **`max-age=0, must-revalidate`** behavior that forced browsers to revalidate every Vite chunk on repeat visits.
> 
> A Vitest reads **`public/_headers`** and asserts that exact policy, so the long-lived cache stays limited to fingerprinted build assets and is not applied to SSR HTML documents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76bbbd694af6104980d41b737cfdd4d5f85cf3da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->