### PR TITLE
Route owned iterate.com apex through os-prd

### DIFF
--- a/.agents/skills/recreate-production/SKILL.md
+++ b/.agents/skills/recreate-production/SKILL.md
@@ -111,6 +111,23 @@ the complete [GitHub production smoke](../../../docs/github-smoke-testing.md),
 and project-worker boot. Add PR-specific checks for whatever
 changed. Do not trigger externally visible provider actions without approval.
 
+### Production website (`iterate.com`)
+
+The company website is the `iterate` project worker, reached on the owned apex
+via Worker routes `iterate.com/*` and `*.iterate.com/*` → `os-prd` (see
+`ownedProjectCustomApexes` in root `envs.ts`). Those routes alone are not
+enough: ingress still needs the project-directory KV registration
+
+```text
+hostname:iterate.com → { id, slug, organizationId, name } of project "iterate"
+```
+
+Re-prime that key after every production erase (same shape as `slug:iterate`).
+Do **not** register `hostname:www.iterate.com` — the custom-domain parent
+fallback would treat `www` as an app slug and the seed homepage would emit
+`tasks.www.iterate.com` links. Do not add a www↔apex redirect unless a human
+explicitly asks for one.
+
 For Slack, run
 [`scripts/verify-slack-connection.itx.js`](scripts/verify-slack-connection.itx.js)
 without a project context immediately after OAuth. It requires a successful

--- a/apps/os/scripts/generate-wrangler-config.test.ts
+++ b/apps/os/scripts/generate-wrangler-config.test.ts
@@ -203,6 +203,18 @@ it("routes Cloudflare for SaaS custom hostnames through the project provider zon
   });
 });
 
