### PR TITLE
Processor docs: settle vocabulary, conflict rule, and the unwritten conventions (audit E1-E6 + D doc-halves)

### DIFF
--- a/docs/domain-objects-and-stream-processors.md
+++ b/docs/domain-objects-and-stream-processors.md
@@ -106,20 +106,23 @@ reduce({ state, event }) {
 }
 
 processEvent({ state, event }) {
-  if (event.type === "events.iterate.com/widget/created") {
+  if (state.birthCertificate === null) return;
+
+  if (event?.type === "events.iterate.com/widget/created") {
     // Optional birth reactions belong here.
     return;
   }
-  if (state.birthCertificate === null) return;
 
   // Ordinary actions are allowed only after birth.
 }
 ```
 
 Reducers still reduce ordinary events before birth; they do not need a second
-dispatcher or a `reduceConfiguredEvent` abstraction. The pre-birth guard is
-only around actions. Command/RPC methods that require a live object assert
-that `birthCertificate !== null` and fail clearly when called too early.
+dispatcher or a `reduceConfiguredEvent` abstraction. Gate the whole
+`processEvent` hook on the birth certificate unless a pre-birth event
+legitimately has a consequence; in that exceptional case, gate per switch case
+and add a comment saying why. Command/RPC methods that require a live object
+assert that `birthCertificate !== null` and fail clearly when called too early.
 
 A second distinct birth is a corrupt stream and MUST throw. Retrying the same
 create command with the exact same batch is different: creators use stable
@@ -151,6 +154,15 @@ An agent creation batch is the reference shape:
 4. the workspace capability and boot-context setup events;
 5. explicit Agent and Capability Host subscriptions;
 6. `waitUntilProcessed({ offset: finalBatchOffset })` on both processors.
+
+A domain's shared birth batch lives in `<domain>-defaults.ts` as
+`<name>CreationEvents(...)`. Its event bodies are fully deterministic, its
+idempotency keys derive from `(projectId, path)` only, and it is safe to
+re-append on every contact. Explicit create doors and birthing routers share
+that builder so their keys collide by design. This determinism is
+load-bearing: Telegram's router re-appends the whole batch on every forwarded
+contact and relies on key dedupe, so one `now()` or random value in the builder
+would break that consumer while first-contact-only routers stayed green.
 
 Agent `create()` deliberately takes no arguments. It establishes only the
 shipped defaults and machinery above; caller-selected context, model
@@ -258,13 +270,17 @@ is `ConsumedInput<AgentProcessorContract>`. Use the lower-level
 `agent.stream.append(...)` only when intentionally writing an event outside
 the Agent processor's vocabulary or an ephemeral event to the shared stream.
 
-Config patches use `mergeProcessorConfig` with these exact rules:
+Agent's config patches use `mergeProcessorConfig` with these exact rules:
 
 - plain JSON objects merge recursively;
 - omitted keys retain their current values;
 - arrays, scalars, and `null` replace the old value wholesale;
 - the processor validates the complete merged value with its full config
   schema before storing it.
+
+The `<slug>/configured` suffix does not imply merge semantics: each event's
+description must say whether that domain patch-merges (Agent and Workspace),
+uses per-key null-unset behavior (Sandbox), or replaces wholesale (Telegram).
 
 Facet processors whose config is immutable simply keep it in their birth
 certificate. A processor may define its own later config events when the

--- a/docs/writing-stream-processors.md
+++ b/docs/writing-stream-processors.md
@@ -95,8 +95,8 @@ the re-run). Blocking is the exception, so justify it in a call-site comment:
 name the per-event consequence that would be lost forever if the append were
 dropped.
 `runInBackground` alone gives **at-most-once**: the checkpoint
-advances immediately and an eviction loses the closure. Every side effect in
-a `process*` hook must pick one deliberately:
+advances immediately and an eviction loses the closure. Every asynchronous
+side effect in a `process*` hook must pick one deliberately:
 
 | Primitive                   | Guarantee                                                                              | On eviction                                                   | Use for                                            |
 | --------------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------- | -------------------------------------------------- |
@@ -106,10 +106,20 @@ a `process*` hook must pick one deliberately:
 `blockProcessorWhile` is not for long work: it head-of-line-blocks every later
 event — including the cancellation the user is frantically sending.
 
+A synchronous in-memory poke that is only an idempotent cache hint needs no
+side-effect lane. The cache notification in
+`repo-processor-implementation.ts` is the reference; it does not carry a
+durable consequence.
+
 Registrations run in strict FIFO order: each blocker starts only after the
 previous one settles, so a later registration in the same `processEvent` body
 observes the earlier work's appends. Order state-derived work after per-event
 work by writing it later in the function — there is no separate lane.
+
+At head, settlement appends that must land promptly use one outer
+`blockProcessorWhile`; holding the frame lets redelivery retry them. Everything
+that can be re-derived from state at leisure is a droppable `runInBackground`
+attempt: keepalive revival and the next at-head pass derive it again.
 
 The question every `runInBackground` callsite must answer in a comment or by
 obvious construction: **"what recovers the outcome if this attempt drops?"**
@@ -143,14 +153,15 @@ attempt + restart from state**:
 
 1. **Evidence**: a `…-requested` event opens the obligation; the reduced
    state tracks it (with everything needed to start an attempt from state alone — model,
-   code, expiry). A `…-started` event marks that an attempt began, appended
-   durably **before** the work body runs — and if that append FAILS, the body
-   must not run and no completion may be appended: the obligation stays
-   `requested`, the failure propagates (marking the keepalive window), and a
-   later at-head pass retries the whole attempt. Release the live-set entry
-   in a `finally` either way, or the restart code skips the id for the rest of
-   the incarnation. Terminal events (`…-completed`, a cancellation) close the
-   obligation and delete it from the reduced state.
+   code, expiry). When a domain needs to distinguish whether external work may
+   have begun, a `…-started` event marks that boundary and is appended durably
+   **before** the work body runs. If that append fails, the body must not run
+   and no settlement may be appended: the obligation stays `requested`, the
+   failure propagates (marking the keepalive window), and a later at-head pass
+   retries the whole attempt. Release the live-set entry in a `finally` either
+   way, or the restart code skips the id for the rest of the incarnation.
+   Domains such as Agent that can safely adopt the recorded request need no
+   separate started fact.
 2. **Attempt**: `runInBackground`, registered in an in-memory live-set
    _synchronously, before any await_, so the same pass never classifies its
    own attempt as undriven.
@@ -167,9 +178,39 @@ attempt + restart from state**:
      could re-drive. This is why this code is hand-written per processor,
      not machinery.
 
-Settlements reuse the normal completion path's **idempotency keys**, so a
-race between a late attempt and the restart — or a full stream replay —
-collapses to one durable outcome at the append dedup layer.
+Use one terminal event per obligation, named `…-settled`, with a result union
+whose kinds include success, failure, and cancellation; `completed` reads as
+success. Cancellation is one way the obligation settles, so it shares the
+settlement key and stale-result reduce guard; the user's separate intent to
+stop remains its own event. Do not split one terminal state across
+`…-succeeded`, `…-failed`, and `…-cancelled` event types. Repos still has split `…-completed` and
+`…-failed` terminal events for stream-compatibility reasons; that shape is
+grandfathered, not the template for new work.
+
+For most domains, the settlement result union is also the durable failure
+record. `stream/error-occurred` is the agent-visible error lane: among domain
+processors, only `AgentProcessor` emits its failures there today so the agent
+can transcribe them into model-visible context. General runner-side emission
+remains a filed follow-up.
+
+Build processor-owned idempotency keys with
+`this.idempotencyKey(key, event)` by default. When the deciding identity must
+be embedded by hand, separate it with `@` (`settle@<identity>`); when an event
+is supplied, the helper's own `@<path>:<offset>` suffix prevents same-slug
+processors forwarding into one stream from colliding. A raw string key is
+reserved for deliberate cross-processor convergence, such as shared agent
+binding and route-configuration keys, and needs a comment saying that the
+collision is the point.
+
+Settlements reuse the normal path's idempotency key. Identical bodies really
+do dedupe, but settlement bodies often contain incarnation-dependent values
+such as durations, partial text, or freshly signed URLs; when two such bodies
+race under one key, the stream rejects the loser as a same-key-different-body
+conflict. Use tolerate-as-settlement when losing the race means the obligation
+is already settled (the fleet's `#appendUnlessLostIdempotencyRace` shape). Use
+read-back-the-winner when the loser must know the authoritative outcome
+(`CapabilityHostProcessor`). Use observe-before-append when an unexpected
+occupant is a bug that must surface loudly (`SchedulerProcessor`).
 
 ## Staleness: wake whenever, act only within the intent's horizon
 
@@ -187,18 +228,20 @@ how far your reduced state sits from the stream head) before starting anything.
   safe by construction: an agent revived a week late reports a failure, it
   does not answer a week-old prompt, and an attempt cannot run unbounded after
   the intent expired. Every new obligation type should carry an explicit
