### PR TITLE
Lazy-load project navigation dialog

### DIFF
--- a/apps/os/src/components/global-command-palette.tsx
+++ b/apps/os/src/components/global-command-palette.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { lazy, Suspense, useEffect, useMemo, useState } from "react";
 import { useMatches, useNavigate } from "@tanstack/react-router";
 import {
   Dialog,
@@ -8,12 +8,17 @@ import {
   DialogTitle,
 } from "@iterate-com/ui/components/dialog";
 import { connectItx, connectIterateSession, useIterateSessionQuery } from "iterate/react";
-import { CommandPaletteDialog } from "./command-palette-dialog.tsx";
 import { OPEN_GLOBAL_COMMAND_PALETTE_EVENT } from "~/components/global-command-palette-events.ts";
 import { NULL_DURABLE_OBJECT_PROJECT_ID } from "~/lib/stream-navigation.ts";
 import { activeStreamBreadcrumb } from "~/lib/route-breadcrumbs.ts";
 import { linkOptionsForStreamPath } from "~/lib/stream-routes.ts";
 import type { StreamNavigator } from "~/lib/stream-navigation.ts";
+
+const CommandPaletteDialog = lazy(() =>
+  import("./command-palette-dialog.tsx").then((module) => ({
+    default: module.CommandPaletteDialog,
+  })),
+);
 
 /**
  * The global ⌘K navigator, live on every app page. The active project and
@@ -150,20 +155,22 @@ export function GlobalCommandPalette() {
     );
   }
 
-  return (
-    <CommandPaletteDialog
-      open={open}
-      onOpenChange={handleOpenChange}
-      currentPath={activeStream.streamPath}
-      navigator={streamNavigator}
-      scope={activeStream.projectId}
-      // The admin lane browses through platform-wide operator authority, and its
-      // `__null__` deployment namespace has no project DO to index — dialing
-      // `projects.get("__null__")` would just retry forever. Admin gets the
-      // tree; the live index is the app lane's.
-      liveIndex={adminStream == null}
-    />
-  );
+  return open ? (
+    <Suspense fallback={<p role="status">Loading project navigation…</p>}>
+      <CommandPaletteDialog
+        open
+        onOpenChange={handleOpenChange}
+        currentPath={activeStream.streamPath}
+        navigator={streamNavigator}
+        scope={activeStream.projectId}
+        // The admin lane browses through platform-wide operator authority, and its
+        // `__null__` deployment namespace has no project DO to index — dialing
+        // `projects.get("__null__")` would just retry forever. Admin gets the
+        // tree; the live index is the app lane's.
+        liveIndex={adminStream == null}
+      />
+    </Suspense>
+  ) : null;
 }
 
 /**

--- a/specs/dashboard.spec.ts
+++ b/specs/dashboard.spec.ts
@@ -8,6 +8,23 @@ test("can enter the dashboard with a forged session", async ({ helpers, page }) 
   await page.getByRole("link", { name: fixture.project.slug }).waitFor();
 });
 
+test("loads project navigation only when it opens", async ({ helpers, page }) => {
+  await using fixture = await helpers.createFixture("lazy-project-navigation");
+  const dialogRequests: string[] = [];
+  page.on("request", (request) => {
+    if (request.url().includes("command-palette-dialog")) dialogRequests.push(request.url());
+  });
+
+  await page.goto(`/projects/${fixture.project.slug}`);
+  await page.getByRole("button", { name: "Collapse sidebar" }).click();
+  expect(dialogRequests).toEqual([]);
+
+  await page.getByRole("button", { name: "/ ⌘K" }).click();
+  await page.getByRole("dialog", { name: "Project navigation" }).waitFor();
+
+  expect(dialogRequests).toHaveLength(1);
+});
+
 test("opening OS returns to the most recently active project", async ({ helpers, page }) => {
   await using fixture = await helpers.createFixture("recent-project", { projectCount: 2 });
   const recent = fixture.projects[1]!;


### PR DESCRIPTION
## Summary

- keep the global navigation controller mounted, but defer the heavy dialog and result tree until first open
- expose a small loading status during the dynamic import
- prove the loading boundary and normal open behavior with Playwright

## Performance

- app-shell preload: 52,855 to 33,509 bytes Brotli (-19,346 / -36.6%)
- app-shell raw JavaScript: 168,257 to 100,151 bytes (-68,106 / -40.5%)
- deferred dialog chunk: 59,852 raw / 17,659 Brotli
- net diff: +24 lines across two TypeScript files; no Markdown changes

## Validation

- pnpm install --frozen-lockfile
- pnpm format
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm --dir apps/os build
- pnpm spec -g "loads project navigation only when it opens"
- Full local Playwright passed the first 29 tests, including this flow and the SSR proof; the shared dev server then exited on an unrelated ECONNRESET flake and the remaining tests lost their connection
- React Doctor reported no findings in the changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bundle-splitting and conditional mount of an existing dialog; behavior unchanged aside from a brief loading state on first open.
> 
> **Overview**
> Defers loading the heavy **⌘K project navigation** UI until the user opens it, shrinking the initial app shell bundle while keeping the global palette controller mounted.
> 
> `CommandPaletteDialog` is now loaded via `React.lazy` and only mounted when the palette is open, with a short **Suspense** status while the chunk loads. A Playwright test asserts that `command-palette-dialog` is not requested on project page load and is fetched exactly once after opening navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a71c02683b8ed379f53636f4241c19c21c57117. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| UI components | +23 -16 | +18 -12 🟩🟩🟩🟥🟥 |
| Tests | +17 -0 | +13 -0 🟩🟩⬜⬜⬜ |
| **Total** | **+40 -16** | **+31 -12** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between d302af7 and 6a71c02, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-21T12:04:07.995Z",
      "headSha": "6a71c02683b8ed379f53636f4241c19c21c57117",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/165596013737784",
      "shortSha": "6a71c02",
      "cleanupDurationMs": 18026,
      "deployDurationMs": 109471,
      "testDurationMs": 487371,
      "testRetries": null,
      "workerSizeKib": 17364.01,
      "workerGzipKib": 4655.98,
      "mainWorkerGzipKib": 4665.44
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-21T12:03:52.513Z",
      "headSha": "6a71c02683b8ed379f53636f4241c19c21c57117",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/165596013737784",
      "shortSha": "6a71c02",
      "cleanupDurationMs": 2542,
      "deployDurationMs": 16439,
      "testDurationMs": 10514,
      "testRetries": null,
      "workerSizeKib": 3963.27,
      "workerGzipKib": 810.14,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-21T12:03:50.595Z",
      "headSha": "6a71c02683b8ed379f53636f4241c19c21c57117",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/165596013737784",
      "shortSha": "6a71c02",
      "cleanupDurationMs": 621,
      "deployDurationMs": 12942,
      "testDurationMs": 10182,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `6a71c02` | [https://auth.iterate-preview-5.com](https://auth.iterate-preview-5.com) | 810.1 KiB | 16.4s | 10.5s |  | 2.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/165596013737784) | 2026-07-21T12:03:52.513Z | Preview app released. |
| Dummy Petshop | released | `6a71c02` | [https://dummy-petshop.iterate-preview-5.com](https://dummy-petshop.iterate-preview-5.com) | 198.2 KiB | 12.9s | 10.2s |  | 621ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/165596013737784) | 2026-07-21T12:03:50.595Z | Preview app released. |
| OS | released | `6a71c02` | [https://os.iterate-preview-5.com](https://os.iterate-preview-5.com) | 4.55 MiB (-9.5 KiB vs main) | 109.5s | 487.4s |  | 18.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/165596013737784) | 2026-07-21T12:04:07.995Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->