### PR TITLE
Bundle pkg.pr.new Iterate apps through esm.sh

### DIFF
--- a/apps/os/config-repo-template/AGENTS.md
+++ b/apps/os/config-repo-template/AGENTS.md
@@ -65,11 +65,11 @@ worker-bundler unchanged.
 
 `apps/todo` and `apps/guestbook` show the intentionally smallest browser-app
 shape: one `server.tsx` Durable Object and one `client.tsx` browser entry per
-app. The client entry is served separately and imports React directly from
-`esm.sh`; those browser dependencies are not copied into the Worker bundle.
-This is an example, not a platform file-layout rule. The apps deliberately
-avoid Vite and framework adapters. Their HTML leaves CSP unset so the platform
-can inject the small Iterate status overlay in the corner.
+app. The same worker-bundler call bundles and tree-shakes the server and client
+graphs; React is an ordinary root dependency and no URL import is left for the
+browser. This is an example, not a platform file-layout rule. The apps
+deliberately avoid Vite and framework adapters. Their HTML leaves CSP unset so
+the platform can inject the small Iterate status overlay in the corner.
 
 `InternalApp` is the canonical authenticated userspace-app shape: partial-fetch
 HTTP auth plus an explicitly authenticated Cap'n Web `/api` that returns an

--- a/apps/os/config-repo-template/README.md
+++ b/apps/os/config-repo-template/README.md
@@ -7,15 +7,19 @@ pipeline bundles it and the files it imports into loader-ready code on first
 use, so committing a change here changes the running worker on its next use.
 The platform passes this repo's files and build options directly to
 `@cloudflare/worker-bundler`; when `package.json` declares dependencies, that
-library attempts to install and bundle them.
+library attempts to install and bundle them. The pinned pkg.pr.new `iterate`
+entry is the one exception: bundled apps resolve its unbundled esm.sh graph
+inside the same client and server esbuild passes, preserving final tree
+shaking without leaving URL imports at runtime.
 
 `apps/todo` and `apps/guestbook` are deliberately basic browser examples.
 Each contains only `server.tsx` and `client.tsx`: the server exports a
-Durable Object and the client becomes a separately served browser module. JSX is
-compiled with the classic transform, so the explicit React imports remain
-direct `esm.sh` URLs instead of becoming npm dependencies. There is no
-app-local install, Vite config, router generator, or framework adapter. Iterate
-injects its small status overlay into the HTML response in production.
+Durable Object and the client becomes a separately served browser bundle. The
+same worker-bundler call bundles and tree-shakes the server and client graphs;
+React is an ordinary root dependency and no URL imports reach the browser.
+There is no app-local install, Vite config, router generator, or framework
+adapter. Iterate injects its small status overlay into the HTML response in
+production.
 Their two-file layout is only an example: app refs may choose arbitrary server
 and client entry points from the complete `files` map passed to the bundler.
 