-  expiry.
+  expiry. Processors with expiry or deadline logic take `now` as a required
+  dependency; making it optional makes virtual-time tests depend on the host
+  clock. New contracts stamp expiries as epoch-ms numbers, not ISO strings.
 - **Vendor idempotency for dangerous effects.** For a payment-shaped effect,
   the obligation key must ride to the vendor (e.g. a Stripe idempotency key)
   so at-least-once attempts collapse server-side. Dangerous **and**
   non-idempotent at the vendor ⇒ short expiry, fail closed, escalate to a
   human-visible failure.
 - **Hesitation windows.** For retractable intents, put deliberate wall-clock
-  between evidence and attempt so invalidating events can land — the agent's
-  debounce between `llm-request-scheduled` and `llm-request-requested` is
-  this pattern (and its timer is a droppable attempt: losing it costs
-  latency, never the request, because the settle logic re-derives it from
-  the reduced state).
+  between evidence and attempt so invalidating events can land. The agent
+  computes debounce plus failure backoff from the pending trigger, then
+  appends `llm-request-requested`; its timer is a droppable attempt because
+  losing it costs latency, never the request, and the next at-head pass
+  derives the same intent from reduced state.
 
 ## Reprocessing safety: the whole stream can be replayed at you
 
@@ -218,7 +261,14 @@ shape would re-add 👀 reactions to every historical Slack message (a
 rate-limit crash-loop inside `blockProcessorWhile`, with reaction
 resurrection as the user-visible symptom).
 
