### PR TITLE
Avoid refetching the project list when navigation opens

### DIFF
--- a/apps/os/src/components/global-command-palette.tsx
+++ b/apps/os/src/components/global-command-palette.tsx
@@ -11,6 +11,7 @@ import { connectItx, connectIterateSession, useIterateSessionQuery } from "itera
 import { OPEN_GLOBAL_COMMAND_PALETTE_EVENT } from "~/components/global-command-palette-events.ts";
 import { NULL_DURABLE_OBJECT_PROJECT_ID } from "~/lib/stream-navigation.ts";
 import { activeStreamBreadcrumb } from "~/lib/route-breadcrumbs.ts";
+import { projectsListStaleTime } from "~/lib/projects-query.ts";
 import { linkOptionsForStreamPath } from "~/lib/stream-routes.ts";
 import type { StreamNavigator } from "~/lib/stream-navigation.ts";
 
@@ -190,6 +191,7 @@ function ProjectPickerDialog({
     key: ["projects"],
     query: (session) => session.projects.list(),
     enabled: open,
+    staleTime: projectsListStaleTime,
   });
 
   return (


### PR DESCRIPTION
## Summary

- reuse the existing 30-second project-list freshness policy in the global navigation picker
- avoid a redundant `projects.list()` refetch when the sidebar or projects page already populated the shared query cache

## Validation

- `pnpm format`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm --dir apps/os build`
- `pnpm exec playwright test specs/dashboard.spec.ts`
- `npx react-doctor@latest --verbose --scope changed`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single query-option change for an existing shared cache key; no auth, data, or API behavior changes.
> 
> **Overview**
> The **⌘K project picker** now uses the shared **`projectsListStaleTime`** (30s) on its `["projects"]` session query, matching the sidebar and `/projects` page.
> 
> That keeps the global navigation picker from **immediately refetching** `projects.list()` when the shared query cache was already filled elsewhere within the freshness window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1db9a2d6ee635f048a2389f91200779e1796ed81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| UI components | +2 -0 | +2 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+2 -0** | **+2 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 62758f2 and 1db9a2d, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-21T12:33:33.413Z",
      "headSha": "1db9a2d6ee635f048a2389f91200779e1796ed81",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/320201078093198",
      "shortSha": "1db9a2d",
      "cleanupDurationMs": 24075,
      "deployDurationMs": 116899,
      "testDurationMs": 486862,
      "testRetries": null,
      "workerSizeKib": 17325.17,
      "workerGzipKib": 4647.09,
      "mainWorkerGzipKib": 4657.96
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-21T12:33:10.326Z",
      "headSha": "1db9a2d6ee635f048a2389f91200779e1796ed81",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/320201078093198",
      "shortSha": "1db9a2d",
      "cleanupDurationMs": 985,
      "deployDurationMs": 24567,
      "testDurationMs": 13677,
      "testRetries": null,
      "workerSizeKib": 1915.06,
      "workerGzipKib": 440.92,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-21T12:33:13.502Z",
      "headSha": "1db9a2d6ee635f048a2389f91200779e1796ed81",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/320201078093198",
      "shortSha": "1db9a2d",
      "cleanupDurationMs": 4160,
      "deployDurationMs": 22099,
      "testDurationMs": 10355,
      "testRetries": null,
      "workerSizeKib": 3963.27,
      "workerGzipKib": 810.08,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-21T12:33:25.807Z",
      "headSha": "1db9a2d6ee635f048a2389f91200779e1796ed81",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/320201078093198",
      "shortSha": "1db9a2d",
      "cleanupDurationMs": 16461,
      "deployDurationMs": 87842,
      "testDurationMs": 57209,
      "testRetries": null,
      "workerSizeKib": 5367.97,
      "workerGzipKib": 1517.83,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-21T12:33:10.408Z",
      "headSha": "1db9a2d6ee635f048a2389f91200779e1796ed81",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/320201078093198",
      "shortSha": "1db9a2d",
      "cleanupDurationMs": 1060,
      "deployDurationMs": 7125,
      "testDurationMs": 10710,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `1db9a2d` | [https://auth.iterate-preview-5.com](https://auth.iterate-preview-5.com) | 810.1 KiB | 22.1s | 10.4s |  | 4.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/320201078093198) | 2026-07-21T12:33:13.502Z | Preview app released. |
| Dummy Petshop | released | `1db9a2d` | [https://dummy-petshop.iterate-preview-5.com](https://dummy-petshop.iterate-preview-5.com) | 198.2 KiB | 7.1s | 10.7s |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/320201078093198) | 2026-07-21T12:33:10.408Z | Preview app released. |
| OS | released | `1db9a2d` | [https://os.iterate-preview-5.com](https://os.iterate-preview-5.com) | 4.54 MiB (-10.9 KiB vs main) | 116.9s | 486.9s |  | 24.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/320201078093198) | 2026-07-21T12:33:33.413Z | Preview app released. |
| Semaphore | released | `1db9a2d` | [https://semaphore.iterate-preview-5.com](https://semaphore.iterate-preview-5.com) | 440.9 KiB | 24.6s | 13.7s |  | 985ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/320201078093198) | 2026-07-21T12:33:10.326Z | Preview app released. |
| Streams Example App | released | `1db9a2d` | [https://streams.iterate-preview-5.com](https://streams.iterate-preview-5.com) | 1.48 MiB | 87.8s | 57.2s |  | 16.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/320201078093198) | 2026-07-21T12:33:25.807Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->