### PR TITLE
Add default user-space favicon

### DIFF
--- a/apps/os/docs/dynamic-worker-dispatch.md
+++ b/apps/os/docs/dynamic-worker-dispatch.md
@@ -143,7 +143,13 @@ Project ingress uses it to inject the small **Iterate overlay** into HTML
 documents (HTMLRewriter, appended before `</body>`). Injection is skipped for
 non-documents, encoded bodies, responses with CSP, and responses opting out
 through `x-iterate-overlay`; the seeded basic apps intentionally omit CSP so
-the floating corner mark remains visible. See `worker-serve-overlay.ts`.
+the floating corner mark remains visible. The same streaming transform adds
+an inverted Iterate favicon before `</head>` when the app has no `rel=icon`
+link of its own. Its reserved same-origin asset lives at
+`/.iterate/favicon.svg`, so normal self-only CSPs accept it without embedding
+the full SVG in every document. CSP and overlay opt-out affect the script
+widget, not the favicon fallback; an app-provided icon always wins. See
+`worker-serve-overlay.ts`.
 
 ## Live capabilities and WebSockets: the specification, and today's boundary
 

--- a/apps/os/docs/dynamic-worker-dispatch.md
+++ b/apps/os/docs/dynamic-worker-dispatch.md
@@ -147,9 +147,10 @@ the floating corner mark remains visible. The same streaming transform adds
 an inverted Iterate favicon before `</head>` when the app has no `rel=icon`
 link of its own. Its reserved same-origin asset lives at
 `/.iterate/favicon.svg`, so normal self-only CSPs accept it without embedding
-the full SVG in every document. CSP and overlay opt-out affect the script
-widget, not the favicon fallback; an app-provided icon always wins. See
-`worker-serve-overlay.ts`.
+the full SVG in every document. On the `/prj_<id>` path lane, the link keeps
+that browser-visible prefix while dispatch serves the rewritten project path.
+CSP and overlay opt-out affect the script widget, not the favicon fallback; an
+app-provided icon always wins. See `worker-serve-overlay.ts`.
 
 ## Live capabilities and WebSockets: the specification, and today's boundary
 

--- a/apps/os/docs/dynamic-worker-dispatch.md
+++ b/apps/os/docs/dynamic-worker-dispatch.md
@@ -144,8 +144,8 @@ documents (HTMLRewriter, appended before `</body>`). Injection is skipped for
 non-documents, encoded bodies, responses with CSP, and responses opting out
 through `x-iterate-overlay`; the seeded basic apps intentionally omit CSP so
 the floating corner mark remains visible. The same streaming transform adds
-an inverted Iterate favicon before `</head>` when the app has no `rel=icon`
-link of its own. Its reserved same-origin asset lives at
+an inverted Iterate favicon at document end when the app has no `rel=icon`
+link anywhere in its document. Its reserved same-origin asset lives at
 `/.iterate/favicon.svg`, so normal self-only CSPs accept it without embedding
 the full SVG in every document. On the `/prj_<id>` path lane, the link keeps
 that browser-visible prefix while dispatch serves the rewritten project path.

