### PR TITLE
Delete all event examples from processor contracts (audit B9)

### DIFF
--- a/apps/os/src/components/event-docs-pages.tsx
+++ b/apps/os/src/components/event-docs-pages.tsx
@@ -415,25 +415,6 @@ export function EventDocPage({ event }: { event: EventDoc }) {
           <DocSection title="Payload schema">
             <SchemaView schema={event.payloadJsonSchema} />
           </DocSection>
-          <DocSection title="Examples">
-            {event.examples.length === 0 ? (
-              <p className="text-sm text-muted-foreground">
-                No examples documented for this event type yet.
-              </p>
-            ) : (
-              <div className="space-y-4">
-                {event.examples.map((example, index) => (
-                  <div key={example.description} className="space-y-2">
-                    <p className="text-sm text-muted-foreground">{example.description}</p>
-                    <JsonBlock value={example.payload} />
-                    {index === 0 ? (
-                      <CommittedEventExample event={event} payload={example.payload} />
-                    ) : null}
-                  </div>
-                ))}
-              </div>
-            )}
-          </DocSection>
         </section>
         <aside className="space-y-4">
           <InfoList
@@ -441,7 +422,6 @@ export function EventDocPage({ event }: { event: EventDoc }) {
               ["URL path", event.href],
               ["Owned by", event.processor.contractSlug],
               ["Event path", event.eventPath],
-              ["Examples", String(event.examples.length)],
             ]}
           />
           <DocSection title="Owned by">
@@ -456,39 +436,6 @@ export function EventDocPage({ event }: { event: EventDoc }) {
         </aside>
       </main>
     </EventDocsShell>
-  );
-}
-
-/**
- * The first example payload wrapped in the committed-event envelope, so
- * readers see what an actual stream row for this type looks like. Offset,
- * createdAt, and path are assigned by the stream at commit time; the values
- * here are illustrative.
- */
-function CommittedEventExample({ event, payload }: { event: EventDoc; payload: unknown }) {
-  const committedEvent = {
-    type: event.type,
-    payload,
-    metadata: {},
-    source: {
-      processor: {
-        slug: event.processor.contractSlug,
-        version: event.processor.version ?? "0.1.0",
-      },
-    },
-    offset: 42,
-    createdAt: "2026-07-09T12:34:56.789Z",
-    path: "<stream path>",
-  };
-  return (
-    <details className="rounded-md border">
-      <summary className="cursor-pointer px-4 py-2 text-sm text-muted-foreground hover:text-foreground">
-        As a committed stream event (envelope fields are illustrative)
-      </summary>
-      <div className="border-t p-2">
-        <JsonBlock value={committedEvent} bare />
-      </div>
-    </details>
   );
 }
 
@@ -538,9 +485,6 @@ function EventListRow({
 }) {
   const preview = payloadPreview(event.payloadJsonSchema);
   const meta: string[] = [];
-  if (event.examples.length > 0) {
-    meta.push(`${event.examples.length} example${event.examples.length === 1 ? "" : "s"}`);
-  }
   if (showCrossReferences) {
     if (event.emittedBy.length > 0) meta.push(`emitted by ${event.emittedBy.length}`);
     if (event.consumedBy.length > 0) meta.push(`consumed by ${event.consumedBy.length}`);

--- a/apps/os/src/domains/agents/agent-collection-processor-contract.ts
+++ b/apps/os/src/domains/agents/agent-collection-processor-contract.ts
@@ -53,7 +53,6 @@ export const AgentCollectionProcessorContract = defineProcessorContract({
     "events.iterate.com/agent-collection/created": {
       description: "Creates the singleton agent collection processor for a project.",
       payloadSchema: z.strictObject({}),
-      examples: [{ description: "Create the project agent collection.", payload: {} }],
     },
   },
   consumes: [

--- a/apps/os/src/domains/agents/agent-processor-contract.ts
+++ b/apps/os/src/domains/agents/agent-processor-contract.ts
@@ -319,54 +319,10 @@ export const AgentProcessorContract = defineProcessorContract({
         "Model-visible context arrived (user message, developer note, assistant output, system " +
         "item). The single source of truth for what the LLM sees.",
       payloadSchema: agentContextItemSchema(),
-      examples: [
-        {
-          description: "A project installs or replaces the system prompt.",
-          payload: {
-            role: "system",
-            key: "agent/system-prompt",
-            content:
-              "You are Acme's release manager. Track open pull requests and nag reviewers politely.",
-          },
-        },
-        {
-          description: "A user sends a chat message from the web UI.",
-          payload: {
-            role: "user",
-            content: "What's on my calendar today?",
-            actor: { type: "user", origin: "web" },
-            llmRequestPolicy: { behaviour: "after-current-request" },
-          },
-        },
-        {
-          description:
-            "A Slack transcriber adds a compact description and a coordinate for the raw webhook.",
-          payload: {
-            role: "developer",
-            content: "A Slack user asked: what's our uptime this month?",
-            actor: { type: "slack", userId: "U0788AB12CD" },
-            refs: [
-              {
-                type: "event",
-                streamPath: "/integrations/slack/acme",
-                offset: 81,
-                eventType: "events.iterate.com/slack/webhook-received",
-              },
-            ],
-            llmRequestPolicy: { behaviour: "after-current-request" },
-          },
-        },
-      ],
     },
     "events.iterate.com/agent/created": {
       description: "The agent exists. Payload is open — provenance may ride along.",
       payloadSchema: z.looseObject({}),
-      examples: [
-        {
-          description: "An agent existence fact has no caller-selected configuration.",
-          payload: {},
-        },
-      ],
     },
     "events.iterate.com/agent/configured": {
       description:
@@ -397,12 +353,6 @@ export const AgentProcessorContract = defineProcessorContract({
           .strict()
           .meta({ description: "Partial patch, deep-merged into the current config." }),
       }),
-      examples: [
-        {
-          description: "Select the model used for subsequent requests.",
-          payload: { config: { llm: { model: "openai/gpt-5.6-sol" } } },
-        },
-      ],
     },
     "events.iterate.com/agents/web-message-sent": {
       description:
@@ -415,15 +365,6 @@ export const AgentProcessorContract = defineProcessorContract({
           .optional()
           .meta({ description: "Files attached to the message." }),
       }),
-      examples: [
-        {
-          description: "The agent sends a visible chat reply to the web UI.",
-          payload: {
-            message:
-              "You have 4 unread emails. The two that look important are from Dana (contract renewal) and GitHub (a failing build on main).",
-          },
-        },
-      ],
     },
     "events.iterate.com/agent/llm-request-requested": {
       description:
@@ -439,14 +380,6 @@ export const AgentProcessorContract = defineProcessorContract({
             "past it the request settles cancelled/expired instead of running.",
         }),
       }),
-      examples: [
-        {
-          description:
-            "The debounce elapsed and the intent was recorded; this event's own offset becomes " +
-            "the requestOffset every later fact references.",
-          payload: { model: "openai/gpt-5.6-sol", expiresAt: 1752000600000 },
-        },
-      ],
     },
     "events.iterate.com/agent/llm-request-settled": {
       description:
@@ -500,42 +433,6 @@ export const AgentProcessorContract = defineProcessorContract({
           ])
           .meta({ description: "How the request settled." }),
       }),
-      examples: [
-        {
-          description: "The LLM returned assistant output, with normalized token usage.",
-          payload: {
-            requestOffset: 57,
-            durationMs: 2340,
-            result: {
-              status: "succeeded",
-              text: "You have 4 unread emails.",
-              usage: { inputTokens: 4096, outputTokens: 118 },
-            },
-          },
-        },
-        {
-          description:
-            "The LLM call failed; the error rides a stream/error-occurred event into " +
-            "model-visible context and the reduce schedules the retry.",
-          payload: {
-            requestOffset: 61,
-            durationMs: 30012,
-            result: { status: "failed", errorMessage: "LLM request timed out after 30000ms" },
-          },
-        },
-        {
-          description:
-            "New user input interrupted the running request; the streamed partial is preserved.",
-          payload: {
-            requestOffset: 58,
-            result: {
-              status: "cancelled",
-              reason: "interrupted-by-user-input",
-              partialText: "Let me check your cal",
-            },
-          },
-        },
-      ],
     },
     "events.iterate.com/agent/llm-response-chunk": {
       description:
@@ -561,16 +458,6 @@ export const AgentProcessorContract = defineProcessorContract({
           .nonnegative()
           .meta({ description: "Chunk ordinal within the response." }),
       }),
-      examples: [
-        {
-          description: "The first streamed text delta of a response.",
-          payload: {
-            chunk: { choices: [{ delta: { content: "Hello" } }] },
-            llmRequestOffset: 57,
-            sequence: 0,
-          },
-        },
-      ],
     },
     "events.iterate.com/agent/token-usage-reported": {
       description:
@@ -615,21 +502,6 @@ export const AgentProcessorContract = defineProcessorContract({
           .optional()
           .meta({ description: "Reasoning/thinking tokens, where the model reports them." }),
       }),
-      examples: [
-        {
-          description:
-            "An OpenAI model reports a mostly-cache-hit request at about a tenth of the model's window.",
-          payload: {
-            llmRequestOffset: 57,
-            model: "openai/gpt-5.6-sol",
-            maxContextTokens: 272000,
-            inputTokens: 29295,
-            outputTokens: 111,
-            cachedInputTokens: 28416,
-            reasoningOutputTokens: 0,
-          },
-        },
-      ],
     },
     "events.iterate.com/agent/summary-updated": {
       description:
@@ -639,24 +511,6 @@ export const AgentProcessorContract = defineProcessorContract({
         "({ waitingFor: null, clearWaitingForThroughOffset }) only clears a wait established " +
         "at or before the waking input's offset.",
       payloadSchema: AgentSummaryUpdated,
-      examples: [
-        {
-          description: "The agent names its work and describes the current phase.",
-          payload: {
-            title: "Lisbon trip planning",
-            activity: "Comparing flight prices",
-            description: "Helping Jane plan a three-day Lisbon trip in September.",
-          },
-        },
-        {
-          description: "The agent has finished its current work and needs an answer.",
-          payload: { waitingFor: "user_input", activity: "Waiting for travel dates" },
-        },
-        {
-          description: "A later wake clears a stale dependency.",
-          payload: { waitingFor: null },
-        },
-      ],
     },
     "events.iterate.com/agent/binding-set": {
       description:
@@ -664,17 +518,6 @@ export const AgentProcessorContract = defineProcessorContract({
         "normally emitted atomically with integration agent creation, never inferred from " +
         "paths. Contract-owned but reduced by integration processors, not by the agent.",
       payloadSchema: AgentBinding,
-      examples: [
-        {
-          description: "A Slack thread is attached to its routed agent.",
-          payload: {
-            type: "slack_thread",
-            connection: "acme-slack",
-            channelId: "C0123",
-            threadTs: "1751980451.123456",
-          },
-        },
-      ],
     },
     "events.iterate.com/agent/paused": {
       description:
@@ -683,26 +526,12 @@ export const AgentProcessorContract = defineProcessorContract({
       payloadSchema: z.object({
         reason: z.string().trim().min(1).optional().meta({ description: "Why the loop paused." }),
       }),
-      examples: [
-        {
-          description: "The circuit breaker parked an agent chaining autonomous script turns.",
-          payload: {
-            reason: "autonomous turn limit reached (100 consecutive turns without external input)",
-          },
-        },
-      ],
     },
     "events.iterate.com/agent/resumed": {
       description: "The agent resumed scheduling turns. Mirrors stream/resumed.",
       payloadSchema: z.object({
         reason: z.string().trim().min(1).optional().meta({ description: "Why the loop resumed." }),
       }),
-      examples: [
-        {
-          description: "A user message woke the paused agent with a fresh autonomous budget.",
-          payload: { reason: "external input" },
-        },
-      ],
     },
   },
   consumes: [

--- a/apps/os/src/domains/capability-host/capability-host-processor-contract.ts
+++ b/apps/os/src/domains/capability-host/capability-host-processor-contract.ts
@@ -198,17 +198,6 @@ export const CapabilityHostProcessorContract = defineProcessorContract({
       description:
         "Creates a capability-host processor on this stream. The birth certificate records the scope's `fallback`: the itx expression a capability miss follows (usually straight to the project root host), or null at the root.",
       payloadSchema: capabilityHostBirthCertificateSchema(),
-      examples: [
-        {
-          description: "The project root host is born with no fallback — resolution ends here.",
-          payload: { config: {}, fallback: null },
-        },
-        {
-          description:
-            'An agent scope host is born falling back directly to the project root: a miss at this scope re-resolves at itx.capabilityHosts.get("/").',
-          payload: { config: {}, fallback: ["capabilityHosts", ["get", "/"]] },
-        },
-      ],
     },
     "events.iterate.com/capability-host/capability-provided": {
       description: "A capability was mounted at a path.",
@@ -292,32 +281,6 @@ export const CapabilityHostProcessorContract = defineProcessorContract({
         .meta({
           description: "The mount record — everything durable about the capability.",
         }) satisfies z.ZodType<CapabilityProvidedPayload, unknown>,
-      examples: [
-        {
-          description:
-            "A live capability object mounted at tools.weather; it lives only as long as the providing session.",
-          payload: {
-            instructions: "Call tools.weather.forecast({ city }) for a 3-day forecast.",
-            path: ["tools", "weather"],
-            type: "live",
-          },
-        },
-        {
-          description:
-            "An OpenAPI connection persisted as an itx expression and mounted at pets; each use re-evaluates the expression.",
-          payload: {
-            expression: [
-              "openapi",
-              ["connect", { specUrl: "https://petstore.example.com/openapi.json" }],
-            ],
-            instructions: "The pet store API. List pets with pets.listPets().",
-            path: ["pets"],
-            type: "itx-expression",
-            types:
-              "export type Capability = { listPets(): Promise<{ id: number; name: string }[]> };",
-          },
-        },
-      ],
     },
     "events.iterate.com/capability-host/capability-revoked": {
       description: "A dynamic capability was removed.",
@@ -337,13 +300,6 @@ export const CapabilityHostProcessorContract = defineProcessorContract({
               "newer mount.",
           }),
       }) satisfies z.ZodType<RevokeCapabilityInput, unknown>,
-      examples: [
-        {
-          description:
-            "The current mount at pets is removed; pass providedAtOffset to revoke one exact mount instead.",
-          payload: { path: ["pets"] },
-        },
-      ],
     },
     "events.iterate.com/capability-host/script-run-requested": {
       description:
@@ -366,16 +322,6 @@ export const CapabilityHostProcessorContract = defineProcessorContract({
               "instead of running.",
           }),
       }),
-      examples: [
-        {
-          description: "An agent codemode turn asks the scope to run a script.",
-          payload: {
-            code: 'async (itx) => {\n  await itx.chat.sendMessage("Checking your email now...");\n}',
-            executionId: "d0f7f2a4-9c1b-4e0e-8f3a-2b7c6d5e4a31",
-            expiresAt: 1783012500000,
-          },
-        },
-      ],
     },
     "events.iterate.com/capability-host/script-run-started": {
       description:
@@ -383,12 +329,6 @@ export const CapabilityHostProcessorContract = defineProcessorContract({
       payloadSchema: z.looseObject({
         executionId: z.string().meta({ description: "The obligation this attempt belongs to." }),
       }),
-      examples: [
-        {
-          description: "The scope began executing the requested script.",
-          payload: { executionId: "d0f7f2a4-9c1b-4e0e-8f3a-2b7c6d5e4a31" },
-        },
-      ],
     },
     "events.iterate.com/capability-host/script-run-settled": {
       description:
@@ -397,29 +337,6 @@ export const CapabilityHostProcessorContract = defineProcessorContract({
         executionId: z.string().meta({ description: "The obligation this settlement closes." }),
         settlement: ScriptExecutionSettlement,
       }),
-      examples: [
-        {
-          description: "The script finished and returned a value.",
-          payload: {
-            executionId: "d0f7f2a4-9c1b-4e0e-8f3a-2b7c6d5e4a31",
-            settlement: { status: "succeeded", result: { unreadCount: 3 } },
-          },
-        },
-        {
-          description: "The script threw; the error message is recorded in the settlement.",
-          payload: {
-            executionId: "7c9e6679-7425-40de-944b-e07fc1f90ae7",
-            settlement: {
-              status: "failed",
-              error: "TypeError: itx.integrations.gmail.get(...).listMessages is not a function",
-              failureKind: "runtime",
-              phase: "execution",
-              executionMayHaveOccurred: true,
-              cancellation: "external-work-may-continue",
-            },
-          },
-        },
-      ],
     },
   },
   consumes: [

--- a/apps/os/src/domains/devices/device-processor-contract.ts
+++ b/apps/os/src/domains/devices/device-processor-contract.ts
@@ -166,39 +166,12 @@ export const DeviceProcessorContract = defineProcessorContract({
         "notification-intent subscription that copies project-level notification/requested " +
         "intents onto this device stream.",
       payloadSchema: deviceBirthCertificateSchema(),
-      examples: [
-        {
-          description: "An iPhone enrolls after the user grants notification permission.",
-          payload: {
-            config: {
-              appVersion: "2.4.0",
-              label: "Misha's iPhone",
-              notificationsStatus: "granted",
-              ownerId: "usr_01HZX3K9M2",
-              platform: "ios",
-              pushTokenSecretPath: "/secrets/devices/dvc_3f8a/expo-push-token",
-              pushTokenSecretUpdatedOffset: 4,
-            },
-          },
-        },
-      ],
     },
     "events.iterate.com/device/notification-requested": {
       description:
         "Requests one expiring push notification to this device. The event's own offset is " +
         "the obligation's identity; every later fact points back with requestOffset.",
       payloadSchema: deviceNotificationRequestSchema(),
-      examples: [
-        {
-          description: "An approval request pushes to the phone with a five-minute deadline.",
-          payload: {
-            body: "POST api.stripe.com is waiting for your approval.",
-            destination: { kind: "approvals", approvalRequestEventOffset: 17 },
-            expiresAt: 1784536200000,
-            title: "Approval needed",
-          },
-        },
-      ],
     },
     "events.iterate.com/device/push-token-updated": {
       description:
@@ -245,19 +218,6 @@ export const DeviceProcessorContract = defineProcessorContract({
               "revision every send and clear is fenced on.",
           }),
       }),
-      examples: [
-        {
-          description: "The app rotates its Expo token after an OS update.",
-          payload: {
-            appVersion: "2.5.1",
-            label: "Misha's iPhone",
-            notificationsStatus: "granted",
-            ownerId: "usr_01HZX3K9M2",
-            pushTokenSecretPath: "/secrets/devices/dvc_3f8a/expo-push-token",
-            pushTokenSecretUpdatedOffset: 9,
-          },
-        },
-      ],
     },
     "events.iterate.com/device/revoked": {
       description:
@@ -272,14 +232,6 @@ export const DeviceProcessorContract = defineProcessorContract({
             "DeviceNotRegistered), sign-out.",
         }),
       }),
-      examples: [
-        { description: "The user signs out of the app.", payload: { reason: "sign-out" } },
-        {
-          description:
-            "Expo reported DeviceNotRegistered, so the processor cleared the credential and revoked itself.",
-          payload: { reason: "push-token-invalid" },
-        },
-      ],
     },
     "events.iterate.com/device/notification-attempt-started": {
       description:
@@ -291,12 +243,6 @@ export const DeviceProcessorContract = defineProcessorContract({
           description: "The obligation being attempted: the offset of its requesting event.",
         }),
       }),
-      examples: [
-        {
-          description: "The processor is about to dial Expo for the request at offset 12.",
-          payload: { requestOffset: 12 },
-        },
-      ],
     },
     "events.iterate.com/device/notification-ticket-observed": {
       description:
@@ -312,12 +258,6 @@ export const DeviceProcessorContract = defineProcessorContract({
           .min(1)
           .meta({ description: "Expo's receipt ticket id, polled later for the outcome." }),
       }),
-      examples: [
-        {
-          description: "Expo queued the push and handed back a ticket.",
-          payload: { requestOffset: 12, ticketId: "0f38e7d2-6a4b-4c8e-9f3a-2b1d5e7c9a01" },
-        },
-      ],
     },
     "events.iterate.com/device/notification-settled": {
       description:
@@ -402,22 +342,6 @@ export const DeviceProcessorContract = defineProcessorContract({
           description: "The settled obligation: the offset of its requesting event.",
         }),
       }),
-      examples: [
-        {
-          description: "The receipt came back clean: APNs/FCM accepted the push.",
-          payload: {
-            outcome: {
-              kind: "accepted-by-push-service",
-              ticketId: "0f38e7d2-6a4b-4c8e-9f3a-2b1d5e7c9a01",
-            },
-            requestOffset: 12,
-          },
-        },
-        {
-          description: "Nobody attempted the push before its deadline, so it settled expired.",
-          payload: { outcome: { kind: "expired" }, requestOffset: 12 },
-        },
-      ],
     },
     "events.iterate.com/device/notification-opened": {
       description: "The app observed that the user opened a correlated notification.",
@@ -430,12 +354,6 @@ export const DeviceProcessorContract = defineProcessorContract({
           description: "The notification that was opened: the offset of its requesting event.",
         }),
       }),
