### PR TITLE
Open the most recently active project

### DIFF
--- a/apps/os/src/lib/project-root-redirect.test.ts
+++ b/apps/os/src/lib/project-root-redirect.test.ts
@@ -18,6 +18,7 @@ describe("chooseRootProjectRedirect", () => {
     expect(
       chooseRootProjectRedirect({
         preferredProjectSlug: "beta",
+        preferredProjectOnboarding: false,
         projects: [project({ id: "prj_a", slug: "alpha" }), project({ id: "prj_b", slug: "beta" })],
       }),
     ).toMatchObject({
@@ -27,10 +28,25 @@ describe("chooseRootProjectRedirect", () => {
     });
   });
 
+  test("checks onboarding for the most recently active project", () => {
+    expect(
+      chooseRootProjectRedirect({
+        preferredProjectSlug: "beta",
+        preferredProjectOnboarding: true,
+        projects: [project({ id: "prj_a", slug: "alpha" }), project({ id: "prj_b", slug: "beta" })],
+      }),
+    ).toMatchObject({
+      kind: "project",
+      project: { slug: "beta" },
+      onboarding: true,
+    });
+  });
+
   test("sends the only ready project to onboarding", () => {
     expect(
       chooseRootProjectRedirect({
         preferredProjectSlug: null,
+        preferredProjectOnboarding: false,
         projects: [project({ id: "prj_a", slug: "alpha" })],
       }),
     ).toMatchObject({
@@ -44,6 +60,7 @@ describe("chooseRootProjectRedirect", () => {
     expect(
       chooseRootProjectRedirect({
         preferredProjectSlug: null,
+        preferredProjectOnboarding: false,
         projects: [project({ id: "prj_a", slug: "alpha", deploymentStatus: "missing" })],
       }),
     ).toMatchObject({
@@ -57,6 +74,7 @@ describe("chooseRootProjectRedirect", () => {
     expect(
       chooseRootProjectRedirect({
         preferredProjectSlug: null,
+        preferredProjectOnboarding: false,
         projects: [
           project({ id: "prj_a", slug: "alpha", deploymentStatus: "missing" }),
           project({ id: "prj_b", slug: "beta", deploymentStatus: "missing" }),
@@ -67,6 +85,7 @@ describe("chooseRootProjectRedirect", () => {
     expect(
       chooseRootProjectRedirect({
         preferredProjectSlug: null,
+        preferredProjectOnboarding: false,
         projects: [project({ id: "prj_a", slug: "alpha", deploymentStatus: "unknown" })],
       }),
     ).toEqual({ kind: "projects" });

--- a/apps/os/src/lib/project-root-redirect.ts
+++ b/apps/os/src/lib/project-root-redirect.ts
@@ -20,6 +20,7 @@ export type RootProjectRedirectDecision =
 
 export function chooseRootProjectRedirect(input: {
   preferredProjectSlug: string | null;
+  preferredProjectOnboarding: boolean;
   projects: RootRedirectProject[];
 }): RootProjectRedirectDecision {
   const readyProjects = input.projects.filter((project) => project.deploymentStatus === "ready");
@@ -28,7 +29,11 @@ export function chooseRootProjectRedirect(input: {
   );
 
   if (preferredReadyProject) {
-    return { kind: "project", project: preferredReadyProject, onboarding: false };
+    return {
+      kind: "project",
+      project: preferredReadyProject,
+      onboarding: input.preferredProjectOnboarding,
+    };
   }
 
   if (readyProjects.length === 1) {

--- a/apps/os/src/lib/project-server-fns.ts
+++ b/apps/os/src/lib/project-server-fns.ts
@@ -1,4 +1,5 @@
 import { createServerFn } from "@tanstack/react-start";
+import { getCookie } from "@tanstack/react-start/server";
 import { env } from "cloudflare:workers";
 import type { ProjectDeploymentStatus } from "../project-deployment-status.ts";
 import { itxAuthFromPrincipal } from "~/auth.ts";
@@ -91,7 +92,8 @@ export const getRootProjectRedirectServerFn: (input?: {
         ctx: context.executionCtx,
       });
       const decision = chooseRootProjectRedirect({
-        preferredProjectSlug: data.preferredProjectSlug,
+        preferredProjectSlug:
+          data.preferredProjectSlug ?? getCookie("iterate_recent_project") ?? null,
         projects: await projects.list({ scope: "mine" }),
       });
 

--- a/apps/os/src/lib/project-server-fns.ts
+++ b/apps/os/src/lib/project-server-fns.ts
@@ -94,6 +94,7 @@ export const getRootProjectRedirectServerFn: (input?: {
       const decision = chooseRootProjectRedirect({
         preferredProjectSlug:
           data.preferredProjectSlug ?? getCookie("iterate_recent_project") ?? null,
+        preferredProjectOnboarding: data.preferredProjectSlug == null,
         projects: await projects.list({ scope: "mine" }),
       });
 

--- a/apps/os/src/routes/_app/projects/$projectSlug/route.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/route.tsx
@@ -1,8 +1,13 @@
-import { Suspense } from "react";
+import { Suspense, useEffect } from "react";
 import { Outlet, createFileRoute } from "@tanstack/react-router";
+import { createClientOnlyFn } from "@tanstack/react-start";
 import { ProjectScope } from "iterate/react";
 import { ItxResourceLoading } from "~/components/itx-boundary.tsx";
 import { getProjectBySlugServerFn } from "~/lib/project-server-fns.ts";
+
+const rememberProject = createClientOnlyFn((slug: string) => {
+  document.cookie = `iterate_recent_project=${encodeURIComponent(slug)}; Path=/; Max-Age=31536000; SameSite=Lax`;
+});
 
 export const Route = createFileRoute("/_app/projects/$projectSlug")({
   // <ProjectScope> pre-warms the one itx socket, which dials a WebSocket and
@@ -24,6 +29,7 @@ export const Route = createFileRoute("/_app/projects/$projectSlug")({
 
 function ProjectLayout() {
   const { project } = Route.useRouteContext();
+  useEffect(() => rememberProject(project.slug), [project.slug]);
   // The whole tab shares ONE itx session socket; <ProjectScope> carries this
   // project's slug so `useItx()` / `useItxQuery()` resolve without an explicit
   // argument (the browser passes the URL slug straight through, no slug→id hop)

--- a/apps/os/src/routes/_app/projects/$projectSlug/route.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/route.tsx
@@ -1,13 +1,8 @@
 import { Suspense, useEffect } from "react";
 import { Outlet, createFileRoute } from "@tanstack/react-router";
-import { createClientOnlyFn } from "@tanstack/react-start";
 import { ProjectScope } from "iterate/react";
 import { ItxResourceLoading } from "~/components/itx-boundary.tsx";
 import { getProjectBySlugServerFn } from "~/lib/project-server-fns.ts";
-
-const rememberProject = createClientOnlyFn((slug: string) => {
-  document.cookie = `iterate_recent_project=${encodeURIComponent(slug)}; Path=/; Max-Age=31536000; SameSite=Lax`;
-});
 
 export const Route = createFileRoute("/_app/projects/$projectSlug")({
   // <ProjectScope> pre-warms the one itx socket, which dials a WebSocket and
@@ -29,7 +24,9 @@ export const Route = createFileRoute("/_app/projects/$projectSlug")({
 
 function ProjectLayout() {
   const { project } = Route.useRouteContext();
-  useEffect(() => rememberProject(project.slug), [project.slug]);
+  useEffect(() => {
+    document.cookie = `iterate_recent_project=${encodeURIComponent(project.slug)}; Path=/; Max-Age=31536000; SameSite=Lax`;
+  }, [project.slug]);
   // The whole tab shares ONE itx session socket; <ProjectScope> carries this
   // project's slug so `useItx()` / `useItxQuery()` resolve without an explicit
   // argument (the browser passes the URL slug straight through, no slug→id hop)

--- a/specs/dashboard.spec.ts
+++ b/specs/dashboard.spec.ts
@@ -1,3 +1,4 @@
+import { expect } from "@playwright/test";
 import { test } from "./test-support/test.ts";
 
 test("can enter the dashboard with a forged session", async ({ helpers, page }) => {
@@ -5,4 +6,15 @@ test("can enter the dashboard with a forged session", async ({ helpers, page }) 
 
   await page.goto("/projects");
   await page.getByRole("link", { name: fixture.project.slug }).waitFor();
+});
+
+test("opening OS returns to the most recently active project", async ({ helpers, page }) => {
+  await using fixture = await helpers.createFixture("recent-project", { projectCount: 2 });
+  const recent = fixture.projects[1]!;
+
+  await page.goto(`/projects/${recent.slug}`);
+  await page.getByTestId("project-settings-panel").waitFor();
+  await page.goto("/");
+
+  expect(page.url()).toContain(`/projects/${recent.slug}`);
 });

--- a/specs/test-support/forged-session.ts
+++ b/specs/test-support/forged-session.ts
@@ -50,12 +50,20 @@ let configPromise: Promise<OsPlaywrightAuthConfig> | undefined;
 
 export async function createProjectFixture(
   slugPrefix: string,
-  input: { baseURL: string | undefined; page: Page },
+  input: { baseURL: string | undefined; page: Page; projectCount?: number },
 ) {
-  if (!input.baseURL) throw new Error("Playwright baseURL fixture is required.");
+  const baseUrl = input.baseURL;
+  if (!baseUrl) throw new Error("Playwright baseURL fixture is required.");
 
   const projectSlug = uniqueFixtureSlug(slugPrefix);
-  const projectFixture = await createAdminProject({ baseUrl: input.baseURL, slug: projectSlug });
+  const projectFixtures = await Promise.all(
+    Array.from({ length: input.projectCount ?? 1 }, (_, index) =>
+      createAdminProject({
+        baseUrl,
+        slug: index === 0 ? projectSlug : uniqueFixtureSlug(`${slugPrefix}-${index + 1}`),
+      }),
+    ),
+  );
   try {
     const organization = {
       id: `org_${crypto.randomUUID().replaceAll("-", "").slice(0, 16)}`,
@@ -64,16 +72,13 @@ export async function createProjectFixture(
       slug: uniqueFixtureSlug(`${slugPrefix}-org`),
     };
     const session = await mintIterateSession({
-      baseUrl: input.baseURL,
+      baseUrl,
       email: `forged-${projectSlug}+test@nustom.com`,
       organizations: [organization],
-      projects: [
-        {
-          id: projectFixture.project.id,
-          organizationId: organization.id,
-          slug: projectFixture.project.slug,
-        },
-      ],
+      projects: projectFixtures.map(({ project }) => ({
+        ...project,
+        organizationId: organization.id,
+      })),
     });
 
     await input.page.context().addCookies([
@@ -82,8 +87,8 @@ export async function createProjectFixture(
         httpOnly: true,
         name: "iterate_session",
         sameSite: "Lax",
-        secure: new URL(input.baseURL).protocol === "https:",
-        url: input.baseURL,
+        secure: new URL(baseUrl).protocol === "https:",
+        url: baseUrl,
         value: encodeURIComponent(
           JSON.stringify({
             accessToken: session.accessToken,
@@ -97,14 +102,15 @@ export async function createProjectFixture(
 
     return {
       organization,
-      project: projectFixture.project,
+      project: projectFixtures[0]!.project,
+      projects: projectFixtures.map(({ project }) => project),
       session,
       async [Symbol.asyncDispose]() {
-        await projectFixture[Symbol.asyncDispose]();
+        await Promise.all(projectFixtures.map((fixture) => fixture[Symbol.asyncDispose]()));
       },
     };
   } catch (error) {
-    await projectFixture[Symbol.asyncDispose]();
+    await Promise.all(projectFixtures.map((fixture) => fixture[Symbol.asyncDispose]()));
     throw error;
   }
 }

--- a/specs/test-support/test.ts
+++ b/specs/test-support/test.ts
@@ -9,8 +9,6 @@ import {
 import { createProjectFixture as createForgedProjectFixture } from "./forged-session.ts";
 import { screenshot } from "./screenshot.ts";
 
-type ForgedProjectFixture = Awaited<ReturnType<typeof createForgedProjectFixture>>;
-
 const addPagePlugins = (page: Page, testInfo: TestInfo) =>
   addPlugins({
     page,
@@ -33,14 +31,18 @@ const addPagePlugins = (page: Page, testInfo: TestInfo) =>
 
 export const test = base.extend<{
   helpers: {
-    createFixture: (slugPrefix: string) => Promise<ForgedProjectFixture>;
+    createFixture: (
+      slugPrefix: string,
+      options?: { projectCount?: number },
+    ) => Promise<Awaited<ReturnType<typeof createForgedProjectFixture>>>;
   };
   page: Awaited<ReturnType<typeof addPagePlugins>>;
 }>({
   helpers: async ({ baseURL, page }, use) => {
     if (!baseURL) throw new Error("Playwright baseURL fixture is required.");
     await use({
-      createFixture: (slugPrefix) => createForgedProjectFixture(slugPrefix, { baseURL, page }),
+      createFixture: (slugPrefix, options) =>
+        createForgedProjectFixture(slugPrefix, { baseURL, page, ...options }),
     });
   },
   page: async ({ page: basePage }, use, testInfo) => {


### PR DESCRIPTION
## What

- Remember the most recently rendered project in a small, non-sensitive cookie.
- Prefer that still-accessible, ready project when a logged-in user opens the OS root.
- Cover the two-project return flow with a lightweight Playwright spec.

## Why

On the dashboard hostname, the root loader had no project preference for users with multiple projects, so it fell back to the project picker instead of returning them to where they were last working.

Stale or inaccessible cookie values are ignored by the existing typed project-selection logic.

## Testing

- `pnpm install && pnpm typecheck && pnpm lint && pnpm format && pnpm test`
- `pnpm spec dashboard --project=web` (2 passed)

No screenshot: this changes redirect behavior and adds no visual UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Redirect-only UX change with a non-sensitive cookie fallback; stale or inaccessible slugs still fall through to existing project-list logic.
> 
> **Overview**
> Multi-project users visiting **`/`** on the dashboard host are sent to their last-opened project instead of the project picker.
> 
> The project layout writes a **`iterate_recent_project`** cookie (slug only) when a project renders. The root redirect server function uses that cookie when no host-based **`preferredProjectSlug`** is passed, and still runs the existing onboarding snapshot logic by setting **`preferredProjectOnboarding`** when the preference comes from the cookie.
> 
> **`chooseRootProjectRedirect`** no longer forces **`onboarding: false`** for a matching ready preferred project; it honors the caller’s **`preferredProjectOnboarding`** flag. Playwright fixtures can create multiple projects, with a spec that visits a project then **`/`** and asserts the URL returns to that slug.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a58610c8786a67096dce38bd7a95ef62da051a34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +14 -3 | +14 -3 🟩🟩⬜⬜⬜ |
| Tests | +31 -0 | +27 -0 🟩🟩🟩⬜⬜ |
| Other | +28 -20 | +28 -19 🟩🟩🟩🟥🟥 |
| **Total** | **+73 -23** | **+69 -22** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 9010d58 and a58610c, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-21T10:49:40.024Z",
      "headSha": "a58610c8786a67096dce38bd7a95ef62da051a34",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/57341349726255",
      "shortSha": "a58610c",
      "cleanupDurationMs": 15657,
      "deployDurationMs": 106898,
      "testDurationMs": 365302,
      "testRetries": "2 retried: toggle a markdown file between Code and its rendered Preview (specs x1) — \u001b[31mTest timeout of 90000ms exceeded.\u001b[39m · toggle an svg file between Code and its sandboxed Preview (specs x1) — \u001b[31mTest timeout of 90000ms exceeded.\u001b[39m",
      "workerSizeKib": 17362.44,
      "workerGzipKib": 4654.86,
      "mainWorkerGzipKib": 4665.06
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-21T10:49:26.880Z",
      "headSha": "a58610c8786a67096dce38bd7a95ef62da051a34",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/57341349726255",
      "shortSha": "a58610c",
      "cleanupDurationMs": 2510,
      "deployDurationMs": 18719,
      "testDurationMs": 10564,
      "testRetries": null,
      "workerSizeKib": 3963.27,
      "workerGzipKib": 810.08,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-21T10:49:24.947Z",
      "headSha": "a58610c8786a67096dce38bd7a95ef62da051a34",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/57341349726255",
      "shortSha": "a58610c",
      "cleanupDurationMs": 576,
      "deployDurationMs": 13273,
      "testDurationMs": 10020,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `a58610c` | [https://auth.iterate-preview-5.com](https://auth.iterate-preview-5.com) | 810.1 KiB | 18.7s | 10.6s |  | 2.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/57341349726255) | 2026-07-21T10:49:26.880Z | Preview app released. |
| Dummy Petshop | released | `a58610c` | [https://dummy-petshop.iterate-preview-5.com](https://dummy-petshop.iterate-preview-5.com) | 198.2 KiB | 13.3s | 10.0s |  | 576ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/57341349726255) | 2026-07-21T10:49:24.947Z | Preview app released. |
| OS | released | `a58610c` | [https://os.iterate-preview-5.com](https://os.iterate-preview-5.com) | 4.55 MiB (-10.2 KiB vs main) | 106.9s | 365.3s | 2 retried: toggle a markdown file between Code and its rendered Preview (specs x1) — [31mTest timeout of 90000ms exceeded.[39m · toggle an svg file between Code and its sandboxed Preview (specs x1) — [31mTest timeout of 90000ms exceeded.[39m | 15.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/57341349726255) | 2026-07-21T10:49:40.024Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->