--- a/apps/os/config-repo-template/apps/guestbook/client.tsx
+++ b/apps/os/config-repo-template/apps/guestbook/client.tsx
@@ -1,10 +1,5 @@
-import React, {
-  type FormEvent,
-  useCallback,
-  useEffect,
-  useState,
-} from "https://esm.sh/react@19.2.4";
-import { createRoot } from "https://esm.sh/react-dom@19.2.4/client";
+import React, { type FormEvent, useCallback, useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
 
 type Entry = {
   id: string;

--- a/apps/os/config-repo-template/apps/todo/client.tsx
+++ b/apps/os/config-repo-template/apps/todo/client.tsx
@@ -1,10 +1,5 @@
-import React, {
-  type FormEvent,
-  useCallback,
-  useEffect,
-  useState,
-} from "https://esm.sh/react@19.2.4";
-import { createRoot } from "https://esm.sh/react-dom@19.2.4/client";
+import React, { type FormEvent, useCallback, useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
 
 type Todo = {
   createdAt: string;

--- a/apps/os/config-repo-template/package.json
+++ b/apps/os/config-repo-template/package.json
@@ -3,7 +3,11 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "description": "Iterate project worker. Runtime modules imported by worker.ts are supplied by the platform; devDependencies are only for local typechecking and editor support.",
+  "description": "Iterate project worker and bundled browser apps.",
+  "dependencies": {
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
+  },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250620.0",
     "@iterate-com/capnweb": "0.10.0",

--- a/apps/os/config-repo-template/worker.ts
+++ b/apps/os/config-repo-template/worker.ts
@@ -19,7 +19,7 @@ const todoAppRef = {
   path: "/",
   source: {
     createApp: {
-      bundle: false,
+      bundle: true,
       client: "apps/todo/client.tsx",
       files: repoFiles,
       server: "apps/todo/server.tsx",
@@ -33,7 +33,7 @@ const guestbookAppRef = {
   path: "/",
   source: {
     createApp: {
-      bundle: false,
+      bundle: true,
       client: "apps/guestbook/client.tsx",
       files: repoFiles,
       server: "apps/guestbook/server.tsx",

--- a/apps/os/e2e/vitest/project-ingress.e2e.test.ts
+++ b/apps/os/e2e/vitest/project-ingress.e2e.test.ts
@@ -118,10 +118,9 @@ test("routes seeded apps by host and serves worker-bundler browser assets", asyn
   const read = await fetchApp(`counter--${slug}`);
   expect(await read.text()).toContain('count: <span id="n">2</span>');
 
-  // createApp keeps the server in transform-only mode, compiles the browser
-  // entry at its unchanged repo path, and lets worker-bundler's asset handler
-  // serve the result. URL imports remain external instead of copying React
-  // into the generated asset.
+  // createApp bundles both graphs, keeps the browser entry at its unchanged
+  // repo path, and lets worker-bundler's asset handler serve the result. React
+  // is present in the generated asset rather than left as a browser URL import.
   const guestbook = await fetchAppReady(`guestbook--${slug}`);
   expect(guestbook).toMatchObject({ status: 200 });
   const guestbookHtml = await guestbook.text();
@@ -136,8 +135,57 @@ test("routes seeded apps by host and serves worker-bundler browser assets", asyn
   expect(guestbookClient).toMatchObject({ status: 200 });
   expect(guestbookClient.headers.get("content-type")).toBe("application/javascript; charset=utf-8");
   const guestbookClientSource = await guestbookClient.text();
-  expect(guestbookClientSource).toContain("https://esm.sh/react@19.2.4");
-  expect(guestbookClientSource).toContain("https://esm.sh/react-dom@19.2.4/client");
+  expect(guestbookClientSource).toContain("createRoot");
+  expect(guestbookClientSource).not.toContain("https://esm.sh");
+  expect(guestbookClientSource).not.toMatch(/from\s*["'](?:react|react-dom)/);
+
+  // Prove the preview's exact pkg.pr.new Iterate build works on BOTH sides of
+  // createApp. The server executes a bundled live-state import; the client
+  // asset contains the same package's code without retaining an esm.sh import.
+  await project.repo.commitFiles({
+    changes: [
+      {
+        path: "apps/guestbook/client.tsx",
+        content: `
+          import { diff } from "iterate/live-state";
+
+          document.documentElement.dataset.iterateBundleProof = JSON.stringify(
+            diff({ status: "before" }, { status: "after" }),
+          );
+        `,
+      },
+      {
+        path: "apps/guestbook/server.tsx",
+        content: `
+          import { DurableObject } from "cloudflare:workers";
+          import { diff } from "iterate/live-state";
+
+          export class GuestbookApp extends DurableObject {
+            fetch() {
+              return Response.json(diff({ status: "before" }, { status: "after" }), {
+                headers: { "x-iterate-esm-proof": "server-bundled" },
+              });
+            }
+          }
+        `,
+      },
+    ],
+    message: "Prove Iterate bundles in both app graphs",
+  });
+  const iterateServerProof = await fetchAppReady(`guestbook--${slug}`);
+  expect(iterateServerProof).toMatchObject({ status: 200 });
+  expect(iterateServerProof.headers.get("x-iterate-esm-proof")).toBe("server-bundled");
+  expect(await iterateServerProof.json()).toEqual({ fields: { status: { set: "after" } } });
+
+  const iterateClientProof = await fetchApp(`guestbook--${slug}`, {
+    path: "/apps/guestbook/client.js",
+  });
+  const iterateClientSource = await iterateClientProof.text();
+  expect(iterateClientProof).toMatchObject({ status: 200 });
+  expect(iterateClientSource).toContain("iterateBundleProof");
+  expect(iterateClientSource).not.toMatch(
+    /(?:from\s*|import\s*\()\s*["'](?:https:\/\/esm\.sh|\/pr\/iterate\/iterate)/,
+  );
 
   // The seeded repo is readable through the itx repo capability.
   const workerSource = await project.repo.readFile({ path: "worker.ts" });

--- a/apps/os/src/README.md
+++ b/apps/os/src/README.md
@@ -300,6 +300,13 @@ masked by include/exclude globs), and an isolated workerd sidecar runs
 repo-aware value and otherwise passes the serializable options and unchanged
 paths to the named library function. App layouts and entry points are not
 fixed, and worker-bundler may install root `package.json` dependencies.
+For bundled apps, the sidecar recognizes the exact
+`https://pkg.pr.new/iterate/iterate/iterate@<ref>` manifest entry, removes
+only that unsupported direct URL from worker-bundler's npm-install input, and
+resolves `iterate/*` through esm.sh's unbundled graph. The same esbuild passes
+still produce and tree-shake the client asset and server Worker; URL imports
+never become browser or Worker Loader dependencies. Ordinary npm dependencies
+continue through worker-bundler's installer.
 Project build commands do not run. One JSON artifact record is
 cached in KV under a deterministic key shared by identical inputs. Builds pass
 inert source text by value and leave no events in the journal; errors returned

--- a/apps/os/src/domains/repos/config-repo-template.generated.ts
+++ b/apps/os/src/domains/repos/config-repo-template.generated.ts
@@ -75,11 +75,11 @@ export const PROJECT_REPO_INITIAL_FILES: Array<{ content: string; path: string }
       "\n" +
       "`apps/todo` and `apps/guestbook` show the intentionally smallest browser-app\n" +
       "shape: one `server.tsx` Durable Object and one `client.tsx` browser entry per\n" +
-      "app. The client entry is served separately and imports React directly from\n" +
-      "`esm.sh`; those browser dependencies are not copied into the Worker bundle.\n" +
-      "This is an example, not a platform file-layout rule. The apps deliberately\n" +
-      "avoid Vite and framework adapters. Their HTML leaves CSP unset so the platform\n" +
-      "can inject the small Iterate status overlay in the corner.\n" +
+      "app. The same worker-bundler call bundles and tree-shakes the server and client\n" +
+      "graphs; React is an ordinary root dependency and no URL import is left for the\n" +
+      "browser. This is an example, not a platform file-layout rule. The apps\n" +
+      "deliberately avoid Vite and framework adapters. Their HTML leaves CSP unset so\n" +
+      "the platform can inject the small Iterate status overlay in the corner.\n" +
       "\n" +
       "`InternalApp` is the canonical authenticated userspace-app shape: partial-fetch\n" +
       "HTTP auth plus an explicitly authenticated Cap'n Web `/api` that returns an\n" +
@@ -145,15 +145,19 @@ export const PROJECT_REPO_INITIAL_FILES: Array<{ content: string; path: string }
       "use, so committing a change here changes the running worker on its next use.\n" +
       "The platform passes this repo's files and build options directly to\n" +
       "`@cloudflare/worker-bundler`; when `package.json` declares dependencies, that\n" +
-      "library attempts to install and bundle them.\n" +
+      "library attempts to install and bundle them. The pinned pkg.pr.new `iterate`\n" +
+      "entry is the one exception: bundled apps resolve its unbundled esm.sh graph\n" +
+      "inside the same client and server esbuild passes, preserving final tree\n" +
+      "shaking without leaving URL imports at runtime.\n" +
       "\n" +
       "`apps/todo` and `apps/guestbook` are deliberately basic browser examples.\n" +
       "Each contains only `server.tsx` and `client.tsx`: the server exports a\n" +
-      "Durable Object and the client becomes a separately served browser module. JSX is\n" +
-      "compiled with the classic transform, so the explicit React imports remain\n" +
-      "direct `esm.sh` URLs instead of becoming npm dependencies. There is no\n" +
-      "app-local install, Vite config, router generator, or framework adapter. Iterate\n" +
-      "injects its small status overlay into the HTML response in production.\n" +
+      "Durable Object and the client becomes a separately served browser bundle. The\n" +
+      "same worker-bundler call bundles and tree-shakes the server and client graphs;\n" +
+      "React is an ordinary root dependency and no URL imports reach the browser.\n" +
+      "There is no app-local install, Vite config, router generator, or framework\n" +
+      "adapter. Iterate injects its small status overlay into the HTML response in\n" +
+      "production.\n" +
       "Their two-file layout is only an example: app refs may choose arbitrary server\n" +
       "and client entry points from the complete `files` map passed to the bundler.\n" +
       "\n" +
@@ -210,13 +214,8 @@ export const PROJECT_REPO_INITIAL_FILES: Array<{ content: string; path: string }
   {
     path: "apps/guestbook/client.tsx",
     content:
-      "import React, {\n" +
-      "  type FormEvent,\n" +
-      "  useCallback,\n" +
-      "  useEffect,\n" +
-      "  useState,\n" +
-      "} from \"https://esm.sh/react@19.2.4\";\n" +
-      "import { createRoot } from \"https://esm.sh/react-dom@19.2.4/client\";\n" +
+      "import React, { type FormEvent, useCallback, useEffect, useState } from \"react\";\n" +
+      "import { createRoot } from \"react-dom/client\";\n" +
       "\n" +
       "type Entry = {\n" +
       "  id: string;\n" +
@@ -414,13 +413,8 @@ export const PROJECT_REPO_INITIAL_FILES: Array<{ content: string; path: string }
   {
     path: "apps/todo/client.tsx",
     content:
-      "import React, {\n" +
-      "  type FormEvent,\n" +
-      "  useCallback,\n" +
-      "  useEffect,\n" +
-      "  useState,\n" +
-      "} from \"https://esm.sh/react@19.2.4\";\n" +
-      "import { createRoot } from \"https://esm.sh/react-dom@19.2.4/client\";\n" +
+      "import React, { type FormEvent, useCallback, useEffect, useState } from \"react\";\n" +
+      "import { createRoot } from \"react-dom/client\";\n" +
       "\n" +
       "type Todo = {\n" +
       "  createdAt: string;\n" +
@@ -662,7 +656,11 @@ export const PROJECT_REPO_INITIAL_FILES: Array<{ content: string; path: string }
       "  \"private\": true,\n" +
       "  \"version\": \"0.0.0\",\n" +
       "  \"type\": \"module\",\n" +
-      "  \"description\": \"Iterate project worker. Runtime modules imported by worker.ts are supplied by the platform; devDependencies are only for local typechecking and editor support.\",\n" +
+      "  \"description\": \"Iterate project worker and bundled browser apps.\",\n" +
+      "  \"dependencies\": {\n" +
+      "    \"react\": \"19.2.4\",\n" +
+      "    \"react-dom\": \"19.2.4\"\n" +
+      "  },\n" +
       "  \"devDependencies\": {\n" +
       "    \"@cloudflare/workers-types\": \"^4.20250620.0\",\n" +
       "    \"@iterate-com/capnweb\": \"0.10.0\",\n" +
@@ -714,7 +712,7 @@ export const PROJECT_REPO_INITIAL_FILES: Array<{ content: string; path: string }
       "  path: \"/\",\n" +
       "  source: {\n" +
       "    createApp: {\n" +
-      "      bundle: false,\n" +
+      "      bundle: true,\n" +
       "      client: \"apps/todo/client.tsx\",\n" +
       "      files: repoFiles,\n" +
       "      server: \"apps/todo/server.tsx\",\n" +
@@ -728,7 +726,7 @@ export const PROJECT_REPO_INITIAL_FILES: Array<{ content: string; path: string }
       "  path: \"/\",\n" +
       "  source: {\n" +
       "    createApp: {\n" +
-      "      bundle: false,\n" +
+      "      bundle: true,\n" +
       "      client: \"apps/guestbook/client.tsx\",\n" +
       "      files: repoFiles,\n" +
       "      server: \"apps/guestbook/server.tsx\",\n" +

--- a/apps/os/src/domains/repos/config-repo-template.test.ts
+++ b/apps/os/src/domains/repos/config-repo-template.test.ts
@@ -34,20 +34,21 @@ test("template ships only the two deliberately basic app pairs", () => {
     dependencies?: Record<string, string>;
     devDependencies: Record<string, string>;
   };
-  // The seed needs no runtime packages because its root Worker uses platform
-  // virtual modules. This is a template choice, not a build restriction.
-  expect(templatePackageJson.dependencies).toBeUndefined();
+  expect(templatePackageJson.dependencies).toEqual({
+    react: "19.2.4",
+    "react-dom": "19.2.4",
+  });
   expect(templatePackageJson.devDependencies).toMatchObject({
     "@iterate-com/capnweb": expect.any(String),
   });
 });
 
-test("basic apps use one server entry, one client entry, and external browser imports", () => {
+test("basic apps use one server entry, one bundled client entry, and ordinary imports", () => {
   for (const app of ["guestbook", "todo"]) {
     expect(templateFile(`apps/${app}/server.tsx`)).toContain('from "cloudflare:workers"');
     const client = templateFile(`apps/${app}/client.tsx`);
-    expect(client).toContain('from "https://esm.sh/react@19.2.4"');
-    expect(client).toContain('from "https://esm.sh/react-dom@19.2.4/client"');
+    expect(client).toContain('from "react"');
+    expect(client).toContain('from "react-dom/client"');
     expect(client).toContain(`export function ${app === "todo" ? "Todo" : "Guestbook"}Client()`);
     expect(client).not.toContain("react/jsx-runtime");
     // Platform overlay injection owns the final response and skips CSP pages.
@@ -58,6 +59,7 @@ test("basic apps use one server entry, one client entry, and external browser im
   expect(worker.match(/createApp:/g)).toHaveLength(2);
   expect(worker.match(/client: "apps\/(?:todo|guestbook)\/client\.tsx"/g)).toHaveLength(2);
   expect(worker.match(/server: "apps\/(?:todo|guestbook)\/server\.tsx"/g)).toHaveLength(2);
+  expect(worker.match(/bundle: true/g)).toHaveLength(2);
   expect(worker).not.toContain("rootDir");
   expect(worker).not.toContain("clientEntryPoint");
   expect(worker).not.toContain("pipeline:");

--- a/apps/os/src/domains/workers/build-backend.ts
+++ b/apps/os/src/domains/workers/build-backend.ts
@@ -16,6 +16,10 @@ import type { DynamicWorkerSource, WorkerBundlerAssetConfig } from "./schemas.ts
  * build key so a bundler upgrade cannot reuse artifacts made by older code. */
 export const WORKER_BUNDLER_VERSION = "0.2.1";
 
+/** Bump whenever our worker-bundler adapter changes emitted artifacts without
+ * changing the upstream package pin or artifact schema. */
+export const WORKER_BUNDLER_ADAPTER_VERSION = 1;
+
 /** Dynamic-worker compatibility moves independently from the OS worker. */
 export const WORKER_COMPATIBILITY_DATE = "2026-05-01";
 export const WORKER_COMPATIBILITY_FLAGS = ["nodejs_compat"];

--- a/apps/os/src/domains/workers/build-key.test.ts
+++ b/apps/os/src/domains/workers/build-key.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { workerBuildKey, type WorkerBuildInput } from "./build-key.ts";
-import { WORKER_BUNDLER_VERSION } from "./build-backend.ts";
+import { WORKER_BUNDLER_ADAPTER_VERSION, WORKER_BUNDLER_VERSION } from "./build-backend.ts";
 
 const buildSource = (entryPoint: string): WorkerBuildInput["source"] => ({
   createWorker: {
@@ -104,10 +104,11 @@ describe("workerBuildKey", () => {
     );
   });
 
-  it("pins the build-key version to the worker-bundler dependency", () => {
+  it("pins both compiler versions used by the build key", () => {
     const packageJson = JSON.parse(
       readFileSync(new URL("../../../package.json", import.meta.url), "utf8"),
     ) as { dependencies: Record<string, string> };
     expect(packageJson.dependencies["@cloudflare/worker-bundler"]).toBe(WORKER_BUNDLER_VERSION);
+    expect(WORKER_BUNDLER_ADAPTER_VERSION).toBe(1);
   });
 });

--- a/apps/os/src/domains/workers/build-key.ts
+++ b/apps/os/src/domains/workers/build-key.ts
@@ -1,6 +1,10 @@
 import { stableSha256 } from "./utils.ts";
 import { WORKER_BUILD_ARTIFACT_SCHEMA_VERSION } from "./artifact-store.ts";
-import { WORKER_BUNDLER_VERSION, workerVirtualModules } from "./build-backend.ts";
+import {
+  WORKER_BUNDLER_ADAPTER_VERSION,
+  WORKER_BUNDLER_VERSION,
+  workerVirtualModules,
+} from "./build-backend.ts";
 import type { DynamicWorkerSource } from "./schemas.ts";
 
 /**
@@ -54,9 +58,9 @@ function virtualModulesDigest(overrides?: Record<string, string>): Promise<strin
 
 /**
  * Deterministic identity of one build: normalized source snapshot, build
- * options, the bundler pin, compatibility settings, and the artifact schema
- * version. Same input, same key — concurrent callers converge on one artifact
- * and a repeated request is a cache hit.
+ * options, the bundler pin, our adapter version, compatibility settings, and
+ * the artifact schema version. Same input, same key — concurrent callers
+ * converge on one artifact and a repeated request is a cache hit.
  *
  * Identical build requests share this key across projects. If package ranges
  * are not locked, the first successful worker-bundler resolution becomes the
@@ -80,6 +84,7 @@ export async function workerBuildKey(input: WorkerBuildInput): Promise<string> {
     compatibilityDate: input.compatibilityDate,
     compatibilityFlags: input.compatibilityFlags,
     files: normalizeResolvedSource(input.files),
+    bundlerAdapterVersion: WORKER_BUNDLER_ADAPTER_VERSION,
     bundlerVersion: WORKER_BUNDLER_VERSION,
     type: "worker-build-key",
   });

--- a/apps/os/src/domains/workers/worker-loader.serve.test.ts
+++ b/apps/os/src/domains/workers/worker-loader.serve.test.ts
@@ -73,6 +73,7 @@ const h = vi.hoisted(() => {
 
 vi.mock("../../env.ts", () => ({ itxEnv: h.itxEnv }));
 vi.mock("./build-backend.ts", () => ({
+  WORKER_BUNDLER_ADAPTER_VERSION: 1,
   WORKER_BUNDLER_VERSION: "0.2.1",
   WORKER_COMPATIBILITY_DATE: "2026-05-01",
   WORKER_COMPATIBILITY_FLAGS: ["nodejs_compat"],

--- a/apps/os/src/esm-sh-iterate-plugin.test.ts
+++ b/apps/os/src/esm-sh-iterate-plugin.test.ts
@@ -1,0 +1,155 @@
+import { build } from "esbuild";
+import { describe, expect, it, vi } from "vitest";
+import { createEsmShIteratePlugin, withEsmShIteratePackage } from "./esm-sh-iterate-plugin.ts";
+
+const PACKAGE_SPEC =
+  "https://pkg.pr.new/iterate/iterate/iterate@0123456789abcdef0123456789abcdef01234567";
+const ESM_SH_ROOT =
+  "https://esm.sh/pr/iterate/iterate/iterate@0123456789abcdef0123456789abcdef01234567";
+
+describe("withEsmShIteratePackage", () => {
+  it("removes only Iterate's direct URL and adds the internal esbuild plugin", () => {
+    const options = {
+      bundle: true,
+      files: {
+        "package.json": JSON.stringify({
+          dependencies: { iterate: PACKAGE_SPEC, react: "19.2.4" },
+          devDependencies: { iterate: PACKAGE_SPEC, typescript: "5.9.3" },
+          private: true,
+        }),
+        "src/client.ts": "source",
+      },
+    };
+
+    const prepared = withEsmShIteratePackage(options);
+
+    expect(prepared).not.toBe(options);
+    expect(JSON.parse(prepared.files["package.json"]!)).toEqual({
+      dependencies: { react: "19.2.4" },
+      devDependencies: { typescript: "5.9.3" },
+      private: true,
+    });
+    expect(JSON.parse(options.files["package.json"])).toMatchObject({
+      dependencies: { iterate: PACKAGE_SPEC },
+    });
+    expect(prepared.__dangerouslyUseEsBuildPluginsDoNotUseOrYouWillBeFired).toHaveLength(1);
+  });
+
+  it("leaves transform-only and ordinary npm manifests to worker-bundler", () => {
+    const transformOnly = {
+      bundle: false,
+      files: { "package.json": JSON.stringify({ devDependencies: { iterate: PACKAGE_SPEC } }) },
+    };
+    const registryPackage = {
+      files: { "package.json": JSON.stringify({ dependencies: { iterate: "^0.3.0" } }) },
+    };
+
+    expect(withEsmShIteratePackage(transformOnly)).toBe(transformOnly);
+    expect(withEsmShIteratePackage(registryPackage)).toBe(registryPackage);
+  });
+
+  it("rejects ambiguous or malformed pkg.pr.new refs", () => {
+    expect(() =>
+      withEsmShIteratePackage({
+        files: {
+          "package.json": JSON.stringify({
+            dependencies: { iterate: `${PACKAGE_SPEC}-one` },
+            devDependencies: { iterate: `${PACKAGE_SPEC}-two` },
+          }),
+        },
+      }),
+    ).toThrow(/different pkg\.pr\.new versions/);
+    expect(() =>
+      withEsmShIteratePackage({
+        files: {
+          "package.json": JSON.stringify({
+            dependencies: { iterate: `${PACKAGE_SPEC}/../../other` },
+          }),
+        },
+      }),
+    ).toThrow(/Unsupported Iterate pkg\.pr\.new ref/);
+  });
+});
+
+describe("createEsmShIteratePlugin", () => {
+  it("bundles and tree-shakes separate browser and Worker graphs with no remote imports", async () => {
+    const modules = new Map([
+      [
+        `${ESM_SH_ROOT}/live-state?bundle=false&target=es2022`,
+        'export { chosen, unused } from "/pr/iterate/iterate/iterate@0123456789abcdef0123456789abcdef01234567/es2022/live-state.nobundle.mjs";',
+      ],
+      [
+        `${ESM_SH_ROOT}/es2022/live-state.nobundle.mjs`,
+        'export function chosen() { return "client-kept"; } export function unused() { return "client-dropped"; }',
+      ],
+      [
+        `${ESM_SH_ROOT}/sdk?bundle=false&target=es2022`,
+        'export { chosen, unused } from "/pr/iterate/iterate/iterate@0123456789abcdef0123456789abcdef01234567/es2022/sdk.nobundle.mjs";',
+      ],
+      [
+        `${ESM_SH_ROOT}/es2022/sdk.nobundle.mjs`,
+        'import { WorkerEntrypoint } from "/cloudflare:workers?target=es2022"; export function chosen() { return WorkerEntrypoint.name + "-server-kept"; } export function unused() { return "server-dropped"; }',
+      ],
+    ]);
+    const fetcher = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      const source = modules.get(url);
+      if (source === undefined) return new Response("missing", { status: 404 });
+      return new Response(source, {
+        headers: { "content-type": "application/javascript" },
+      });
+    });
+    const plugin = createEsmShIteratePlugin(ESM_SH_ROOT, { fetcher });
+
+    const client = await bundle(
+      'import { chosen } from "iterate/live-state"; document.body.textContent = chosen();',
+      plugin,
+    );
+    const server = await bundle(
+      'import { chosen } from "iterate/sdk"; export default { fetch() { return new Response(chosen()); } };',
+      plugin,
+    );
+
+    expect(client).toContain("client-kept");
+    expect(client).not.toContain("client-dropped");
+    expect(server).toContain("server-kept");
+    expect(server).not.toContain("server-dropped");
+    expect(server).toContain('from "cloudflare:workers"');
+    for (const output of [client, server]) {
+      expect(output).not.toMatch(
+        /(?:from\s*|import\s*\()\s*["'](?:https:\/\/esm\.sh|\/pr\/iterate\/iterate)/,
+      );
+    }
+    expect(fetcher).toHaveBeenCalledTimes(4);
+  });
+
+  it("bounds remote module count and response size", async () => {
+    const fetcher = vi.fn(
+      async () =>
+        new Response("export const value = 'this response is too large';", {
+          headers: { "content-type": "application/javascript" },
+        }),
+    );
+    const plugin = createEsmShIteratePlugin(ESM_SH_ROOT, {
+      fetcher,
+      maxModuleBytes: 8,
+      maxModules: 1,
+    });
+
+    await expect(bundle('import "iterate/sdk";', plugin)).rejects.toThrow(/exceeds 8 bytes/);
+  });
+});
+
+async function bundle(source: string, plugin: ReturnType<typeof createEsmShIteratePlugin>) {
+  const result = await build({
+    bundle: true,
+    format: "esm",
+    logLevel: "silent",
+    platform: "browser",
+    plugins: [plugin],
+    stdin: { contents: source, loader: "ts", resolveDir: ".", sourcefile: "entry.ts" },
+    target: "es2022",
+    write: false,
+  });
+  return result.outputFiles[0]!.text;
+}

--- a/apps/os/src/esm-sh-iterate-plugin.ts
+++ b/apps/os/src/esm-sh-iterate-plugin.ts
@@ -1,0 +1,256 @@
+import type { Plugin } from "esbuild";
+
+const ESM_SH_ORIGIN = "https://esm.sh";
+const ESM_SH_NAMESPACE = "esm-sh-iterate";
+const ITERATE_PACKAGE_PREFIX = "https://pkg.pr.new/iterate/iterate/iterate@";
+const MAX_REMOTE_MODULES = 256;
+const MAX_REMOTE_MODULE_BYTES = 2 * 1024 * 1024;
+const MAX_REMOTE_GRAPH_BYTES = 8 * 1024 * 1024;
+const REMOTE_MODULE_TIMEOUT_MS = 30_000;
+
+type BundlerOptions = {
+  bundle?: boolean;
+  files: Record<string, string>;
+};
+
+type BundlerPluginOptions = {
+  __dangerouslyUseEsBuildPluginsDoNotUseOrYouWillBeFired?: unknown[];
+};
+
+type PackageManifest = {
+  dependencies?: Record<string, unknown>;
+  devDependencies?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+/**
+ * Replace a validated pkg.pr.new Iterate dependency with an esm.sh resolver.
+ *
+ * worker-bundler installs manifest dependencies before its esbuild plugins
+ * run, and its npm installer only understands registry versions. Removing
+ * this one direct URL from the in-memory manifest prevents that unsupported
+ * install without changing the source snapshot or any ordinary npm package.
+ */
+export function withEsmShIteratePackage<T extends BundlerOptions>(
+  options: T,
+): T & BundlerPluginOptions {
+  if (options.bundle === false) return options;
+
+  const manifestSource = options.files["package.json"];
+  if (manifestSource === undefined) return options;
+
+  let manifest: PackageManifest;
+  try {
+    manifest = JSON.parse(manifestSource) as PackageManifest;
+  } catch {
+    // Preserve worker-bundler's own package.json diagnostics.
+    return options;
+  }
+
+  const dependencySpec = packageSpec(manifest.dependencies);
+  const devDependencySpec = packageSpec(manifest.devDependencies);
+  if (
+    dependencySpec !== undefined &&
+    devDependencySpec !== undefined &&
+    dependencySpec !== devDependencySpec
+  ) {
+    throw new Error(
+      "package.json declares different pkg.pr.new versions for iterate in dependencies and devDependencies",
+    );
+  }
+  const packageSpecValue = dependencySpec ?? devDependencySpec;
+  if (packageSpecValue === undefined) return options;
+
+  const iterateEsmShRoot = esmShRootForPkgPrNew(packageSpecValue);
+  if (iterateEsmShRoot === undefined) return options;
+
+  const preparedManifest: PackageManifest = { ...manifest };
+  preparedManifest.dependencies = withoutIterate(manifest.dependencies);
+  preparedManifest.devDependencies = withoutIterate(manifest.devDependencies);
+  if (preparedManifest.dependencies === undefined) delete preparedManifest.dependencies;
+  if (preparedManifest.devDependencies === undefined) delete preparedManifest.devDependencies;
+
+  const pluginOptions = options as T & BundlerPluginOptions;
+  return {
+    ...options,
+    files: {
+      ...options.files,
+      "package.json": JSON.stringify(preparedManifest),
+    },
+    __dangerouslyUseEsBuildPluginsDoNotUseOrYouWillBeFired: [
+      createEsmShIteratePlugin(iterateEsmShRoot),
+      ...(pluginOptions.__dangerouslyUseEsBuildPluginsDoNotUseOrYouWillBeFired ?? []),
+    ] as unknown[],
+  };
+}
+
+type EsmShIteratePluginOptions = {
+  fetcher?: typeof fetch;
+  maxGraphBytes?: number;
+  maxModuleBytes?: number;
+  maxModules?: number;
+};
+
+/** Fetch an unbundled esm.sh graph and let the caller's esbuild tree-shake it. */
+export function createEsmShIteratePlugin(
+  iterateEsmShRoot: string,
+  options: EsmShIteratePluginOptions = {},
+): Plugin {
+  const root = esmShUrl(iterateEsmShRoot).href.replace(/\/$/, "");
+  const fetcher = options.fetcher ?? globalThis.fetch;
+  const maxGraphBytes = options.maxGraphBytes ?? MAX_REMOTE_GRAPH_BYTES;
+  const maxModuleBytes = options.maxModuleBytes ?? MAX_REMOTE_MODULE_BYTES;
+  const maxModules = options.maxModules ?? MAX_REMOTE_MODULES;
+  const moduleSources = new Map<string, Promise<string>>();
+  let graphBytes = 0;
+
+  const loadModule = (moduleUrl: string): Promise<string> => {
+    const url = esmShUrl(moduleUrl).href;
+    const cached = moduleSources.get(url);
+    if (cached !== undefined) return cached;
+    if (moduleSources.size >= maxModules) {
+      throw new Error(`esm.sh Iterate graph exceeded ${maxModules} modules`);
+    }
+
+    const loading = (async () => {
+      const response = await fetcher(url, {
+        headers: { accept: "application/javascript, text/javascript;q=0.9" },
+        redirect: "follow",
+        signal: AbortSignal.timeout(REMOTE_MODULE_TIMEOUT_MS),
+      });
+      if (!response.ok) {
+        throw new Error(
+          `esm.sh returned ${response.status} ${response.statusText} for ${JSON.stringify(url)}`,
+        );
+      }
+      if (response.url !== "") esmShUrl(response.url);
+
+      const contentType = response.headers.get("content-type");
+      if (
+        contentType !== null &&
+        !contentType.includes("javascript") &&
+        !contentType.startsWith("text/plain")
+      ) {
+        throw new Error(
+          `esm.sh returned unsupported content type ${JSON.stringify(contentType)} for ${JSON.stringify(url)}`,
+        );
+      }
+      const contentLength = Number(response.headers.get("content-length"));
+      if (Number.isFinite(contentLength) && contentLength > maxModuleBytes) {
+        throw new Error(`esm.sh module ${JSON.stringify(url)} exceeds ${maxModuleBytes} bytes`);
+      }
+
+      const reader = response.body?.getReader();
+      if (reader === undefined) return "";
+      const decoder = new TextDecoder();
+      let source = "";
+      let moduleBytes = 0;
+      for (;;) {
+        const chunk = await reader.read();
+        if (chunk.done) break;
+        moduleBytes += chunk.value.byteLength;
+        graphBytes += chunk.value.byteLength;
+        if (moduleBytes > maxModuleBytes) {
+          await reader.cancel();
+          throw new Error(`esm.sh module ${JSON.stringify(url)} exceeds ${maxModuleBytes} bytes`);
+        }
+        if (graphBytes > maxGraphBytes) {
+          await reader.cancel();
+          throw new Error(`esm.sh Iterate graph exceeded ${maxGraphBytes} bytes`);
+        }
+        source += decoder.decode(chunk.value, { stream: true });
+      }
+      return source + decoder.decode();
+    })();
+    moduleSources.set(url, loading);
+    return loading;
+  };
+
+  return {
+    name: ESM_SH_NAMESPACE,
+    setup(build) {
+      build.onResolve({ filter: /^iterate(?:\/.*)?$/ }, (args) => {
+        const subpath = iterateSubpath(args.path);
+        return {
+          namespace: ESM_SH_NAMESPACE,
+          path: `${root}${subpath === "" ? "" : `/${subpath}`}?bundle=false&target=es2022`,
+        };
+      });
+      build.onResolve({ filter: /.*/, namespace: ESM_SH_NAMESPACE }, (args) => {
+        const cloudflareModule = cloudflareSpecifier(args.path);
+        if (cloudflareModule !== undefined) {
+          return { external: true, path: cloudflareModule };
+        }
+        if (
+          args.path.startsWith("/") ||
+          args.path.startsWith("./") ||
+          args.path.startsWith("../") ||
+          args.path.startsWith(`${ESM_SH_ORIGIN}/`)
+        ) {
+          return {
+            namespace: ESM_SH_NAMESPACE,
+            path: esmShUrl(new URL(args.path, args.importer).href).href,
+          };
+        }
+        throw new Error(
+          `esm.sh Iterate module ${JSON.stringify(args.importer)} returned unsupported import ${JSON.stringify(args.path)}`,
+        );
+      });
+      build.onLoad({ filter: /.*/, namespace: ESM_SH_NAMESPACE }, async (args) => ({
+        contents: await loadModule(args.path),
+        loader: "js",
+      }));
+    },
+  };
+}
+
+function packageSpec(section: Record<string, unknown> | undefined): string | undefined {
+  const value = section?.iterate;
+  return typeof value === "string" ? value : undefined;
+}
+
+function withoutIterate(
+  section: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (section === undefined || !Object.hasOwn(section, "iterate")) return section;
+  const copy = { ...section };
+  delete copy.iterate;
+  return Object.keys(copy).length === 0 ? undefined : copy;
+}
+
+function esmShRootForPkgPrNew(spec: string): string | undefined {
+  if (!spec.startsWith(ITERATE_PACKAGE_PREFIX)) return undefined;
+  const ref = spec.slice(ITERATE_PACKAGE_PREFIX.length);
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(ref)) {
+    throw new Error(`Unsupported Iterate pkg.pr.new ref ${JSON.stringify(ref)}`);
+  }
+  return `${ESM_SH_ORIGIN}/pr/iterate/iterate/iterate@${encodeURIComponent(ref)}`;
+}
+
+function iterateSubpath(specifier: string): string {
+  if (specifier === "iterate") return "";
+  const subpath = specifier.slice("iterate/".length);
+  if (!/^[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(subpath) || subpath.split("/").includes("..")) {
+    throw new Error(`Unsupported Iterate package subpath ${JSON.stringify(subpath)}`);
+  }
+  return subpath;
+}
+
+function cloudflareSpecifier(specifier: string): string | undefined {
+  const normalized = specifier.startsWith("/") ? specifier.slice(1) : specifier;
+  if (!normalized.startsWith("cloudflare:")) return undefined;
+  return normalized.split(/[?#]/, 1)[0];
+}
+
+function esmShUrl(value: string): URL {
+  const url = new URL(value);
+  if (
+    url.origin !== ESM_SH_ORIGIN ||
+    url.username !== "" ||
+    url.password !== "" ||
+    url.hash !== ""
+  ) {
+    throw new Error(`Refusing non-esm.sh module URL ${JSON.stringify(value)}`);
+  }
+  return url;
+}

--- a/apps/os/src/worker-bundler.test.ts
+++ b/apps/os/src/worker-bundler.test.ts
@@ -132,6 +132,44 @@ describe("worker-bundler RPC boundary", () => {
     expect(createWorker).not.toHaveBeenCalled();
   });
 
+  it("adds the internal esm.sh resolver for a pkg.pr.new Iterate app dependency", async () => {
+    createApp.mockResolvedValue({
+      assetManifest: new Map(),
+      assets: {},
+      mainModule: "bundle.js",
+      modules: { "bundle.js": "server" },
+    });
+    const packageSpec =
+      "https://pkg.pr.new/iterate/iterate/iterate@0123456789abcdef0123456789abcdef01234567";
+    const packageJson = JSON.stringify({
+      dependencies: { iterate: packageSpec, react: "19.2.4" },
+    });
+
+    await bundler.createApp({
+      bundle: true,
+      client: "client.tsx",
+      files: {
+        "client.tsx": 'import { diff } from "iterate/live-state";',
+        "package.json": packageJson,
+        "server.ts": "export default {};",
+      },
+      server: "server.ts",
+    });
+
+    expect(createApp).toHaveBeenCalledOnce();
+    const options = createApp.mock.calls[0]![0] as {
+      __dangerouslyUseEsBuildPluginsDoNotUseOrYouWillBeFired: unknown[];
+      files: Record<string, string>;
+    };
+    expect(JSON.parse(options.files["package.json"]!)).toEqual({
+      dependencies: { react: "19.2.4" },
+    });
+    expect(options.__dangerouslyUseEsBuildPluginsDoNotUseOrYouWillBeFired).toEqual([
+      expect.objectContaining({ name: "esm-sh-iterate", setup: expect.any(Function) }),
+    ]);
+    expect(packageJson).toContain(packageSpec);
+  });
+
   it("preserves non-fatal worker-bundler warnings and JSON/text modules", async () => {
     createWorker.mockResolvedValue({
       mainModule: "src/index.js",

--- a/apps/os/src/worker-bundler.ts
+++ b/apps/os/src/worker-bundler.ts
@@ -23,6 +23,7 @@ import type {
   WorkerBundlerCreateAppOptions,
   WorkerBundlerCreateWorkerOptions,
 } from "./domains/workers/schemas.ts";
+import { withEsmShIteratePackage } from "./esm-sh-iterate-plugin.ts";
 
 type WorkerBundlerCreateWorkerResult = {
   mainModule: string;
@@ -61,7 +62,7 @@ export default class WorkerBundlerEntrypoint extends WorkerEntrypoint {
     },
   ): Promise<WorkerBundlerBuildResult<WorkerBundlerCreateAppResult>> {
     return await captureBuildResult(async () =>
-      normalizeAppBuildResult(await workerBundlerCreateApp(options)),
+      normalizeAppBuildResult(await workerBundlerCreateApp(withEsmShIteratePackage(options))),
     );
   }
 


### PR DESCRIPTION
## Summary

- resolve the exact pkg.pr.new Iterate dependency through the unbundled esm.sh graph inside the Worker Bundler esbuild plugin boundary
- retain ordinary final bundling and tree shaking for both the browser and Worker graphs, with no runtime esm.sh imports
- bundle the seeded React clients normally from bare react imports and invalidate cached artifacts when the local bundler adapter changes

## Why

Worker Bundler installs package.json dependencies before its esbuild plugins run, while its installer does not understand the pkg.pr.new URL used by preview projects. esm.sh can expose that exact build as an ESM graph. Asking esm.sh for bundle=false lets the existing Worker Bundler client and server passes remain responsible for the final bundle, so only reachable exports are emitted.

The resolver is intentionally limited to createApp builds with bundle enabled and an exact https://pkg.pr.new/iterate/iterate/iterate@<ref> manifest entry. It bounds graph size, module size/count, request time, redirects, origins, and content types. Ordinary npm dependencies still use Worker Bundler unchanged.

## Proof

- native esbuild against the current Iterate pkg.pr.new graph emitted a 100,537-byte client bundle for iterate/live-state and a 2,193-byte server bundle for iterate/sdk, with no remote runtime imports
- unit coverage proves separate client/server graphs retain selected exports, remove unused markers, and preserve cloudflare:workers as a native external
- the production-shaped project-ingress e2e edits a seeded app so both client and server import iterate/live-state; the server executes the result and the served client asset contains bundled code with no esm.sh import
- seeded React clients now use bare react and react-dom/client imports and are served as ordinary bundled assets
- forced-cache-miss local compiler timing: 1.269s for the ordinary guestbook and 3.254s after both graphs import iterate/live-state; the full cold request was 4.588s and the warm artifact request was 8ms
- deployed preview-8 passed the project-ingress proof twice (25.089s and 33.592s for the complete three-test file); the second aggregate preview run finished green, with unrelated retry telemetry retained in the environment report

## Test plan

- [x] pnpm install
- [x] pnpm typecheck
- [x] pnpm lint
- [x] pnpm format:check
- [x] pnpm test (OS: 2,129 passed, 6 expected failures, 1 skipped)
- [x] doppler run --config dev -- pnpm e2e --project node e2e/vitest/project-ingress.e2e.test.ts (3 passed)

## What users see

No visual change. Seeded app clients load as normal bundled JavaScript; browsers and dynamic Workers do not fetch esm.sh at runtime.

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +277 -21 | +237 -18 🟩🟩🟩🟩🟩 |
| Tests | +259 -14 | +233 -8 🟩🟩🟩🟩🟩 |
| Config | +5 -1 | +5 -1 🟩⬜⬜⬜⬜ |
| Docs | +22 -11 | +22 -11 🟩⬜⬜⬜⬜ |
| Generated | +26 -28 | +26 -28 🟥⬜⬜⬜⬜ |
| **Total** | **+589 -75** | **+523 -66** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 54d502f and c45cf3c, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-21T12:22:20.979Z",
      "headSha": "c45cf3c263e25af34af89084c83c9d9cca9c9003",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/302543725724827",
      "shortSha": "c45cf3c",
      "cleanupDurationMs": 23404,
      "deployDurationMs": 117442,
      "testDurationMs": 331039,
      "testRetries": "11 retried: URL-path secret material is not returned in Response metadata (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · Live capabilities reject the removed target spelling (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · Live bare function capabilities survive provideCapability return (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · Top-level RpcTarget live capabilities dispatch by member path (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · itx.kv round-trips small values, lists by prefix, and is project-scoped (vitest x1) — WebSocket connection failed. · the boundary, pinned: a socket-carrying Response dies crossing the worker mesh (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · itx.liveState indexes stream activity as a peer slice (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · wake expressions traverse dynamic dispatch surfaces (the slack router shape) (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · reactivity page processor panel goes live and repaints from a server push (specs x1) — Error: stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · runs \"scheduler-basics\" through the project REPL (specs x1) — Error: stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · runs \"typed-capability-mount\" through the project REPL (specs x1) — Error: stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits).",
      "workerSizeKib": 17360.19,
      "workerGzipKib": 4654.53,
      "mainWorkerGzipKib": 4665.44
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-21T12:21:58.676Z",
      "headSha": "c45cf3c263e25af34af89084c83c9d9cca9c9003",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/302543725724827",
      "shortSha": "c45cf3c",
      "cleanupDurationMs": 1098,
      "deployDurationMs": 27653,
      "testDurationMs": 23749,
      "testRetries": null,
      "workerSizeKib": 1915.06,
      "workerGzipKib": 440.92,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-21T12:22:04.920Z",
      "headSha": "c45cf3c263e25af34af89084c83c9d9cca9c9003",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/302543725724827",
      "shortSha": "c45cf3c",
      "cleanupDurationMs": 7339,
      "deployDurationMs": 22291,
      "testDurationMs": 11336,
      "testRetries": null,
      "workerSizeKib": 3963.27,
      "workerGzipKib": 810.12,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-21T12:22:14.492Z",
      "headSha": "c45cf3c263e25af34af89084c83c9d9cca9c9003",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/302543725724827",
      "shortSha": "c45cf3c",
      "cleanupDurationMs": 16909,
      "deployDurationMs": 104330,
      "testDurationMs": 58952,
      "testRetries": null,
      "workerSizeKib": 5409.7,
      "workerGzipKib": 1527.37,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-21T12:21:58.463Z",
      "headSha": "c45cf3c263e25af34af89084c83c9d9cca9c9003",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/302543725724827",
      "shortSha": "c45cf3c",
      "cleanupDurationMs": 878,
      "deployDurationMs": 13287,
      "testDurationMs": 5767,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `c45cf3c` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 810.1 KiB | 22.3s | 11.3s |  | 7.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/302543725724827) | 2026-07-21T12:22:04.920Z | Preview app released. |
| Dummy Petshop | released | `c45cf3c` | [https://dummy-petshop.iterate-preview-8.com](https://dummy-petshop.iterate-preview-8.com) | 198.2 KiB | 13.3s | 5.8s |  | 878ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/302543725724827) | 2026-07-21T12:21:58.463Z | Preview app released. |
| OS | released | `c45cf3c` | [https://os.iterate-preview-8.com](https://os.iterate-preview-8.com) | 4.55 MiB (-10.9 KiB vs main) | 117.4s | 331.0s | 11 retried: URL-path secret material is not returned in Response metadata (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · Live capabilities reject the removed target spelling (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · Live bare function capabilities survive provideCapability return (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · Top-level RpcTarget live capabilities dispatch by member path (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · itx.kv round-trips small values, lists by prefix, and is project-scoped (vitest x1) — WebSocket connection failed. · the boundary, pinned: a socket-carrying Response dies crossing the worker mesh (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · itx.liveState indexes stream activity as a peer slice (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · wake expressions traverse dynamic dispatch surfaces (the slack router shape) (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · reactivity page processor panel goes live and repaints from a server push (specs x1) — Error: stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · runs "scheduler-basics" through the project REPL (specs x1) — Error: stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · runs "typed-capability-mount" through the project REPL (specs x1) — Error: stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). | 23.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/302543725724827) | 2026-07-21T12:22:20.979Z | Preview app released. |
| Semaphore | released | `c45cf3c` | [https://semaphore.iterate-preview-8.com](https://semaphore.iterate-preview-8.com) | 440.9 KiB | 27.7s | 23.7s |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/302543725724827) | 2026-07-21T12:21:58.676Z | Preview app released. |
| Streams Example App | released | `c45cf3c` | [https://streams.iterate-preview-8.com](https://streams.iterate-preview-8.com) | 1.49 MiB | 104.3s | 59.0s |  | 16.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/302543725724827) | 2026-07-21T12:22:14.492Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->