-      examples: [
-        {
-          description: "The user tapped the approval notification.",
-          payload: { openedAt: "2026-07-18T08:12:30.000Z", requestOffset: 12 },
-        },
-      ],
     },
   },
   consumes: [

--- a/apps/os/src/domains/email/email-processor-contract.ts
+++ b/apps/os/src/domains/email/email-processor-contract.ts
@@ -67,12 +67,6 @@ export const EmailProcessorContract = defineProcessorContract({
         "Birth certificate for this email router processor. Appended once by project " +
         "creation; the router routes no mail before it reduces.",
       payloadSchema: emailRouterBirthCertificateSchema(),
-      examples: [
-        {
-          description: "Project creation births the router on /integrations/email.",
-          payload: { config: {} },
-        },
-      ],
     },
     "events.iterate.com/email-agent/created": {
       description:
@@ -92,20 +86,6 @@ export const EmailProcessorContract = defineProcessorContract({
           })
           .meta({ description: "Thread identity fixed at the facet's birth." }),
       }),
-      examples: [
-        {
-          description:
-            "The router births the email facet for a new inbound thread (thread id = the " +
-            "received event's offset).",
-          payload: {
-            config: {
-              threadId: "2",
-              counterpart: "jonas@example.com",
-              subject: "Quarterly report",
-            },
-          },
-        },
-      ],
     },
     "events.iterate.com/email/received": {
       description:
@@ -223,53 +203,6 @@ export const EmailProcessorContract = defineProcessorContract({
         })
         .loose()
         .meta({ description: "One parsed inbound email as the ingress door captures it." }),
-      examples: [
-        {
-          description: "A person emails the project inbox; the door parsed and stored it.",
-          payload: {
-            envelope: { from: "jonas@example.com", to: "acme@iterate.app" },
-            recipient: { slug: "acme", threadId: null },
-            projectId: "prj_0123456789abcdef",
-            automated: false,
-            message: {
-              messageId: "msg-1@mail.example",
-              inReplyTo: null,
-              references: [],
-              from: { address: "jonas@example.com", name: "Jonas" },
-              replyToAddress: null,
-              subject: "Quarterly report",
-              text: "Can you pull the Q2 numbers together?",
-              attachments: [
-                {
-                  filename: "q2.pdf",
-                  mimeType: "application/pdf",
-                  size: 1234,
-                  path: "/email/inbound/msg-1-0-q2.pdf",
-                },
-              ],
-            },
-          },
-        },
-        {
-          description:
-            "A reply to the thread's +t-tagged Reply-To address carries its own route back.",
-          payload: {
-            envelope: { from: "jonas@example.com", to: "acme+t2@iterate.app" },
-            recipient: { slug: "acme", threadId: "2" },
-            projectId: "prj_0123456789abcdef",
-            automated: false,
-            message: {
-              messageId: "msg-2@mail.example",
-              inReplyTo: "out-1@iterate.app",
-              references: ["msg-1@mail.example", "out-1@iterate.app"],
-              from: { address: "jonas@example.com", name: "Jonas" },
-              subject: "Re: Quarterly report",
-              text: "Looks great, thanks!",
-              attachments: [],
-            },
-          },
-        },
-      ],
     },
     "events.iterate.com/email/rejected": {
       description:
@@ -294,16 +227,6 @@ export const EmailProcessorContract = defineProcessorContract({
         })
         .loose()
         .meta({ description: "Envelope-sized audit fact for one refused inbound email." }),
-      examples: [
-        {
-          description: "Mail from a sender outside the project allowlist bounces at the door.",
-          payload: {
-            envelope: { from: "stranger@example.net", to: "acme@iterate.app" },
-            reason: "sender-not-allowed",
-            projectId: "prj_0123456789abcdef",
-          },
-        },
-      ],
     },
     "events.iterate.com/email/sent": {
       description:
@@ -336,20 +259,6 @@ export const EmailProcessorContract = defineProcessorContract({
         })
         .loose()
         .meta({ description: "One outbound email's audit trail entry." }),
-      examples: [
-        {
-          description: "The agent replies inside thread 2; the audit fact carries the thread id.",
-          payload: {
-            from: "acme@iterate.app",
-            messageId: "out-1@iterate.app",
-            projectId: "prj_0123456789abcdef",
-            subject: "Re: Quarterly report",
-            to: "jonas@example.com",
-            threadId: "2",
-            inReplyTo: "msg-1@mail.example",
-          },
-        },
-      ],
     },
     "events.iterate.com/email/sender-allowed": {
       description:
@@ -366,16 +275,6 @@ export const EmailProcessorContract = defineProcessorContract({
           .optional()
           .meta({ description: "Why the pattern was added (audit note)." }),
       }),
-      examples: [
-        {
-          description: "Project birth seeds the creator's address.",
-          payload: { pattern: "jonas@example.com", reason: "project-creator" },
-        },
-        {
-          description: "Open the inbox to a whole trusted domain.",
-          payload: { pattern: "*@example.com" },
-        },
-      ],
     },
     "events.iterate.com/email/thread-route-configured": {
       description:
@@ -402,26 +301,6 @@ export const EmailProcessorContract = defineProcessorContract({
           .optional()
           .meta({ description: "The thread's subject when the route was created." }),
       }),
-      examples: [
-        {
-          description: "A new inbound thread routes to its own email agent stream.",
-          payload: {
-            threadId: "2",
-            streamPath: "/agents/email/t2",
-            counterpart: "jonas@example.com",
-            subject: "Quarterly report",
-          },
-        },
-        {
-          description:
-            "An agent-initiated conversation binds replies to the sending agent's stream.",
-          payload: {
-            threadId: "a1b2c3d4e5f6",
-            streamPath: "/agents/slack/conn/c123/ts-1",
-            counterpart: "jonas@example.com",
-          },
-        },
-      ],
     },
   },
   consumes: [

--- a/apps/os/src/domains/integrations/slack-processor-contract.ts
+++ b/apps/os/src/domains/integrations/slack-processor-contract.ts
@@ -47,12 +47,6 @@ export const SlackProcessorContract = defineProcessorContract({
     "events.iterate.com/slack/created": {
       description: "Birth certificate for this Slack webhook router.",
       payloadSchema: slackRouterBirthCertificateSchema(),
-      examples: [
-        {
-          description: "A Slack connection router is born for one named installation.",
-          payload: { config: { connection: "acme-slack" } },
-        },
-      ],
     },
     "events.iterate.com/slack-agent/created": {
       description: "Birth certificate for the Slack facet on an agent stream.",
@@ -69,18 +63,6 @@ export const SlackProcessorContract = defineProcessorContract({
           })
           .meta({ description: "The one Slack thread this agent stream is bound to." }),
       }),
-      examples: [
-        {
-          description: "A Slack facet binds an agent stream to one thread.",
-          payload: {
-            config: {
-              connection: "acme-slack",
-              channel: "C01234567",
-              threadTs: "1751980451.001200",
-            },
-          },
-        },
-      ],
     },
     "events.iterate.com/slack/webhook-received": {
       description:
@@ -96,30 +78,6 @@ export const SlackProcessorContract = defineProcessorContract({
         .meta({
           description: "The webhook envelope; extra keys (headers, team id) ride along untouched.",
         }),
-      examples: [
-        {
-          description:
-            "A threaded Slack message, as Slack's Events API delivers it (trimmed to the typical fields).",
-          payload: {
-            body: {
-              type: "event_callback",
-              team_id: "T0XYZ1234",
-              api_app_id: "A0AB12CD3",
-              event: {
-                type: "message",
-                channel: "C0AB12CD3",
-                user: "U0DE45FG6",
-                text: "Hey @iterate, can you take a look at this?",
-                ts: "1751980451.204569",
-                thread_ts: "1751980423.123456",
-                channel_type: "channel",
-              },
-              event_id: "Ev0HI78JK9",
-              event_time: 1751980451,
-            },
-          },
-        },
-      ],
     },
     "events.iterate.com/slack/thread-route-configured": {
       description:
@@ -132,17 +90,6 @@ export const SlackProcessorContract = defineProcessorContract({
           .string()
           .meta({ description: "Stream path future webhooks for this thread forward to." }),
       }),
-      examples: [
-        {
-          description:
-            "A fresh Slack thread gets its own routed agent stream (`/agents/slack/{connection}/{channel}/ts-{threadTs}`, channel and ts sanitized to lowercase kebab).",
-          payload: {
-            channel: "C0AB12CD3",
-            threadTs: "1751980423.123456",
-            streamPath: "/agents/slack/acme/c0ab12cd3/ts-1751980423-123456",
-          },
-        },
-      ],
     },
   },
   consumes: [

--- a/apps/os/src/domains/integrations/telegram-agent-processor-contract.ts
+++ b/apps/os/src/domains/integrations/telegram-agent-processor-contract.ts
@@ -70,13 +70,6 @@ export const TelegramAgentProcessorContract = defineProcessorContract({
           text: z.string().meta({ description: "The message text to deliver." }),
         })
         .loose(),
-      examples: [
-        {
-          description:
-            "An agent reply on its own session stream; chat_id is filled from the path on delivery.",
-          payload: { text: "The deploy is green — all three checks passed." },
-        },
-      ],
     },
   },
   // TelegramProcessorContract brings the forwarded webhook, the send marker,

--- a/apps/os/src/domains/integrations/telegram-processor-contract.ts
+++ b/apps/os/src/domains/integrations/telegram-processor-contract.ts
@@ -106,12 +106,6 @@ export const TelegramProcessorContract = defineProcessorContract({
     "events.iterate.com/telegram/created": {
       description: "Birth certificate for this Telegram webhook router.",
       payloadSchema: telegramRouterBirthCertificateSchema(),
-      examples: [
-        {
-          description: "A Telegram connection router is born for one bot connection.",
-          payload: { config: { connection: "support-bot" } },
-        },
-      ],
     },
     "events.iterate.com/telegram/access-configured": {
       description:
@@ -127,12 +121,6 @@ export const TelegramProcessorContract = defineProcessorContract({
               "authorization principal.",
           }),
       }),
-      examples: [
-        {
-          description: "Two Telegram users may talk to this project bot.",
-          payload: { allowedUserIds: ["555123", "777456"] },
-        },
-      ],
     },
     "events.iterate.com/telegram-agent/created": {
       description: "Birth certificate for the Telegram facet on an agent stream.",
@@ -154,14 +142,6 @@ export const TelegramProcessorContract = defineProcessorContract({
             description: "The immutable chat coordinates every journaled send is forced to.",
           }),
       }),
