### PR TITLE
Mint display identity (email/name) into project-app-session claims

### DIFF
--- a/apps/auth-contract/src/worker.ts
+++ b/apps/auth-contract/src/worker.ts
@@ -49,6 +49,10 @@ export type OAuthAccessTokenIntrospectionResult =
 
 export type MintProjectAppSessionInput = {
   audience: string;
+  /** Display identity baked into the claims for the app behind the proxy
+   * (presence, authorship). Carries no authority — userId is the principal. */
+  email?: string;
+  name?: string;
   projectId: string;
   userId: string;
 };

--- a/apps/auth/src/server/project-app-session.test.ts
+++ b/apps/auth/src/server/project-app-session.test.ts
@@ -76,4 +76,39 @@ describe("project app sessions", () => {
       null,
     );
   });
+
+  it("bakes optional display identity into the claims and still validates", async () => {
+    const userCanAccessProject = async () => true;
+    const issued = await mintProjectAppSession(
+      { audience, projectId, userId: "usr_one", email: "one@example.com", name: "One Person" },
+      { secret, userCanAccessProject },
+    );
+    assert.ok(issued);
+
+    const payload = JSON.parse(
+      Buffer.from(issued.token.split(".")[1]!, "base64url").toString("utf8"),
+    ) as Record<string, unknown>;
+    assert.equal(payload.email, "one@example.com");
+    assert.equal(payload.name, "One Person");
+    assert.equal(payload.userId, "usr_one");
+
+    // The strict claims schema accepts the enriched token…
+    const valid = await validateProjectAppSession(
+      { audience, projectId, token: issued.token },
+      { secret, userCanAccessProject },
+    );
+    assert.equal(valid?.userId, "usr_one");
+
+    // …and blank display fields stay out of the claims entirely.
+    const bare = await mintProjectAppSession(
+      { audience, projectId, userId: "usr_one", email: "", name: "  " },
+      { secret, userCanAccessProject },
+    );
+    assert.ok(bare);
+    const bareClaims = JSON.parse(
+      Buffer.from(bare.token.split(".")[1]!, "base64url").toString("utf8"),
+    ) as Record<string, unknown>;
+    assert.equal("email" in bareClaims, false);
+    assert.equal("name" in bareClaims, false);
+  });
 });