+it("routes the owned iterate.com apex and single-label apps to the production os worker", () => {
+  const productionRoutes = config.env.prd.routes ?? [];
+  expect(productionRoutes).toContainEqual({
+    pattern: "iterate.com/*",
+    zone_name: "iterate.com",
+  });
+  expect(productionRoutes).toContainEqual({
+    pattern: "*.iterate.com/*",
+    zone_name: "iterate.com",
+  });
+});
+
 it("does not add SaaS catch-all routes to preview zones without SSL-for-SaaS quota", () => {
   expect(config.env.preview_6.routes ?? []).not.toContainEqual({
     pattern: "*/*",

--- a/apps/os/scripts/generate-wrangler-config.ts
+++ b/apps/os/scripts/generate-wrangler-config.ts
@@ -389,9 +389,10 @@ function workerBindings(input: {
 
 /**
  * Every hostname routed to the os worker: the app base URL, public event docs,
- * the MCP host, project-host patterns, and any SaaS-enabled provider-zone
- * catch-all routes. The zone is the hostname minus its first label for
- * app/MCP/event-docs hosts; project bases are themselves zones.
+ * the MCP host, project-host patterns, any SaaS-enabled provider-zone
+ * catch-all routes, and owned custom apexes (e.g. prod `iterate.com`). The
+ * zone is the hostname minus its first label for app/MCP/event-docs hosts;
+ * project bases and owned apexes are themselves zones.
  *
  * Project bases get three built-in project-host patterns: `base/*`,
  * `*.base/*`, and `*base/*`.
@@ -399,6 +400,10 @@ function workerBindings(input: {
  * only reliably invoked the worker for project hosts once all three existed
  * (observed 2026-06) — kept verbatim; collapse only with an edge experiment
  * proving it.
+ *
+ * Owned custom apexes get apex/* + *.apex/* only (not a SaaS catch-all).
+ * More-specific routes on that zone (os., auth., mcp., …) stay owned by
+ * other workers and win by specificity.
  */
 function routes(env: DeployedEnv) {
   const appHost = new URL(env.baseUrl).hostname;
@@ -420,6 +425,10 @@ function routes(env: DeployedEnv) {
         ? [{ pattern: "*/*", zone_name: base }, ...projectRoutes]
         : projectRoutes;
     }),
+    ...env.ownedProjectCustomApexes.flatMap((apex) => [
+      { pattern: `${apex}/*`, zone_name: apex },
+      { pattern: `*.${apex}/*`, zone_name: apex },
+    ]),
   ];
 }
 

--- a/envs.ts
+++ b/envs.ts
@@ -79,6 +79,15 @@ export interface DeployedEnv {
    */
   cloudflareForSaasProjectHostnameBases: string[];
   /**
+   * Owned Cloudflare zones where OS serves project custom-domain traffic at the
+   * apex and single-label subdomains (`apex/*`, `*.apex/*`). More-specific
+   * routes on the same zone (`os.`, `auth.`, `mcp.`, …) stay with their workers
+   * and win by specificity. Used for the prod website: `iterate.com` → the
+   * `iterate` project worker (also requires `hostname:iterate.com` in
+   * PROJECT_DIRECTORY KV).
+   */
+  ownedProjectCustomApexes: string[];
+  /**
    * How agent LLM turns travel through the Cloudflare AI Gateway: `unified`
    * = partner models on Cloudflare's unified billing; `byok` = the gateway's
    * universal endpoint with our own OpenAI key (correct prompt-cache
@@ -123,6 +132,7 @@ function previewSlot(n: number, resources: DeployedEnv["resources"]): DeployedEn
     authBaseUrl: `https://auth.iterate-preview-${n}.com`,
     projectHostnameBases: [`iterate-preview-${n}.app`],
     cloudflareForSaasProjectHostnameBases: [],
+    ownedProjectCustomApexes: [],
     cloudflareAiGatewayTransport: "byok",
     // 7 days: long enough that overnight marathons and PR-lifetime reruns
     // replay each other, short enough that stale answers age out on their own.
@@ -143,6 +153,7 @@ export const envs = {
     authBaseUrl: "https://auth.iterate.com",
     projectHostnameBases: ["iterate.app"],
     cloudflareForSaasProjectHostnameBases: ["iterate.app"],
+    ownedProjectCustomApexes: ["iterate.com"],
     // BYOK, like every other env: unified billing meters OpenAI-prompt-cached
     // tokens at the uncached price (~6x at our hit rate), and BYOK benchmarked
     // latency-neutral-or-better. NO response cache here — that knob stays


### PR DESCRIPTION
## Summary

- Make production deploys keep Worker routes `iterate.com/*` and `*.iterate.com/*` on `os-prd` via `ownedProjectCustomApexes` in `envs.ts` (more-specific hosts like `tunnels.` / `auth.` / `os.` still win by Cloudflare route specificity).
- Document post-reset re-priming of project-directory KV `hostname:iterate.com` only — do **not** register `www` (that made app links like `tasks.www.iterate.com`).
- No www↔apex redirect.

## Production recovery already applied

- Re-created CF routes `iterate.com/*` and `*.iterate.com/*` → `os-prd` (a deploy had wiped the earlier one-off routes).
- Primed `hostname:iterate.com` → iterate project; deleted `hostname:www.iterate.com`.

This PR is what stops the next `os-prd` deploy from dropping the apex routes again.

## Test plan

- [x] `pnpm --dir apps/os exec vitest run scripts/generate-wrangler-config.test.ts`
- [ ] After merge + deploy: `curl -sI https://iterate.com/` → 200 from project worker (`x-iterate-worker-serve`)
- [ ] `https://tasks.iterate.com/` (not `tasks.www.iterate.com`) from homepage links when opened on apex
- [ ] `tunnels.iterate.com` / `auth.iterate.com` / `os.iterate.com` still hit their dedicated workers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production edge routing for the public apex; behavior is tested and narrower than a zone catch-all, but a misconfiguration could affect `iterate.com` traffic until corrected.
> 
> **Overview**
> Production **`os-prd`** deploys will keep Cloudflare Worker routes **`iterate.com/*`** and **`*.iterate.com/*`** instead of dropping one-off apex routes on each release.
> 
> This adds **`ownedProjectCustomApexes`** on **`DeployedEnv`** (prod: **`iterate.com`**; previews: empty) and extends wrangler route generation to emit apex + single-label subdomain patterns only—no SaaS catch-all—so hosts like **`os.`**, **`auth.`**, and **`mcp.`** still win by route specificity. A unit test locks the prod route list.
> 
> The **recreate-production** skill now documents post-erase checks for the company site: re-prime **`PROJECT_DIRECTORY`** KV **`hostname:iterate.com`** for the **`iterate`** project, and **do not** register **`www`** (avoids **`tasks.www.iterate.com`** links) or add www↔apex redirects unless explicitly requested.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fb8e0a2a00eb3b3b717e01f00a1cf024010146f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +12 -0 | +11 -0 🟩🟩🟩⬜⬜ |
| CI & scripts | +12 -3 | +4 -0 🟩⬜⬜⬜⬜ |
| Other | +28 -0 | +16 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+52 -3** | **+31 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 72c83ae and 4fb8e0a, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

> [!CAUTION]
> Teardown failed but the lease was released; preview-2 is left dirty and its next acquire erases it before use. (preview cleanup at 2026-07-21T13:16:20.425Z)

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "cleanup-failed",
      "updatedAt": "2026-07-21T13:16:18.437Z",
      "headSha": "4fb8e0a2a00eb3b3b717e01f00a1cf024010146f",
      "message": "...(truncated)\n3524de763666c15/workers/scripts/semaphore-preview-13/settings (attempt 2/5); retrying in 120s (Retry-After)...\nCloudflare API rate limited (429) on GET /accounts/376ef7ed81b0573f93524de763666c15/workers/scripts/semaphore-preview-14/settings (attempt 2/5); retrying in 120s (Retry-After)...\nCloudflare API rate limited (429) on GET /accounts/376ef7ed81b0573f93524de763666c15/workers/scripts/semaphore-preview-18/settings (attempt 1/5); retrying in 120s (Retry-After)...\nCloudflare API rate limited (429) on GET /accounts/376ef7ed81b0573f93524de763666c15/workers/scripts/semaphore-preview-15/settings (attempt 2/5); retrying in 120s (Retry-After)...\nCloudflare API rate limited (429) on GET /accounts/376ef7ed81b0573f93524de763666c15/workers/scripts/semaphore-preview-19/settings (attempt 1/5); retrying in 120s (Retry-After)...\nCloudflare API rate limited (429) on GET /accounts/376ef7ed81b0573f93524de763666c15/workers/scripts/semaphore-preview-17/settings (attempt 2/5); retrying in 120s (Retry-After)...\nCloudflare API rate limited (429) on GET /accounts/376ef7ed81b0573f93524de763666c15/workers/scripts/semaphore-preview-2/settings (attempt 1/5); retrying in 120s (Retry-After)...\nCloudflare API rate limited (429) on GET /accounts/376ef7ed81b0573f93524de763666c15/workers/scripts/semaphore-preview-3/settings (attempt 1/5); retrying in 120s (Retry-After)...\nCloudflare API rate limited (429) on GET /accounts/376ef7ed81b0573f93524de763666c15/workers/scripts/semaphore-preview-4/settings (attempt 1/5); retrying in 120s (Retry-After)...\nError: DO reset: parked deploy failed for os-preview-2 (see output above).\n    at resetWorkerDurableObjects (/home/runner/work/iterate/iterate/scripts/lib/do-reset.ts:451:17)\n    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)\n    at async eraseData (/home/runner/work/iterate/iterate/apps/os/scripts/erase-data.ts:93:3)\n    at async Command.<anonymous> (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:416:32)\n    at async Command.parseAsync (/home/runner/work/iterate/iterate/node_modules/.pnpm/commander@14.0.3/node_modules/commander/lib/command.js:1122:5)\n    at async Command.<anonymous> (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:457:21)\n    at async Command.parseAsync (/home/runner/work/iterate/iterate/node_modules/.pnpm/commander@14.0.3/node_modules/commander/lib/command.js:1122:5)\n    at async Object.run (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:527:9)\n\n\n> @iterate-com/os@0.0.1 destroy /home/runner/work/iterate/iterate/apps/os\n> tsx ./scripts/erase-data.ts --env preview_2\n\nErasing all data in preview_2 (worker os-preview-2, auth D1 c5a24ab5-e10b-4ca5-a2f2-2451803bc146, KV 237cc9a316a146e98f04f00218b0a69c)\nretired Worker secrets absent: os-preview-2\nDO reset: os-preview-2 is on the declarative exports flow (API 100403) — parking via exports tombstones instead\n$ pnpm exec wrangler deploy --config /tmp/do-reset-59LxiH/wrangler.json\n\n ⛅️ wrangler 4.107.0 (update available 4.112.0)\n───────────────────────────────────────────────\n\n✘ [ERROR] Received a malformed response from the API\n\n  \n  GET /accounts/376ef7ed81b0573f93524de763666c15/workers/scripts/os-preview-2/deployments -> 429 Too Many Requests\n  Cloudflare Ray ID: a1ea7ab649470434-IAD\n  \n  If you think this is a bug, please open an issue at: https://github.com/cloudflare/workers-sdk/issues/new/choose\n\n\n🪵  Logs were written to \"/home/runner/.config/.wrangler/logs/wrangler-2026-07-21_13-16-17_847.log\"\n\n ELIFECYCLE  Command failed with exit code 1.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/302728555750802",
      "shortSha": "4fb8e0a",
      "cleanupDurationMs": 501492,
      "deployDurationMs": 155550,
      "workerSizeKib": 30250.23,
      "workerGzipKib": 7174.73,
      "mainWorkerGzipKib": 4657.68
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-21T13:07:57.840Z",
      "headSha": "4fb8e0a2a00eb3b3b717e01f00a1cf024010146f",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/302728555750802",
      "shortSha": "4fb8e0a",
      "cleanupDurationMs": 891,
      "deployDurationMs": 12900,
      "workerSizeKib": 1915.06,
      "workerGzipKib": 440.92,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-21T13:08:00.018Z",
      "headSha": "4fb8e0a2a00eb3b3b717e01f00a1cf024010146f",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/302728555750802",
      "shortSha": "4fb8e0a",
      "cleanupDurationMs": 3068,
      "deployDurationMs": 20129,
      "workerSizeKib": 3963.35,
      "workerGzipKib": 810.03,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-21T13:10:30.455Z",
      "headSha": "4fb8e0a2a00eb3b3b717e01f00a1cf024010146f",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/302728555750802",
      "shortSha": "4fb8e0a",
      "cleanupDurationMs": 153502,
      "deployDurationMs": 124946,
      "workerSizeKib": null,
      "workerGzipKib": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-21T13:07:57.667Z",
      "headSha": "4fb8e0a2a00eb3b3b717e01f00a1cf024010146f",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/302728555750802",
      "shortSha": "4fb8e0a",
      "cleanupDurationMs": 712,
      "deployDurationMs": 2306,
      "workerSizeKib": null,
      "workerGzipKib": null,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": "Teardown failed but the lease was released; preview-2 is left dirty and its next acquire erases it before use. (preview cleanup at 2026-07-21T13:16:20.425Z)"
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `4fb8e0a` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 810.0 KiB | 20.1s |  |  | 3.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/302728555750802) | 2026-07-21T13:08:00.018Z | Preview app released. |
| Dummy Petshop | released | `4fb8e0a` | [https://dummy-petshop.iterate-preview-2.com](https://dummy-petshop.iterate-preview-2.com) |  | 2.3s |  |  | 712ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/302728555750802) | 2026-07-21T13:07:57.667Z | Preview app released. |
| OS | cleanup failed | `4fb8e0a` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 7.01 MiB (+2.46 MiB vs main) | 155.6s |  |  | 501.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/302728555750802) | 2026-07-21T13:16:18.437Z | Error: DO reset: parked deploy failed for os-preview-2 (see output above). |
| Semaphore | released | `4fb8e0a` | [https://semaphore.iterate-preview-2.com](https://semaphore.iterate-preview-2.com) | 440.9 KiB | 12.9s |  |  | 891ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/302728555750802) | 2026-07-21T13:07:57.840Z | Preview app released. |
| Streams Example App | released | `4fb8e0a` | [https://streams.iterate-preview-2.com](https://streams.iterate-preview-2.com) |  | 124.9s |  |  | 153.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/302728555750802) | 2026-07-21T13:10:30.455Z | Preview app released. |

</details>

<details>
<summary>OS failure details</summary>

<pre>...(truncated)
3524de763666c15/workers/scripts/semaphore-preview-13/settings (attempt 2/5); retrying in 120s (Retry-After)...
Cloudflare API rate limited (429) on GET /accounts/376ef7ed81b0573f93524de763666c15/workers/scripts/semaphore-preview-14/settings (attempt 2/5); retrying in 120s (Retry-After)...
Cloudflare API rate limited (429) on GET /accounts/376ef7ed81b0573f93524de763666c15/workers/scripts/semaphore-preview-18/settings (attempt 1/5); retrying in 120s (Retry-After)...
Cloudflare API rate limited (429) on GET /accounts/376ef7ed81b0573f93524de763666c15/workers/scripts/semaphore-preview-15/settings (attempt 2/5); retrying in 120s (Retry-After)...
Cloudflare API rate limited (429) on GET /accounts/376ef7ed81b0573f93524de763666c15/workers/scripts/semaphore-preview-19/settings (attempt 1/5); retrying in 120s (Retry-After)...
Cloudflare API rate limited (429) on GET /accounts/376ef7ed81b0573f93524de763666c15/workers/scripts/semaphore-preview-17/settings (attempt 2/5); retrying in 120s (Retry-After)...
Cloudflare API rate limited (429) on GET /accounts/376ef7ed81b0573f93524de763666c15/workers/scripts/semaphore-preview-2/settings (attempt 1/5); retrying in 120s (Retry-After)...
Cloudflare API rate limited (429) on GET /accounts/376ef7ed81b0573f93524de763666c15/workers/scripts/semaphore-preview-3/settings (attempt 1/5); retrying in 120s (Retry-After)...
Cloudflare API rate limited (429) on GET /accounts/376ef7ed81b0573f93524de763666c15/workers/scripts/semaphore-preview-4/settings (attempt 1/5); retrying in 120s (Retry-After)...
Error: DO reset: parked deploy failed for os-preview-2 (see output above).
    at resetWorkerDurableObjects (/home/runner/work/iterate/iterate/scripts/lib/do-reset.ts:451:17)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async eraseData (/home/runner/work/iterate/iterate/apps/os/scripts/erase-data.ts:93:3)
    at async Command.&lt;anonymous&gt; (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:416:32)
    at async Command.parseAsync (/home/runner/work/iterate/iterate/node_modules/.pnpm/commander@14.0.3/node_modules/commander/lib/command.js:1122:5)
    at async Command.&lt;anonymous&gt; (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:457:21)
    at async Command.parseAsync (/home/runner/work/iterate/iterate/node_modules/.pnpm/commander@14.0.3/node_modules/commander/lib/command.js:1122:5)
    at async Object.run (/home/runner/work/iterate/iterate/node_modules/.pnpm/trpc-cli@0.15.1_@orpc+server@1.13.14_@opentelemetry+api@1.9.0_crossws@0.4.4_srvx@0.11.1_4eb263ef2d44bd3d623d178b0159b94d/node_modules/trpc-cli/dist/index.js:527:9)


&gt; @iterate-com/os@0.0.1 destroy /home/runner/work/iterate/iterate/apps/os
&gt; tsx ./scripts/erase-data.ts --env preview_2

Erasing all data in preview_2 (worker os-preview-2, auth D1 c5a24ab5-e10b-4ca5-a2f2-2451803bc146, KV 237cc9a316a146e98f04f00218b0a69c)
retired Worker secrets absent: os-preview-2
DO reset: os-preview-2 is on the declarative exports flow (API 100403) — parking via exports tombstones instead
$ pnpm exec wrangler deploy --config /tmp/do-reset-59LxiH/wrangler.json

 ⛅️ wrangler 4.107.0 (update available 4.112.0)
───────────────────────────────────────────────

✘ [ERROR] Received a malformed response from the API

  
  GET /accounts/376ef7ed81b0573f93524de763666c15/workers/scripts/os-preview-2/deployments -&gt; 429 Too Many Requests
  Cloudflare Ray ID: a1ea7ab649470434-IAD
  
  If you think this is a bug, please open an issue at: https://github.com/cloudflare/workers-sdk/issues/new/choose


🪵  Logs were written to "/home/runner/.config/.wrangler/logs/wrangler-2026-07-21_13-16-17_847.log"

 ELIFECYCLE  Command failed with exit code 1.</pre>

</details>
<!-- /CLOUDFLARE_PREVIEW -->