### PR TITLE
Render cached streams before ITX connects

### DIFF
--- a/apps/os/src/components/agent-pill-composer.tsx
+++ b/apps/os/src/components/agent-pill-composer.tsx
@@ -54,6 +54,7 @@ export function AgentPillComposer({
   message,
   raw,
   examples,
+  disabled = false,
   isSubmitting = false,
   error,
   autoFocusMessage = false,
@@ -66,6 +67,7 @@ export function AgentPillComposer({
   raw: AgentComposerRawConfig;
   /** The example picker rendered as the composer body in "examples" mode. */
   examples?: ReactNode;
+  disabled?: boolean;
   isSubmitting?: boolean;
   error?: string;
   autoFocusMessage?: boolean;
@@ -76,6 +78,7 @@ export function AgentPillComposer({
   const activeMode: AgentComposerMode = mode === "message" && message == null ? "raw" : mode;
   const isExamples = activeMode === "examples";
   const canSubmit =
+    !disabled &&
     !isSubmitting &&
     !isExamples &&
     (activeMode === "message"
@@ -94,7 +97,7 @@ export function AgentPillComposer({
   }
 
   function interrupt() {
-    if (isSubmitting || isInterrupting || onInterrupt == null) return;
+    if (disabled || isSubmitting || isInterrupting || onInterrupt == null) return;
     void onInterrupt();
   }
 
@@ -219,7 +222,7 @@ export function AgentPillComposer({
                   : "Send message"
             }
             onClick={showInterrupt ? interrupt : submit}
-            disabled={showInterrupt ? isSubmitting || isInterrupting : !canSubmit}
+            disabled={showInterrupt ? disabled || isSubmitting || isInterrupting : !canSubmit}
             className="relative overflow-hidden rounded-full"
           >
             {showInterrupt ? (

--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -363,7 +363,7 @@ function MirroredProjectStreamView({
             <QueuedMessagesPanel
               messages={queuedUserMessages}
               isInterrupting={interrupt?.isInterrupting ?? false}
-              {...(interrupt == null ? {} : { onInterrupt: interrupt.run })}
+              {...(interrupt == null || !streamIsLive ? {} : { onInterrupt: interrupt.run })}
             />
             <StreamViewComposer
               autoFocusMessage={autoFocusMessageComposer}

--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -266,10 +266,11 @@ function MirroredProjectStreamView({
     streamPath,
   });
 
-  const streamIsConnected =
-    snapshot.connectionStatus === "connected" || snapshot.connectionStatus === "subscribed";
+  // Election starts only after createStreamClient resolves, so every non-idle
+  // role has a usable transport (including followers, which never subscribe).
+  const streamTransportReady = snapshot.subscriptionStatus !== "idle";
   const connectionLabel =
-    snapshot.connectionError ?? (streamIsConnected ? emptyLabel : snapshot.connectionStatus);
+    snapshot.connectionError ?? (streamTransportReady ? emptyLabel : snapshot.connectionStatus);
   // Busy = work is actively running, independent of chat-message timing.
   const agentBusy = isAgentUiActivityWorking(presentedAgentUiState?.live ?? null, agentRuntime);
   const presence = presentedAgentUiState?.presence ?? [];
@@ -317,7 +318,7 @@ function MirroredProjectStreamView({
       {...(caps.agentFeed ? { onInspectScriptExecution: panels.inspectScriptExecution } : {})}
       emptyLabel={connectionLabel}
       projectSlug={projectSlug}
-      isPending={caps.agentFeed ? agentUiState == null : !streamIsConnected}
+      isPending={caps.agentFeed ? agentUiState == null : !streamTransportReady}
       pendingLabel={caps.agentFeed ? "Initializing agent" : undefined}
     />
   );
@@ -343,7 +344,7 @@ function MirroredProjectStreamView({
 
       <div className="shrink-0 px-4 pb-2.5 pt-2.5">
         <div className="mx-auto flex w-full max-w-3xl flex-col gap-1.5">
-          {eventCount > 0 && !streamIsConnected ? (
+          {eventCount > 0 && !streamTransportReady ? (
             <p
               className="px-4 text-xs text-muted-foreground"
               data-testid="stream-cache-status"
@@ -363,7 +364,9 @@ function MirroredProjectStreamView({
             <QueuedMessagesPanel
               messages={queuedUserMessages}
               isInterrupting={interrupt?.isInterrupting ?? false}
-              {...(interrupt == null || !streamIsConnected ? {} : { onInterrupt: interrupt.run })}
+              {...(interrupt == null || !streamTransportReady
+                ? {}
+                : { onInterrupt: interrupt.run })}
             />
             <StreamViewComposer
               autoFocusMessage={autoFocusMessageComposer}
@@ -377,7 +380,7 @@ function MirroredProjectStreamView({
               onNudgeDeliveries={nudgeDeliveries}
               presence={presence}
               store={store}
-              disabled={!streamIsConnected}
+              disabled={!streamTransportReady}
             />
           </div>
         </div>

--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -266,9 +266,11 @@ function MirroredProjectStreamView({
     streamPath,
   });
 
+  const streamIsLive =
+    snapshot.connectionStatus === "subscribed" ||
+    (snapshot.connectionStatus === "connected" && snapshot.subscriptionStatus === "follower");
   const connectionLabel =
-    snapshot.connectionError ??
-    (snapshot.connectionStatus === "subscribed" ? emptyLabel : snapshot.connectionStatus);
+    snapshot.connectionError ?? (streamIsLive ? emptyLabel : snapshot.connectionStatus);
   // Busy = work is actively running, independent of chat-message timing.
   const agentBusy = isAgentUiActivityWorking(presentedAgentUiState?.live ?? null, agentRuntime);
   const presence = presentedAgentUiState?.presence ?? [];
@@ -316,7 +318,7 @@ function MirroredProjectStreamView({
       {...(caps.agentFeed ? { onInspectScriptExecution: panels.inspectScriptExecution } : {})}
       emptyLabel={connectionLabel}
       projectSlug={projectSlug}
-      isPending={agentUiState == null && snapshot.connectionStatus !== "subscribed"}
+      isPending={agentUiState == null && !streamIsLive}
     />
   );
 
@@ -341,6 +343,18 @@ function MirroredProjectStreamView({
 
       <div className="shrink-0 px-4 pb-2.5 pt-2.5">
         <div className="mx-auto flex w-full max-w-3xl flex-col gap-1.5">
+          {eventCount > 0 && !streamIsLive ? (
+            <p
+              className="px-4 text-xs text-muted-foreground"
+              data-testid="stream-cache-status"
+              role="status"
+            >
+              Showing cached events while
+              {snapshot.connectionStatus === "reconnecting" || snapshot.connectionError != null
+                ? " reconnecting…"
+                : " connecting…"}
+            </p>
+          ) : null}
           <div>
             {/* Queued messages are part of the composer: the panel tucks
                 behind the pill (painted first, overlapped via its negative
@@ -363,6 +377,7 @@ function MirroredProjectStreamView({
               onNudgeDeliveries={nudgeDeliveries}
               presence={presence}
               store={store}
+              disabled={!streamIsLive}
             />
           </div>
         </div>

--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -266,11 +266,10 @@ function MirroredProjectStreamView({
     streamPath,
   });
 
-  const streamIsLive =
-    snapshot.connectionStatus === "subscribed" ||
-    (snapshot.connectionStatus === "connected" && snapshot.subscriptionStatus === "follower");
+  const streamIsConnected =
+    snapshot.connectionStatus === "connected" || snapshot.connectionStatus === "subscribed";
   const connectionLabel =
-    snapshot.connectionError ?? (streamIsLive ? emptyLabel : snapshot.connectionStatus);
+    snapshot.connectionError ?? (streamIsConnected ? emptyLabel : snapshot.connectionStatus);
   // Busy = work is actively running, independent of chat-message timing.
   const agentBusy = isAgentUiActivityWorking(presentedAgentUiState?.live ?? null, agentRuntime);
   const presence = presentedAgentUiState?.presence ?? [];
@@ -318,7 +317,7 @@ function MirroredProjectStreamView({
       {...(caps.agentFeed ? { onInspectScriptExecution: panels.inspectScriptExecution } : {})}
       emptyLabel={connectionLabel}
       projectSlug={projectSlug}
-      isPending={agentUiState == null && !streamIsLive}
+      isPending={agentUiState == null && !streamIsConnected}
     />
   );
 
@@ -343,7 +342,7 @@ function MirroredProjectStreamView({
 
       <div className="shrink-0 px-4 pb-2.5 pt-2.5">
         <div className="mx-auto flex w-full max-w-3xl flex-col gap-1.5">
-          {eventCount > 0 && !streamIsLive ? (
+          {eventCount > 0 && !streamIsConnected ? (
             <p
               className="px-4 text-xs text-muted-foreground"
               data-testid="stream-cache-status"
@@ -363,7 +362,7 @@ function MirroredProjectStreamView({
             <QueuedMessagesPanel
               messages={queuedUserMessages}
               isInterrupting={interrupt?.isInterrupting ?? false}
-              {...(interrupt == null || !streamIsLive ? {} : { onInterrupt: interrupt.run })}
+              {...(interrupt == null || !streamIsConnected ? {} : { onInterrupt: interrupt.run })}
             />
             <StreamViewComposer
               autoFocusMessage={autoFocusMessageComposer}
@@ -377,7 +376,7 @@ function MirroredProjectStreamView({
               onNudgeDeliveries={nudgeDeliveries}
               presence={presence}
               store={store}
-              disabled={!streamIsLive}
+              disabled={!streamIsConnected}
             />
           </div>
         </div>

--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -317,7 +317,8 @@ function MirroredProjectStreamView({
       {...(caps.agentFeed ? { onInspectScriptExecution: panels.inspectScriptExecution } : {})}
       emptyLabel={connectionLabel}
       projectSlug={projectSlug}
-      isPending={agentUiState == null && !streamIsConnected}
+      isPending={caps.agentFeed ? agentUiState == null : !streamIsConnected}
+      pendingLabel={caps.agentFeed ? "Initializing agent" : undefined}
     />
   );
 

--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -269,6 +269,13 @@ function MirroredProjectStreamView({
   // Election starts only after createStreamClient resolves, so every non-idle
   // role has a usable transport (including followers, which never subscribe).
   const streamTransportReady = snapshot.subscriptionStatus !== "idle";
+  // Cached rows can paint immediately. With an empty local mirror, a leader
+  // stays pending until reconcile and the atomic live subscribe have finished;
+  // a follower reads the mirror already owned by another tab.
+  const streamContentsReady =
+    eventCount > 0 ||
+    snapshot.subscriptionStatus === "follower" ||
+    snapshot.connectionStatus === "subscribed";
   const connectionLabel =
     snapshot.connectionError ?? (streamTransportReady ? emptyLabel : snapshot.connectionStatus);
   // Busy = work is actively running, independent of chat-message timing.
@@ -318,7 +325,7 @@ function MirroredProjectStreamView({
       {...(caps.agentFeed ? { onInspectScriptExecution: panels.inspectScriptExecution } : {})}
       emptyLabel={connectionLabel}
       projectSlug={projectSlug}
-      isPending={caps.agentFeed ? agentUiState == null : !streamTransportReady}
+      isPending={caps.agentFeed ? agentUiState == null : !streamContentsReady}
       pendingLabel={caps.agentFeed ? "Initializing agent" : undefined}
     />
   );

--- a/apps/os/src/components/stream-feed-view.tsx
+++ b/apps/os/src/components/stream-feed-view.tsx
@@ -65,6 +65,7 @@ export function StreamFeedView({
   emptyLabel = "No events in this stream yet.",
   filter,
   isPending = false,
+  pendingLabel = "Connecting to the stream",
   liveState,
   transientAgentItems = EMPTY_AGENT_ITEMS,
   runtime = ZERO_AGENT_RUNTIME,
@@ -78,6 +79,7 @@ export function StreamFeedView({
   /** Which kind families (and constraints within them) this mode shows. */
   filter: StreamFeedQueryInput;
   isPending?: boolean;
+  pendingLabel?: string;
   /** Reduced agent state for the live tail; null hides the trailing items. */
   liveState: AgentUiState | null;
   /** Runtime-projected settled items which are not journal database rows. */
@@ -237,7 +239,7 @@ export function StreamFeedView({
           <Empty className="min-h-48">
             <EmptyHeader>
               {isPending ? <Spinner className="size-4" /> : null}
-              <EmptyTitle>{isPending ? "Connecting to the stream" : "Nothing here yet"}</EmptyTitle>
+              <EmptyTitle>{isPending ? pendingLabel : "Nothing here yet"}</EmptyTitle>
               {isPending ? null : (
                 <EmptyDescription>
                   {filtersNarrow ? "No feed items match the current filters." : emptyLabel}

--- a/apps/os/src/components/stream-view-composer.tsx
+++ b/apps/os/src/components/stream-view-composer.tsx
@@ -46,6 +46,7 @@ export type StreamInterrupt = {
 export function StreamViewComposer({
   autoFocusMessage,
   defaultMode,
+  disabled,
   interrupt,
   messageComposer,
   onNudgeDeliveries,
@@ -54,6 +55,7 @@ export function StreamViewComposer({
 }: {
   autoFocusMessage: boolean;
   defaultMode?: "message" | "raw";
+  disabled: boolean;
   /** Null while no turn is running (or the stream has no interrupt hook). */
   interrupt: StreamInterrupt | null;
   messageComposer?: StreamMessageComposer;
@@ -235,6 +237,7 @@ export function StreamViewComposer({
           onSubmit: submitRawEvents,
         }}
         isSubmitting={isSubmitting}
+        disabled={disabled}
         {...(error == null ? {} : { error })}
       />
     </>

--- a/apps/os/src/routes/_app/projects/$projectSlug/streams/$.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/streams/$.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useItx } from "iterate/sdk/itx/react";
+import { connectItx } from "iterate/sdk/itx/react";
 import { ProjectStreamView } from "~/components/project-stream-view.lazy.tsx";
 import {
   breadcrumbLoaderData,
@@ -32,9 +32,9 @@ export const Route = createFileRoute("/_app/projects/$projectSlug/streams/$")({
 function ProjectStreamDetailContent() {
   const { project } = Route.useLoaderData();
   const { _splat: streamPath } = Route.useParams();
-  const itx = useItx();
 
   async function submitMessage(message: string) {
+    const itx = await connectItx(project.id);
     const [event] = await itx.streams.get(streamPath).append({
       type: "events.iterate.com/agents/context-added",
       payload: {

--- a/specs/agent-chat.spec.ts
+++ b/specs/agent-chat.spec.ts
@@ -55,7 +55,7 @@ test("agent replies to a browser chat message in the feed", async ({ helpers, pa
     // interacting with the deliberately tight default action budget.
     await composer.waitFor({ timeout: 30_000 });
     await composer.fill(message);
-    await page.getByRole("button", { name: "Send message" }).click();
+    await page.getByRole("button", { name: "Send message" }).click({ timeout: 30_000 });
 
     await page.locator(userMessage).getByText(marker).waitFor({ timeout: 30_000 });
 

--- a/specs/stream-cache-before-live.spec.ts
+++ b/specs/stream-cache-before-live.spec.ts
@@ -37,6 +37,39 @@ test("a new agent stream stays initializing while its connection opens", async (
   });
 });
 
+test("a cold stream stays pending until its server history catches up", async ({
+  baseURL,
+  helpers,
+  page,
+}) => {
+  await using fixture = await helpers.createFixture("stream-cold-history");
+  using admin = await connectAdminItx(baseURL!);
+  using project = admin.projects.get(fixture.project.id);
+  const streamPath = `/spec/cold-history-${crypto.randomUUID().slice(0, 8)}`;
+  using stream = project.streams.get(streamPath);
+  await stream.append({ type: "events.iterate.com/spec/cold-history", payload: {} });
+
+  await page.routeWebSocket(
+    (url) => url.pathname === "/api",
+    (socket) => {
+      const server = socket.connectToServer();
+      socket.onMessage((message) => server.send(message));
+      server.onMessage((message) => setTimeout(() => socket.send(message), 1_000));
+    },
+  );
+
+  await page.goto(`/projects/${fixture.project.slug}/streams${streamPath}`);
+  await page
+    .getByRole("button", { name: "Append events (⌘↵)", disabled: false })
+    .waitFor({ timeout: 30_000 });
+  await page.getByText("Connecting to the stream", { exact: true }).waitFor();
+  await page.getByText("Nothing here yet").waitFor({ state: "hidden" });
+  await page
+    .getByTestId("stream-feed-inspect")
+    .filter({ hasText: "spec/cold-history" })
+    .waitFor({ timeout: 30_000 });
+});
+
 test("a cached stream opens before its live connection", async ({ baseURL, helpers, page }) => {
   await using fixture = await helpers.createFixture("stream-cache");
   using admin = await connectAdminItx(baseURL!);

--- a/specs/stream-cache-before-live.spec.ts
+++ b/specs/stream-cache-before-live.spec.ts
@@ -1,6 +1,41 @@
 import { expect, type WebSocketRoute } from "@playwright/test";
+import { spinnerWaiter } from "middlewright";
 import { connectAdminItx } from "./test-support/forged-session.ts";
 import { test } from "./test-support/test.ts";
+
+test("a new agent stream stays initializing while its connection opens", async ({
+  baseURL,
+  helpers,
+  page,
+}) => {
+  await using fixture = await helpers.createFixture("agent-initializing");
+  using admin = await connectAdminItx(baseURL!);
+  using project = admin.projects.get(fixture.project.id);
+  const agentPath = `/agents/initializing-${crypto.randomUUID().slice(0, 8)}`;
+  await project.agents.get(agentPath).create();
+
+  let restoreConnections = false;
+  const stalledSockets: WebSocketRoute[] = [];
+  await page.routeWebSocket(
+    (url) => url.pathname === "/api",
+    (socket) => {
+      if (restoreConnections) socket.connectToServer();
+      else stalledSockets.push(socket);
+    },
+  );
+  await spinnerWaiter.settings.run({ disabled: true }, async () => {
+    await page.goto(`/projects/${fixture.project.slug}/agents/streams${agentPath}`);
+    await page.getByText("Initializing agent", { exact: true }).waitFor({ timeout: 5_000 });
+    await page.getByText("Nothing here yet").waitFor({ state: "hidden" });
+    await expect.poll(() => stalledSockets.length).toBeGreaterThan(0);
+
+    restoreConnections = true;
+    await Promise.all(stalledSockets.map((socket) => socket.close({ code: 1012 })));
+    await page
+      .getByText("Initializing agent", { exact: true })
+      .waitFor({ state: "hidden", timeout: 30_000 });
+  });
+});
 
 test("a cached stream opens before its live connection", async ({ baseURL, helpers, page }) => {
   await using fixture = await helpers.createFixture("stream-cache");
@@ -37,7 +72,7 @@ test("a cached stream opens before its live connection", async ({ baseURL, helpe
   await cachedRow.waitFor({ timeout: 5_000 });
   await page.getByTestId("stream-cache-status").waitFor();
   await page.getByRole("button", { name: "Append events (⌘↵)", disabled: true }).waitFor();
-  expect(stalledSockets.length).toBeGreaterThan(0);
+  await expect.poll(() => stalledSockets.length).toBeGreaterThan(0);
 
   restoreConnections = true;
   await Promise.all(

--- a/specs/stream-cache-before-live.spec.ts
+++ b/specs/stream-cache-before-live.spec.ts
@@ -1,0 +1,51 @@
+import { expect, type WebSocketRoute } from "@playwright/test";
+import { connectAdminItx } from "./test-support/forged-session.ts";
+import { test } from "./test-support/test.ts";
+
+test("a cached stream opens before its live connection", async ({ baseURL, helpers, page }) => {
+  await using fixture = await helpers.createFixture("stream-cache");
+  using admin = await connectAdminItx(baseURL!);
+  using project = admin.projects.get(fixture.project.id);
+  const streamPath = `/spec/cache-before-live-${crypto.randomUUID().slice(0, 8)}`;
+  using stream = project.streams.get(streamPath);
+  await stream.append({
+    type: "events.iterate.com/spec/cached-before-live",
+    payload: {},
+  });
+
+  const route = `/projects/${fixture.project.slug}/streams${streamPath}`;
+  const cachedRow = page
+    .getByTestId("stream-feed-inspect")
+    .filter({ hasText: "spec/cached-before-live" });
+
+  // Warm the real OPFS mirror, then make only the next /api WebSocket look
+  // like a very slow network: it opens but never returns an ITX frame.
+  await page.goto(route);
+  await cachedRow.waitFor({ timeout: 30_000 });
+  let restoreConnections = false;
+  const stalledSockets: WebSocketRoute[] = [];
+  await page.routeWebSocket(
+    (url) => url.pathname === "/api",
+    (socket) => {
+      if (restoreConnections) socket.connectToServer();
+      else stalledSockets.push(socket);
+    },
+  );
+
+  await page.reload();
+
+  await cachedRow.waitFor({ timeout: 5_000 });
+  await page.getByTestId("stream-cache-status").waitFor();
+  await page.getByRole("button", { name: "Append events (⌘↵)", disabled: true }).waitFor();
+  expect(stalledSockets.length).toBeGreaterThan(0);
+
+  restoreConnections = true;
+  await Promise.all(
+    stalledSockets.map((socket) =>
+      socket.close({ code: 1012, reason: "restore the test connection" }),
+    ),
+  );
+  await page.getByTestId("stream-cache-status").waitFor({ state: "hidden", timeout: 30_000 });
+  await page.getByRole("button", { name: "Append events (⌘↵)", disabled: false }).waitFor();
+  await expect.poll(() => cachedRow.count()).toBe(1);
+});

--- a/specs/stream-cache-before-live.spec.ts
+++ b/specs/stream-cache-before-live.spec.ts
@@ -57,6 +57,15 @@ test("a cached stream opens before its live connection", async ({ baseURL, helpe
   // like a very slow network: it opens but never returns an ITX frame.
   await page.goto(route);
   await cachedRow.waitFor({ timeout: 30_000 });
+
+  // The first tab holds the mirror lock; the follower's own ITX transport can still write.
+  const follower = await page.context().newPage();
+  await follower.goto(route);
+  await follower
+    .getByRole("button", { name: "Append events (⌘↵)", disabled: false })
+    .waitFor({ timeout: 30_000 });
+  await follower.close();
+
   let restoreConnections = false;
   const stalledSockets: WebSocketRoute[] = [];
   await page.routeWebSocket(


### PR DESCRIPTION
## What changed

- mount generic stream mirrors without suspending on the first ITX connection
- render persisted OPFS/SQLite rows immediately with a truthful cached/connecting status
- disable stream writes and queued interrupts until the ITX transport is connected
- show a gentle “Initializing agent” state until a new agent’s first reduced state arrives, instead of briefly declaring “Nothing here yet”
- keep cold, uncached streams in the gentle connecting state until server history has caught up
- add Playwright coverage for blackholed `/api`, delayed catch-up, cached/initializing paint, follower-tab writes, and clean live transitions

## Root cause

The generic stream detail route called the suspending `useItx()` hook before `ProjectStreamView` could mount. On a slow or half-open WebSocket, TanStack Start therefore remained on the route-level loading fallback even though the stream's SQLite mirror already contained renderable rows. Separately, an agent feed treated socket connection as enough evidence that a new stream was empty, before its initial reduced state had arrived.

## Impact

Warm streams remain readable while ITX connects, cold streams do not claim to be empty before catch-up, writes cannot enter an unready transport, and newly created agents display one accurate, gentle initialization state rather than a misleading empty state.

Product code is +33 net lines; tests are +128 net; the total is +161 net. No Markdown files are included.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test` (all workspaces; OS: 2,127 passed, 6 expected failures, 1 skipped)
- `pnpm spec specs/stream-cache-before-live.spec.ts` (3 passed)
- `npx react-doctor@latest --verbose --scope changed` (no touched-file findings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches stream connection readiness, pending UI, and write gating across the main stream view path; behavior change on slow or half-open WebSockets but scoped to client orchestration with new e2e tests.
> 
> **Overview**
> Stream detail pages no longer block on a suspending ITX hook at the route: **`ProjectStreamView` mounts immediately** and message appends call **`connectItx` on submit** instead of holding the whole page on the first WebSocket.
> 
> **Warm mirrors** paint SQLite/OPFS rows right away, with a **“Showing cached events while connecting…”** status when live transport is still idle. **Appends, interrupts, and queued-message cancel** stay disabled until `subscriptionStatus` leaves `idle`. Agent feeds show **“Initializing agent”** until reduced state exists, avoiding a false empty feed; generic streams stay pending until history is ready or the socket is subscribed.
> 
> **`StreamFeedView`** accepts a custom **`pendingLabel`**; **`AgentPillComposer`** gains a **`disabled`** flag wired through the composer stack. Playwright coverage exercises stalled `/api` WebSockets, cold history, and cached-before-live transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a08438381e75bcbb2e944f5144856f2bab289e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +2 -2 | +2 -2 🟩⬜⬜⬜⬜ |
| UI components | +40 -7 | +35 -7 🟩🟩⬜⬜⬜ |
| Tests | +129 -1 | +112 -1 🟩🟩🟩🟩🟩 |
| **Total** | **+171 -10** | **+149 -10** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 2fc9426 and 9a08438, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-21T15:29:28.719Z",
      "headSha": "9a08438381e75bcbb2e944f5144856f2bab289e3",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/174919637661018",
      "shortSha": "9a08438",
      "cleanupDurationMs": 22550,
      "deployDurationMs": 137811,
      "testDurationMs": 206527,
      "testRetries": "1 retried: itx expression capabilities mount project workers, streams, method aliases, and functions (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits).",
      "workerSizeKib": 17133.77,
      "workerGzipKib": 4606.02,
      "mainWorkerGzipKib": 4617.96
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-21T15:29:07.225Z",
      "headSha": "9a08438381e75bcbb2e944f5144856f2bab289e3",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/174919637661018",
      "shortSha": "9a08438",
      "cleanupDurationMs": 1053,
      "deployDurationMs": 13338,
      "testDurationMs": 29674,
      "testRetries": null,
      "workerSizeKib": 1915.12,
      "workerGzipKib": 440.96,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-21T15:29:10.059Z",
      "headSha": "9a08438381e75bcbb2e944f5144856f2bab289e3",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/174919637661018",
      "shortSha": "9a08438",
      "cleanupDurationMs": 3884,
      "deployDurationMs": 18078,
      "testDurationMs": 11364,
      "testRetries": null,
      "workerSizeKib": 3965.97,
      "workerGzipKib": 811.45,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-21T15:29:18.728Z",
      "headSha": "9a08438381e75bcbb2e944f5144856f2bab289e3",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/174919637661018",
      "shortSha": "9a08438",
      "cleanupDurationMs": 12548,
      "deployDurationMs": 109703,
      "testDurationMs": 62997,
      "testRetries": null,
      "workerSizeKib": 5161.45,
      "workerGzipKib": 1473.34,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-21T15:29:06.691Z",
      "headSha": "9a08438381e75bcbb2e944f5144856f2bab289e3",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/174919637661018",
      "shortSha": "9a08438",
      "cleanupDurationMs": 508,
      "deployDurationMs": 7400,
      "testDurationMs": 5285,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `9a08438` | [https://auth.iterate-preview-12.com](https://auth.iterate-preview-12.com) | 811.5 KiB | 18.1s | 11.4s |  | 3.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/174919637661018) | 2026-07-21T15:29:10.059Z | Preview app released. |
| Dummy Petshop | released | `9a08438` | [https://dummy-petshop.iterate-preview-12.com](https://dummy-petshop.iterate-preview-12.com) | 198.2 KiB | 7.4s | 5.3s |  | 508ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/174919637661018) | 2026-07-21T15:29:06.691Z | Preview app released. |
| OS | released | `9a08438` | [https://os.iterate-preview-12.com](https://os.iterate-preview-12.com) | 4.50 MiB (-11.9 KiB vs main) | 137.8s | 206.5s | 1 retried: itx expression capabilities mount project workers, streams, method aliases, and functions (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). | 22.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/174919637661018) | 2026-07-21T15:29:28.719Z | Preview app released. |
| Semaphore | released | `9a08438` | [https://semaphore.iterate-preview-12.com](https://semaphore.iterate-preview-12.com) | 441.0 KiB | 13.3s | 29.7s |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/174919637661018) | 2026-07-21T15:29:07.225Z | Preview app released. |
| Streams Example App | released | `9a08438` | [https://streams.iterate-preview-12.com](https://streams.iterate-preview-12.com) | 1.44 MiB | 109.7s | 63.0s |  | 12.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/174919637661018) | 2026-07-21T15:29:18.728Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->