--- a/apps/auth/src/server/project-app-session.ts
+++ b/apps/auth/src/server/project-app-session.ts
@@ -10,8 +10,13 @@ const SESSION_TTL_SECONDS = 15 * 60;
 const ProjectAppSessionClaims = z
   .object({
     audience: z.string(),
+    // Display identity for the app behind the proxy (presence, authorship).
+    // Optional: pre-rollout tokens without them stay valid, and they carry
+    // no authority — userId is the principal; these are what to call it.
+    email: z.string().trim().min(1).max(320).optional(),
     exp: z.number().int(),
     iat: z.number().int(),
+    name: z.string().trim().min(1).max(256).optional(),
     projectId: z.string().trim().min(1).max(256),
     type: z.literal("project-app-session"),
     userId: z.string().trim().min(1).max(256),
@@ -42,6 +47,8 @@ export async function mintProjectAppSession(
     token: await signJWT(
       {
         audience: input.audience,
+        ...(input.email === undefined ? {} : { email: input.email }),
+        ...(input.name === undefined ? {} : { name: input.name }),
         projectId: input.projectId,
         type: "project-app-session",
         userId: input.userId,
@@ -84,9 +91,17 @@ export async function validateProjectAppSession(
 function parseMintInput(input: MintProjectAppSessionInput) {
   return {
     audience: parseAudience(input.audience),
+    email: optionalDisplayField(input.email, 320),
+    name: optionalDisplayField(input.name, 256),
     projectId: z.string().trim().min(1).max(256).parse(input.projectId),
     userId: z.string().trim().min(1).max(256).parse(input.userId),
   };
+}
+
+/** Empty or absent display fields stay out of the claims entirely. */
+function optionalDisplayField(value: string | undefined, maxLength: number): string | undefined {
+  const trimmed = z.string().max(maxLength).optional().parse(value)?.trim();
+  return trimmed === undefined || trimmed === "" ? undefined : trimmed;
 }
 
 function parseValidateInput(input: ValidateProjectAppSessionInput) {

--- a/apps/os/src/auth/project-auth.ts
+++ b/apps/os/src/auth/project-auth.ts
@@ -159,7 +159,7 @@ export async function handleProjectAuthStart(input: {
   mintSession(input: MintProjectAppSessionInput): Promise<{ token: string } | null>;
   request: Request;
   resolveProjectId(targetUrl: string): Promise<string | null>;
-  session: { userId: string } | null;
+  session: { userId: string; email?: string; name?: string } | null;
 }): Promise<Response> {
   if (input.request.method !== "GET") return methodNotAllowed("GET");
   const requestUrl = new URL(input.request.url);
@@ -190,6 +190,8 @@ export async function handleProjectAuthStart(input: {
   try {
     issued = await input.mintSession({
       audience: target.origin,
+      email: input.session.email,
+      name: input.session.name,
       projectId,
       userId: input.session.userId,
     });

--- a/apps/os/src/routes/api.$.ts
+++ b/apps/os/src/routes/api.$.ts
@@ -18,7 +18,11 @@ export const Route = createFileRoute("/api/$")({
           return await handleProjectAuthStart({
             request,
             session: context.iterateAuthSession
-              ? { userId: context.iterateAuthSession.user.id }
+              ? {
+                  userId: context.iterateAuthSession.user.id,
+                  email: context.iterateAuthSession.user.email || undefined,
+                  name: context.iterateAuthSession.user.name || undefined,
+                }
               : null,
             mintSession: (input) => itxEnv.AUTH.mintProjectAppSession(input),
             resolveProjectId: async (targetUrl) => {


### PR DESCRIPTION
Remote apps behind the config-worker proxy (e.g. the tasks vessel) receive the user's short-lived session token but the claims carried only `userId` — so collaborative presence showed anonymous names and nothing could record who created a task.

This bakes the better-auth session's **email** and **name** into the project-app-session JWT at mint time as optional display claims. Apps already verify the token by use against os; after that they can trust the claims for presence chips and authorship metadata with zero extra round trips.

- No authority rides on the new claims — `userId` remains the principal; these are only what to call it.
- `ProjectAppSessionClaims` stays `.strict()` with the two fields optional: pre-rollout tokens keep validating, blank values stay out of the payload entirely (test covers both).
- os's local verifier is `.loose()` and needs no change; verified end-to-end against the deployed tasks app with a hand-minted enriched token (presence chip renders the real name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional JWT claims and OS session forwarding; validation unchanged for authority (`userId` only) and backward-compatible for tokens without display fields.
> 
> **Overview**
> **Project-app session JWTs** can now carry optional **email** and **name** for display (presence, authorship) in proxied project apps. **`userId` stays the only principal**; the new fields are documented and parsed as non-authoritative display identity.
> 
> Auth **mints** enriched claims when OS passes the logged-in user’s email/name from **`/api/project-auth/start`**, with **trim/length validation** and **omission of empty or whitespace-only values** so older tokens and bare mints stay valid under the strict claims schema. Tests assert payload contents and that blank fields never appear in the JWT.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62b467af0631c95d966fbc2be5b44a06f8fd43fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +27 -2 | +20 -2 🟩🟩🟩🟩⬜ |
| Tests | +35 -0 | +29 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+62 -2** | **+49 -2** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between dc3e491 and 62b467a, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-21T13:18:29.813Z",
      "headSha": "62b467af0631c95d966fbc2be5b44a06f8fd43fe",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/252761437045900",
      "shortSha": "62b467a",
      "cleanupDurationMs": 748166,
      "deployDurationMs": 126298,
      "testDurationMs": 163743,
      "testRetries": null,
      "workerSizeKib": 17325.11,
      "workerGzipKib": 4646.8,
      "mainWorkerGzipKib": 4657.93
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-21T13:06:04.505Z",
      "headSha": "62b467af0631c95d966fbc2be5b44a06f8fd43fe",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/252761437045900",
      "shortSha": "62b467a",
      "cleanupDurationMs": 2855,
      "deployDurationMs": 17358,
      "testDurationMs": 4414,
      "testRetries": null,
      "workerSizeKib": 3963.84,
      "workerGzipKib": 810.32,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-21T13:06:02.302Z",
      "headSha": "62b467af0631c95d966fbc2be5b44a06f8fd43fe",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/252761437045900",
      "shortSha": "62b467a",
      "cleanupDurationMs": 650,
      "deployDurationMs": 6789,
      "testDurationMs": 5312,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `62b467a` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 810.3 KiB | 17.4s | 4.4s |  | 2.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/252761437045900) | 2026-07-21T13:06:04.505Z | Preview app released. |
| Dummy Petshop | released | `62b467a` | [https://dummy-petshop.iterate-preview-1.com](https://dummy-petshop.iterate-preview-1.com) | 198.2 KiB | 6.8s | 5.3s |  | 650ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/252761437045900) | 2026-07-21T13:06:02.302Z | Preview app released. |
| OS | released | `62b467a` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 4.54 MiB (-11.1 KiB vs main) | 126.3s | 163.7s |  | 748.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/252761437045900) | 2026-07-21T13:18:29.813Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->