-      examples: [
-        {
-          description: "A Telegram facet binds an agent stream to one chat topic.",
-          payload: {
-            config: { connection: "support-bot", chatId: "555123", messageThreadId: "42" },
-          },
-        },
-      ],
     },
     "events.iterate.com/telegram/webhook-received": {
       description:
@@ -176,24 +156,6 @@ export const TelegramProcessorContract = defineProcessorContract({
           }),
         })
         .loose(),
-      examples: [
-        {
-          description: "A private-chat text message, as Telegram's Bot API delivers it.",
-          payload: {
-            botId: "7000001",
-            body: {
-              update_id: 100001,
-              message: {
-                message_id: 42,
-                from: { id: 555123, is_bot: false, first_name: "Misha", username: "misha" },
-                chat: { id: 555123, type: "private" },
-                date: 1_751_980_451,
-                text: "Hey, can you check the deploy status?",
-              },
-            },
-          },
-        },
-      ],
     },
     "events.iterate.com/telegram/message-sent": {
       description:
@@ -226,21 +188,6 @@ export const TelegramProcessorContract = defineProcessorContract({
           }),
         })
         .loose(),
-      examples: [
-        {
-          description:
-            "The connection-stream provenance claim: bot message_id → the session stream its send-requested lived on.",
-          payload: {
-            messageId: 9001,
-            chatId: "555123",
-            sessionPath: "/agents/telegram/mishas-helper-bot/chat-555123/session-1751980500",
-            request: {
-              offset: 7,
-              stream: "/agents/telegram/mishas-helper-bot/chat-555123/session-1751980500",
-            },
-          },
-        },
-      ],
     },
   },
   consumes: [

--- a/apps/os/src/domains/notifications/notification-intent-contract.ts
+++ b/apps/os/src/domains/notifications/notification-intent-contract.ts
@@ -93,20 +93,6 @@ export const NotificationIntentContract = defineProcessorContract({
           }),
         title: z.string().trim().min(1).max(200).meta({ description: "Notification title line." }),
       }),
-      examples: [
-        {
-          description:
-            "A held Stripe transfer wants a human decision; every channel points its " +
-            "recipients at the approvals screen for that one held request.",
-          payload: {
-            audience: { kind: "project" },
-            title: "Approval needed",
-            body: "POST api.stripe.com is waiting for approval.",
-            destination: { kind: "approvals", approvalRequestEventOffset: 42 },
-            expiresAt: 1784448300000,
-          },
-        },
-      ],
     },
   },
   consumes: [],

--- a/apps/os/src/domains/notifications/notification-lifecycle-contract.ts
+++ b/apps/os/src/domains/notifications/notification-lifecycle-contract.ts
@@ -25,13 +25,6 @@ export const NotificationLifecycleContract = defineProcessorContract({
           .object({})
           .meta({ description: "Reserved for birth-time configuration; empty today." }),
       }),
-      examples: [
-        {
-          description:
-            "Project bootstrap births the notification facet with the (currently empty) config.",
-          payload: { config: {} },
-        },
-      ],
     },
   },
   consumes: [],