--- a/apps/os/e2e/vitest/project-ingress.e2e.test.ts
+++ b/apps/os/e2e/vitest/project-ingress.e2e.test.ts
@@ -29,6 +29,13 @@ test("project ingress serves the static seeded homepage at the root", async () =
   expect(pageResponse).toMatchObject({ status: 200 });
   const homepage = await pageResponse.text();
   expect(homepage).toContain("Hello from your iterate project worker");
+  // The seeded homepage intentionally omits <head>; ingress still places the
+  // default user-space icon before its body (the browser's implied head).
+  expect(homepage).toContain("data-iterate-default-favicon");
+  const favicon = await fetch(buildUrl({ path: `/${projectId}/.iterate/favicon.svg` }));
+  expect(favicon).toMatchObject({ status: 200 });
+  expect(favicon.headers.get("content-type")).toContain("image/svg+xml");
+  expect(await favicon.text()).toContain('fill="white"');
   // The homepage links to each seeded app on its own host: the current host
   // prefixed with "<app>--".
   const requestHost = new URL(buildUrl({ path: "/" })).host;
@@ -171,6 +178,7 @@ test("routes seeded apps by host and serves worker-bundler browser assets", asyn
   expect(guestbook).toMatchObject({ status: 200 });
   const guestbookHtml = await guestbook.text();
   expect(guestbookHtml).toContain("<title>Guestbook</title>");
+  expect(guestbookHtml).toContain("data-iterate-default-favicon");
   expect(guestbookHtml).toContain(
     '<script type="module" src="/apps/guestbook/client.js"></script>',
   );

--- a/apps/os/e2e/vitest/project-ingress.e2e.test.ts
+++ b/apps/os/e2e/vitest/project-ingress.e2e.test.ts
@@ -29,8 +29,8 @@ test("project ingress serves the static seeded homepage at the root", async () =
   expect(pageResponse).toMatchObject({ status: 200 });
   const homepage = await pageResponse.text();
   expect(homepage).toContain("Hello from your iterate project worker");
-  // The seeded homepage intentionally omits <head>; ingress still places the
-  // default user-space icon before its body (the browser's implied head).
+  // The seeded homepage intentionally omits <head>; ingress still supplies a
+  // default user-space icon after checking the whole document for app icons.
   expect(homepage).toContain(
     `href="/${projectId}/.iterate/favicon.svg" data-iterate-default-favicon`,
   );

--- a/apps/os/e2e/vitest/project-ingress.e2e.test.ts
+++ b/apps/os/e2e/vitest/project-ingress.e2e.test.ts
@@ -31,7 +31,9 @@ test("project ingress serves the static seeded homepage at the root", async () =
   expect(homepage).toContain("Hello from your iterate project worker");
   // The seeded homepage intentionally omits <head>; ingress still places the
   // default user-space icon before its body (the browser's implied head).
-  expect(homepage).toContain("data-iterate-default-favicon");
+  expect(homepage).toContain(
+    `href="/${projectId}/.iterate/favicon.svg" data-iterate-default-favicon`,
+  );
   const favicon = await fetch(buildUrl({ path: `/${projectId}/.iterate/favicon.svg` }));
   expect(favicon).toMatchObject({ status: 200 });
   expect(favicon.headers.get("content-type")).toContain("image/svg+xml");

--- a/apps/os/e2e/vitest/worker-build-overlay.e2e.test.ts
+++ b/apps/os/e2e/vitest/worker-build-overlay.e2e.test.ts
@@ -51,7 +51,7 @@ test(
 
     const customIconSource = original!.content.replace(
       "        <html>\n          <body>",
-      '        <html>\n          <head><link rel="shortcut ICON" href="/my-icon.svg"></head>\n          <body>',
+      '        <html>\n          <body>\n            <link rel="shortcut ICON" href="/my-icon.svg">',
     );
     expect(customIconSource).not.toBe(original!.content);
     const customized = await project.repo.commitFiles({
@@ -63,6 +63,8 @@ test(
       "the worker with its own favicon",
     );
     const customIconHomepage = await customIcon.response.text();
+    // A body icon is valid HTML and can appear after the transform has seen
+    // </head>; the app's icon must still suppress the fallback.
     expect(customIconHomepage).toContain('rel="shortcut ICON" href="/my-icon.svg"');
     expect(customIconHomepage).not.toContain("data-iterate-default-favicon");
 

--- a/apps/os/e2e/vitest/worker-build-overlay.e2e.test.ts
+++ b/apps/os/e2e/vitest/worker-build-overlay.e2e.test.ts
@@ -49,6 +49,23 @@ test(
     const original = await project.repo.readFile({ path: "worker.ts" });
     expect(original?.content).toContain("export default class ProjectWorker");
 
+    const customIconSource = original!.content.replace(
+      "        <html>\n          <body>",
+      '        <html>\n          <head><link rel="shortcut ICON" href="/my-icon.svg"></head>\n          <body>',
+    );
+    expect(customIconSource).not.toBe(original!.content);
+    const customized = await project.repo.commitFiles({
+      changes: [{ path: "worker.ts", content: customIconSource }],
+      message: "set a custom favicon",
+    });
+    const customIcon = await pollHome(
+      ({ commitOid, response }) => response.status === 200 && commitOid === customized.commitOid,
+      "the worker with its own favicon",
+    );
+    const customIconHomepage = await customIcon.response.text();
+    expect(customIconHomepage).toContain('rel="shortcut ICON" href="/my-icon.svg"');
+    expect(customIconHomepage).not.toContain("data-iterate-default-favicon");
+
     await project.repo.commitFiles({
       changes: [{ path: "worker.ts", content: "this is not valid typescript ((((" }],
       message: "break the worker build",

--- a/apps/os/e2e/vitest/worker-build-overlay.e2e.test.ts
+++ b/apps/os/e2e/vitest/worker-build-overlay.e2e.test.ts
@@ -76,7 +76,9 @@ test(
       "worker-bundler's build failure",
     );
     expect(failed.commitOid).toBeNull();
-    expect(await failed.response.text()).toContain("Worker build failed");
+    const failedHomepage = await failed.response.text();
+    expect(failedHomepage).toContain("Worker build failed");
+    expect(failedHomepage).toContain(`href="/${projectId}/.iterate/favicon.svg"`);
 
     const fixed = await project.repo.commitFiles({
       changes: [{ path: "worker.ts", content: original!.content }],

--- a/apps/os/src/domains/itx/itx-entrypoint.ts
+++ b/apps/os/src/domains/itx/itx-entrypoint.ts
@@ -94,7 +94,10 @@ export class ItxEntrypoint extends WorkerEntrypoint<Env, ItxEntrypointProps> {
       // Fetch responses can't carry a named error across the hop the way RPC
       // does; a budget-expired cold build becomes the retryable building
       // page, a failed first-ever build the build-failed page.
-      const buildStatus = workerBuildStatus(error);
+      const buildStatus = workerBuildStatus(
+        error,
+        taken.request.headers.get("x-iterate-url-prefix") ?? "",
+      );
       if (buildStatus !== null) return buildStatus.response;
       throw error;
     }

--- a/apps/os/src/domains/workers/project-serve.test.ts
+++ b/apps/os/src/domains/workers/project-serve.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "vitest";
 import { serveProjectResponse } from "./project-serve.ts";
 import { workerBuildingResponse } from "./worker-fetch-dispatch.ts";
 import { WORKER_SERVE_ERROR_HEADER } from "./worker-serve-info.ts";
+import { WORKER_DEFAULT_FAVICON_PATH } from "./worker-serve-overlay.ts";
 
 // The overlay's HTMLRewriter injection is workerd-only and e2e-proven
 // (worker-build-overlay.e2e.test.ts); these responses all pass the overlay
@@ -26,6 +27,20 @@ test("a healthy response passes through with no outcome", async () => {
   });
   expect(served.outcome).toBeNull();
   expect(served.response).toBe(upstream);
+});
+
+test("the reserved user-space favicon bypasses the dynamic worker", async () => {
+  const served = await serveProjectResponse({
+    fetchWorker: async () => {
+      throw new Error("favicon must not dispatch to user code");
+    },
+    onError: failOnError,
+    request: new Request(`https://app.example.com${WORKER_DEFAULT_FAVICON_PATH}`),
+  });
+  expect(served.outcome).toBeNull();
+  expect(served.response.status).toBe(200);
+  expect(served.response.headers.get("content-type")).toContain("image/svg+xml");
+  expect(await served.response.text()).toContain('fill="white"');
 });
 
 test("document navigations get the short cold-build race, other requests the long one", async () => {

--- a/apps/os/src/domains/workers/project-serve.ts
+++ b/apps/os/src/domains/workers/project-serve.ts
@@ -42,6 +42,7 @@ export async function serveProjectResponse({
   onError: (error: unknown) => void;
   request: Request;
 }): Promise<{ outcome: ProjectServeOutcome | null; response: Response }> {
+  const urlPrefix = request.headers.get("x-iterate-url-prefix") ?? "";
   const favicon = workerDefaultFaviconResponse(request);
   if (favicon !== null) return { outcome: null, response: favicon };
   try {
@@ -57,9 +58,9 @@ export async function serveProjectResponse({
         : null;
     return { outcome, response: applyProjectWorkerOverlay(request, response) };
   } catch (error) {
-    const buildStatus = workerBuildStatus(error);
+    const buildStatus = workerBuildStatus(error, urlPrefix);
     if (buildStatus !== null) return buildStatus;
     onError(error);
-    return { outcome: "worker_serve_error", response: workerServeErrorResponse() };
+    return { outcome: "worker_serve_error", response: workerServeErrorResponse(urlPrefix) };
   }
 }

--- a/apps/os/src/domains/workers/project-serve.ts
+++ b/apps/os/src/domains/workers/project-serve.ts
@@ -4,7 +4,11 @@ import {
   workerBuildStatus,
 } from "./worker-fetch-dispatch.ts";
 import { WORKER_BUILD_FAILED_HEADER } from "./worker-serve-info.ts";
-import { applyProjectWorkerOverlay, workerServeErrorResponse } from "./worker-serve-overlay.ts";
+import {
+  applyProjectWorkerOverlay,
+  workerDefaultFaviconResponse,
+  workerServeErrorResponse,
+} from "./worker-serve-overlay.ts";
 
 /** Long enough for warm-cache loads and quick bundles; past it, show the page. */
 const PROJECT_HOST_BUILD_BUDGET_MS = 15_000;
@@ -20,7 +24,8 @@ type ProjectServeOutcome = "worker_build_failed" | "worker_building" | "worker_s
  * - classification of build-lifecycle errors into their stand-in pages
  *   (workerBuildStatus) and of pages bubbling back from inner hops into
  *   their observability outcomes,
- * - the @iterate overlay on served HTML documents,
+ * - the @iterate overlay and app-override-aware default favicon on served
+ *   HTML documents,
  * - and the catch-all: any other serve failure answers the branded retrying
  *   page instead of escaping as a naked 500/1101 — a project host always
  *   shows platform chrome, however broken the build machinery is. The error
@@ -37,6 +42,8 @@ export async function serveProjectResponse({
   onError: (error: unknown) => void;
   request: Request;
 }): Promise<{ outcome: ProjectServeOutcome | null; response: Response }> {
+  const favicon = workerDefaultFaviconResponse(request);
+  if (favicon !== null) return { outcome: null, response: favicon };
   try {
     const response = await fetchWorker(
       buildBudgetForRequest(request, PROJECT_HOST_BUILD_BUDGET_MS),

--- a/apps/os/src/domains/workers/stateful-worker-durable-object.ts
+++ b/apps/os/src/domains/workers/stateful-worker-durable-object.ts
@@ -79,7 +79,10 @@ export class StatefulWorkerDurableObject extends DurableObject<Env> {
       // Answer the building/failed cases HERE rather than relying on the
       // error name surviving the Durable Object fetch hop back to the
       // dispatching entrypoint — same pages every fetch-lane hop serves.
-      const buildStatus = workerBuildStatus(error);
+      const buildStatus = workerBuildStatus(
+        error,
+        taken.request.headers.get("x-iterate-url-prefix") ?? "",
+      );
       if (buildStatus !== null) return buildStatus.response;
       throw error;
     }

--- a/apps/os/src/domains/workers/worker-fetch-dispatch.test.ts
+++ b/apps/os/src/domains/workers/worker-fetch-dispatch.test.ts
@@ -59,7 +59,7 @@ describe("worker fetch dispatch header", () => {
   });
 
   test("building response is a marked, retryable, self-refreshing 503", async () => {
-    const response = workerBuildingResponse();
+    const response = workerBuildingResponse("/prj_test");
     expect(response.status).toBe(503);
     expect(response.headers.get(WORKER_BUILDING_HEADER)).toBe("1");
     expect(response.headers.get("retry-after")).not.toBeNull();
@@ -72,13 +72,18 @@ describe("worker fetch dispatch header", () => {
     expect(body).toContain('<noscript><meta http-equiv="refresh"');
     expect(body).toContain('data-spinner="true"');
     expect(body).toContain("data-iterate-default-favicon");
+    expect(body).toContain('href="/prj_test/.iterate/favicon.svg"');
   });
 
   test("the classifier answers build-lifecycle errors with their pages, nothing else", async () => {
     // Errors arrive over RPC name-preserved, class identity lost — so the
     // classifier is exercised exactly the way real hops see them.
-    const building = workerBuildStatus(namedError("WorkerBuildInProgressError", "still building"));
+    const building = workerBuildStatus(
+      namedError("WorkerBuildInProgressError", "still building"),
+      "/prj_test",
+    );
     expect(building).toMatchObject({ outcome: "worker_building", response: { status: 503 } });
+    expect(await building!.response.text()).toContain('href="/prj_test/.iterate/favicon.svg"');
     expect(
       workerBuildStatus(namedError("RepoNotSeededError", "config repo is still seeding")),
     ).toMatchObject({ outcome: "worker_building", response: { status: 503 } });
@@ -93,6 +98,7 @@ describe("worker fetch dispatch header", () => {
 
     const failed = workerBuildStatus(
       namedError("WorkerBuildFailedError", "Expected ; but found is"),
+      "/prj_test",
     );
     expect(failed).toMatchObject({ outcome: "worker_build_failed", response: { status: 500 } });
     expect(await failed!.response.text()).toContain("Expected ; but found is");

--- a/apps/os/src/domains/workers/worker-fetch-dispatch.test.ts
+++ b/apps/os/src/domains/workers/worker-fetch-dispatch.test.ts
@@ -71,6 +71,7 @@ describe("worker fetch dispatch header", () => {
     expect(body).toContain(WORKER_BUILDING_HEADER);
     expect(body).toContain('<noscript><meta http-equiv="refresh"');
     expect(body).toContain('data-spinner="true"');
+    expect(body).toContain("data-iterate-default-favicon");
   });
 
   test("the classifier answers build-lifecycle errors with their pages, nothing else", async () => {

--- a/apps/os/src/domains/workers/worker-fetch-dispatch.ts
+++ b/apps/os/src/domains/workers/worker-fetch-dispatch.ts
@@ -88,8 +88,8 @@ export const WORKER_BUILDING_HEADER = "x-iterate-worker-building";
 /** The one cold-build response every fetch-lane hop answers with: a polling
  * page for browsers (meta refresh for no-JS clients), retry-after + the
  * marker header for programmatic clients. */
-export function workerBuildingResponse(): Response {
-  return new Response(workerBuildingPageHtml(WORKER_BUILDING_HEADER), {
+export function workerBuildingResponse(urlPrefix = ""): Response {
+  return new Response(workerBuildingPageHtml(WORKER_BUILDING_HEADER, urlPrefix), {
     headers: {
       "content-type": "text/html; charset=utf-8",
       "retry-after": "2",
@@ -111,6 +111,7 @@ export function workerBuildingResponse(): Response {
  */
 export function workerBuildStatus(
   error: unknown,
+  urlPrefix = "",
 ): { outcome: "worker_build_failed" | "worker_building"; response: Response } | null {
   // RepoNotSeededError: a browser can reach a project host inside the
   // project's BIRTH window — the config repo's stream exists before its seed
@@ -120,10 +121,13 @@ export function workerBuildStatus(
   // Cloudflare 1101 on a fresh project's first app request (observed live on
   // preview e2e, 2026-07-17).
   if (isRepoNotSeededError(error) || isWorkerBuildInProgressError(error)) {
-    return { outcome: "worker_building", response: workerBuildingResponse() };
+    return { outcome: "worker_building", response: workerBuildingResponse(urlPrefix) };
   }
   if (isWorkerBuildFailedError(error)) {
-    return { outcome: "worker_build_failed", response: workerBuildFailedResponse(error) };
+    return {
+      outcome: "worker_build_failed",
+      response: workerBuildFailedResponse(error, urlPrefix),
+    };
   }
   return null;
 }

--- a/apps/os/src/domains/workers/worker-serve-overlay.test.ts
+++ b/apps/os/src/domains/workers/worker-serve-overlay.test.ts
@@ -7,7 +7,12 @@ import {
   withWorkerCommit,
 } from "./worker-serve-info.ts";
 import {
+  relIncludesIcon,
+  WORKER_DEFAULT_FAVICON_PATH,
+  workerDefaultFaviconHtml,
+  workerDefaultFaviconResponse,
   workerBuildFailedResponse,
+  workerFaviconDecision,
   workerOverlayDecision,
   workerOverlayHtml,
   workerServeErrorResponse,
@@ -93,6 +98,44 @@ describe("workerOverlayDecision", () => {
   });
 });
 
+describe("user-space favicon", () => {
+  const documentRequest = new Request("https://app.example.com/");
+
+  test("recognizes icon as a case-insensitive rel token", () => {
+    expect(relIncludesIcon("icon")).toBe(true);
+    expect(relIncludesIcon("shortcut ICON")).toBe(true);
+    expect(relIncludesIcon("apple-touch-icon")).toBe(false);
+    expect(relIncludesIcon(null)).toBe(false);
+  });
+
+  test("uses an inverted Iterate mark", async () => {
+    const html = workerDefaultFaviconHtml();
+    expect(html).toContain('rel="icon"');
+    expect(html).toContain("data-iterate-default-favicon");
+    expect(html).toContain(`href="${WORKER_DEFAULT_FAVICON_PATH}"`);
+    const response = workerDefaultFaviconResponse(
+      new Request(`https://app.example.com${WORKER_DEFAULT_FAVICON_PATH}`),
+    );
+    expect(response).not.toBeNull();
+    expect(response!.headers.get("content-type")).toContain("image/svg+xml");
+    const svg = await response!.text();
+    expect(svg).toContain('<rect width="500" height="500" fill="white"');
+    expect(svg.match(/fill="black"/g)).toHaveLength(2);
+  });
+
+  test("remains eligible when only the inline overlay is opted out", () => {
+    expect(
+      workerFaviconDecision(
+        documentRequest,
+        htmlResponse({
+          [OVERLAY_OPT_OUT_HEADER]: "1",
+          "content-security-policy": "default-src 'self'",
+        }),
+      ),
+    ).toBe(true);
+  });
+});
+
 describe("workerOverlayHtml", () => {
   test("carries the iterate mark and the serve info", () => {
     const html = workerOverlayHtml({ commitOid, kind: "live" });
@@ -143,6 +186,7 @@ describe("workerServeErrorResponse", () => {
     // An error pops its details open immediately; nothing spins on it.
     expect(body).toContain('<div id="panel">');
     expect(body).toContain('[data-kind="serveError"] #ring rect { stroke-dasharray: none');
+    expect(body).toContain("data-iterate-default-favicon");
   });
 });
 
@@ -159,5 +203,6 @@ describe("workerBuildFailedResponse", () => {
     expect(body).not.toContain("<b>zod</b>");
     expect(body).toContain("then reload this page");
     expect(body).not.toContain("const poll = async");
+    expect(body).toContain("data-iterate-default-favicon");
   });
 });

--- a/apps/os/src/domains/workers/worker-serve-overlay.test.ts
+++ b/apps/os/src/domains/workers/worker-serve-overlay.test.ts
@@ -12,7 +12,6 @@ import {
   workerDefaultFaviconHtml,
   workerDefaultFaviconResponse,
   workerBuildFailedResponse,
-  workerFaviconDecision,
   workerOverlayDecision,
   workerOverlayHtml,
   workerServeErrorResponse,
@@ -99,8 +98,6 @@ describe("workerOverlayDecision", () => {
 });
 
 describe("user-space favicon", () => {
-  const documentRequest = new Request("https://app.example.com/");
-
   test("recognizes icon as a case-insensitive rel token", () => {
     expect(relIncludesIcon("icon")).toBe(true);
     expect(relIncludesIcon("shortcut ICON")).toBe(true);
@@ -123,16 +120,10 @@ describe("user-space favicon", () => {
     expect(svg.match(/fill="black"/g)).toHaveLength(2);
   });
 
-  test("remains eligible when only the inline overlay is opted out", () => {
-    expect(
-      workerFaviconDecision(
-        documentRequest,
-        htmlResponse({
-          [OVERLAY_OPT_OUT_HEADER]: "1",
-          "content-security-policy": "default-src 'self'",
-        }),
-      ),
-    ).toBe(true);
+  test("includes the browser-visible project prefix on the path lane", () => {
+    expect(workerDefaultFaviconHtml("/prj_test")).toContain(
+      `href="/prj_test${WORKER_DEFAULT_FAVICON_PATH}"`,
+    );
   });
 });
 
@@ -173,7 +164,7 @@ describe("workerOverlayHtml", () => {
 
 describe("workerServeErrorResponse", () => {
   test("marked, self-retrying, overlay-exempt 500 that keeps internals in the logs", async () => {
-    const response = workerServeErrorResponse();
+    const response = workerServeErrorResponse("/prj_test");
     expect(response.status).toBe(500);
     expect(response.headers.get(WORKER_SERVE_ERROR_HEADER)).toBe("1");
     expect(response.headers.get(OVERLAY_OPT_OUT_HEADER)).toBe("1");
@@ -187,12 +178,16 @@ describe("workerServeErrorResponse", () => {
     expect(body).toContain('<div id="panel">');
     expect(body).toContain('[data-kind="serveError"] #ring rect { stroke-dasharray: none');
     expect(body).toContain("data-iterate-default-favicon");
+    expect(body).toContain(`href="/prj_test${WORKER_DEFAULT_FAVICON_PATH}"`);
   });
 });
 
 describe("workerBuildFailedResponse", () => {
   test("marked 500 with the bundler's error, script-inert, overlay-exempt", async () => {
-    const response = workerBuildFailedResponse(new Error('Could not resolve "<b>zod</b>"'));
+    const response = workerBuildFailedResponse(
+      new Error('Could not resolve "<b>zod</b>"'),
+      "/prj_test",
+    );
     expect(response.status).toBe(500);
     expect(response.headers.get(WORKER_BUILD_FAILED_HEADER)).toBe("1");
     expect(response.headers.get(OVERLAY_OPT_OUT_HEADER)).toBe("1");
@@ -204,5 +199,6 @@ describe("workerBuildFailedResponse", () => {
     expect(body).toContain("then reload this page");
     expect(body).not.toContain("const poll = async");
     expect(body).toContain("data-iterate-default-favicon");
+    expect(body).toContain(`href="/prj_test${WORKER_DEFAULT_FAVICON_PATH}"`);
   });
 });

--- a/apps/os/src/domains/workers/worker-serve-overlay.ts
+++ b/apps/os/src/domains/workers/worker-serve-overlay.ts
@@ -38,8 +38,9 @@ export const ITERATE_MARK_SVG = iterateMarkSvg("black", "white");
 const USERSPACE_FAVICON_SVG = iterateMarkSvg("white", "black");
 export const WORKER_DEFAULT_FAVICON_PATH = "/.iterate/favicon.svg";
 
-export function workerDefaultFaviconHtml(): string {
-  return `<link rel="icon" type="image/svg+xml" href="${WORKER_DEFAULT_FAVICON_PATH}" data-iterate-default-favicon>`;
+export function workerDefaultFaviconHtml(urlPrefix = ""): string {
+  const href = escapeHtml(`${urlPrefix}${WORKER_DEFAULT_FAVICON_PATH}`);
+  return `<link rel="icon" type="image/svg+xml" href="${href}" data-iterate-default-favicon>`;
 }
 
 /** The same-origin asset referenced by the injected link. Keeping this out of
@@ -193,6 +194,7 @@ function standInPageHtml(input: {
   script?: string;
   state: WorkerOverlayState;
   title: string;
+  urlPrefix?: string;
 }): string {
   return `<!doctype html>
 <html>
@@ -200,7 +202,7 @@ function standInPageHtml(input: {
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>${escapeHtml(input.title)}</title>
-    ${workerDefaultFaviconHtml()}
+    ${workerDefaultFaviconHtml(input.urlPrefix)}
     ${input.head ?? ""}
     <style>
       body { margin: 0; min-height: 100vh; background: #fff; }
@@ -232,12 +234,13 @@ function reloadWhenHeaderClearsScript(headerName: string, intervalMs: number): s
  * 503/WORKER_BUILDING_HEADER contract by workerBuildingResponse, which also
  * owns that header's name — passed in here to keep the dependency one-way.
  */
-export function workerBuildingPageHtml(buildingHeader: string): string {
+export function workerBuildingPageHtml(buildingHeader: string, urlPrefix = ""): string {
   return standInPageHtml({
     head: `<noscript><meta http-equiv="refresh" content="3" /></noscript>`,
     script: `<script>${reloadWhenHeaderClearsScript(buildingHeader, 1_500)}</script>`,
     state: { kind: "building" },
     title: "Building…",
+    urlPrefix,
   });
 }
 
@@ -246,11 +249,12 @@ export function workerBuildingPageHtml(buildingHeader: string): string {
  * error waits in the click-open menu. No automatic retry of a potentially
  * broken source — fixing it and reloading heals.
  */
-export function workerBuildFailedResponse(error: unknown): Response {
+export function workerBuildFailedResponse(error: unknown, urlPrefix = ""): Response {
   return new Response(
     standInPageHtml({
       state: { kind: "buildFailed", message: buildFailureMessageFromError(error) },
       title: "Worker build failed",
+      urlPrefix,
     }),
     {
       headers: {
@@ -270,13 +274,14 @@ export function workerBuildFailedResponse(error: unknown): Response {
  * dependency hiccup), so the red ring keeps spinning and the page polls its
  * way back into the app; internals stay in the logs.
  */
-export function workerServeErrorResponse(): Response {
+export function workerServeErrorResponse(urlPrefix = ""): Response {
   return new Response(
     standInPageHtml({
       head: `<noscript><meta http-equiv="refresh" content="5" /></noscript>`,
       script: `<script>${reloadWhenHeaderClearsScript(WORKER_SERVE_ERROR_HEADER, 3_000)}</script>`,
       state: { kind: "serveError" },
       title: "Something went wrong",
+      urlPrefix,
     }),
     {
       headers: {
@@ -308,10 +313,6 @@ function workerHtmlDocumentCommit(request: Request, response: Response): string 
   return raw.length > 0 ? raw : null;
 }
 
-export function workerFaviconDecision(request: Request, response: Response): boolean {
-  return workerHtmlDocumentCommit(request, response) !== null;
-}
-
 export function workerOverlayDecision(request: Request, response: Response): string | null {
   const commitOid = workerHtmlDocumentCommit(request, response);
   if (commitOid === null) return null;
@@ -330,8 +331,9 @@ export function workerOverlayDecision(request: Request, response: Response): str
  * through untouched.
  */
 export function applyProjectWorkerOverlay(request: Request, response: Response): Response {
-  if (!workerFaviconDecision(request, response)) return response;
+  if (workerHtmlDocumentCommit(request, response) === null) return response;
   const commitOid = workerOverlayDecision(request, response);
+  const urlPrefix = request.headers.get("x-iterate-url-prefix") ?? "";
   let hasFavicon = false;
   let insertedFavicon = false;
   let sawHead = false;
@@ -346,7 +348,7 @@ export function applyProjectWorkerOverlay(request: Request, response: Response):
         sawHead = true;
         element.onEndTag((endTag) => {
           if (!hasFavicon) {
-            endTag.before(workerDefaultFaviconHtml(), { html: true });
+            endTag.before(workerDefaultFaviconHtml(urlPrefix), { html: true });
             insertedFavicon = true;
           }
         });
@@ -358,7 +360,7 @@ export function applyProjectWorkerOverlay(request: Request, response: Response):
         // the link immediately before body lets the browser put it in the
         // implied head without buffering the document.
         if (!sawHead && !hasFavicon) {
-          element.before(workerDefaultFaviconHtml(), { html: true });
+          element.before(workerDefaultFaviconHtml(urlPrefix), { html: true });
           insertedFavicon = true;
         }
         if (commitOid !== null) {
@@ -371,7 +373,7 @@ export function applyProjectWorkerOverlay(request: Request, response: Response):
         // Keep even malformed/minimal HTML branded when it has neither an
         // explicit head nor body. Browsers accept rel=icon at document end.
         if (!hasFavicon && !insertedFavicon) {
-          end.append(workerDefaultFaviconHtml(), { html: true });
+          end.append(workerDefaultFaviconHtml(urlPrefix), { html: true });
         }
       },
     });

--- a/apps/os/src/domains/workers/worker-serve-overlay.ts
+++ b/apps/os/src/domains/workers/worker-serve-overlay.ts
@@ -325,44 +325,24 @@ export function workerOverlayDecision(request: Request, response: Response): str
 
 /**
  * Ingress's one call: dress a project-worker response in the platform's
- * user-space chrome. HTML documents get the default favicon before </head>
- * unless the app supplied one, plus (when allowed) the widget before </body>.
- * HTMLRewriter keeps the transformation streaming; everything else passes
- * through untouched.
+ * user-space chrome. HTML documents get the default favicon at document end
+ * unless the app supplied one anywhere, plus (when allowed) the widget before
+ * </body>. HTMLRewriter keeps the transformation streaming; everything else
+ * passes through untouched.
  */
 export function applyProjectWorkerOverlay(request: Request, response: Response): Response {
   if (workerHtmlDocumentCommit(request, response) === null) return response;
   const commitOid = workerOverlayDecision(request, response);
   const urlPrefix = request.headers.get("x-iterate-url-prefix") ?? "";
   let hasFavicon = false;
-  let insertedFavicon = false;
-  let sawHead = false;
   const rewriter = new HTMLRewriter()
     .on("link", {
       element(element) {
         hasFavicon ||= relIncludesIcon(element.getAttribute("rel"));
       },
     })
-    .on("head", {
-      element(element) {
-        sawHead = true;
-        element.onEndTag((endTag) => {
-          if (!hasFavicon) {
-            endTag.before(workerDefaultFaviconHtml(urlPrefix), { html: true });
-            insertedFavicon = true;
-          }
-        });
-      },
-    })
     .on("body", {
       element(element) {
-        // A head element is optional HTML. When the app omitted it, placing
-        // the link immediately before body lets the browser put it in the
-        // implied head without buffering the document.
-        if (!sawHead && !hasFavicon) {
-          element.before(workerDefaultFaviconHtml(urlPrefix), { html: true });
-          insertedFavicon = true;
-        }
         if (commitOid !== null) {
           element.append(workerOverlayHtml({ commitOid, kind: "live" }), { html: true });
         }
@@ -370,9 +350,10 @@ export function applyProjectWorkerOverlay(request: Request, response: Response):
     })
     .onDocument({
       end(end) {
-        // Keep even malformed/minimal HTML branded when it has neither an
-        // explicit head nor body. Browsers accept rel=icon at document end.
-        if (!hasFavicon && !insertedFavicon) {
+        // Wait until every app-authored link has been observed: rel=icon is
+        // legal in the body too, and the app's icon always wins. Browsers
+        // accept the fallback link at document end even without head/body.
+        if (!hasFavicon) {
           end.append(workerDefaultFaviconHtml(urlPrefix), { html: true });
         }
       },

--- a/apps/os/src/domains/workers/worker-serve-overlay.ts
+++ b/apps/os/src/domains/workers/worker-serve-overlay.ts
@@ -18,11 +18,47 @@ import {
  * document mounting the SAME overlay component in the matching state:
  * a spinner ring tracing the mark's border while something is happening,
  * a red ring for errors, a tooltip on hover, details in a click-open menu.
+ * The same streaming transform supplies an inverted Iterate favicon only
+ * when the user-space document did not provide a rel=icon link itself.
  */
 
-/** The iterate mark — the letter i from the product logo. Also the face of
+/** The Iterate mark's canonical path geometry. */
+const ITERATE_I_PATH =
+  "M264.649 170.149H289.821L286.092 186.904L276.303 233.444L270.709 259.971L263.717 293.015L258.124 320.008L251.131 352.586L249.267 364.687V371.668L249.733 372.133H253.462L259.522 369.806L266.048 365.617L275.371 357.24L282.829 349.328L286.558 345.14L288.888 346.071L294.948 350.725L308 360.498L307.068 362.36L303.339 367.944L296.813 376.322L291.685 382.837L286.558 388.422L282.363 393.076L275.837 399.592L272.108 402.849L267.446 406.573L262.785 409.83L256.725 413.554L247.869 417.742L238.08 420.535L231.554 421H224.096L216.637 420.069L211.51 418.673L206.382 416.811L201.255 413.088L196.594 408.434L192.865 400.988L191.466 394.938L191 389.818V383.768L193.797 365.152L199.857 335.832L207.315 301.392L224.096 223.205L225.028 216.224V206.916L224.562 205.054L222.231 204.123L219.434 203.193L206.382 203.658L196.127 204.589H193.331V178.526L194.263 175.734L258.59 170.615L264.649 170.149Z";
+const ITERATE_DOT_PATH =
+  "M264.649 78H268.844L275.836 78.9308L282.362 80.7924L287.49 83.5848L292.151 87.7734L295.414 92.8928L297.278 96.616L299.143 105.924L299.609 113.836L299.143 118.49L298.677 122.213L296.812 128.729L293.549 134.779L290.286 138.502L286.091 141.76L282.362 143.621L278.167 145.018L274.438 145.948L267.912 146.414H260.92L254.394 145.483L249.267 144.087L244.139 141.294L239.944 138.037L236.681 133.383L233.884 127.332L232.486 121.282L232.02 117.559V108.716L232.952 101.735L234.816 95.6852L237.613 90.1004L240.41 86.3772L246.936 82.1886L252.529 79.8616L259.522 78.4654L264.649 78Z";
+
+/** The Iterate mark — the letter i from the product logo. Also the face of
  * platform-chrome pages outside this module (the project-app sign-in page). */
-export const ITERATE_MARK_SVG = `<svg class="mark" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg" aria-label="iterate"><rect width="500" height="500" fill="black" rx="112"/><g transform="translate(20 20) scale(0.92)"><path d="M264.649 170.149H289.821L286.092 186.904L276.303 233.444L270.709 259.971L263.717 293.015L258.124 320.008L251.131 352.586L249.267 364.687V371.668L249.733 372.133H253.462L259.522 369.806L266.048 365.617L275.371 357.24L282.829 349.328L286.558 345.14L288.888 346.071L294.948 350.725L308 360.498L307.068 362.36L303.339 367.944L296.813 376.322L291.685 382.837L286.558 388.422L282.363 393.076L275.837 399.592L272.108 402.849L267.446 406.573L262.785 409.83L256.725 413.554L247.869 417.742L238.08 420.535L231.554 421H224.096L216.637 420.069L211.51 418.673L206.382 416.811L201.255 413.088L196.594 408.434L192.865 400.988L191.466 394.938L191 389.818V383.768L193.797 365.152L199.857 335.832L207.315 301.392L224.096 223.205L225.028 216.224V206.916L224.562 205.054L222.231 204.123L219.434 203.193L206.382 203.658L196.127 204.589H193.331V178.526L194.263 175.734L258.59 170.615L264.649 170.149Z" fill="white"/><path d="M264.649 78H268.844L275.836 78.9308L282.362 80.7924L287.49 83.5848L292.151 87.7734L295.414 92.8928L297.278 96.616L299.143 105.924L299.609 113.836L299.143 118.49L298.677 122.213L296.812 128.729L293.549 134.779L290.286 138.502L286.091 141.76L282.362 143.621L278.167 145.018L274.438 145.948L267.912 146.414H260.92L254.394 145.483L249.267 144.087L244.139 141.294L239.944 138.037L236.681 133.383L233.884 127.332L232.486 121.282L232.02 117.559V108.716L232.952 101.735L234.816 95.6852L237.613 90.1004L240.41 86.3772L246.936 82.1886L252.529 79.8616L259.522 78.4654L264.649 78Z" fill="white"/></g></svg>`;
+function iterateMarkSvg(background: "black" | "white", foreground: "black" | "white"): string {
+  return `<svg class="mark" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg" aria-label="iterate"><rect width="500" height="500" fill="${background}" rx="112"/><g transform="translate(20 20) scale(0.92)"><path d="${ITERATE_I_PATH}" fill="${foreground}"/><path d="${ITERATE_DOT_PATH}" fill="${foreground}"/></g></svg>`;
+}
+
+export const ITERATE_MARK_SVG = iterateMarkSvg("black", "white");
+const USERSPACE_FAVICON_SVG = iterateMarkSvg("white", "black");
+export const WORKER_DEFAULT_FAVICON_PATH = "/.iterate/favicon.svg";
+
+export function workerDefaultFaviconHtml(): string {
+  return `<link rel="icon" type="image/svg+xml" href="${WORKER_DEFAULT_FAVICON_PATH}" data-iterate-default-favicon>`;
+}
+
+/** The same-origin asset referenced by the injected link. Keeping this out of
+ * a data URL lets ordinary `img-src 'self'` CSPs accept the default. */
+export function workerDefaultFaviconResponse(request: Request): Response | null {
+  if (new URL(request.url).pathname !== WORKER_DEFAULT_FAVICON_PATH) return null;
+  if (request.method !== "GET" && request.method !== "HEAD") return null;
+  return new Response(request.method === "HEAD" ? null : USERSPACE_FAVICON_SVG, {
+    headers: {
+      "cache-control": "public, max-age=3600",
+      "content-type": "image/svg+xml; charset=utf-8",
+      "x-content-type-options": "nosniff",
+    },
+  });
+}
+
+export function relIncludesIcon(rel: string | null): boolean {
+  return rel?.split(/\s+/).some((token) => token.toLowerCase() === "icon") ?? false;
+}
 
 function escapeHtml(text: string): string {
   return text
@@ -164,6 +200,7 @@ function standInPageHtml(input: {
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>${escapeHtml(input.title)}</title>
+    ${workerDefaultFaviconHtml()}
     ${input.head ?? ""}
     <style>
       body { margin: 0; min-height: 100vh; background: #fff; }
@@ -254,24 +291,15 @@ export function workerServeErrorResponse(): Response {
   );
 }
 
-/**
- * Whether (and with what) to inject the overlay into a project-lane response:
- * an HTML document carrying platform serve info, not a socket, not opted out,
- * and nothing we would corrupt by transforming (own CSP, pre-encoded body).
- * Exported for unit tests — the HTMLRewriter call itself is proven in e2e
- * (workerd-only API).
- */
-export function workerOverlayDecision(request: Request, response: Response): string | null {
+/** The common streaming-transform boundary: a project-served HTML document,
+ * not a socket, encoded body, or subresource. */
+function workerHtmlDocumentCommit(request: Request, response: Response): string | null {
   if (response.status === 101 || response.webSocket || response.body === null) return null;
   const raw = response.headers.get(WORKER_SERVE_HEADER);
   if (raw === null) return null;
   if (!response.headers.get("content-type")?.includes("text/html")) return null;
-  if (response.headers.has(OVERLAY_OPT_OUT_HEADER)) return null;
-  // A page with its own CSP likely forbids inline scripts — injecting would
-  // only produce console errors, never a widget. A pre-encoded body (a worker
-  // returning bytes it compressed itself) cannot be parsed, let alone
-  // transformed.
-  if (response.headers.has("content-security-policy")) return null;
+  // A pre-encoded body (a worker returning bytes it compressed itself) cannot
+  // be parsed, let alone transformed.
   if (response.headers.has("content-encoding")) return null;
   // Subresource fetches (XHR returning HTML fragments) don't need chrome;
   // absent sec-fetch-dest (curl, old clients) counts as a document.
@@ -280,22 +308,74 @@ export function workerOverlayDecision(request: Request, response: Response): str
   return raw.length > 0 ? raw : null;
 }
 
+export function workerFaviconDecision(request: Request, response: Response): boolean {
+  return workerHtmlDocumentCommit(request, response) !== null;
+}
+
+export function workerOverlayDecision(request: Request, response: Response): string | null {
+  const commitOid = workerHtmlDocumentCommit(request, response);
+  if (commitOid === null) return null;
+  if (response.headers.has(OVERLAY_OPT_OUT_HEADER)) return null;
+  // A page with its own CSP likely forbids the inline overlay script. The
+  // favicon remains eligible: an app can override it with any rel=icon link.
+  if (response.headers.has("content-security-policy")) return null;
+  return commitOid;
+}
+
 /**
  * Ingress's one call: dress a project-worker response in the platform's
- * overlay. HTML documents get the widget appended before </body> via
- * HTMLRewriter (streaming — bytes flow while the parser looks for the body
- * end tag); everything else passes through untouched.
+ * user-space chrome. HTML documents get the default favicon before </head>
+ * unless the app supplied one, plus (when allowed) the widget before </body>.
+ * HTMLRewriter keeps the transformation streaming; everything else passes
+ * through untouched.
  */
 export function applyProjectWorkerOverlay(request: Request, response: Response): Response {
+  if (!workerFaviconDecision(request, response)) return response;
   const commitOid = workerOverlayDecision(request, response);
-  if (commitOid === null) return response;
-  const transformed = new HTMLRewriter()
-    .on("body", {
+  let hasFavicon = false;
+  let insertedFavicon = false;
+  let sawHead = false;
+  const rewriter = new HTMLRewriter()
+    .on("link", {
       element(element) {
-        element.append(workerOverlayHtml({ commitOid, kind: "live" }), { html: true });
+        hasFavicon ||= relIncludesIcon(element.getAttribute("rel"));
       },
     })
-    .transform(response);
+    .on("head", {
+      element(element) {
+        sawHead = true;
+        element.onEndTag((endTag) => {
+          if (!hasFavicon) {
+            endTag.before(workerDefaultFaviconHtml(), { html: true });
+            insertedFavicon = true;
+          }
+        });
+      },
+    })
+    .on("body", {
+      element(element) {
+        // A head element is optional HTML. When the app omitted it, placing
+        // the link immediately before body lets the browser put it in the
+        // implied head without buffering the document.
+        if (!sawHead && !hasFavicon) {
+          element.before(workerDefaultFaviconHtml(), { html: true });
+          insertedFavicon = true;
+        }
+        if (commitOid !== null) {
+          element.append(workerOverlayHtml({ commitOid, kind: "live" }), { html: true });
+        }
+      },
+    })
+    .onDocument({
+      end(end) {
+        // Keep even malformed/minimal HTML branded when it has neither an
+        // explicit head nor body. Browsers accept rel=icon at document end.
+        if (!hasFavicon && !insertedFavicon) {
+          end.append(workerDefaultFaviconHtml(), { html: true });
+        }
+      },
+    });
+  const transformed = rewriter.transform(response);
   const out = new Response(transformed.body, transformed);
   // The transform changes byte length, and fetch already decompressed the
   // upstream body — a copied length header would lie about this body.

--- a/apps/os/src/worker.ts
+++ b/apps/os/src/worker.ts
@@ -222,7 +222,8 @@ async function apiFetch(
     });
     // The serve envelope (domains/workers/project-serve.ts) owns everything a
     // browser sees around the dispatch: cold-build budget, building /
-    // build-failed / serve-error stand-in pages, the @iterate overlay.
+    // build-failed / serve-error stand-in pages, the @iterate overlay, and
+    // the default user-space favicon.
     const { outcome, response } = await serveProjectResponse({
       fetchWorker: (buildBudgetMs) =>
         runner.fetch({
@@ -244,7 +245,13 @@ async function apiFetch(
           waitUntil: (promise) => ctx.waitUntil(promise),
         });
       },
-      request,
+      // Use the worker-visible URL so the /prj_<id>/... development lane
+      // recognizes reserved project paths after its prefix rewrite. Preserve
+      // the routed headers: serve policy only needs request metadata.
+      request: new Request(route.fetch.url, {
+        headers: route.fetch.headers,
+        method: route.fetch.method,
+      }),
     });
     if (outcome !== null) wideLogger.setOutcome(outcome);
     return response;

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -327,7 +327,7 @@ describe("preview workflow scope", () => {
         headSha,
       }),
     ).toEqual([
-      "OS_BASE_URL=https://os.iterate-preview-7.com",
+      "APP_CONFIG_BASE_URL=https://os.iterate-preview-7.com",
       "PETSHOP_BASE_URL=https://dummy-petshop.iterate-preview-7.com",
     ]);
   });

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -282,6 +282,10 @@ describe("preview workflow scope", () => {
         "dummy-petshop": "PETSHOP_BASE_URL",
       },
     });
+    expect(os.resolvePreviewAppConfig?.("preview_3")).toEqual({
+      baseUrl: "https://os.iterate-preview-3.com",
+      projectHostnameBases: ["iterate-preview-3.app"],
+    });
     expect(
       readFileSync(resolve(repoRoot, ".depot/workflows/cloudflare-previews.yml"), "utf8"),
     ).toContain("- packages/iterate/**");

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -222,6 +222,26 @@ describe("preview workflow scope", () => {
     expect(cloudflarePreviewSharedPaths).toContain("patches/**");
   });
 
+  test("reads every app's public preview origin from envs.ts", () => {
+    expect(
+      Object.fromEntries(
+        Object.entries(cloudflarePreviewApps).map(([slug, app]) => [
+          slug,
+          app.resolvePreviewAppConfig("preview_3"),
+        ]),
+      ),
+    ).toEqual({
+      auth: { baseUrl: "https://auth.iterate-preview-3.com" },
+      "dummy-petshop": { baseUrl: "https://dummy-petshop.iterate-preview-3.com" },
+      os: {
+        baseUrl: "https://os.iterate-preview-3.com",
+        projectHostnameBases: ["iterate-preview-3.app"],
+      },
+      semaphore: { baseUrl: "https://semaphore.iterate-preview-3.com" },
+      "streams-example-app": { baseUrl: "https://streams.iterate-preview-3.com" },
+    });
+  });
+
   test("runs the auth OAuth provider e2e against its deployed preview", () => {
     // The auth lane runs the full apps/auth/e2e suite (authorize → code →
     // token exchange), not a discovery curl: a bare metadata probe is what
@@ -281,10 +301,6 @@ describe("preview workflow scope", () => {
       previewTestDependencyBaseUrlEnvVars: {
         "dummy-petshop": "PETSHOP_BASE_URL",
       },
-    });
-    expect(os.resolvePreviewAppConfig?.("preview_3")).toEqual({
-      baseUrl: "https://os.iterate-preview-3.com",
-      projectHostnameBases: ["iterate-preview-3.app"],
     });
     expect(
       readFileSync(resolve(repoRoot, ".depot/workflows/cloudflare-previews.yml"), "utf8"),

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -1673,7 +1673,7 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
     // retry-clean historical full-fleet deploys completed around 72s.
     previewDeployBudgetMs: 90_000,
     previewTestBudgetMs: 100_000,
-    previewTestBaseUrlEnvVar: "OS_BASE_URL",
+    previewTestBaseUrlEnvVar: "APP_CONFIG_BASE_URL",
     previewTestDependencyBaseUrlEnvVars: {
       "dummy-petshop": "PETSHOP_BASE_URL",
     },

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -13,7 +13,14 @@ import {
   deploymentReadinessProbeWaveCount,
 } from "../../apps/os/src/deployment-readiness.ts";
 import { createSemaphoreClient } from "../../apps/semaphore/src/contract.ts";
-import { dummyPetshopEnvs, envs as osEnvs, previewEnvironmentSlotNumbers } from "../../envs.ts";
+import {
+  authEnvs,
+  dummyPetshopEnvs,
+  envs as osEnvs,
+  previewEnvironmentSlotNumbers,
+  semaphoreEnvs,
+  streamsExampleEnvs,
+} from "../../envs.ts";
 import { createSemaphoreTokenProvider } from "../auth/semaphore-token.ts";
 import { markdownAnnotator } from "../../packages/shared/src/dev/markdown-annotator.ts";
 import { stripAnsi } from "../../packages/shared/src/dev/strip-ansi.ts";
@@ -1351,11 +1358,10 @@ export type CloudflarePreviewApp = {
   destroyCommandArgs: readonly [string, ...string[]];
   dopplerProject: string;
   /**
-   * Resolve non-secret public app config from the repo instead of Doppler.
-   * Most apps mirror this into APP_CONFIG_BASE_URL; apps whose envs.ts entry
-   * is the sole source of truth can opt into that source directly.
+   * Resolve non-secret public app config from envs.ts. Doppler supplies only
+   * secrets; readiness probes merge their bearer token into this config.
    */
-  resolvePreviewAppConfig?: (dopplerConfig: string) => {
+  resolvePreviewAppConfig: (dopplerConfig: string) => {
     baseUrl: string;
     projectHostnameBases?: string[];
   };
@@ -1750,6 +1756,13 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
     // self-cleans; there is nothing slot-scoped to erase on release.
     destroyCommandArgs: ["pnpm", "run-script", "destroy"],
     dopplerProject: "semaphore",
+    resolvePreviewAppConfig: (dopplerConfig) => {
+      const env = semaphoreEnvs[dopplerConfig as keyof typeof semaphoreEnvs];
+      if (!env) {
+        throw new Error(`Unknown Semaphore environment ${JSON.stringify(dopplerConfig)}.`);
+      }
+      return { baseUrl: env.baseUrl };
+    },
     paths: ["apps/semaphore/**"],
     // Co-select auth for an environment-coherent test run. Deploys are independent.
     previewDependencies: ["auth"],
@@ -1780,6 +1793,13 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
     deployCommandArgs: ["pnpm", "run-script", "deploy"],
     destroyCommandArgs: ["pnpm", "run-script", "destroy"],
     dopplerProject: "auth",
+    resolvePreviewAppConfig: (dopplerConfig) => {
+      const env = authEnvs[dopplerConfig as keyof typeof authEnvs];
+      if (!env) {
+        throw new Error(`Unknown Auth environment ${JSON.stringify(dopplerConfig)}.`);
+      }
+      return { baseUrl: env.authBaseUrl };
+    },
     paths: ["apps/auth/**", "apps/auth-contract/**"],
     // better-auth's liveness endpoint; auth has no /api/__internal/health.
     previewReadyUrlPath: "/api/auth/ok",
@@ -1801,6 +1821,15 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
     deployCommandArgs: ["pnpm", "run-script", "deploy"],
     destroyCommandArgs: ["pnpm", "run-script", "destroy"],
     dopplerProject: "streams-example-app",
+    resolvePreviewAppConfig: (dopplerConfig) => {
+      const env = streamsExampleEnvs[dopplerConfig as keyof typeof streamsExampleEnvs];
+      if (!env) {
+        throw new Error(
+          `Unknown streams-example-app environment ${JSON.stringify(dopplerConfig)}.`,
+        );
+      }
+      return { baseUrl: env.baseUrl };
+    },
     paths: ["apps/streams-example-app/**", "apps/os/src/domains/streams/**"],
     previewDependencies: ["auth"],
     previewReadyUrlPath: "/api/__internal/health",
@@ -3637,8 +3666,8 @@ async function readPreviewAppConfig(input: {
     }
     return parsed;
   };
-  const repoConfig = input.app.resolvePreviewAppConfig?.(input.dopplerConfig);
-  if (repoConfig && !input.app.previewReadyBearerTokenEnvVar) {
+  const repoConfig = input.app.resolvePreviewAppConfig(input.dopplerConfig);
+  if (!input.app.previewReadyBearerTokenEnvVar) {
     return parsePreviewAppConfig(repoConfig);
   }
 
@@ -3691,7 +3720,7 @@ async function readPreviewAppConfig(input: {
 
   const dopplerConfig: unknown = JSON.parse(result.stdout);
   return parsePreviewAppConfig(
-    repoConfig && typeof dopplerConfig === "object" && dopplerConfig !== null
+    typeof dopplerConfig === "object" && dopplerConfig !== null
       ? {
           ...dopplerConfig,
           baseUrl: repoConfig.baseUrl,

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -13,7 +13,7 @@ import {
   deploymentReadinessProbeWaveCount,
 } from "../../apps/os/src/deployment-readiness.ts";
 import { createSemaphoreClient } from "../../apps/semaphore/src/contract.ts";
-import { dummyPetshopEnvs, previewEnvironmentSlotNumbers } from "../../envs.ts";
+import { dummyPetshopEnvs, envs as osEnvs, previewEnvironmentSlotNumbers } from "../../envs.ts";
 import { createSemaphoreTokenProvider } from "../auth/semaphore-token.ts";
 import { markdownAnnotator } from "../../packages/shared/src/dev/markdown-annotator.ts";
 import { stripAnsi } from "../../packages/shared/src/dev/strip-ansi.ts";
@@ -1616,6 +1616,16 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
     deployCommandArgs: ["pnpm", "run-script", "deploy"],
     destroyCommandArgs: ["pnpm", "run-script", "destroy"],
     dopplerProject: "os",
+    resolvePreviewAppConfig: (dopplerConfig) => {
+      const env = osEnvs[dopplerConfig as keyof typeof osEnvs];
+      if (!env) {
+        throw new Error(`Unknown OS environment ${JSON.stringify(dopplerConfig)}.`);
+      }
+      return {
+        baseUrl: env.baseUrl,
+        projectHostnameBases: env.projectHostnameBases,
+      };
+    },
     // oRPC's /api/__internal/health is gone with the teardown — readiness now
     // probes the plain /api/health route that replaced it. Without this, the
     // preview deploy waits the full 10min readiness timeout on a 404 and fails.
@@ -3628,7 +3638,7 @@ async function readPreviewAppConfig(input: {
     return parsed;
   };
   const repoConfig = input.app.resolvePreviewAppConfig?.(input.dopplerConfig);
-  if (repoConfig) {
+  if (repoConfig && !input.app.previewReadyBearerTokenEnvVar) {
     return parsePreviewAppConfig(repoConfig);
   }
 
@@ -3679,7 +3689,20 @@ async function readPreviewAppConfig(input: {
     throw new Error("Failed to read preview app config.");
   }
 
-  return parsePreviewAppConfig(JSON.parse(result.stdout));
+  const dopplerConfig: unknown = JSON.parse(result.stdout);
+  return parsePreviewAppConfig(
+    repoConfig && typeof dopplerConfig === "object" && dopplerConfig !== null
+      ? {
+          ...dopplerConfig,
+          baseUrl: repoConfig.baseUrl,
+          projectHostnameBases:
+            repoConfig.projectHostnameBases ??
+            ("projectHostnameBases" in dopplerConfig
+              ? dopplerConfig.projectHostnameBases
+              : undefined),
+        }
+      : dopplerConfig,
+  );
 }
 
 async function runPreviewDeployCommand(input: {


### PR DESCRIPTION
## What

- inject an inverted Iterate favicon into project-worker HTML only when the app has no `rel=icon` of its own
- serve the fallback from the reserved same-origin `/.iterate/favicon.svg` path, including `HEAD`, so normal self-only CSPs work without repeating an SVG data URL in every document
- add the same fallback to building, build-failed, and serve-error stand-in pages
- preserve explicit app favicons, overlay opt-out behavior, streaming HTML transformation, and the `/prj_<id>` development path rewrite

## Why

User-space apps otherwise inherit a blank/generic browser tab unless every app author remembers to add an icon. The inverted existing Iterate mark gives those apps a recognizable but distinct default without introducing a separate brittle asset pipeline.

## Impact

Project HTML responses without an app-provided icon gain one small `<link>` element. Requests to the reserved favicon path bypass dynamic user code and return a cacheable SVG. Non-HTML, encoded, subresource, and WebSocket responses are unchanged.

## Checks

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `doppler run --config dev -- pnpm e2e e2e/vitest/project-ingress.e2e.test.ts e2e/vitest/worker-build-overlay.e2e.test.ts`

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +126 -38 | +94 -21 🟩🟩🟩🟩🟥 |
| Tests | +120 -6 | +110 -6 🟩🟩🟩🟩🟩 |
| CI & scripts | +61 -9 | +59 -6 🟩🟩🟩⬜⬜ |
| Docs | +8 -1 | +8 -1 🟩⬜⬜⬜⬜ |
| **Total** | **+315 -54** | **+271 -34** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between c9993b0 and 1109479, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches central project ingress/HTML transformation and reserved paths on every HTML response; preview script changes affect CI env wiring (OS preview failures may relate to APP_CONFIG_BASE_URL merge).
> 
> **Overview**
> Project ingress now gives user-space HTML a **default Iterate favicon** when the document has no `rel=icon` link (anywhere in the page). A streaming **HTMLRewriter** pass scans links and appends a `<link>` at document end; an explicit app icon, including unconventional placements like `rel="shortcut ICON"` in the body, **suppresses** the fallback.
> 
> The icon is served from reserved **`/.iterate/favicon.svg`** (inverted mark SVG, cacheable, GET/HEAD) **before** dynamic worker dispatch, so user code never handles that path. Building, build-failed, and serve-error stand-in pages get the same favicon, with hrefs prefixed by **`x-iterate-url-prefix`** for the `/prj_<id>` dev lane. Project serve now builds the envelope `Request` from **`route.fetch.url`** so that prefix and reserved paths match what the browser sees.
> 
> **Preview CI** changes are bundled: every preview app resolves public **`baseUrl`** from `envs.ts` (required `resolvePreviewAppConfig`), OS e2e uses **`APP_CONFIG_BASE_URL`** instead of `OS_BASE_URL`, and readiness config merges repo URLs with Doppler secrets only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 110947972525055aba372f683a976d059908b374. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-21T14:02:02.368Z",
      "headSha": "110947972525055aba372f683a976d059908b374",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-10.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/36869596401897",
      "shortSha": "1109479",
      "cleanupDurationMs": 21478,
      "deployDurationMs": 135479,
      "testDurationMs": 320411,
      "testRetries": "9 retried: An agent scope provides a capability to the whole project via capabilityHosts.get(\"/\") (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · agents.get(path).create explicitly appends and processes the complete birth batch (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · Project egress substitutes path-addressed secrets for explicit and project worker fetches (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · itx.kv round-trips small values, lists by prefix, and is project-scoped (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · a lost ancestor announcement heals on the stream's next wake (vitest x1, still failed) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · a new user can create a project through the UI form (specs x1) — TimeoutError: locator.waitFor: Timeout 60000ms exceeded. Call log: \u001b[2m - waiting for getByPlaceholder('Message this agent') to be visible\u001b[22m \u001b[2m - waiting for\" https://os.iterate-preview-10.com/api/iterate-auth/callback?code=Yut3zjTdFZXIO7SR8fxWCddGbr5wxOa6&state=1cU5iLzoTr6PzHbGAA749SEpeixxH... · runs \"run-script\" through the project REPL (specs x1) — Error: stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · flags a package.json schema violation with a red squiggle (specs x1) — Error: stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · the seeded internal app authenticates a real project member (specs x1, still failed) — TimeoutError: locator.click: Timeout 1ms exceeded. Call log: \u001b[2m - waiting for getByRole('button', { name: 'Continue with Iterate' })\u001b[22m \u001b[33m If this is a slow operation, update the product code to add a spinner while it's running. This will improve the user experience and buy you more time f...",
      "workerSizeKib": 17125.69,
      "workerGzipKib": 4603.7,
      "mainWorkerGzipKib": 4614.04
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-21T14:01:44.327Z",
      "headSha": "110947972525055aba372f683a976d059908b374",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-10.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/36869596401897",
      "shortSha": "1109479",
      "cleanupDurationMs": 3434,
      "deployDurationMs": 17268,
      "testDurationMs": 11336,
      "testRetries": null,
      "workerSizeKib": 3965.81,
      "workerGzipKib": 811.32,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-21T14:01:41.858Z",
      "headSha": "110947972525055aba372f683a976d059908b374",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-10.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/36869596401897",
      "shortSha": "1109479",
      "cleanupDurationMs": 963,
      "deployDurationMs": 6167,
      "testDurationMs": 5701,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-21T14:01:41.575Z",
      "headSha": "110947972525055aba372f683a976d059908b374",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-10.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/36869596401897",
      "shortSha": "1109479",
      "cleanupDurationMs": 678,
      "deployDurationMs": 13059,
      "testDurationMs": 21737,
      "testRetries": null,
      "workerSizeKib": 1915.12,
      "workerGzipKib": 440.96,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-21T14:01:56.170Z",
      "headSha": "110947972525055aba372f683a976d059908b374",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-10.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/36869596401897",
      "shortSha": "1109479",
      "cleanupDurationMs": 15271,
      "deployDurationMs": 121779,
      "testDurationMs": 58509,
      "testRetries": null,
      "workerSizeKib": 5161.14,
      "workerGzipKib": 1473.24,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `1109479` | [https://auth.iterate-preview-10.com](https://auth.iterate-preview-10.com) | 811.3 KiB | 17.3s | 11.3s |  | 3.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/36869596401897) | 2026-07-21T14:01:44.327Z | Preview app released. |
| Dummy Petshop | released | `1109479` | [https://dummy-petshop.iterate-preview-10.com](https://dummy-petshop.iterate-preview-10.com) | 198.2 KiB | 6.2s | 5.7s |  | 963ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/36869596401897) | 2026-07-21T14:01:41.858Z | Preview app released. |
| OS | released | `1109479` | [https://os.iterate-preview-10.com](https://os.iterate-preview-10.com) | 4.50 MiB (-10.3 KiB vs main) | 135.5s | 320.4s | 9 retried: An agent scope provides a capability to the whole project via capabilityHosts.get("/") (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · agents.get(path).create explicitly appends and processes the complete birth batch (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · Project egress substitutes path-addressed secrets for explicit and project worker fetches (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · itx.kv round-trips small values, lists by prefix, and is project-scoped (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · a lost ancestor announcement heals on the stream's next wake (vitest x1, still failed) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · a new user can create a project through the UI form (specs x1) — TimeoutError: locator.waitFor: Timeout 60000ms exceeded. Call log: [2m - waiting for getByPlaceholder('Message this agent') to be visible[22m [2m - waiting for" https://os.iterate-preview-10.com/api/iterate-auth/callback?code=Yut3zjTdFZXIO7SR8fxWCddGbr5wxOa6&state=1cU5iLzoTr6PzHbGAA749SEpeixxH... · runs "run-script" through the project REPL (specs x1) — Error: stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · flags a package.json schema violation with a red squiggle (specs x1) — Error: stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · the seeded internal app authenticates a real project member (specs x1, still failed) — TimeoutError: locator.click: Timeout 1ms exceeded. Call log: [2m - waiting for getByRole('button', { name: 'Continue with Iterate' })[22m [33m If this is a slow operation, update the product code to add a spinner while it's running. This will improve the user experience and buy you more time f... | 21.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/36869596401897) | 2026-07-21T14:02:02.368Z | Preview app released. |
| Semaphore | released | `1109479` | [https://semaphore.iterate-preview-10.com](https://semaphore.iterate-preview-10.com) | 441.0 KiB | 13.1s | 21.7s |  | 678ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/36869596401897) | 2026-07-21T14:01:41.575Z | Preview app released. |
| Streams Example App | released | `1109479` | [https://streams.iterate-preview-10.com](https://streams.iterate-preview-10.com) | 1.44 MiB | 121.8s | 58.5s |  | 15.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/36869596401897) | 2026-07-21T14:01:56.170Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->