-Every side effect in a `process*` hook must be one of exactly three shapes:
+A per-event append under an idempotency key must have a body that is a
+deterministic function of that event and its reduced configuration. A `now()`,
+random id, or freshly signed URL in the body turns at-least-once redelivery
+into a same-key-different-body conflict that wedges the frame forever. Anchor
+deadlines to `event.createdAt`, not the delivery clock.
+
+Every consequential side effect in a `process*` hook must be one of exactly
+three shapes:
 
 1. **An append with a stable idempotency key.** Safe by construction: the
    stream dedupes the replay. This is why the durable forwards (Slack
@@ -226,8 +276,8 @@ Every side effect in a `process*` hook must be one of exactly three shapes:
    replay re-dials the appends and they all collapse.
 2. **An obligation restarted from the AT-HEAD reduced state** (the pattern
    above). Safe because the at-head reduced state has absorbed every
-   committed completion:
-   requested-and-completed pairs cancel out _before_ `processEvent` acts.
+   committed settlement:
+   requested-and-settled pairs cancel out _before_ `processEvent` acts.
    The `delivery.caughtUp` branch in `RepoProcessor.processEvent` is the
    minimal creation example—reduce `createRequest` and `birthCertificate`,
    then provision only when the at-head state has an open request and no
@@ -239,6 +289,23 @@ Every side effect in a `process*` hook must be one of exactly three shapes:
    repaint are the references (`webhookAckIsFresh` in
    `integrations/utils.ts`); the status lane is additionally
    latest-fact-wins, painted at most once per at-head batch.
+
+For transient vendor cosmetics, remember the latest qualifying fact in an
+in-memory field, then at head read and clear that field first and paint it at
+most once; `#unpaintedPresenceFact` in
+`slack-agent-processor-implementation.ts` and `#unpaintedTypingFact` in
+`telegram-agent-processor-implementation.ts` are the reference pair.
+
+Integration transcription also has one concrete shape: append exactly one
+`agents/context-added` per source event, with `role: developer`, a transcript
+headed by the literal source event type, an `actor` naming the untrusted
+sender, and one `refs` entry pointing at that exact source event. Set
+`dont-trigger-request` unless that surface's wake rule fires, and turn a
+permanent enrichment failure into an explicit note inside the content rather
+than silently dropping data. `slack-agent-processor-implementation.ts`,
+`telegram-agent-processor-implementation.ts`, and
+`email-agent-processor-implementation.ts` are greppable checks of the same
+convention.
 
 Vendor work that is **idempotent-by-overwrite** inside a durable lane
 (re-downloading Slack-shared files to a per-event storage key) is acceptable:
@@ -286,10 +353,12 @@ gets its alarm fired in a fresh incarnation, which revives the processor:
    the consumed fact guarantees a turn, and the runner guarantees the final
    at-head pass even if a later unconsumed raw event has reached the stream.
 
-Recovery therefore has exactly one entrypoint — batch delivery — and the
-stream narrates the whole episode: `…llm-request-requested` →
-`…/revived` → `…llm-request-completed {failure: orphaned}` →
-`…llm-request-scheduled`.
+Recovery therefore has exactly one entrypoint — batch delivery. For Agent, the
+stream story is `…llm-request-requested` → `…/revived` →
+`…llm-request-settled`: the fresh incarnation adopts the still-open request.
+When that settlement is a retryable failure, its `reduce` arm turns the
+failure into the next pending trigger under the cap; the next at-head pass
+applies backoff and records a new `…llm-request-requested` intent.
 
 The keepalive is also a **crash-loop breaker**, because a DO must never stay
 awake forever from a bug: every revival durably marks a counter _before_
@@ -364,7 +433,7 @@ Scenarios every obligation-carrying processor should have (crib from
 2. eviction before any attempt → provably-never-ran work starts late (or
    expires);
 3. expired obligation → settled without the vendor ever being dialed;
-4. full-stream replay → completions dedupe, nothing re-executes (the replay
+4. full-stream replay → settlements dedupe, nothing re-executes (the replay
    test above — required for every processor that touches a vendor);
 5. the crash-loop breaker engaging on your processor's poison shape;
 6. a failed started-append → nothing runs, nothing settles, the live-set is
@@ -390,14 +459,17 @@ Scenarios every obligation-carrying processor should have (crib from
       `ProcessorContract.parseConsumedInput(...)`; no one-event wrapper methods
       without additional domain semantics.
 - [ ] Every `runInBackground` answers "what recovers the outcome?"
-- [ ] Obligations: requested/started/completed events; the reduced state
-      carries what an attempt needs; terminal events delete the entry.
+- [ ] Obligations: a `…-requested` event opens the reduced-state entry; an
+      optional `…-started` event records a meaningful attempt boundary; one
+      `…-settled` terminal with a success/failure/cancelled result union
+      deletes the entry.
 - [ ] `delivery.caughtUp` branch: start undriven fresh work, settle orphans and
       expired intent, idempotency keys shared with the normal path.
 - [ ] `expiresAt` stamped by the requester; the at-head branch honors it (and the
       `createdAt + DEFAULT` fallback covers raw appends).
 - [ ] A failed started-append never settles and never leaks the live-set.
-- [ ] Injected `now` dep for anything clock-dependent.
+- [ ] Required injected `now` dep for expiry/deadline logic; new expiry fields
+      are epoch-ms numbers.
 - [ ] Every vendor side effect is one of the three replay-safe shapes:
       idempotency-keyed append, at-head reduced-state comparison, or
       freshness-gated ack — never guarded by event-time state alone.

--- a/tasks/processor-audit-2026-07.md
+++ b/tasks/processor-audit-2026-07.md
@@ -483,7 +483,7 @@ Doc rule shipped in the docs PR; code half still open.
 
 ### D7. Only the agent emits `stream/error-occurred`
 
-**Status:** in-pr #2186.
+**Status:** in-pr #2188.
 
 The style guide says failures journal `stream/error-occurred` next to
 settlements; in code only the agent does (`:562,699`). Everyone else uses
@@ -566,7 +566,7 @@ home).
 
 ### E2. The same-key-different-body conflict rule is implemented 5×, documented 0×
 
-**Status:** in-pr #2186.
+**Status:** in-pr #2188.
 
 The doc's replay story (`:170-172`) stops at "races collapse at the append
 dedup layer" — identical bodies only. Real settle bodies carry
@@ -579,7 +579,7 @@ when each applies (pairs with A1's predicate).
 
 ### E3. "Deterministic body: anchor to `event.createdAt`, never `now`" — codify
 
-**Status:** in-pr #2186.
+**Status:** in-pr #2188.
 
 The replay-wedge rule (a `now`-stamped expiry turns redelivery into a
 same-key conflict forever) is re-explained in near-identical comments at 5+
@@ -590,7 +590,7 @@ shrink to one line naming the concrete hazard.
 
 ### E4. `<domain>-defaults.ts` creation-batch convention — write it down
 
-**Status:** in-pr #2186.
+**Status:** in-pr #2188.
 
 ~9 files export deterministic birth batches (`capabilityHostCreationEvents`,
 `schedulerCreationEvents`, `agentCreationForPath`, …); the load-bearing
@@ -607,7 +607,7 @@ contact, shared by create doors and birthing routers.
 
 ### E5. Chat-facet transcription wire shape — convention, not code
 
-**Status:** in-pr #2186.
+**Status:** in-pr #2188.
 
 slack-agent/telegram-agent/email-agent share an identical `refs` block
 (email:141-148, telegram:225-232, slack:191-197), identical YAML transcript

--- a/tasks/processor-audit-2026-07.md
+++ b/tasks/processor-audit-2026-07.md
@@ -388,6 +388,8 @@ failures.
 
 **Recommendation:** (a).
 
+Doc rule shipped in the docs PR; code half still open.
+
 ### D2. slack-agent blocks a cosmetic repaint that telegram-agent backgrounds
 
 **Status:** needs decision.
@@ -459,6 +461,8 @@ keys; raw literal ONLY for intentional cross-processor convergence, flagged
 by comment). Telegram's committed keys are declared stable wire formats
 (`telegram-agent:20-21`) — migrate new streams only, note the fan-in caveat.
 
+Doc rule shipped in the docs PR; code half still open.
+
 ### D6. Birth-gate placement varies four ways
 
 **Status:** open (doc rule only).
@@ -475,9 +479,11 @@ Nothing records which choice is deliberate.
 legitimately has a consequence; then gate per-case with a comment." No
 mechanical alignment (agent semantics look intentional).
 
+Doc rule shipped in the docs PR; code half still open.
+
 ### D7. Only the agent emits `stream/error-occurred`
 
-**Status:** tracked elsewhere; doc truth needed.
+**Status:** in-pr.
 
 The style guide says failures journal `stream/error-occurred` next to
 settlements; in code only the agent does (`:562,699`). Everyone else uses
@@ -485,6 +491,8 @@ settle unions, domain `-failed` events, console, or throw-to-hold-frame.
 Runner-side emission is already on the simplify-streams outstanding list —
 that's the right long-term home. Meanwhile reword the style rule to match
 reality (settle unions ARE the error record outside agent-visible streams).
+
+Doc rule shipped in the docs PR; code half still open.
 
 ### D8. Scheduler: base-class background lane + synthetic UUID, both unjustified in-file
 
@@ -511,22 +519,26 @@ ever wanted.
   slack-agent:677, slack:151, capability-host:991, projects:542), two inline
   `(this.deps.now ?? Date.now)()` (telegram-agent:240,300), and
   optional-vs-required `now` dep split with no principle. Doc rule: required
-  `now` for anything with expiry logic.
+  `now` for anything with expiry logic. Doc rule shipped in the docs PR; code
+  half still open.
 - Expiry stamp types drift: epoch-ms (agent, capability-host, devices,
   notifications) vs ISO strings (project approvals, scheduler) — visible
   where `notification-processor-implementation.ts:55` converts at the
-  boundary. Pick epoch-ms for new contracts (majority).
+  boundary. Pick epoch-ms for new contracts (majority). Doc rule shipped in
+  the docs PR; code half still open.
 - `<slug>/configured` implies three different merge semantics (agent/workspace
   patch-merge via `mergeProcessorConfig`; sandbox per-key null-unset;
   telegram wholesale replace). Fine per-domain; one doc sentence so the
-  suffix stops implying the recipe.
+  suffix stops implying the recipe. Doc rule shipped in the docs PR; code half
+  still open.
 - `.meta`/examples coverage is bimodal: agent contract 105 descriptions,
   repos 87, projects 74 — vs email-agent 5, telegram-agent 7, slack-agent 9,
   notifications 2, browser-feed 1; four facet contracts have zero examples.
   Backfill opportunistically.
 - `repo-processor-implementation.ts:126-130` — the only laneless synchronous
   side effect in the fleet (idempotent in-memory cache poke); one doc
-  sentence legitimizes it.
+  sentence legitimizes it. Doc rule shipped in the docs PR; code half still
+  open.
 - 10 inline `error instanceof Error ? error.message : String(error)` across
   8 files plus two named variants — below the threshold where a shared
   helper beats visible code; leave.
@@ -537,7 +549,7 @@ ever wanted.
 
 ### E1. `docs/writing-stream-processors.md` teaches the pre-#2168 contract
 
-**Status:** open. **Urgent and free.**
+**Status:** in-pr. **Urgent and free.**
 
 - `:199-201` and `:290-292` narrate `llm-request-scheduled` and
   `llm-request-completed {failure: orphaned}` — both deleted by #2168 (the
@@ -554,7 +566,7 @@ home).
 
 ### E2. The same-key-different-body conflict rule is implemented 5×, documented 0×
 
-**Status:** open.
+**Status:** in-pr.
 
 The doc's replay story (`:170-172`) stops at "races collapse at the append
 dedup layer" — identical bodies only. Real settle bodies carry
@@ -567,7 +579,7 @@ when each applies (pairs with A1's predicate).
 
 ### E3. "Deterministic body: anchor to `event.createdAt`, never `now`" — codify
 
-**Status:** open.
+**Status:** in-pr.
 
 The replay-wedge rule (a `now`-stamped expiry turns redelivery into a
 same-key conflict forever) is re-explained in near-identical comments at 5+
@@ -578,7 +590,7 @@ shrink to one line naming the concrete hazard.
 
 ### E4. `<domain>-defaults.ts` creation-batch convention — write it down
 
-**Status:** open.
+**Status:** in-pr.
 
 ~9 files export deterministic birth batches (`capabilityHostCreationEvents`,
 `schedulerCreationEvents`, `agentCreationForPath`, …); the load-bearing
@@ -595,7 +607,7 @@ contact, shared by create doors and birthing routers.
 
 ### E5. Chat-facet transcription wire shape — convention, not code
 
-**Status:** open.
+**Status:** in-pr.
 
 slack-agent/telegram-agent/email-agent share an identical `refs` block
 (email:141-148, telegram:225-232, slack:191-197), identical YAML transcript
@@ -610,7 +622,7 @@ three files become greppable checks of each other.
 
 ### E6. At-head memo repaint pattern
 
-**Status:** open (one sentence).
+**Status:** in-pr (one sentence).
 
 slack-agent `#unpaintedPresenceFact` (`:91-109,525-588`) and telegram-agent
 `#unpaintedTypingFact` (`:75-79,296-308`) deliberately mirror each other with

--- a/tasks/processor-audit-2026-07.md
+++ b/tasks/processor-audit-2026-07.md
@@ -483,7 +483,7 @@ Doc rule shipped in the docs PR; code half still open.
 
 ### D7. Only the agent emits `stream/error-occurred`
 
-**Status:** in-pr.
+**Status:** in-pr #2186.
 
 The style guide says failures journal `stream/error-occurred` next to
 settlements; in code only the agent does (`:562,699`). Everyone else uses
@@ -566,7 +566,7 @@ home).
 
 ### E2. The same-key-different-body conflict rule is implemented 5×, documented 0×
 
-**Status:** in-pr.
+**Status:** in-pr #2186.
 
 The doc's replay story (`:170-172`) stops at "races collapse at the append
 dedup layer" — identical bodies only. Real settle bodies carry
@@ -579,7 +579,7 @@ when each applies (pairs with A1's predicate).
 
 ### E3. "Deterministic body: anchor to `event.createdAt`, never `now`" — codify
 
-**Status:** in-pr.
+**Status:** in-pr #2186.
 
 The replay-wedge rule (a `now`-stamped expiry turns redelivery into a
 same-key conflict forever) is re-explained in near-identical comments at 5+
@@ -590,7 +590,7 @@ shrink to one line naming the concrete hazard.
 
 ### E4. `<domain>-defaults.ts` creation-batch convention — write it down
 
-**Status:** in-pr.
+**Status:** in-pr #2186.
 
 ~9 files export deterministic birth batches (`capabilityHostCreationEvents`,
 `schedulerCreationEvents`, `agentCreationForPath`, …); the load-bearing
@@ -607,7 +607,7 @@ contact, shared by create doors and birthing routers.
 
 ### E5. Chat-facet transcription wire shape — convention, not code
 
-**Status:** in-pr.
+**Status:** in-pr #2186.
 
 slack-agent/telegram-agent/email-agent share an identical `refs` block
 (email:141-148, telegram:225-232, slack:191-197), identical YAML transcript

--- a/tasks/processor-audit-2026-07.md
+++ b/tasks/processor-audit-2026-07.md
@@ -549,7 +549,7 @@ ever wanted.
 
 ### E1. `docs/writing-stream-processors.md` teaches the pre-#2168 contract
 
-**Status:** in-pr. **Urgent and free.**
+**Status:** in-pr #2188. **Urgent and free.**
 
 - `:199-201` and `:290-292` narrate `llm-request-scheduled` and
   `llm-request-completed {failure: orphaned}` — both deleted by #2168 (the
@@ -622,7 +622,7 @@ three files become greppable checks of each other.
 
 ### E6. At-head memo repaint pattern
 
-**Status:** in-pr (one sentence).
+**Status:** in-pr #2188 (one sentence).
 
 slack-agent `#unpaintedPresenceFact` (`:91-109,525-588`) and telegram-agent
 `#unpaintedTypingFact` (`:75-79,296-308`) deliberately mirror each other with


### PR DESCRIPTION
## What

Docs-only PR for audit findings **E1–E6** plus the doc-rule halves of **D1, D5, D6, D7, D9** (`tasks/processor-audit-2026-07.md`). Targets `docs/writing-stream-processors.md` and `docs/domain-objects-and-stream-processors.md`; minimal diffs in each doc's voice.

**Falsified content fixed (E1):** the recovery narration cited `llm-request-scheduled` and `llm-request-completed {failure: orphaned}` — both deleted by #2168. It now tells the shipped story (`…-requested` → `…/revived` → `…-settled`, with the settle's reduce arm deriving the retry intent under backoff). The obligation checklist teaches one `…-settled` terminal with a success/failure/cancelled result union; `…-started` is optional for domains that need the attempt boundary; repos' split terminals are named as grandfathered, not the template.

**Implemented-but-undocumented rules written down (E2–E6):**
- same-key-**different**-body races are conflicts, not dedups — and the three legitimate responses (tolerate-as-settlement / read-back-the-winner / observe-before-append) with which processor exemplifies each;
- append bodies must be deterministic functions of the event (+config); deadlines anchor to `event.createdAt`, never `now()` — the replay-wedge rule that previously lived only in call-site comments;
- the `<domain>-defaults.ts` creation-batch contract (deterministic bodies, keys from `(projectId, path)`, safe to re-append every contact, create doors + routers collide by design — and why telegram's every-contact re-append makes determinism load-bearing);
- the chat-facet transcription shape (one `agents/context-added` per source event, `refs` to the exact source, explicit loss notes);
- the at-head memo repaint pattern (read-and-clear latest-fact fields).

**Decision rules (D halves):** prompt settlements hold one outer blocked frame vs. re-derivable background attempts (D1); `this.idempotencyKey` taxonomy with raw literals reserved for deliberate cross-processor convergence + a comment (D5); whole-hook birth gating with commented per-case exceptions, sample code updated (D6); settlement unions are the durable failure record, `stream/error-occurred` is the agent-visible lane (D7); required `now` dep for expiry logic, epoch-ms expiries in new contracts, `configured` suffix carries no merge-semantics promise, laneless synchronous cache pokes are fine (D9).

No code changes; repos' wake-event consumption and the runner-side error emission stay as separate items. Ledger: E1–E6 + D7 → `in-pr`; D1/D5/D6/D9 keep their status with a "doc rule shipped, code half open" note.

## Verification

lint pass, format pass, `git diff --check` pass; `llm-request-scheduled`/`llm-request-completed` grep in `docs/`: zero matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and audit ledger updates only; no runtime or processor behavior changes.
> 
> **Overview**
> **Aligns processor documentation with shipped contracts and codifies conventions that previously lived only in code comments or the audit task.**
> 
> `docs/writing-stream-processors.md` replaces pre-#2168 Agent recovery text (`llm-request-scheduled` / `llm-request-completed`) with the **`…-requested` → revival → `…-settled`** story and teaches obligations as one **`…-settled`** terminal (optional **`…-started`**). It adds guidance on **same-key-different-body** settle races (tolerate / read-back / observe-before-append), **deterministic idempotent append bodies** (anchor to `event.createdAt`, not `now()`), **blocked vs background** at-head work, **idempotency key** taxonomy, **freshness-gated** at-head memo repaints, and **integration transcription** shape for chat facets.
> 
> `docs/domain-objects-and-stream-processors.md` documents **`<domain>-defaults.ts`** deterministic creation batches (re-append safe for Telegram-style routers), **whole-hook `processEvent` birth gating** with commented per-case exceptions, and that **`<slug>/configured`** does not imply a single merge semantics.
> 
> `tasks/processor-audit-2026-07.md` marks **E1–E6** and related **D** doc-rule items as addressed in this PR, with notes that code follow-ups remain open where applicable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6100b1f7defb1a01429b4819d265ab71badfe7e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Docs | +147 -47 | +132 -47 🟩🟩🟩🟩🟥 |
| **Total** | **+147 -47** | **+132 -47** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 54d502f and 6100b1f, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->