--- a/apps/os/src/domains/projects/project-processor-contract.ts
+++ b/apps/os/src/domains/projects/project-processor-contract.ts
@@ -154,37 +154,10 @@ export const ProjectProcessorContract = defineProcessorContract({
     "events.iterate.com/project/created": {
       description: "Birth certificate for this project processor.",
       payloadSchema: projectBirthCertificateSchema(),
-      examples: [
-        {
-          description:
-            "A dashboard signup created the project: onboarding starts and the creator's email seeds the inbound-email sender allowlist.",
-          payload: {
-            config: {
-              onboardingActive: true,
-              slug: "acme-inc",
-              creatorEmail: "jane@acme-inc.com",
-            },
-          },
-        },
-        {
-          description:
-            "An admin/CLI create: no creating user, so no onboarding and no allowlist seed.",
-          payload: {
-            config: { slug: "acme-staging" },
-          },
-        },
-      ],
     },
     "events.iterate.com/project/ready": {
       description: "The project bootstrap saga completed and its default worker is ready.",
       payloadSchema: z.object({}),
-      examples: [
-        {
-          description:
-            "The bootstrap saga finished: the root repo exists and the project worker answered its probe.",
-          payload: {},
-        },
-      ],
     },
     "events.iterate.com/project/onboarding-completed": {
       description: "The project owner completed the onboarding agent flow.",
@@ -193,14 +166,6 @@ export const ProjectProcessorContract = defineProcessorContract({
           .string()
           .meta({ description: "Stream path of the onboarding agent that finished the flow." }),
       }),
-      examples: [
-        {
-          description: "The onboarding agent marked its flow done for the project owner.",
-          payload: {
-            agentPath: "/agents/onboarding",
-          },
-        },
-      ],
     },
     "events.iterate.com/project/custom-domain-add-requested": {
       description: "A custom domain should be provisioned and routed to this project.",
@@ -209,88 +174,22 @@ export const ProjectProcessorContract = defineProcessorContract({
           .string()
           .meta({ description: "The DNS hostname to provision, e.g. app.acme-inc.com." }),
       }),
-      examples: [
-        {
-          description: "The owner asked to serve the project on their own domain.",
-          payload: {
-            hostname: "app.acme-inc.com",
-          },
-        },
-      ],
     },
     "events.iterate.com/project/custom-domain-refresh-requested": {
       description: "Refresh Cloudflare status for a custom domain.",
       payloadSchema: z.object({
         hostname: z.string().meta({ description: "The already-configured hostname to re-poll." }),
       }),
-      examples: [
-        {
-          description:
-            "A dashboard refresh re-polls Cloudflare while the domain is pending validation.",
-          payload: {
-            hostname: "app.acme-inc.com",
-          },
-        },
-      ],
     },
     "events.iterate.com/project/custom-domain-remove-requested": {
       description: "A custom domain should be removed from this project.",
       payloadSchema: z.object({
         hostname: z.string().meta({ description: "The hostname to detach from the project." }),
       }),
-      examples: [
-        {
-          description: "The owner asked to detach their domain from the project.",
-          payload: {
-            hostname: "app.acme-inc.com",
-          },
-        },
-      ],
     },
     "events.iterate.com/project/custom-domain-cloudflare-observed": {
       description: "Cloudflare custom-hostname status observed for a project custom domain.",
       payloadSchema: projectCustomDomainCloudflareSnapshotSchema(),
-      examples: [
-        {
-          description:
-            "First observation after provisioning: certificate validation is pending, so the owner still has DNS records to create.",
-          payload: {
-            cloudflareHostnameId: "0d89c70d-ad9f-4843-b99f-6cc0252067e9",
-            error: null,
-            hostname: "app.acme-inc.com",
-            hostnameStatus: "pending",
-            ownershipVerification: {
-              name: "_cf-custom-hostname.app.acme-inc.com",
-              value: "5cc07c04-ea62-4a5d-b4b0-069bc47533f8",
-            },
-            sslStatus: "pending_validation",
-            status: "pending_validation",
-            validationRecords: [
-              {
-                name: "_acme-challenge.app.acme-inc.com",
-                status: "pending",
-                value: "ca3-f8e2b4c9d1a04e7f9b6c3d2e1f0a5b4c",
-              },
-            ],
-            wildcard: true,
-          },
-        },
-        {
-          description:
-            "A later refresh observed the hostname and certificate both active: the domain now routes to the project.",
-          payload: {
-            cloudflareHostnameId: "0d89c70d-ad9f-4843-b99f-6cc0252067e9",
-            error: null,
-            hostname: "app.acme-inc.com",
-            hostnameStatus: "active",
-            ownershipVerification: null,
-            sslStatus: "active",
-            status: "active",
-            validationRecords: [],
-            wildcard: true,
-          },
-        },
-      ],
     },
     "events.iterate.com/project/custom-domain-provision-failed": {
       description: "Custom-domain provisioning failed before an observed Cloudflare status.",
@@ -298,31 +197,12 @@ export const ProjectProcessorContract = defineProcessorContract({
         error: z.string().meta({ description: "What the provisioning attempt reported." }),
         hostname: z.string().meta({ description: "The hostname the attempt was for." }),
       }),
-      examples: [
-        {
-          description: "Cloudflare rejected the custom-hostname create call.",
-          payload: {
-            error:
-              "Cloudflare /zones/f1e2d3c4b5a69788c9d0e1f2a3b4c5d6/custom_hostnames failed with 409: Duplicate custom hostname found.",
-            hostname: "app.acme-inc.com",
-          },
-        },
-      ],
     },
     "events.iterate.com/project/custom-domain-removed": {
       description: "A custom domain was removed from Cloudflare and routing KV.",
       payloadSchema: z.object({
         hostname: z.string().meta({ description: "The hostname that no longer routes here." }),
       }),
-      examples: [
-        {
-          description:
-            "The remove request completed: Cloudflare and routing KV no longer know the hostname.",
-          payload: {
-            hostname: "app.acme-inc.com",
-          },
-        },
-      ],
     },
     "events.iterate.com/project/egress-rules-configured": {
       description:
@@ -335,29 +215,6 @@ export const ProjectProcessorContract = defineProcessorContract({
           .array(egressRuleSchema())
           .meta({ description: "The complete ordered rule list now in force." }),
       }),
-      examples: [
-        {
-          description:
-            "Mutating Stripe calls need a human; anything spending the production Stripe secret is held too, wherever it goes.",
-          payload: {
-            rules: [
-              {
-                ruleKey: "stripe-mutations",
-                description: "Mutating calls to the Stripe API",
-                match: { hosts: ["api.stripe.com"], methods: ["POST", "PUT", "DELETE"] },
-                verdict: "hold",
-                approvalTimeoutMs: 600_000,
-              },
-              {
-                ruleKey: "stripe-prod-secret",
-                description: "Any request spending the production Stripe key",
-                match: { secretPaths: ["/secrets/stripe/prod"] },
-                verdict: "hold",
-              },
-            ],
-          },
-        },
-      ],
     },
     "events.iterate.com/project/human-approval-key-added": {
       description:
@@ -376,32 +233,12 @@ export const ProjectProcessorContract = defineProcessorContract({
           .optional()
           .meta({ description: "Human-readable device label, e.g. the enrolling machine." }),
       }),
-      examples: [
-        {
-          description:
-            "The owner enrolled their MacBook's Secure Enclave key via `iterate approve --enroll`.",
-          payload: {
-            keyId: "9f2c47a1b8d3e605",
-            publicKey:
-              "BGx1uJ9lZ7Yw2cQ4vX8pR3nK6tA1sD5fG0hJ9kL2mN4oP7qS8uV3wY6zB1cE4gI7jM0nQ5rT8vX2yA5bD8fH1kN4pS7u",
-            label: "jonas-macbook-enclave",
-          },
-        },
-      ],
     },
     "events.iterate.com/project/human-approval-key-revoked": {
       description: "Revoke an enrolled approval key; signatures from it stop being accepted.",
       payloadSchema: z.object({
         keyId: z.string().meta({ description: "The enrolled key to stop accepting." }),
       }),
-      examples: [
-        {
-          description: "The owner rotated their laptop and revoked the old enclave key.",
-          payload: {
-            keyId: "9f2c47a1b8d3e605",
-          },
-        },
-      ],
     },
     "events.iterate.com/project/human-approval-requested": {
       description:
@@ -429,25 +266,6 @@ export const ProjectProcessorContract = defineProcessorContract({
           description: "ISO horizon after which the hold auto-rejects with reason expired.",
         }),
       }),
-      examples: [
-        {
-          description:
-            "An agent tried to move money: a POST to Stripe spending the production key waits for approval.",
-          payload: {
-            method: "POST",
-            url: "https://api.stripe.com/v1/transfers",
-            headers: {
-              authorization: 'Bearer getSecret("/secrets/stripe/prod")',
-              "content-type": "application/x-www-form-urlencoded",
-            },
-            bodySha256: "9c56cc51b374c3ba189210d5b6d4bf57790d351c96c47c02190ecf1e430ba0aa",
-            bodyPreview: "amount=420000&currency=gbp&destination=acct_1MTfjCQ9PRzxCzLK",
-            secretPaths: ["/secrets/stripe/prod"],
-            ruleKey: "stripe-mutations",
-            expiresAt: "2026-07-10T12:34:56.000Z",
-          },
-        },
-      ],
     },
     "events.iterate.com/project/human-approval-granted": {
       description:
@@ -468,17 +286,6 @@ export const ProjectProcessorContract = defineProcessorContract({
             "Base64 raw 64-byte r‖s ECDSA P-256 signature over the canonical approval message.",
         }),
       }),
