### PR TITLE
Support direct tarball dependencies in worker-bundler

### DIFF
--- a/patches/@cloudflare__worker-bundler@0.2.1.patch
+++ b/patches/@cloudflare__worker-bundler@0.2.1.patch
@@ -1,0 +1,74 @@
+diff --git a/dist/installer-Ns4ivVf5.js b/dist/installer-Ns4ivVf5.js
+index 0220df7c889d58e6a670214eb1b6e1aa10215b2f..47627a3aad06d1de1f732ed48ccdf7e82197805a 100644
+--- a/dist/installer-Ns4ivVf5.js
++++ b/dist/installer-Ns4ivVf5.js
+@@ -75,20 +75,32 @@ async function installPackage(name, versionRange, result, fileSystem, installedP
+ 	if (existing) return existing;
+ 	const installPromise = (async () => {
+ 		try {
+-			const metadata = await fetchPackageMetadata(name, registry);
+-			const version = resolveVersion(versionRange, metadata);
+-			if (!version) {
+-				result.warnings.push(`Could not resolve version for ${name}@${versionRange}`);
+-				return;
+-			}
+-			const versionMetadata = metadata.versions[version];
+-			if (!versionMetadata) {
+-				result.warnings.push(`Version ${version} not found for ${name}`);
+-				return;
++			const tarballUrl = directTarballUrl(versionRange);
++			let packageFiles;
++			let versionMetadata;
++			if (tarballUrl) {
++				packageFiles = await fetchPackageFiles(name, {
++					version: versionRange,
++					dist: { tarball: tarballUrl }
++				});
++				versionMetadata = packageMetadataFromTarball(name, tarballUrl, packageFiles);
++			} else {
++				const metadata = await fetchPackageMetadata(name, registry);
++				const version = resolveVersion(versionRange, metadata);
++				if (!version) {
++					result.warnings.push(`Could not resolve version for ${name}@${versionRange}`);
++					return;
++				}
++				versionMetadata = metadata.versions[version];
++				if (!versionMetadata) {
++					result.warnings.push(`Version ${version} not found for ${name}`);
++					return;
++				}
++				packageFiles = await fetchPackageFiles(name, versionMetadata);
+ 			}
++			const version = versionMetadata.version;
+ 			installedPackages.set(name, version);
+ 			result.installed.push(`${name}@${version}`);
+-			const packageFiles = await fetchPackageFiles(name, versionMetadata);
+ 			for (const [filePath, content] of Object.entries(packageFiles)) fileSystem.write(`node_modules/${name}/${filePath}`, content);
+ 			const deps = versionMetadata.dependencies ?? {};
+ 			await Promise.all(Object.entries(deps).map(([depName, depVersion]) => installPackage(depName, depVersion, result, fileSystem, installedPackages, inProgress, registry)));
+@@ -104,6 +116,25 @@ async function installPackage(name, versionRange, result, fileSystem, installedP
+ 		inProgress.delete(name);
+ 	}
+ }
++/** Return an HTTP(S) dependency spec as a normalized direct-tarball URL. */
++function directTarballUrl(versionRange) {
++	if (!versionRange.startsWith("https://") && !versionRange.startsWith("http://")) return;
++	return new URL(versionRange).toString();
++}
++/** Read and validate the identity and dependency metadata inside a direct tarball. */
++function packageMetadataFromTarball(expectedName, tarballUrl, packageFiles) {
++	const packageJson = packageFiles["package.json"];
++	if (!packageJson) throw new Error(`Direct tarball for ${expectedName} has no package.json (${tarballUrl})`);
++	let metadata;
++	try {
++		metadata = JSON.parse(packageJson);
++	} catch {
++		throw new Error(`Direct tarball for ${expectedName} has an invalid package.json (${tarballUrl})`);
++	}
++	if (metadata.name !== expectedName) throw new Error(`Direct tarball dependency ${expectedName} contains package ${JSON.stringify(metadata.name)} (${tarballUrl})`);
++	if (typeof metadata.version !== "string" || metadata.version.length === 0) throw new Error(`Direct tarball for ${expectedName} has no valid package version (${tarballUrl})`);
++	return metadata;
++}
+ /**
+ * Fetch package metadata from npm registry.
+ */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ patchedDependencies:
   '@better-auth/oauth-provider@1.6.9':
     hash: e05b6e0e968dd85c546197511b6b7bdeaf9f4449572e4a143d90d5d31008fb40
     path: patches/@better-auth__oauth-provider@1.6.9.patch
+  '@cloudflare/worker-bundler@0.2.1':
+    hash: d2bb8caf8f458739322f7e885d1dae5c152accfc58d5812f0097897843f293db
+    path: patches/@cloudflare__worker-bundler@0.2.1.patch
   '@cloudflare/workers-types@4.20260621.1':
     hash: ae8908e1d45f2ea02ffeabf1230701598cc2878240ef700403ff76df72677af2
     path: patches/@cloudflare__workers-types@4.20260621.1.patch
@@ -536,7 +539,7 @@ importers:
         version: 0.3.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@tanstack/ai@0.10.2)(ai@6.0.159(zod@4.3.6))(zod@4.3.6)
       '@cloudflare/worker-bundler':
         specifier: 0.2.1
-        version: 0.2.1
+        version: 0.2.1(patch_hash=d2bb8caf8f458739322f7e885d1dae5c152accfc58d5812f0097897843f293db)
       '@codemirror/autocomplete':
         specifier: ^6.20.1
         version: 6.20.1
@@ -14305,7 +14308,7 @@ snapshots:
       - utf-8-validate
       - workerd
 
-  '@cloudflare/worker-bundler@0.2.1':
+  '@cloudflare/worker-bundler@0.2.1(patch_hash=d2bb8caf8f458739322f7e885d1dae5c152accfc58d5812f0097897843f293db)':
     dependencies:
       '@typescript/vfs': 1.6.4(typescript@6.0.3)
       es-module-lexer: 2.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -96,6 +96,7 @@ packageExtensions:
 
 patchedDependencies:
   '@better-auth/oauth-provider@1.6.9': patches/@better-auth__oauth-provider@1.6.9.patch
+  '@cloudflare/worker-bundler@0.2.1': patches/@cloudflare__worker-bundler@0.2.1.patch
   '@cloudflare/workers-types@4.20260621.1': patches/@cloudflare__workers-types@4.20260621.1.patch
   '@journeyapps/wa-sqlite@1.7.0': patches/@journeyapps__wa-sqlite@1.7.0.patch
   middlewright@0.1.3: patches/middlewright@0.1.3.patch


### PR DESCRIPTION
## Summary

Allow dynamic-worker projects to install dependencies declared as direct HTTP(S) tarballs, including exact `pkg.pr.new` builds.

```json
{
  "dependencies": {
    "iterate": "https://pkg.pr.new/iterate/iterate/iterate@<commit>"
  }
}
```

worker-bundler 0.2.1 currently sends every dependency spec through npm registry semver resolution, so a URL is never installed and the eventual bundle fails with `No such module`.

This pnpm patch keeps registry installs unchanged. For HTTP(S) specs it uses worker-bundler's existing tarball fetch/extract path, validates the embedded package name and version, then installs the package's declared dependencies through the existing recursive installer.

## Why a dependency patch

The published `dist/installer-*.js` is readable generated output, and the change is isolated to its package-install branch. This lets OS consume the fix now while we decide whether to upstream the same source change.

## Verification

- frozen pnpm install applies the patch
- patched installer passes `node --check`
- existing worker-bundler boundary tests: 6 passing
- stacked proof: #2175
- fresh public proof: https://pkg-proof-head-2175.iterate-preview-2.app/

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Config | +1 -0 | +1 -0 🟩⬜⬜⬜⬜ |
| Other | +74 -0 | +74 -0 🟩🟩🟩🟩🟩 |
| Generated | +5 -2 | +5 -2 🟩⬜⬜⬜⬜ |
| **Total** | **+80 -2** | **+80 -2** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 0f2df9d and 4e4d48d, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

> [!CAUTION]
> This PR is a draft, so it doesn't claim a preview slot. To get previews: add the `preview` label, mark the PR ready for review, or dispatch the Cloudflare Previews workflow for a one-off run.

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": "This PR is a draft, so it doesn't claim a preview slot. To get previews: add the `preview` label, mark the PR ready for review, or dispatch the Cloudflare Previews workflow for a one-off run."
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches third-party bundler install logic used when building user workers; mistakes could break dependency installs or allow mismatched tarball names, though registry paths are preserved and tarball metadata is validated.
> 
> **Overview**
> Adds a **pnpm patch** on `@cloudflare/worker-bundler@0.2.1` so dynamic-worker installs can use **HTTP(S) tarball specs** (e.g. `pkg.pr.new` URLs) instead of failing semver resolution against the npm registry.
> 
> In `installPackage`, when the version range is an `http://` or `https://` URL, the patched installer **fetches that tarball** via the existing `fetchPackageFiles` path, **validates** `package.json` (presence, parse, matching `name`, non-empty `version`), then writes `node_modules` and **recursively installs** declared dependencies as before. Registry-based installs are unchanged.
> 
> `pnpm-workspace.yaml` and `pnpm-lock.yaml` register the new patch so installs apply it automatically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e4d48dcda271e7dc3125cd3adf1e616fc35acfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->