### PR TITLE
Route new projects through the welcome flow

### DIFF
--- a/apps/os/src/lib/project-root-redirect.test.ts
+++ b/apps/os/src/lib/project-root-redirect.test.ts
@@ -14,59 +14,42 @@ const project = (
 });
 
 describe("chooseRootProjectRedirect", () => {
-  test("prefers the current project host when that project is ready", () => {
+  test("opens a preferred ready project at its home", () => {
     expect(
       chooseRootProjectRedirect({
         preferredProjectSlug: "beta",
-        preferredProjectOnboarding: false,
         projects: [project({ id: "prj_a", slug: "alpha" }), project({ id: "prj_b", slug: "beta" })],
       }),
     ).toMatchObject({
       kind: "project",
       project: { slug: "beta" },
-      onboarding: false,
+      welcome: false,
     });
   });
 
-  test("checks onboarding for the most recently active project", () => {
-    expect(
-      chooseRootProjectRedirect({
-        preferredProjectSlug: "beta",
-        preferredProjectOnboarding: true,
-        projects: [project({ id: "prj_a", slug: "alpha" }), project({ id: "prj_b", slug: "beta" })],
-      }),
-    ).toMatchObject({
-      kind: "project",
-      project: { slug: "beta" },
-      onboarding: true,
-    });
-  });
-
-  test("sends the only ready project to onboarding", () => {
+  test("opens the only ready project at its home", () => {
     expect(
       chooseRootProjectRedirect({
         preferredProjectSlug: null,
-        preferredProjectOnboarding: false,
         projects: [project({ id: "prj_a", slug: "alpha" })],
       }),
     ).toMatchObject({
       kind: "project",
       project: { slug: "alpha" },
-      onboarding: true,
+      welcome: false,
     });
   });
 
-  test("sends a single auth-created missing project to onboarding", () => {
+  test("welcomes a single auth-created missing project through its creation flow", () => {
     expect(
       chooseRootProjectRedirect({
         preferredProjectSlug: null,
-        preferredProjectOnboarding: false,
         projects: [project({ id: "prj_a", slug: "alpha", deploymentStatus: "missing" })],
       }),
     ).toMatchObject({
       kind: "project",
       project: { slug: "alpha" },
-      onboarding: true,
+      welcome: true,
     });
   });
 
@@ -74,7 +57,6 @@ describe("chooseRootProjectRedirect", () => {
     expect(
       chooseRootProjectRedirect({
         preferredProjectSlug: null,
-        preferredProjectOnboarding: false,
         projects: [
           project({ id: "prj_a", slug: "alpha", deploymentStatus: "missing" }),
           project({ id: "prj_b", slug: "beta", deploymentStatus: "missing" }),
@@ -85,7 +67,6 @@ describe("chooseRootProjectRedirect", () => {
     expect(
       chooseRootProjectRedirect({
         preferredProjectSlug: null,
-        preferredProjectOnboarding: false,
         projects: [project({ id: "prj_a", slug: "alpha", deploymentStatus: "unknown" })],
       }),
     ).toEqual({ kind: "projects" });

--- a/apps/os/src/lib/project-root-redirect.ts
+++ b/apps/os/src/lib/project-root-redirect.ts
@@ -12,7 +12,7 @@ export type RootProjectRedirectDecision =
   | {
       kind: "project";
       project: RootRedirectProject;
-      onboarding: boolean;
+      welcome: boolean;
     }
   | {
       kind: "projects";
@@ -20,7 +20,6 @@ export type RootProjectRedirectDecision =
 
 export function chooseRootProjectRedirect(input: {
   preferredProjectSlug: string | null;
-  preferredProjectOnboarding: boolean;
   projects: RootRedirectProject[];
 }): RootProjectRedirectDecision {
   const readyProjects = input.projects.filter((project) => project.deploymentStatus === "ready");
@@ -32,16 +31,16 @@ export function chooseRootProjectRedirect(input: {
     return {
       kind: "project",
       project: preferredReadyProject,
-      onboarding: input.preferredProjectOnboarding,
+      welcome: false,
     };
   }
 
   if (readyProjects.length === 1) {
-    return { kind: "project", project: readyProjects[0]!, onboarding: true };
+    return { kind: "project", project: readyProjects[0]!, welcome: false };
   }
 
   if (input.projects.length === 1 && input.projects[0]!.deploymentStatus === "missing") {
-    return { kind: "project", project: input.projects[0]!, onboarding: true };
+    return { kind: "project", project: input.projects[0]!, welcome: true };
   }
 
   return { kind: "projects" };
@@ -49,7 +48,7 @@ export function chooseRootProjectRedirect(input: {
 
 /**
  * Commit a missing project's birth before the root SSR redirect, without
- * waiting for the bootstrap saga's `project/ready` event. The onboarding page
+ * waiting for the bootstrap saga's `project/ready` event. The project home
  * renders that remaining progress from live state.
  */
 export async function createMissingRootRedirectProject(

--- a/apps/os/src/lib/project-server-fns.ts
+++ b/apps/os/src/lib/project-server-fns.ts
@@ -4,7 +4,6 @@ import { env } from "cloudflare:workers";
 import type { ProjectDeploymentStatus } from "../project-deployment-status.ts";
 import { itxAuthFromPrincipal } from "~/auth.ts";
 import { getUserPrincipal } from "~/auth/principal.ts";
-import { isOnboardingActive } from "~/lib/onboarding-agent.ts";
 import { canReadDirectoryProject } from "~/lib/project-directory-authorization.ts";
 import { buildProjectWorkerUrl } from "~/lib/project-host-routing.ts";
 import {
@@ -58,15 +57,15 @@ type ProjectWithIngressUrl = Project & { ingressUrl: string };
 
 /**
  * The root `/` redirect decision, made entirely server-side so `/` answers
- * with one redirect straight to the final page (onboarding agent stream,
- * project home, or the projects list) before anything renders.
+ * with one redirect straight to the project home or projects list before
+ * anything renders.
  *
  * A brand-new auth signup creates the user/org/project records in auth before
  * OS has a project stream. When that single auth-known project is still
  * missing, this runs the OS bootstrap through the explicit project handle,
  * waiting for the atomic birth and processor catch-up but not `project/ready`.
- * Single-project users then route straight to the onboarding agent stream;
- * that page renders the remaining bootstrap progress from live state.
+ * Single-project users then enter the project home's welcome flow, which
+ * renders the remaining bootstrap progress from live state before onboarding.
  *
  * Failures degrade to `/projects`, where the client-side recovery button and
  * auto-recovery still render the real list.
@@ -94,33 +93,12 @@ export const getRootProjectRedirectServerFn: (input?: {
       const decision = chooseRootProjectRedirect({
         preferredProjectSlug:
           data.preferredProjectSlug ?? getCookie("iterate_recent_project") ?? null,
-        preferredProjectOnboarding: data.preferredProjectSlug == null,
         projects: await projects.list({ scope: "mine" }),
       });
 
       if (
         decision.kind === "project" &&
-        decision.onboarding &&
-        decision.project.deploymentStatus === "ready"
-      ) {
-        try {
-          const project = await projects.get(decision.project.id);
-          const { state } = await project.processor.snapshot();
-          // The agent stream route can render before the agent capability is
-          // listed. `onboardingActive` is the phase marker; waiting for the
-          // reduced agent list here can wrongly send fresh signups to home.
-          decision.onboarding = isOnboardingActive(state);
-        } catch {
-          // Do not guess "home" on a transient project snapshot failure. The
-          // /projects list still shows the project, while direct home would
-          // strand an in-progress signup away from onboarding.
-          return { kind: "projects" };
-        }
-      }
-
-      if (
-        decision.kind === "project" &&
-        decision.onboarding &&
+        decision.welcome &&
         decision.project.deploymentStatus === "missing"
       ) {
         try {

--- a/apps/os/src/routes/_app/projects/index.tsx
+++ b/apps/os/src/routes/_app/projects/index.tsx
@@ -26,7 +26,7 @@ type OrganizationSummary = {
 const NO_ORGANIZATIONS: OrganizationSummary[] = [];
 
 // The plain projects list. The root `/` owns the redirect decision (single
-// project → onboarding agent or project home, server-side before rendering);
+// project → project home, server-side before rendering);
 // navigating here directly always shows the list — the sidebar's "All
 // projects" must not hijack single-project users back into their project.
 export const Route = createFileRoute("/_app/projects/")({

--- a/apps/os/src/routes/index.tsx
+++ b/apps/os/src/routes/index.tsx
@@ -2,7 +2,6 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 import { requireAuthenticatedRootRedirectTargetFromSession } from "../lib/auth.ts";
 import { EventDocsIndexPage } from "~/components/event-docs-pages.tsx";
 import { eventDocs, processorDocs } from "~/lib/event-docs.ts";
-import { ONBOARDING_AGENT_PATH } from "~/lib/onboarding-agent.ts";
 import { getRootProjectRedirectServerFn } from "~/lib/project-server-fns.ts";
 
 export const Route = createFileRoute("/")({
@@ -25,22 +24,10 @@ export const Route = createFileRoute("/")({
     });
 
     if (decision.kind === "project") {
-      if (decision.onboarding) {
-        throw redirect({
-          to: "/projects/$projectSlug/agents/streams/$",
-          params: {
-            projectSlug: decision.project.slug,
-            _splat: ONBOARDING_AGENT_PATH,
-          },
-          search: {},
-          replace: true,
-        });
-      }
-
       throw redirect({
         to: "/projects/$projectSlug",
         params: { projectSlug: decision.project.slug },
-        search: {},
+        search: decision.welcome ? { welcome: true } : {},
         replace: true,
       });
     }

--- a/specs/create-project.spec.ts
+++ b/specs/create-project.spec.ts
@@ -28,8 +28,8 @@ test("a new user can create a project through the UI form", async ({ page }) => 
   // the agent page's loading state both render two spinner-matching elements
   // at once, tripping its strict-mode isVisible.
   await spinnerWaiter.settings.run({ disabled: true }, async () => {
-    // Back on OS after auth first-run onboarding: a single project goes
-    // straight to its onboarding agent while project bootstrap catches up.
+    // Back on OS after auth first-run onboarding: a single project enters its
+    // creation flow, which hands off to the onboarding agent once ready.
     // The composer is that route's structural chrome (renders on mount, no
     // LLM output involved); 60s carried over from the waitForURL this
     // replaced — cold-slot bootstrap + redirect can straggle.
@@ -46,10 +46,10 @@ test("a new user can create a project through the UI form", async ({ page }) => 
     await page.goto("/new-project");
 
     await page.getByLabel("Slug").fill(slug, { timeout: 15_000 });
-    // Create resolves only after the atomic birth batch and bootstrap saga
-    // reach project/ready, then the home route hands off to onboarding. The
-    // composer is that destination's structural chrome; 60s covers the cold
-    // birth + saga + handoff.
+    // Create resolves after the atomic birth batch, then project home shows
+    // the bootstrap saga and hands off to onboarding once ready. The composer
+    // is that destination's structural chrome; 60s covers the cold birth +
+    // saga + handoff.
     await page.getByRole("button", { name: "Create project" }).click({ timeout: 15_000 });
     await page.getByPlaceholder("Message this agent").waitFor({ timeout: 60_000 });
   });

--- a/specs/signup.spec.ts
+++ b/specs/signup.spec.ts
@@ -18,15 +18,23 @@ test("can sign up with an email one-time passcode", async ({ page }) => {
   );
 
   const slug = uniqueFixtureSlug("signup");
-  await signUpWithEmailOtp(page, { email: uniqueSignupEmail("signup"), projectSlug: slug });
-
   // Back on OS, signed in: onboarding created the first project's container
-  // on auth, and the root `/` starts the engine bootstrap and redirects
-  // server-side straight to the onboarding agent stream. The agent page's
-  // loading states render two spinner-matching elements at once, which trips
-  // spinner-waiter's strict-mode isVisible — sit it out. The cold-slot
+  // on auth, and the root `/` starts the engine bootstrap. Project home shows
+  // the creation saga, then its explicit welcome flow hands off to the
+  // onboarding agent. Those loading states can render two spinner-matching
+  // elements at once, which trips spinner-waiter's strict-mode isVisible —
+  // sit it out. The cold-slot
   // OAuth-callback straggle traced back to zombie worker routes, which the
   // deploy now verifies + heals (tasks/os-cold-create-latency.md).
+  // Start watching before submitting signup so a fast local bootstrap cannot
+  // make the creation UI disappear before the spec observes it.
+  await Promise.all([
+    signUpWithEmailOtp(page, { email: uniqueSignupEmail("signup"), projectSlug: slug }),
+    spinnerWaiter.settings.run({ disabled: true }, () =>
+      page.getByTestId("project-creation-progress").waitFor({ timeout: 60_000 }),
+    ),
+  ]);
+
   await spinnerWaiter.settings.run({ disabled: true }, async () => {
     // The composer is the destination route's structural chrome — it renders
     // on mount, independent of any LLM output. 60s (carried over from the
@@ -37,4 +45,11 @@ test("can sign up with an email one-time passcode", async ({ page }) => {
   // The composer only renders under an agent-stream route, so the URL has
   // settled — assert the redirect landed on the new project's onboarding agent.
   expect(page.url()).toContain(`/projects/${slug}/agents/streams/agents/onboarding`);
+
+  // `onboardingActive` keeps the manual "Continue onboarding" affordance,
+  // but ordinary OS entry must not turn that durable state into an automatic
+  // agent redirect.
+  await page.goto("/");
+  await page.getByRole("link", { name: "Continue onboarding" }).waitFor();
+  expect(new URL(page.url())).toMatchObject({ pathname: `/projects/${slug}` });
 });


### PR DESCRIPTION
## Summary

- route a newly bootstrapped first project to project home with the existing validated `welcome=true` search state
- show the project creation saga there, then let the existing welcome effect hand off to the onboarding agent once ready
- open recent and sole ready projects at normal project home, leaving unfinished onboarding as the explicit “Continue onboarding” action
- remove the root redirect’s project processor snapshot and onboarding-state inference

## Root cause

The root redirect treated durable `onboardingActive` project state as one-time navigation intent. As a result, ordinary OS entry could reopen the onboarding agent whenever onboarding remained unfinished.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm test`
- `pnpm spec --project=web specs/create-project.spec.ts`
- `pnpm spec --project=web specs/signup.spec.ts --repeat-each=2`
- `npx react-doctor@latest --verbose --scope changed` (no findings in changed files)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-run and return navigation for all authenticated users at `/`, removing processor-based onboarding routing; behavior is covered by updated signup/create E2E tests but affects a critical entry path.
> 
> **Overview**
> **Root `/` no longer sends users straight to the onboarding agent.** Project redirect decisions use a `welcome` flag instead of `onboarding`, and every project hit from `/` goes to **project home**—with `?welcome=true` only when bootstrapping a single auth-created **missing** project.
> 
> **Redirect logic is simplified:** preferred and sole **ready** projects always open normal home (`welcome: false`). The server no longer loads a processor snapshot or uses `onboardingActive` to decide agent vs home, so unfinished onboarding does not re-trigger an automatic agent redirect on ordinary entry; users stay on home with **Continue onboarding**.
> 
> E2E specs were updated for the creation saga on project home and to assert that visiting `/` after signup lands on project home, not the agent stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46e2bb9f013ac9c9b0640635b66eda2ce48fb290. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +12 -48 | +6 -34 🟩🟥🟥🟥🟥 |
| Tests | +33 -37 | +15 -25 🟩🟩🟥🟥🟥 |
| **Total** | **+45 -85** | **+21 -59** 🟩🟥🟥🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between d302af7 and 46e2bb9, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-21T11:42:34.924Z",
      "headSha": "46e2bb9f013ac9c9b0640635b66eda2ce48fb290",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/568146236302964",
      "shortSha": "46e2bb9",
      "cleanupDurationMs": 14798,
      "deployDurationMs": 100637,
      "testDurationMs": 149961,
      "testRetries": "1 retried: runScript caps an in-script sandbox timeout to its absolute deadline and kills the process group (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits).",
      "workerSizeKib": 17359.26,
      "workerGzipKib": 4654.49,
      "mainWorkerGzipKib": 4665.74
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-21T11:42:23.390Z",
      "headSha": "46e2bb9f013ac9c9b0640635b66eda2ce48fb290",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/568146236302964",
      "shortSha": "46e2bb9",
      "cleanupDurationMs": 3261,
      "deployDurationMs": 24001,
      "testDurationMs": 11086,
      "testRetries": null,
      "workerSizeKib": 3963.27,
      "workerGzipKib": 810.06,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-21T11:42:20.747Z",
      "headSha": "46e2bb9f013ac9c9b0640635b66eda2ce48fb290",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/568146236302964",
      "shortSha": "46e2bb9",
      "cleanupDurationMs": 617,
      "deployDurationMs": 7553,
      "testDurationMs": 5653,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `46e2bb9` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 810.1 KiB | 24.0s | 11.1s |  | 3.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/568146236302964) | 2026-07-21T11:42:23.390Z | Preview app released. |
| Dummy Petshop | released | `46e2bb9` | [https://dummy-petshop.iterate-preview-8.com](https://dummy-petshop.iterate-preview-8.com) | 198.2 KiB | 7.6s | 5.7s |  | 617ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/568146236302964) | 2026-07-21T11:42:20.747Z | Preview app released. |
| OS | released | `46e2bb9` | [https://os.iterate-preview-8.com](https://os.iterate-preview-8.com) | 4.55 MiB (-11.3 KiB vs main) | 100.6s | 150.0s | 1 retried: runScript caps an in-script sandbox timeout to its absolute deadline and kills the process group (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). | 14.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/568146236302964) | 2026-07-21T11:42:34.924Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->