-      examples: [
-        {
-          description: "A signed grant from an enrolled Secure Enclave key releases the request.",
-          payload: {
-            approvalRequestEventOffset: 42,
-            keyId: "9f2c47a1b8d3e605",
-            signature:
-              "MEUCIQDx4Zc7HqzUnkl3RaW0mYtVbGJ5cD8fH1kN4pS7uMEUCIQDx4Zc7HqzUnkl3RaW0mYtVbGJ5c=",
-          },
-        },
-      ],
     },
     "events.iterate.com/project/human-approval-rejected": {
       description:
@@ -493,23 +300,6 @@ export const ProjectProcessorContract = defineProcessorContract({
           .enum(["human", "expired"])
           .meta({ description: "Who refused: a human, or the hold's timeout." }),
       }),
-      examples: [
-        {
-          description: "A human refused the request from the approval CLI.",
-          payload: {
-            approvalRequestEventOffset: 42,
-            reason: "human",
-          },
-        },
-        {
-          description:
-            "Nobody answered within the rule's approvalTimeoutMs; the hold auto-rejected.",
-          payload: {
-            approvalRequestEventOffset: 42,
-            reason: "expired",
-          },
-        },
-      ],
     },
     "events.iterate.com/project/human-approval-settled": {
       description:
@@ -530,22 +320,6 @@ export const ProjectProcessorContract = defineProcessorContract({
           .optional()
           .meta({ description: "Delivery failure, when the released request never got a status." }),
       }),
-      examples: [
-        {
-          description: "The released Stripe transfer succeeded.",
-          payload: {
-            approvalRequestEventOffset: 42,
-            status: 200,
-          },
-        },
-        {
-          description: "The upstream call failed after release.",
-          payload: {
-            approvalRequestEventOffset: 42,
-            error: "connection refused",
-          },
-        },
-      ],
     },
   },
   consumes: [

--- a/apps/os/src/domains/repos/repo-processor-contract.ts
+++ b/apps/os/src/domains/repos/repo-processor-contract.ts
@@ -128,68 +128,16 @@ export const RepoProcessorContract = defineProcessorContract({
       description:
         "Requests the repo creation saga: seed an empty repo, import a private GitHub repo at depth one, or import a public GitHub repo through Cloudflare Artifacts (full history unless depth is set). Terminates in repos/created or repos/create-failed.",
       payloadSchema: repoCreateRequestSchema(),
-      examples: [
-        {
-          description: "Create a repo containing Iterate's starter files.",
-          payload: { type: "empty" },
-        },
-        {
-          description: "Pull a private GitHub repository through the Worker at depth one.",
-          payload: {
-            type: "github-private",
-            connection: "install-87654321",
-            owner: "acme-inc",
-            repo: "private-app",
-          },
-        },
-        {
-          description:
-            "Ask Cloudflare Artifacts to import a public GitHub repository directly with full history. Set depth to request a shallow import instead.",
-          payload: {
-            type: "github-public",
-            connection: "install-87654321",
-            owner: "acme-inc",
-            repo: "public-app",
-          },
-        },
-      ],
     },
     "events.iterate.com/repos/created": {
       description:
         "The repo creation saga completed and its backing Artifact is ready — the repo's birth certificate.",
       payloadSchema: repoBirthCertificateSchema(),
-      examples: [
-        {
-          description:
-            "The project's config repo finished bootstrapping: its git remote is a Cloudflare Artifacts repository named after the project id and path.",
-          payload: {
-            request: { type: "empty" },
-            artifactName: "prj_01jzp3v9qkfxeb2m4n8r7wd5ha--L3JlcG9zL2NvbmZpZw",
-            defaultBranch: "main",
-            remote:
-              "https://6d7f0e2c4b9a5138f2ce7a1b8d3e4f50.artifacts.cloudflare.net/git/os-prd-repos/prj_01jzp3v9qkfxeb2m4n8r7wd5ha--L3JlcG9zL2NvbmZpZw.git",
-          },
-        },
-      ],
     },
     "events.iterate.com/repos/create-failed": {
       description:
         "The repo creation saga reached a terminal failure and did not declare the repo created. Fail-closed: nothing else ever reacts on a failed repo's stream.",
       payloadSchema: repoCreateFailureSchema(),
-      examples: [
-        {
-          description: "Cloudflare Artifacts rejected a public repository import.",
-          payload: {
-            error: "Cloudflare Artifacts 10400: An internal error occurred",
-            request: {
-              type: "github-public",
-              connection: "install-87654321",
-              owner: "acme-inc",
-              repo: "public-app",
-            },
-          },
-        },
-      ],
     },
     "events.iterate.com/repo/cloudflare-artifact-event-received": {
       description:
@@ -207,25 +155,6 @@ export const RepoProcessorContract = defineProcessorContract({
           namespace: z.string().meta({ description: "The Artifacts namespace (per deployment)." }),
         })
         .loose(),
-      examples: [
-        {
-          description:
-            "Cloudflare Artifacts reported that main advanced; the repo processor compares the before and after task trees.",
-          payload: {
-            artifactName: "prj_01jzp3v9qkfxeb2m4n8r7wd5ha--L3JlcG9zL2NvbmZpZw",
-            body: {
-              type: "cf.artifacts.repo.pushed",
-              payload: {
-                after: "9f8d2c4b1e7a6a53c0d4e8b2f19a7c3d5e6f8a01",
-                before: "4c1a9b0e2d3f5a6b7c8d9e0f1a2b3c4d5e6f7a80",
-                ref: "refs/heads/main",
-              },
-            },
-            cloudflareEventType: "cf.artifacts.repo.pushed",
-            namespace: "os-prd-repos",
-          },
-        },
-      ],
     },
     "events.iterate.com/repo/commit-completed": {
       description:
@@ -237,76 +166,23 @@ export const RepoProcessorContract = defineProcessorContract({
         branch: z.string().trim().min(1).meta({ description: "The branch that advanced." }),
         commitOid: z.string().trim().min(1).meta({ description: "The new branch head." }),
       }),
-      examples: [
-        {
-          description: "An external Git push advanced main by one or more commits.",
-          payload: {
-            beforeCommitOid: "4c1a9b0e2d3f5a6b7c8d9e0f1a2b3c4d5e6f7a80",
-            branch: "main",
-            commitOid: "9f8d2c4b1e7a6a53c0d4e8b2f19a7c3d5e6f8a01",
-          },
-        },
-      ],
     },
     "events.iterate.com/repo/task-created": {
       description: "A Markdown task file was created on the repo's default branch.",
       payloadSchema: taskFileChangedSchema(),
-      examples: [
-        {
-          description: "A new root task became durable on main.",
-          payload: {
-            branch: "main",
-            commitOid: "9f8d2c4b1e7a6a53c0d4e8b2f19a7c3d5e6f8a01",
-            path: "tasks/ship-board.md",
-          },
-        },
-      ],
     },
     "events.iterate.com/repo/task-updated": {
       description: "A Markdown task file changed on the repo's default branch.",
       payloadSchema: taskFileChangedSchema(),
-      examples: [
-        {
-          description: "Moving a board card changed the task's state frontmatter on main.",
-          payload: {
-            branch: "main",
-            commitOid: "9f8d2c4b1e7a6a53c0d4e8b2f19a7c3d5e6f8a01",
-            path: "apps/os/tasks/ship-board.md",
-          },
-        },
-      ],
     },
     "events.iterate.com/repo/task-deleted": {
       description: "A Markdown task file was deleted from the repo's default branch.",
       payloadSchema: taskFileChangedSchema(),
-      examples: [
-        {
-          description: "A completed task file was removed from main.",
-          payload: {
-            branch: "main",
-            commitOid: "9f8d2c4b1e7a6a53c0d4e8b2f19a7c3d5e6f8a01",
-            path: "tasks/old-task.md",
-          },
-        },
-      ],
     },
     "events.iterate.com/repo/github-link-configured": {
       description:
         "The repo was linked to a GitHub repository (mirror commits out and import fast-forward default-branch pushes).",
       payloadSchema: githubLinkSchema(),
-      examples: [
-        {
-          description:
-            "The repo was linked to acme-inc/acme-config through the GitHub App installation's connection.",
-          payload: {
-            connection: "install-87654321",
-            installationId: "87654321",
-            owner: "acme-inc",
-            repo: "acme-config",
-            repositoryId: 123456789,
-          },
-        },
-      ],
     },
     "events.iterate.com/repo/github-unlinked": {
       description: "The repo's GitHub link was removed.",
@@ -320,17 +196,6 @@ export const RepoProcessorContract = defineProcessorContract({
           .positive()
           .meta({ description: "GitHub's numeric repository id." }),
       }),
-      examples: [
-        {
-          description: "The link to acme-inc/acme-config was removed; mirroring stops.",
-          payload: {
-            connection: "install-87654321",
-            owner: "acme-inc",
-            repo: "acme-config",
-            repositoryId: 123456789,
-          },
-        },
-      ],
     },
     "events.iterate.com/repo/github-push-completed": {
       description: "A mirror push delivered the branch head to the linked GitHub repository.",
@@ -340,17 +205,6 @@ export const RepoProcessorContract = defineProcessorContract({
         owner: z.string().meta({ description: "GitHub owner of the mirror target." }),
         repo: z.string().meta({ description: "GitHub name of the mirror target." }),
       }),
-      examples: [
-        {
-          description: "The default branch's new head was mirrored to GitHub after a commit.",
-          payload: {
-            branch: "main",
-            commitOid: "9f8d2c4b1e7a6a53c0d4e8b2f19a7c3d5e6f8a01",
-            owner: "acme-inc",
-            repo: "acme-config",
-          },
-        },
-      ],
     },
     "events.iterate.com/repo/github-push-failed": {
       description:
@@ -364,32 +218,6 @@ export const RepoProcessorContract = defineProcessorContract({
         owner: z.string().meta({ description: "GitHub owner of the mirror target." }),
         repo: z.string().meta({ description: "GitHub name of the mirror target." }),
       }),
-      examples: [
-        {
-          description:
-            "GitHub rejected the mirror push as non-fast-forward: GitHub has commits this repo does not.",
-          payload: {
-            branch: "main",
-            commitOid: "9f8d2c4b1e7a6a53c0d4e8b2f19a7c3d5e6f8a01",
-            error:
-              'Error: GitHub push of main was rejected (non-fast-forward means GitHub has commits this repo does not; use syncFromGithub() to adopt them or pushToGithub({ force: true }) to overwrite): {"refs/heads/main":"fetch first"}',
-            owner: "acme-inc",
-            repo: "acme-config",
-          },
-        },
-        {
-          description:
-            "The push failed before a head was resolved (null commitOid): the connection's installation token could not be minted.",
-          payload: {
-            branch: "main",
-            commitOid: null,
-            error:
-              'Error: GitHub connection "install-87654321" has no usable installation token (HttpError: Not Found). Use itx.integrations.list() to see connections.',
-            owner: "acme-inc",
-            repo: "acme-config",
-          },
-        },
-      ],
     },
     "events.iterate.com/repo/github-synced": {
       description:
@@ -409,59 +237,15 @@ export const RepoProcessorContract = defineProcessorContract({
           description: "True when the artifact was destroyed and recreated (resetFromGithub).",
         }),
       }),
-      examples: [
-        {
-          description: "A fast-forward sync adopted GitHub's newer branch head.",
-          payload: {
-            branch: "main",
-            commitOid: "9f8d2c4b1e7a6a53c0d4e8b2f19a7c3d5e6f8a01",
-            forced: false,
-            owner: "acme-inc",
-            previousCommitOid: "4c1a9b0e2d3f5a6b7c8d9e0f1a2b3c4d5e6f7a80",
-            repo: "acme-config",
-          },
-        },
-        {
-          description: "A forced sync overwrote diverged local history with GitHub's branch head.",
-          payload: {
-            branch: "main",
-            commitOid: "b7e2f0a9c8d14e3fa6570b2c9d8e1f4a3b5c6d70",
-            forced: true,
-            owner: "acme-inc",
-            previousCommitOid: "9f8d2c4b1e7a6a53c0d4e8b2f19a7c3d5e6f8a01",
-            repo: "acme-config",
-          },
-        },
-      ],
     },
     "events.iterate.com/repo/github-import-requested": {
       description: "A linked GitHub default-branch push opened a durable import obligation.",
       payloadSchema: githubImportRequestSchema(),
-      examples: [
-        {
-          description: "A GitHub push requested that main be adopted into Artifacts.",
-          payload: {
-            branch: "main",
-            requestId: "/repos/config:42",
-            requestedCommitOid: "9f8d2c4b1e7a6a53c0d4e8b2f19a7c3d5e6f8a01",
-          },
-        },
-      ],
     },
     "events.iterate.com/repo/github-import-started": {
       description:
         "The repo processor durably began a GitHub import attempt — journaled BEFORE the sync body runs, so an attempt that dies with its incarnation is visibly owed.",
       payloadSchema: githubImportRequestSchema(),
-      examples: [
-        {
-          description: "The durable GitHub import attempt began.",
-          payload: {
-            branch: "main",
-            requestId: "/repos/config:42",
-            requestedCommitOid: "9f8d2c4b1e7a6a53c0d4e8b2f19a7c3d5e6f8a01",
-          },
-        },
-      ],
     },
     "events.iterate.com/repo/github-import-completed": {
       description:
@@ -488,17 +272,6 @@ export const RepoProcessorContract = defineProcessorContract({
           .min(1)
           .meta({ description: "The head the original push delivery announced." }),
       }),
-      examples: [
-        {
-          description: "Artifacts now contains the current GitHub main head.",
-          payload: {
-            branch: "main",
-            commitOid: "9f8d2c4b1e7a6a53c0d4e8b2f19a7c3d5e6f8a01",
-            requestId: "/repos/config:42",
-            requestedCommitOid: "9f8d2c4b1e7a6a53c0d4e8b2f19a7c3d5e6f8a01",
-          },
-        },
-      ],
     },
     "events.iterate.com/repo/github-import-failed": {
       description:
@@ -517,17 +290,6 @@ export const RepoProcessorContract = defineProcessorContract({
           .min(1)
           .meta({ description: "The head the original push delivery announced." }),
       }),
-      examples: [
-        {
-          description: "GitHub and Artifacts had diverged, so the automatic import failed closed.",
-          payload: {
-            branch: "main",
-            error: 'Error: syncFromGithub is not a fast-forward (GitHub says "diverged").',
-            requestId: "/repos/config:42",
-            requestedCommitOid: "9f8d2c4b1e7a6a53c0d4e8b2f19a7c3d5e6f8a01",
-          },
-        },
-      ],
     },
     "events.iterate.com/github/webhook-received": {
       description:
@@ -568,34 +330,6 @@ export const RepoProcessorContract = defineProcessorContract({
             .meta({ description: "The GitHub App installation the delivery was routed by." }),
         })
         .loose(),
-      examples: [
-        {
-          description:
-            "A push delivery (trimmed): GitHub's webhook body under `body`, plus the delivery headers and the routing installation id.",
-          payload: {
-            body: {
-              ref: "refs/heads/main",
-              before: "4c1a9b0e2d3f5a6b7c8d9e0f1a2b3c4d5e6f7a80",
-              after: "9f8d2c4b1e7a6a53c0d4e8b2f19a7c3d5e6f8a01",
-              commits: [
-                {
-                  id: "9f8d2c4b1e7a6a53c0d4e8b2f19a7c3d5e6f8a01",
-                  message: "Update worker routing",
-                  author: { name: "Jane Doe", email: "jane@acme-inc.com" },
-                },
-              ],
-              repository: { full_name: "acme-inc/acme-config", id: 123456789 },
-              sender: { login: "jane-doe" },
-              installation: { id: 87654321 },
-            },
-            delivery: {
-              id: "72d3162e-cc78-11e3-81ab-4c9367dc0958",
-              name: "push",
-            },
-            installationId: "87654321",
-          },
-        },
-      ],
     },
   },
   processorDeps: [CoreProcessorContract],

--- a/apps/os/src/domains/sandboxes/sandbox-processor-contract.ts
+++ b/apps/os/src/domains/sandboxes/sandbox-processor-contract.ts
@@ -93,111 +93,45 @@ export const SandboxProcessorContract = defineProcessorContract({
             "Initial env-var map, applied as if by setEnvVars (key → getSecret placeholder or non-secret literal; null unsets). Never raw secret material — this lands on a durable stream.",
         }),
       }),
