### PR TITLE
Proposal: slack-agent presence repaint becomes a droppable background attempt (audit D2)

### DIFF
--- a/apps/os/src/domains/integrations/slack-agent-processor-implementation.ts
+++ b/apps/os/src/domains/integrations/slack-agent-processor-implementation.ts
@@ -64,9 +64,11 @@ import {
  *   acknowledges, AFTER it, so receipt is never signalled for a message that
  *   failed to commit.
  *
- * - PRESENCE PAINT (best-effort, latest-fact-wins): summary facts and the
- *   platform revival fact are memoized per delivery and painted ONCE per
- *   at-head pass (`delivery.caughtUp`) from the complete reduced state — the
+ * - PRESENCE PAINT (best-effort, latest-fact-wins, `runInBackground`):
+ *   summary facts and the platform revival fact are memoized per delivery
+ *   and painted ONCE per at-head pass (`delivery.caughtUp`) from the
+ *   complete reduced state — a droppable attempt, so a hanging Slack call
+ *   never head-of-line-blocks the durable lanes above. The paints: the
  *   thread title via `assistant.threads.setTitle` (durable current-state
  *   paint, repainted by a fresh incarnation), the activity text via the
  *   transient thread status (freshness-gated). A revival clears presentation
@@ -114,10 +116,11 @@ export class SlackAgentProcessor extends StreamProcessor<
   // ------------------------------------------------------------ processEvent
   // One flat switch. Early exits inside the webhook case `break` (never
   // `return`), so the at-head repaint registration below the switch always
-  // runs. Per-event blockers register FIRST: `blockProcessorWhile` runs in
-  // FIFO registration order, so the repaint sees their appends.
+  // runs. The repaint reads only the reduced state and the paint memos, so
+  // it does not depend on the frame's blockers having committed first.
   protected override processEvent(args: ProcessEventArgs<SlackAgentProcessorContract>): undefined {
-    const { append, blockProcessorWhile, delivery, event, previousState, state } = args;
+    const { append, blockProcessorWhile, delivery, event, previousState, runInBackground, state } =
+      args;
     const { birthCertificate } = state;
     if (birthCertificate === null) return;
 
@@ -340,13 +343,15 @@ export class SlackAgentProcessor extends StreamProcessor<
 
     // AT-HEAD repaint: `delivery.caughtUp` means `state` is the whole observed
     // reduction. It rides the last consumed event or the runner's eventless
-    // pass. ONE blocking closure — the runner awaits it as this head event's
-    // own work before the frame's deferred commit. The paint owns Slack's
-    // outcome classification: idempotent outcomes are quiet success, while
-    // unexpected cosmetic failures are reported once and settled so they
-    // cannot wedge the durable agent pipeline.
+    // pass. A droppable background attempt — a hanging Slack call must never
+    // head-of-line-block transcription and sends. What recovers a dropped
+    // attempt: the title repaints on the next at-head pass (the painted-title
+    // memo dies with the incarnation, and a revival sets #titleRepaintDue);
+    // a lost transient status costs seconds of stale indicator until the next
+    // pass; a lost revival clear re-arms because dying while owing this
+    // keepalive-backed work produces another revival fact.
     if (delivery.caughtUp) {
-      blockProcessorWhile(() => this.#repaintPresence(args));
+      runInBackground(() => this.#repaintPresence(args));
     }
   }
 

--- a/apps/os/src/domains/integrations/slack-agent-processor-implementation.ts
+++ b/apps/os/src/domains/integrations/slack-agent-processor-implementation.ts
@@ -112,6 +112,11 @@ export class SlackAgentProcessor extends StreamProcessor<
   /** The title this incarnation painted, so repeated repaints of an unchanged
    * title cost no Slack calls. */
   #paintedTitle: string | undefined;
+  /** Serializes background repaint attempts: without it, a slow setTitle from
+   * an earlier at-head pass could finish AFTER a newer paint and leave Slack
+   * (and the memos) wearing the stale value. Ordering lives here, not in the
+   * durable pipeline — a hanging paint delays later paints, never delivery. */
+  #presenceRepaintChain = Promise.resolve();
 
   // ------------------------------------------------------------ processEvent
   // One flat switch. Early exits inside the webhook case `break` (never
@@ -351,7 +356,13 @@ export class SlackAgentProcessor extends StreamProcessor<
     // pass; a lost revival clear re-arms because dying while owing this
     // keepalive-backed work produces another revival fact.
     if (delivery.caughtUp) {
-      runInBackground(() => this.#repaintPresence(args));
+      runInBackground(() => {
+        const attempt = this.#presenceRepaintChain.then(() => this.#repaintPresence(args));
+        // The chain survives a failed attempt (the failure still surfaces
+        // through runInBackground's own logging on `attempt`).
+        this.#presenceRepaintChain = attempt.catch(() => {});
+        return attempt;
+      });
     }
   }
 

--- a/tasks/processor-audit-2026-07.md
+++ b/tasks/processor-audit-2026-07.md
@@ -391,7 +391,7 @@ Doc rule shipped in the docs PR; code half still open.
 
 ### D2. slack-agent blocks a cosmetic repaint that telegram-agent backgrounds
 
-**Status:** in-pr (spike/proposal).
+**Status:** in-pr #2201 (spike/proposal).
 
 `slack-agent-processor-implementation.ts:341-350` blocks the frame on
 `#repaintPresence` — Slack `setTitle`/`setStatus` vendor calls hold the

--- a/tasks/processor-audit-2026-07.md
+++ b/tasks/processor-audit-2026-07.md
@@ -391,7 +391,7 @@ Doc rule shipped in the docs PR; code half still open.
 
 ### D2. slack-agent blocks a cosmetic repaint that telegram-agent backgrounds
 
-**Status:** needs decision.
+**Status:** in-pr (spike/proposal).
 
 `slack-agent-processor-implementation.ts:341-350` blocks the frame on
 `#repaintPresence` — Slack `setTitle`/`setStatus` vendor calls hold the


### PR DESCRIPTION
## This is a proposal, not a decision

Audit finding D2 needed a human call; this PR is my recommended answer as a working spike so the decision has a concrete diff to react to. **It might not be the right call** — the alternatives are at the bottom, and closing this unmerged is a fine outcome.

## What

The slack-agent's at-head presence repaint (`#repaintPresence`: thread-title paint, transient activity status, revival clear) moves from `blockProcessorWhile` to `runInBackground`. One line of behavior, plus honest comments.

## Why I recommend it

- Blocking here head-of-line-blocks the thread's **durable** pipeline (transcription into agent context, bang commands, sends) on **cosmetic** vendor calls — the exact failure mode `stream-processor.ts`'s lane docstring warns about. A slow/hanging `assistant.threads.setStatus` currently stalls real work.
- telegram-agent already backgrounds its exactly-analogous typing repaint with the textbook justification; the sibling processors should agree unless there's a reason they can't.
- Post-#2170/#2178, the blocking site's comment justified *ordering*, not loss-prevention — and the repaint reads only reduced state + in-memory memos, so it doesn't depend on the frame's blockers having committed.

**The recovery analysis** (the question `runInBackground` must answer — what recovers a dropped attempt):
- **Title** (durable current-state paint): the painted-title memo is in-memory, so a fresh incarnation repaints on its next at-head pass; a revival explicitly sets `#titleRepaintDue`.
- **Transient status**: freshness-gated cosmetics; a lost paint costs seconds of stale indicator until the next pass.
- **Revival clear**: dying while owing this keepalive-backed background work produces another revival fact, which re-arms the clear on the next incarnation's at-head pass.

## The alternatives (if this is wrong)

1. **Keep blocking but bound it** — wrap the repaint in a timeout inside the closure and rewrite the comment to name a real per-event loss. Right if you think a title/status paint must land before later events are processed (e.g. strict ordering of status vs. reply visibility matters more than pipeline liveness).
2. **Split lanes** — keep only the revival clear (or only the title) blocked if either genuinely needs at-least-once-before-the-next-event, background the rest. My reading is neither needs it, per the recovery analysis above.

## Verification

Integrations suite 264/264, typecheck, lint, format all pass. Ledger D2 marked `in-pr (spike/proposal)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes delivery semantics for Slack thread UI side effects (cosmetic only) and trades possible brief stale indicators for pipeline liveness if background attempts drop; durable transcription and sends should no longer stall on hanging Slack API calls.
> 
> **Overview**
> Addresses processor audit **D2** by moving the slack-agent at-head **`#repaintPresence`** lane (thread title, transient activity status, revival clear) from **`blockProcessorWhile`** to **`runInBackground`**, matching telegram-agent’s droppable typing repaint pattern.
> 
> A new **`#presenceRepaintChain`** serializes background repaint attempts so a slow older `setTitle`/`setStatus` cannot finish after a newer pass and leave Slack wearing stale cosmetics; a hanging paint can delay later paints but not the durable message pipeline. Comments document recovery if an attempt is dropped (title repaints on the next at-head pass / revival; transient status may lag briefly; revival clear re-arms via keepalive-backed work).
> 
> The audit ledger marks D2 as **in-pr #2201 (spike/proposal)** — this PR is an explicit proposal, not a settled product decision.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb30bbda6b61aae5d9c42af0136ee384e4ec9b07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +28 -12 | +8 -2 🟩🟩🟩🟩🟥 |
| Docs | +1 -1 | +1 -1 🟩⬜⬜⬜⬜ |
| **Total** | **+29 -13** | **+9 -3** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 5c102f9 and fb30bbd, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-21T14:01:38.363Z",
      "headSha": "fb30bbda6b61aae5d9c42af0136ee384e4ec9b07",
      "message": "Preview app released.",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/88922516363749",
      "shortSha": "fb30bbd",
      "cleanupDurationMs": 17842,
      "deployDurationMs": 199
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-21T14:01:23.701Z",
      "headSha": "fb30bbda6b61aae5d9c42af0136ee384e4ec9b07",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-16.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/88922516363749",
      "shortSha": "fb30bbd",
      "cleanupDurationMs": 3177,
      "deployDurationMs": 24585,
      "workerSizeKib": 3963.28,
      "workerGzipKib": 809.77,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-21T14:01:21.263Z",
      "headSha": "fb30bbda6b61aae5d9c42af0136ee384e4ec9b07",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-16.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/88922516363749",
      "shortSha": "fb30bbd",
      "cleanupDurationMs": 738,
      "deployDurationMs": 8398,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `fb30bbd` | [https://auth.iterate-preview-16.com](https://auth.iterate-preview-16.com) | 809.8 KiB | 24.6s |  |  | 3.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/88922516363749) | 2026-07-21T14:01:23.701Z | Preview app released. |
| Dummy Petshop | released | `fb30bbd` | [https://dummy-petshop.iterate-preview-16.com](https://dummy-petshop.iterate-preview-16.com) | 198.2 KiB | 8.4s |  |  | 738ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/88922516363749) | 2026-07-21T14:01:21.263Z | Preview app released. |
| OS | released | `fb30bbd` |  |  | 199ms |  |  | 17.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/88922516363749) | 2026-07-21T14:01:38.363Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->