-      examples: [
-        {
-          description:
-            'itx.sandboxes.get("/sandboxes/main").create claims a basic instance that sleeps after 10 idle minutes, with a getSecret-placeholder env var substituted only at egress.',
-          payload: {
-            path: "/sandboxes/main",
-            instanceType: "basic",
-            sleepAfter: "10m",
-            env: {
-              GH_TOKEN: 'getSecret("/secrets/integrations/github/acme", { field: "accessToken" })',
-            },
-          },
-        },
-      ],
     },
     "events.iterate.com/sandbox/created": {
       description:
         "The sandbox exists: identity and configuration are durably stored and itx.sandboxes.get(path) resolves it. No container is running yet — the first command (or start()) boots one.",
       payloadSchema: sandboxBirthCertificateSchema(),
-      examples: [
-        {
-          description: "A basic sandbox finished setup and is ready to boot on the first command.",
-          payload: { config: { instanceType: "basic" } },
-        },
-      ],
     },
     "events.iterate.com/sandbox/start-requested": {
       description:
         "start() was called: boot the container now (rather than lazily on the first command). `started` confirms the boot.",
       payloadSchema: z.object({}),
-      examples: [
-        {
-          description: "start() was called to boot the container ahead of the first command.",
-          payload: {},
-        },
-      ],
     },
     "events.iterate.com/sandbox/started": {
       description:
         "The sandbox container booted (the SDK's onStart hook) — after an explicit start() OR implicitly because a command reached a stopped sandbox. /workspace is restored from the newest snapshot before commands run.",
       payloadSchema: z.object({}),
-      examples: [
-        {
-          description:
-            "A command reached a stopped sandbox, so a fresh container booted implicitly.",
-          payload: {},
-        },
-      ],
     },
     "events.iterate.com/sandbox/sleep-requested": {
       description:
         "sleep() was called (Cloudflare's word for what the idle timer does, on demand): snapshot /workspace, then tear the container down. The sandbox stays created — the next start (or command) boots a fresh container and restores the snapshot. The SDK's stop() forwards here so no spelling skips the snapshot.",
       payloadSchema: z.object({}),
-      examples: [
-        {
-          description:
-            "sleep() was called: snapshot /workspace, then tear the container down until the next command.",
-          payload: {},
-        },
-      ],
     },
     "events.iterate.com/sandbox/stopped": {
       description:
         "The sandbox container exited (the SDK's onStop hook) — after an explicit sleep(), the idle timer (sleepAfter), or a destroy. May be appended on a LATER wake: the SDK delivers a stop that happened while the Durable Object was hibernated on the next wake.",
       payloadSchema: z.object({}),
-      examples: [
-        {
-          description: "The idle timer expired and the container exited.",
-          payload: {},
-        },
-      ],
     },
     "events.iterate.com/sandbox/kill-requested": {
       description:
         "kill() was called: the current Durable Object incarnation is deliberately aborted after this fact is durably reduced. The container lifecycle and reduced running state are unchanged; the next request boots a fresh object around the same sandbox.",
       payloadSchema: z.object({}),
-      examples: [
-        {
-          description:
-            "An operator requested a Durable Object restart while leaving the running container alone.",
-          payload: {},
-        },
-      ],
     },
     "events.iterate.com/sandbox/destroy-requested": {
       description: "destroy() was called: tear the sandbox down permanently. `destroyed` confirms.",
       payloadSchema: z.object({}),
-      examples: [
-        {
-          description: "destroy() was called: tear the sandbox down permanently.",
-          payload: {},
-        },
-      ],
     },
     "events.iterate.com/sandbox/destroyed": {
       description:
         "The sandbox is permanently gone: container torn down and the identity tombstoned — the path can never be created again (pick a new name). Workspace snapshots in R2 age out on their ttl.",
       payloadSchema: z.object({}),
-      examples: [
-        {
-          description:
-            "The teardown landed: the container is gone and the path is tombstoned forever.",
-          payload: {},
-        },
-      ],
     },
     "events.iterate.com/sandbox/workspace-restored": {
       description:
@@ -207,13 +141,6 @@ export const SandboxProcessorContract = defineProcessorContract({
           description: "The restored R2 snapshot's id (the SDK's random UUID).",
         }),
       }),
-      examples: [
-        {
-          description:
-            "A fresh container restored /workspace from the newest snapshot (backup ids are the SDK's random UUIDs).",
-          payload: { backupId: "3f2c9a4e-8b1d-4e7a-9c6f-2d5b8a1e4f7c" },
-        },
-      ],
     },
     "events.iterate.com/sandbox/backup-created": {
       description:
@@ -224,12 +151,6 @@ export const SandboxProcessorContract = defineProcessorContract({
             "The new R2 snapshot's id (the SDK's random UUID) — the next restore source.",
         }),
       }),
-      examples: [
-        {
-          description: "The idle timer snapshotted /workspace to R2 before stopping the container.",
-          payload: { backupId: "3f2c9a4e-8b1d-4e7a-9c6f-2d5b8a1e4f7c" },
-        },
-      ],
     },
     "events.iterate.com/sandbox/backup-failed": {
       description:
@@ -237,13 +158,6 @@ export const SandboxProcessorContract = defineProcessorContract({
       payloadSchema: z.object({
         error: z.string().meta({ description: "What the snapshot attempt reported." }),
       }),
-      examples: [
-        {
-          description:
-            "The snapshot could not be archived; the previous good backup remains the restore source.",
-          payload: { error: "createBackup failed: container exited before the archive completed" },
-        },
-      ],
     },
     "events.iterate.com/sandbox/configured": {
       description:
@@ -254,18 +168,6 @@ export const SandboxProcessorContract = defineProcessorContract({
             "The entries set in THIS change (key → getSecret placeholder / literal; null unsets the key) — not the full resulting map.",
         }),
       }),
-      examples: [
-        {
-          description:
-            "setEnvVars set GH_TOKEN to a getSecret placeholder (substituted only at egress) and unset DEBUG.",
-          payload: {
-            env: {
-              GH_TOKEN: 'getSecret("/secrets/integrations/github/acme", { field: "accessToken" })',
-              DEBUG: null,
-            },
-          },
-        },
-      ],
     },
   },
   consumes: [

--- a/apps/os/src/domains/scheduler/scheduler-processor-contract.ts
+++ b/apps/os/src/domains/scheduler/scheduler-processor-contract.ts
@@ -146,13 +146,6 @@ export const SchedulerProcessorContract = defineProcessorContract({
         "appends it (idempotency-keyed per project + path) and returns only after the " +
         "processor has reduced it.",
       payloadSchema: schedulerBirthCertificateSchema(),
-      examples: [
-        {
-          description:
-            'itx.schedulers.get("/scheduler/primary").create() births the default project Scheduler.',
-          payload: { config: {} },
-        },
-      ],
     },
     "events.iterate.com/scheduler/schedule-set": {
       description:
@@ -174,33 +167,6 @@ export const SchedulerProcessorContract = defineProcessorContract({
           }),
         recurrence: schedulerRecurrenceSchema(),
       }),
-      examples: [
-        {
-          description: "A weekday 9am London report, re-set idempotently by a declarative client.",
-          payload: {
-            key: "daily-report",
-            recurrence: { cron: "0 9 * * 1-5", timezone: "Europe/London" },
-            action: {
-              kind: "itx-script",
-              script:
-                'async (itx, schedule, trigger) => { await itx.agents.get("/agents/reporter").tell(`Compile the daily report (run ${trigger.runCount})`); }',
-            },
-            metadata: { owner: "ops" },
-          },
-        },
-        {
-          description:
-            "A one-shot at a fixed instant ({ in: seconds } API sugar lowers to { at } before anything is appended, so the log has one spelling).",
-          payload: {
-            key: "renewal-reminder",
-            recurrence: { at: "2026-08-01T09:00:00Z" },
-            action: {
-              kind: "itx-script",
-              script: 'async (itx) => { await itx.friction.report("Domain renewal is due"); }',
-            },
-          },
-        },
-      ],
     },
     "events.iterate.com/scheduler/schedule-cancelled": {
       description:
@@ -209,12 +175,6 @@ export const SchedulerProcessorContract = defineProcessorContract({
       payloadSchema: z.looseObject({
         key: z.string().trim().min(1).meta({ description: "The key to remove." }),
       }),
-      examples: [
-        {
-          description: 'itx.scheduler.cancel("daily-report") removes the Schedule.',
-          payload: { key: "daily-report" },
-        },
-      ],
     },
     "events.iterate.com/scheduler/trigger-requested": {
       description:
@@ -249,19 +209,6 @@ export const SchedulerProcessorContract = defineProcessorContract({
           description: "When this occurrence was due. Equals requestedAt for manual triggers.",
         }),
       }),
-      examples: [
-        {
-          description:
-            "The 9am occurrence of daily-report, requested by the alarm shortly after it came due.",
-          payload: {
-            executionId: "3e6f5f9b-4a67-4b8e-9d2e-6f0a1c2b3d4e",
-            key: "daily-report",
-            requestedAt: "2026-07-20T09:00:01.800Z",
-            runCount: 12,
-            scheduledFor: "2026-07-20T09:00:00.000Z",
-          },
-        },
-      ],
     },
     "events.iterate.com/scheduler/trigger-completed": {
       description:
@@ -292,27 +239,6 @@ export const SchedulerProcessorContract = defineProcessorContract({
             "The Action's JSON-detached return value, when it succeeded and returned one.",
         }),
       }),
-      examples: [
-        {
-          description: "The report script succeeded and returned a value.",
-          payload: {
-            definedAtOffset: 2,
-            executionId: "3e6f5f9b-4a67-4b8e-9d2e-6f0a1c2b3d4e",
-            key: "daily-report",
-            outcome: "succeeded",
-            result: { emailed: true },
-          },
-        },
-        {
-          description:
-            "The Schedule was cancelled between request and execution — completed as skipped without running any code.",
-          payload: {
-            executionId: "9a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d",
-            key: "daily-report",
-            outcome: "skipped",
-          },
-        },
-      ],
     },
   },
   consumes: [

--- a/apps/os/src/domains/secrets/secret-processor-contract.ts
+++ b/apps/os/src/domains/secrets/secret-processor-contract.ts
@@ -110,29 +110,6 @@ export const SecretProcessorContract = defineProcessorContract({
         "certificate; the DO cross-posts this event to the project root stream, where the " +
         "project processor catalogs the secret.",
       payloadSchema: secretBirthCertificateSchema(),
-      examples: [
-        {
-          description: "A secret is born with an egress policy and no refresh strategy.",
-          payload: {
-            config: {
-              egress: { urls: ["https://api.example.com"] },
-              refresh: null,
-            },
-          },
-        },
-        {
-          description:
-            "The born project API key: readable material (reveal() answers it) with an empty " +
-            "egress pin — readable and substitutable are mutually exclusive.",
-          payload: {
-            config: {
-              egress: { urls: [] },
-              refresh: null,
-              visibility: "readable",
-            },
-          },
-        },
-      ],
     },
     "events.iterate.com/secret/updated": {
       description:
@@ -159,33 +136,6 @@ export const SecretProcessorContract = defineProcessorContract({
               "leaves it unchanged.",
           }),
       }),
-      examples: [
-        {
-          description:
-            "A Slack bot token is stored: encrypted-at-rest material plus the egress origins it may be substituted into.",
-          payload: {
-            encryptedMaterial: {
-              algorithm: "AES-GCM-SHA256+SECRET-CELL-V1",
-              ciphertext: "nJ2xkV8mPqvGdL5tYw3eBg==",
-              iv: "9EMTZWEeC2Iy5W5m",
-            },
-            egress: { urls: ["https://slack.com", "https://files.slack.com"] },
-          },
-        },
-        {
-          description:
-            "A GitHub connection secret gets the github-app-installation refresh strategy: the DO mints installation tokens on demand, signing with the platform-owned App key.",
-          payload: {
-            refresh: {
-              kind: "github-app-installation",
-              apiBase: "https://api.github.com",
-              appId: "312345",
-              installationId: "45678901",
-              privateKey: { platform: "integrations.github" },
-            },
-          },
-        },
-      ],
     },
     "events.iterate.com/secret/used": {
       description:
@@ -204,17 +154,6 @@ export const SecretProcessorContract = defineProcessorContract({
           .optional()
           .meta({ description: "The pinned egress URL the request targeted." }),
       }),
-      examples: [
-        {
-          description:
-            "The secret's material was substituted into a Slack Web API call at the egress door.",
-          payload: {
-            usedAt: "2026-07-08T14:31:09.412Z",
-            usedBy: "prj_b9f2c81d4e6a4f0a9c3d7e5b1a8f2c4d",
-            url: "https://slack.com/api/chat.postMessage",
-          },
-        },
-      ],
     },
   },
   consumes: [

--- a/apps/os/src/domains/streams/core-processor-contract.ts
+++ b/apps/os/src/domains/streams/core-processor-contract.ts
@@ -379,113 +379,27 @@ export const CoreProcessorContract = defineProcessorContract({
         projectId: z.string().trim().min(1).nullable(),
         path: z.string().trim().min(1),
       }),
-      examples: [
-        {
-          description: "A project's agent stream is created.",
-          payload: { projectId: "prj_01jzp3v9qkfxeb2m4n8r7wd5ha", path: "/agents/onboarding" },
-        },
-        {
-          description: "A deployment-global stream (no owning project) is created.",
-          payload: { projectId: null, path: "/repos/iterate-config-base" },
-        },
-      ],
     },
     "events.iterate.com/stream/woken": {
       description: "Records that a Durable Object incarnation has started running this stream.",
       payloadSchema: z.object({
         incarnationId: z.string().trim().min(1),
       }),
-      examples: [
-        {
-          description:
-            "A fresh Durable Object incarnation starts running the stream after hibernation.",
-          payload: { incarnationId: "b7f9d2c4-3a1e-4f68-9c05-8d2e6a41f7b3" },
-        },
-      ],
     },
     "events.iterate.com/stream/configured": {
       description: "Configures core stream runtime policy.",
       payloadSchema: StreamConfiguredPayload,
-      examples: [
-        {
-          description: "Sets an explicit append circuit-breaker budget for a capture stream.",
-          payload: {
-            config: { circuitBreaker: { burstCapacity: 100_000, refillRatePerMinute: 6_000_000 } },
-          },
-        },
-      ],
     },
     "events.iterate.com/stream/child-stream-created": {
       description: "Records the immediate child stream segment under this stream.",
       payloadSchema: z.object({
         childPath: z.string().trim().min(1),
       }),
-      examples: [
-        {
-          description: "The project root stream learns a new agent stream was born beneath it.",
-          payload: { childPath: "/agents/onboarding" },
-        },
-        {
-          description:
-            "An ancestor stream records a newborn Slack thread agent; the reducer folds the full path down to the immediate child segment.",
-          payload: { childPath: "/agents/slack/main/C0788AB12CD/ts-1751884800-123456" },
-        },
-      ],
     },
     "events.iterate.com/stream/subscription-configured": {
       description:
         "Configures or replaces a durable subscription for this stream (wake or push delivery; latest event per subscriptionKey wins). Re-configuring keeps the existing delivery cursor unless `deliver` is set, and clears any parked state — new config is a fresh chance.",
       payloadSchema: SubscriptionConfiguredPayload,
-      examples: [
-        {
-          description:
-            "Wake delivery: the agent processor hosted on the agent's Durable Object folds this stream; the subscriber owns its own checkpoint, so no deliver/onPoison here.",
-          payload: {
-            subscriptionKey: "prj_01jzp3v9qkfxeb2m4n8r7wd5ha.iterate/agents/onboarding#agent",
-            delivery: {
-              mode: "wake",
-              expression: [
-                "agents",
-                ["get", "/agents/onboarding"],
-                "processor",
-                "wakeStreamSubscriber",
-              ],
-              processorSlug: "agent",
-            },
-          },
-        },
-        {
-          description:
-            "Push delivery: cross-posts one repository's GitHub webhooks from a connection stream onto the repo's own stream, live-tailing from now.",
-          payload: {
-            subscriptionKey: "github-repo:/repos/root",
-            description:
-              "Copies GitHub webhooks for acme/widgets onto this repo's stream so the repo processor can react to them.",
-            selector: {
-              eventTypes: ["events.iterate.com/github/webhook-received"],
-              condition: 'payload.body.repository.full_name = "acme/widgets"',
-            },
-            delivery: {
-              mode: "push",
-              expression: ["streams", ["get", "/repos/root"], "acceptCrossPost"],
-            },
-            deliver: "new",
-          },
-        },
-        {
-          description:
-            "Webhook delivery: one HTTP POST per event to an external receiver, stepping over a poison event instead of parking the whole feed.",
-          payload: {
-            subscriptionKey: "ops-webhook",
-            delivery: {
-              mode: "webhook",
-              url: "https://hooks.example.com/iterate/stream-events",
-            },
-            deliver: "new",
-            onPoison: "skip",
-          },
-        },
-      ],
     },
     "events.iterate.com/stream/subscription-removed": {
       description:
@@ -493,12 +407,6 @@ export const CoreProcessorContract = defineProcessorContract({
       payloadSchema: z.object({
         subscriptionKey: z.string().trim().min(1),
       }),
-      examples: [
-        {
-          description: "Unlinking a repo from GitHub revokes its webhook cross-post subscription.",
-          payload: { subscriptionKey: "github-repo:/repos/root" },
-        },
-      ],
     },
     "events.iterate.com/stream/subscription-parked": {
       description:
@@ -510,19 +418,6 @@ export const CoreProcessorContract = defineProcessorContract({
         attempts: z.number().int().positive(),
         error: z.string().trim().min(1).optional(),
       }),
-      examples: [
-        {
-          description:
-            "A webhook receiver stayed down through the whole retry ladder, so delivery gave up loudly.",
-          payload: {
-            subscriptionKey: "ops-webhook",
-            atOffset: 1874,
-            attempts: 15,
-            error:
-              "webhook POST https://hooks.example.com/iterate/stream-events failed with status 503",
-          },
-        },
-      ],
     },
     "events.iterate.com/stream/subscription-resumed": {
       description:
@@ -530,13 +425,6 @@ export const CoreProcessorContract = defineProcessorContract({
       payloadSchema: z.object({
         subscriptionKey: z.string().trim().min(1),
       }),
-      examples: [
-        {
-          description:
-            "Un-parks a subscription after the receiver recovered; delivery resumes from the cursor where it stopped.",
-          payload: { subscriptionKey: "ops-webhook" },
-        },
-      ],
     },
     "events.iterate.com/stream/subscription-cursor-set": {
       description:
@@ -545,18 +433,6 @@ export const CoreProcessorContract = defineProcessorContract({
         subscriptionKey: z.string().trim().min(1),
         afterOffset: z.number().int().min(0),
       }),
-      examples: [
-        {
-          description:
-            "Replays the stream's full history into the project worker feed (afterOffset is exclusive; 0 replays everything).",
-          payload: { subscriptionKey: "project-worker", afterOffset: 0 },
-        },
-        {
-          description:
-            "Seeks a cross-post subscription's cursor forward: events at or below offset 512 are never delivered.",
-          payload: { subscriptionKey: "github-repo:/repos/root", afterOffset: 512 },
-        },
-      ],
     },
     "events.iterate.com/stream/subscriber-connected": {
       description:
@@ -566,50 +442,6 @@ export const CoreProcessorContract = defineProcessorContract({
         subscriptionType: StreamSubscriptionType,
         subscriber: StreamSubscriberDescriptor.optional(),
       }),
-      examples: [
-        {
-          description:
-            "A wake subscription's poke handshake completed: the hosted agent processor connected and announced its contract (consumes/emits abridged).",
-          payload: {
-            subscriptionKey: "prj_01jzp3v9qkfxeb2m4n8r7wd5ha.iterate/agents/onboarding#agent",
-            subscriptionType: "configured",
-            subscriber: {
-              processor: {
-                announcement: {
-                  slug: "agent",
-                  version: "5.0.0",
-                  description:
-                    "Maintains model-visible history, schedules debounced offset-identified LLM turns, and executes scripts through the capability host.",
-                  consumes: [
-                    "events.iterate.com/agents/context-added",
-                    "events.iterate.com/agent/llm-request-settled",
-                  ],
-                  emits: [
-                    "events.iterate.com/agents/context-added",
-                    "events.iterate.com/agent/llm-request-requested",
-                  ],
-                  ownedEvents: [
-                    {
-                      type: "events.iterate.com/agents/context-added",
-                      description: "A model-visible context item was added.",
-                    },
-                    { type: "events.iterate.com/agent/llm-request-requested" },
-                  ],
-                },
-              },
-            },
-          },
-        },
-        {
-          description:
-            "An anonymous ephemeral watcher: a browser stream-viewer tab live-tailing the log.",
-          payload: {
-            subscriptionKey: "d4f8a1b2-6c3e-4e9a-8b57-0f1c2d3e4a5b",
-            subscriptionType: "ephemeral",
-            subscriber: { description: "browser" },
-          },
-        },
-      ],
     },
     "events.iterate.com/stream/subscriber-disconnected": {
       description:
@@ -618,23 +450,6 @@ export const CoreProcessorContract = defineProcessorContract({
         subscriptionKey: z.string().trim().min(1),
         reason: StreamSubscriberDisconnectReason,
       }),
-      examples: [
-        {
-          description: "A stream-viewer tab closed and unsubscribed.",
-          payload: {
-            subscriptionKey: "d4f8a1b2-6c3e-4e9a-8b57-0f1c2d3e4a5b",
-            reason: "unsubscribed",
-          },
-        },
-        {
-          description:
-            "The stream went quiet past its idle window and dropped its configured connections so everyone can hibernate; the durable config is kept and the next append re-wakes.",
-          payload: {
-            subscriptionKey: "prj_01jzp3v9qkfxeb2m4n8r7wd5ha.iterate/agents/onboarding#agent",
-            reason: "idle",
-          },
-        },
-      ],
     },
     [STREAM_PROCESSOR_REVIVED_EVENT_TYPE]: {
       description:
@@ -647,13 +462,6 @@ export const CoreProcessorContract = defineProcessorContract({
         revivals: z.number(),
         version: z.string(),
       }),
-      examples: [
-        {
-          description:
-            "The keepalive alarm revived an agent processor after a deploy took an in-flight LLM turn.",
-          payload: { processorSlug: "agent", revivals: 1, version: "2026-07-14.1" },
-        },
-      ],
     },
     "events.iterate.com/stream/error-occurred": {
       description: "Records a structured stream or processor runner error.",
@@ -668,53 +476,18 @@ export const CoreProcessorContract = defineProcessorContract({
           })
           .optional(),
       }),
-      examples: [
-        {
-          description:
-            'The delivery spine stepped over a confirmed poison event on an onPoison: "skip" subscription.',
-          payload: {
-            message:
-              'subscription "project-worker" skipped poison event at offset 812 after 3 attempts: receiver rejected payload',
-          },
-        },
-        {
-          description:
-            "A processor skipped an event that fails its contract's schema, with the structured cause attached.",
-          payload: {
-            message:
-              'stream processor "agent" skipped event at offset 42 ("events.iterate.com/agents/context-added"): it fails the contract\'s schema',
-            error: {
-              name: "ZodError",
-              message: 'Invalid input: expected string, received number at "content"',
-            },
-          },
-        },
-      ],
     },
     "events.iterate.com/stream/paused": {
       description: "Records that the stream is paused and should reject ordinary appends.",
       payloadSchema: z.object({
         reason: z.string().trim().min(1).optional(),
       }),
-      examples: [
-        {
-          description:
-            "The stream paused itself after its append circuit breaker tripped on a runaway producer.",
-          payload: { reason: "circuit breaker tripped: burst rate limit exceeded" },
-        },
-      ],
     },
     "events.iterate.com/stream/resumed": {
       description: "Records that the stream has resumed accepting ordinary appends.",
       payloadSchema: z.object({
         reason: z.string().trim().min(1).optional(),
       }),
-      examples: [
-        {
-          description: "An operator reopened the stream after investigating a tripped breaker.",
-          payload: { reason: "operator resumed after raising the circuit-breaker budget" },
-        },
-      ],
     },
   },
   consumes: [

--- a/apps/os/src/domains/workspaces/workspace-processor-contract.ts
+++ b/apps/os/src/domains/workspaces/workspace-processor-contract.ts
@@ -37,20 +37,6 @@ export const WorkspaceProcessorContract = defineProcessorContract({
       description:
         "Creates a workspace processor on this stream. The birth certificate carries the complete default configuration; explicit creation may append an initial configured patch in the same atomic batch.",
       payloadSchema: workspaceBirthCertificateSchema(),
-      examples: [
-        {
-          description:
-            "A workspace is born with the config repo mounted at its root (committable) and a big imported repo mounted read-only at /iterate.",
-          payload: {
-            config: {
-              mounts: {
-                "/": { policy: "commit-to-main", repoPath: "/repos/config" },
-                "/iterate": { policy: "read-only", repoPath: "/repos/iterate" },
-              },
-            },
-          },
-        },
-      ],
     },
     "events.iterate.com/workspace/configured": {
       description:
@@ -86,20 +72,6 @@ export const WorkspaceProcessorContract = defineProcessorContract({
             description: "A configuration patch: deep-merged per mount point; null unmounts.",
           }),
       }),
-      examples: [
-        {
-          description:
-            "One patch flips the /iterate mount to committable and unmounts /scratch; every other mount is untouched.",
-          payload: {
-            config: {
-              mounts: {
-                "/iterate": { policy: "commit-to-main" },
-                "/scratch": null,
-              },
-            },
-          },
-        },
-      ],
     },
   },
   consumes: ["events.iterate.com/workspace/created", "events.iterate.com/workspace/configured"],

--- a/apps/os/src/lib/event-docs.test.ts
+++ b/apps/os/src/lib/event-docs.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  documentedProcessorContracts,
   eventDocs,
   getEventDocByPath,
   getEventDocByProcessorRoute,
@@ -99,43 +98,6 @@ describe("event docs catalog", () => {
   it("builds a non-empty processor and event catalog", () => {
     expect(processorDocs.length).toBeGreaterThan(5);
     expect(eventDocs.length).toBeGreaterThan(10);
-  });
-});
-
-describe("event docs examples", () => {
-  it("documents at least one example for every owned event type", () => {
-    const undocumented = eventDocs
-      .filter((event) => event.examples.length === 0)
-      .map((event) => event.type);
-    expect(
-      undocumented,
-      "every contract event needs an `examples` entry for the docs site",
-    ).toEqual([]);
-  });
-
-  it("parses every example payload against its event's payload schema", () => {
-    for (const contract of documentedProcessorContracts) {
-      for (const [type, definition] of Object.entries(contract.events)) {
-        for (const example of definition.examples ?? []) {
-          const result = definition.payloadSchema.safeParse(example.payload);
-          expect(
-            result.success,
-            `${type} example "${example.description}" must parse: ${result.error}`,
-          ).toBe(true);
-        }
-      }
-    }
-  });
-
-  it("keeps every example payload JSON-serializable", () => {
-    for (const event of eventDocs) {
-      for (const example of event.examples) {
-        const roundTripped: unknown = JSON.parse(JSON.stringify(example.payload));
-        expect(roundTripped, `${event.type} example "${example.description}"`).toEqual(
-          example.payload,
-        );
-      }
-    }
   });
 });
 

--- a/apps/os/src/lib/event-docs.ts
+++ b/apps/os/src/lib/event-docs.ts
@@ -20,7 +20,6 @@ const PROCESSOR_DOCS_BASE_PATH = "/docs/streams/processors";
 
 type EventDefinitionForDocs = {
   description?: string;
-  examples?: readonly { description: string; payload: unknown }[];
   payloadSchema: z.ZodType;
 };
 
@@ -51,14 +50,6 @@ const processorContracts = [
   BrowserFeedContract,
 ] as const satisfies readonly ProcessorContractForDocs[];
 
-/**
- * The contracts the public event docs are generated from, in docs order —
- * exported so tests can validate documentation invariants (e.g. that every
- * example payload parses against its event's payload schema) against the same
- * list the site renders.
- */
-export const documentedProcessorContracts: readonly ProcessorContractForDocs[] = processorContracts;
-
 export type EventDoc = {
   /** Processors that list this event type in `consumes` (owner included; wildcard consumers excluded). */
   consumedBy: ProcessorReferenceDoc[];
@@ -66,17 +57,11 @@ export type EventDoc = {
   /** Processors that list this event type in `emits`. */
   emittedBy: ProcessorReferenceDoc[];
   eventPath: string;
-  examples: EventExampleDoc[];
   href: string;
   payloadJsonSchema: unknown;
   processor: ProcessorReferenceDoc;
   routeParams: EventRouteParams;
   type: string;
-};
-
-export type EventExampleDoc = {
-  description: string;
-  payload: unknown;
 };
 
 export type EventReferenceDoc = {
@@ -285,10 +270,6 @@ function buildEventDoc(args: {
     consumedBy: args.consumedBy,
     emittedBy: args.emittedBy,
     eventPath,
-    examples: (args.definition.examples ?? []).map((example) => ({
-      description: example.description,
-      payload: example.payload,
-    })),
     href: `${processorDocsPathForSlug(args.processor.slug)}/events/${processorEventPath}`,
     payloadJsonSchema: z.toJSONSchema(args.definition.payloadSchema, {
       io: "input",

--- a/packages/iterate/src/processors/processor-contracts.ts
+++ b/packages/iterate/src/processors/processor-contracts.ts
@@ -50,20 +50,7 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 // payload types from the same declaration and typos fail at the definition site.
 // =============================================================================
 
-/**
- * One documented example payload for an owned event, rendered on the public
- * event docs site (events.iterate.com). The payload must parse against the
- * event's `payloadSchema` — enforced by the event-docs unit tests rather than
- * at module load, so a bad example fails CI instead of bricking a worker boot.
- */
-export type EventExample = {
-  /** What this example shows, e.g. "Push delivery to another stream's acceptCrossPost". */
-  description: string;
-  /** The example payload, in the payload schema's input shape. */
-  payload: unknown;
-};
-
-/** One owned event: its payload schema plus optional human description and examples. */
+/** One owned event: its payload schema plus an optional human description. */
 export type EventDefinition<PayloadOutput = unknown, PayloadInput = PayloadOutput> = {
   description?: string;
   payloadSchema: z.ZodType<PayloadOutput, PayloadInput>;
@@ -75,7 +62,6 @@ export type EventDefinition<PayloadOutput = unknown, PayloadInput = PayloadOutpu
    * an append site impossible instead of a silent storage leak.
    */
   ephemeral?: true;
-  examples?: readonly EventExample[];
 };
 
 /** A contract's owned events, keyed by the durable event type string. */
@@ -875,7 +861,7 @@ function getProcessorSlug(contract: unknown): string {
  * requires that): its ordinary delivery is the guaranteed turn that lands at
  * the stream head, where `processEvent`'s at-head pass
  * (`delivery.caughtUp`) re-drives the processor's open obligations. The
- * event DEFINITION (payload schema, examples) lives with the platform's core
+ * event DEFINITION (payload schema) lives with the platform's core
  * stream contract; this constant is here so contracts and the runner agree on
  * the type string without importing that contract.
  */

--- a/tasks/processor-audit-2026-07.md
+++ b/tasks/processor-audit-2026-07.md
@@ -239,7 +239,7 @@ message-parsing.
 
 ### B9. Contract `examples` volume (LOW priority)
 
-**Status:** in-pr.
+**Status:** in-pr #2180.
 
 ~1,080 lines of `examples:` across the 8 largest contracts (repo 266/832
 lines = 32% of the file, project 226/767, agent 167/1,039, email 121/468).

--- a/tasks/processor-audit-2026-07.md
+++ b/tasks/processor-audit-2026-07.md
@@ -239,14 +239,13 @@ message-parsing.
 
 ### B9. Contract `examples` volume (LOW priority)
 
-**Status:** open (convention only).
+**Status:** in-pr.
 
 ~1,080 lines of `examples:` across the 8 largest contracts (repo 266/832
 lines = 32% of the file, project 226/767, agent 167/1,039, email 121/468).
 Single consumer: `apps/os/src/lib/event-docs.ts` (the public docs site) + a
-CI test parsing each example. These are product content — keep, but adopt
-"one example per event unless the payload is a result union" as a review
-convention and trim repo/project on next touch. No dedicated PR.
+CI test parsing each example. Maintainer call (2026-07-21): delete event
+examples wholesale rather than trim them.
 
 ---
 


### PR DESCRIPTION
## What

Audit finding B9 (`tasks/processor-audit-2026-07.md`), per Jonas's call: delete the contract event `examples` wholesale rather than trim them. **−1,705 lines, 5 added.**

- All 118 `examples:` blocks removed from 17 contract files (biggest: repo 266, core 227, project 226, agent 171, email 121).
- `EventDefinition.examples` and the `EventExample` type deleted from `packages/iterate/src/processors/processor-contracts.ts` — zero producers remain repo-wide, no generator plumbing used them.
- `apps/os/src/lib/event-docs.ts` + `event-docs-pages.tsx`: examples modeling and the docs site's Examples section removed (no empty headings left behind).
- `event-docs.test.ts`: the three example-parsing tests (now vacuous) deleted; catalog and cross-reference tests remain. Payload shape guarantees stay with the type system and schema definitions.
- Ledger B9 records the decision change.

Descriptions and all other `.meta` annotations untouched. The itx REPL/mobile examples catalogue is a separate surface and untouched.

## Verification

- typecheck pass (16/17 projects in scope), lint pass (1,304 files)
- apps/os: 2,120 passed, 6 expected failures, 1 skipped, 0 unexpected
- packages/iterate: 154 passed
- format + `git diff --check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and contract metadata only; runtime event schemas and processor behavior are unchanged.
> 
> **Overview**
> Removes **event `examples`** from processor contracts across the OS domains (~118 blocks in 17 contract files), per audit B9 — descriptions and payload schemas are unchanged.
> 
> **Platform types:** Deletes `EventExample` and the `examples` field on `EventDefinition` in `processor-contracts.ts`, so contracts no longer carry documented sample payloads.
> 
> **Public docs:** `event-docs` stops modeling or rendering examples; event detail pages drop the Examples section, the committed-stream envelope helper, and sidebar example counts. Listing rows no longer show example counts.
> 
> **Tests:** Removes the three CI tests that required every owned event to have parseable, JSON-serializable examples; catalog and cross-reference tests remain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3585dc901f1902edf1758afa5d04590693854f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +2 -1,607 | +0 -1,588 🟥🟥🟥🟥🟥 |
| UI components | +0 -56 | +0 -49 🟥⬜⬜⬜⬜ |
| Tests | +0 -38 | +0 -35 🟥⬜⬜⬜⬜ |
| Docs | +3 -4 | +3 -4 🟥⬜⬜⬜⬜ |
| **Total** | **+5 -1,705** | **+3 -1,676** 🟥🟥🟥🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 715c52d and 0cccd7b, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-21T12:10:01.040Z",
      "headSha": "c3585dc901f1902edf1758afa5d04590693854f4",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/132036129257122",
      "shortSha": "c3585dc",
      "cleanupDurationMs": 16231,
      "deployDurationMs": 117878,
      "testDurationMs": 144261,
      "testRetries": null,
      "workerSizeKib": 17315.37,
      "workerGzipKib": 4643.41,
      "mainWorkerGzipKib": 4665.44
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-21T12:09:47.975Z",
      "headSha": "c3585dc901f1902edf1758afa5d04590693854f4",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/132036129257122",
      "shortSha": "c3585dc",
      "cleanupDurationMs": 3164,
      "deployDurationMs": 16200,
      "testDurationMs": 3368,
      "testRetries": null,
      "workerSizeKib": 3963.27,
      "workerGzipKib": 810.31,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-21T12:10:04.423Z",
      "headSha": "c3585dc901f1902edf1758afa5d04590693854f4",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/132036129257122",
      "shortSha": "c3585dc",
      "cleanupDurationMs": 19610,
      "deployDurationMs": 125763,
      "testDurationMs": 56185,
      "testRetries": null,
      "workerSizeKib": 5367.28,
      "workerGzipKib": 1517.65,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-21T12:09:45.534Z",
      "headSha": "c3585dc901f1902edf1758afa5d04590693854f4",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/132036129257122",
      "shortSha": "c3585dc",
      "cleanupDurationMs": 720,
      "deployDurationMs": 8271,
      "testDurationMs": 5212,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `c3585dc` | [https://auth.iterate-preview-4.com](https://auth.iterate-preview-4.com) | 810.3 KiB | 16.2s | 3.4s |  | 3.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/132036129257122) | 2026-07-21T12:09:47.975Z | Preview app released. |
| Dummy Petshop | released | `c3585dc` | [https://dummy-petshop.iterate-preview-4.com](https://dummy-petshop.iterate-preview-4.com) | 198.2 KiB | 8.3s | 5.2s |  | 720ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/132036129257122) | 2026-07-21T12:09:45.534Z | Preview app released. |
| OS | released | `c3585dc` | [https://os.iterate-preview-4.com](https://os.iterate-preview-4.com) | 4.53 MiB (-22.0 KiB vs main) | 117.9s | 144.3s |  | 16.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/132036129257122) | 2026-07-21T12:10:01.040Z | Preview app released. |
| Streams Example App | released | `c3585dc` | [https://streams.iterate-preview-4.com](https://streams.iterate-preview-4.com) | 1.48 MiB | 125.8s | 56.2s |  | 19.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/132036129257122) | 2026-07-21T12:10:04.423Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->