### PR TITLE
Sidebar Homepage link prefers a project's custom domain

### DIFF
--- a/apps/os/src/components/app-sidebar.tsx
+++ b/apps/os/src/components/app-sidebar.tsx
@@ -549,14 +549,12 @@ function ProjectSidebarGroup({
     queryFn: () => getProjectCustomHostnames({ data: { projectId: projectId ?? "" } }),
     staleTime: 5 * 60_000,
   });
-  const customHostname = customHostnames.data?.[0];
-  const projectWorkerUrl = customHostname
-    ? `https://${customHostname}/`
-    : buildProjectWorkerUrl({
-        projectSlug,
-        projectHostnameBases,
-        appBaseUrl,
-      });
+  const projectWorkerUrl = buildProjectWorkerUrl({
+    projectSlug,
+    customHostname: customHostnames.data?.[0] ?? null,
+    projectHostnameBases,
+    appBaseUrl,
+  });
   const showAgentRows = sidebarAgentRowsVisible({
     isMobile,
     openMobile,

--- a/apps/os/src/components/app-sidebar.tsx
+++ b/apps/os/src/components/app-sidebar.tsx
@@ -549,15 +549,14 @@ function ProjectSidebarGroup({
     queryFn: () => getProjectCustomHostnames({ data: { projectId: projectId ?? "" } }),
     staleTime: 5 * 60_000,
   });
-  // A malformed directory entry must not cost the link entirely — fall back
-  // to the platform host when the custom hostname fails validation.
-  const projectWorkerUrl =
-    buildProjectWorkerUrl({
-      projectSlug,
-      customHostname: customHostnames.data?.[0] ?? null,
-      projectHostnameBases,
-      appBaseUrl,
-    }) ?? buildProjectWorkerUrl({ projectSlug, projectHostnameBases, appBaseUrl });
+  // A malformed directory entry must not cost the link entirely: take the
+  // first registered hostname that passes validation, then the platform host.
+  const projectWorkerUrl = [...(customHostnames.data ?? []), null].reduce<string | null>(
+    (url, customHostname) =>
+      url ??
+      buildProjectWorkerUrl({ projectSlug, customHostname, projectHostnameBases, appBaseUrl }),
+    null,
+  );
   const showAgentRows = sidebarAgentRowsVisible({
     isMobile,
     openMobile,

--- a/apps/os/src/components/app-sidebar.tsx
+++ b/apps/os/src/components/app-sidebar.tsx
@@ -549,12 +549,15 @@ function ProjectSidebarGroup({
     queryFn: () => getProjectCustomHostnames({ data: { projectId: projectId ?? "" } }),
     staleTime: 5 * 60_000,
   });
-  const projectWorkerUrl = buildProjectWorkerUrl({
-    projectSlug,
-    customHostname: customHostnames.data?.[0] ?? null,
-    projectHostnameBases,
-    appBaseUrl,
-  });
+  // A malformed directory entry must not cost the link entirely — fall back
+  // to the platform host when the custom hostname fails validation.
+  const projectWorkerUrl =
+    buildProjectWorkerUrl({
+      projectSlug,
+      customHostname: customHostnames.data?.[0] ?? null,
+      projectHostnameBases,
+      appBaseUrl,
+    }) ?? buildProjectWorkerUrl({ projectSlug, projectHostnameBases, appBaseUrl });
   const showAgentRows = sidebarAgentRowsVisible({
     isMobile,
     openMobile,

--- a/apps/os/src/components/app-sidebar.tsx
+++ b/apps/os/src/components/app-sidebar.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState, type ReactElement } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Link, useMatches, useMatchRoute, useSearch } from "@tanstack/react-router";
 import {
   ArrowLeft,
@@ -73,6 +74,7 @@ import { DeferredSurface } from "~/components/deferred-surface.tsx";
 import type { AppConfig } from "~/config.ts";
 import { deriveAgentDisplayState } from "~/domains/agents/agent-presence.ts";
 import { buildProjectWorkerUrl } from "~/lib/project-host-routing.ts";
+import { getProjectCustomHostnames } from "~/lib/project-custom-hostnames.ts";
 import { projectsListStaleTime } from "~/lib/projects-query.ts";
 import type { PublicRouteConfig } from "~/lib/public-route-config.ts";
 import { StreamPath, type StreamPath as StreamPathType } from "~/lib/stream-links.ts";
@@ -539,11 +541,22 @@ function ProjectSidebarGroup({
       fuzzy: false,
     }) && routeSearch.tasks === true,
   );
-  const projectWorkerUrl = buildProjectWorkerUrl({
-    projectSlug,
-    projectHostnameBases,
-    appBaseUrl,
+  // A registered custom domain (garple.com) is the project's real address —
+  // the Homepage link prefers it over the platform host (<slug>.<base>).
+  const customHostnames = useQuery({
+    enabled: projectId !== null,
+    queryKey: ["project-custom-hostnames", projectId],
+    queryFn: () => getProjectCustomHostnames({ data: { projectId: projectId ?? "" } }),
+    staleTime: 5 * 60_000,
   });
+  const customHostname = customHostnames.data?.[0];
+  const projectWorkerUrl = customHostname
+    ? `https://${customHostname}/`
+    : buildProjectWorkerUrl({
+        projectSlug,
+        projectHostnameBases,
+        appBaseUrl,
+      });
   const showAgentRows = sidebarAgentRowsVisible({
     isMobile,
     openMobile,

--- a/apps/os/src/lib/project-custom-hostnames.ts
+++ b/apps/os/src/lib/project-custom-hostnames.ts
@@ -1,5 +1,6 @@
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
+import { itxAuthFromPrincipal } from "~/auth.ts";
 import { itxEnv as env } from "~/env.ts";
 
 const Input = z.object({ projectId: z.string() });
@@ -18,9 +19,13 @@ const Input = z.object({ projectId: z.string() });
 export const getProjectCustomHostnames = createServerFn({ method: "GET" })
   .validator((input: z.input<typeof Input>) => Input.parse(input))
   .handler(async ({ context, data }): Promise<string[]> => {
-    // Hostnames are public routing facts, but only signed-in dashboard users
-    // have any business enumerating them.
-    if (!context.iterateAuthSession && !context.operatorSession) return [];
+    const principal = context.principal;
+    if (!principal) return [];
+    const auth = itxAuthFromPrincipal(principal, {
+      allowDirectoryFallback: context.operatorSession == null,
+    });
+    await auth.ensureCanAccessProject?.(data.projectId);
+    auth.assertCanAccessProject(data.projectId);
     const hostnames: string[] = [];
     let cursor: string | undefined;
     do {

--- a/apps/os/src/lib/project-custom-hostnames.ts
+++ b/apps/os/src/lib/project-custom-hostnames.ts
@@ -1,0 +1,46 @@
+import { createServerFn } from "@tanstack/react-start";
+import { z } from "zod";
+import { itxEnv as env } from "~/env.ts";
+
+const Input = z.object({ projectId: z.string() });
+
+/**
+ * The custom hostnames ingress routes to one project — a reverse scan of the
+ * hostname directory (`hostname:<host>` keys, written by custom-domain
+ * provisioning). The directory is the routing truth: the processor's
+ * `customDomains` state can lag it or predate it (prd's `iterate.com` is a
+ * direct registration with no domain events behind it). The directory stays
+ * small deployment-wide, so a prefix scan per call is fine, and callers cache.
+ *
+ * Sorted apex-most first — fewest labels, then shortest — so `garple.com`
+ * beats `www.garple.com` as a project's canonical address.
+ */
+export const getProjectCustomHostnames = createServerFn({ method: "GET" })
+  .validator((input: z.input<typeof Input>) => Input.parse(input))
+  .handler(async ({ context, data }): Promise<string[]> => {
+    // Hostnames are public routing facts, but only signed-in dashboard users
+    // have any business enumerating them.
+    if (!context.iterateAuthSession && !context.operatorSession) return [];
+    const hostnames: string[] = [];
+    let cursor: string | undefined;
+    do {
+      const page = await env.PROJECT_DIRECTORY.list({ cursor, prefix: "hostname:" });
+      const records = await Promise.all(
+        page.keys.map((key) =>
+          env.PROJECT_DIRECTORY.get<{ id?: string }>(key.name, "json")
+            .then((record) => ({ key: key.name, record }))
+            .catch(() => null),
+        ),
+      );
+      for (const entry of records) {
+        if (entry?.record?.id === data.projectId) {
+          hostnames.push(entry.key.slice("hostname:".length));
+        }
+      }
+      cursor = page.list_complete ? undefined : page.cursor;
+    } while (cursor);
+    return hostnames.sort(
+      (a, b) =>
+        a.split(".").length - b.split(".").length || a.length - b.length || a.localeCompare(b),
+    );
+  });

--- a/specs/seeded-apps.spec.ts
+++ b/specs/seeded-apps.spec.ts
@@ -113,7 +113,7 @@ test("the seeded internal app authenticates a real project member", async ({ bas
   // into an app-host-only HttpOnly cookie before returning to `/`. The click
   // waits through two origins and three navigations, so give that bounded
   // protocol work a wider budget than an ordinary in-page action.
-  await page.getByRole("button", { name: "Continue with Iterate" }).click({ timeout: 30_000 });
+  await page.getByRole("link", { name: "Continue with iterate" }).click({ timeout: 30_000 });
   await page
     .getByRole("heading", { name: "Latest project root events" })
     .waitFor({ timeout: 30_000 });
@@ -156,7 +156,7 @@ test("the seeded internal app authenticates a real project member", async ({ bas
   // package-backed server and compiles the browser entry.
   await page.goto(appUrl("todo", slug, baseURL!));
   await page.getByRole("heading", { name: "Sign in to Iterate" }).waitFor({ timeout: 60_000 });
-  await page.getByRole("button", { name: "Continue with Iterate" }).click({ timeout: 30_000 });
+  await page.getByRole("link", { name: "Continue with iterate" }).click({ timeout: 30_000 });
   // The cross-origin callback briefly has neither this heading nor a loading
   // marker. Preserve the real cold-build deadline instead of letting
   // spinner-waiter collapse the wait to its no-spinner fast-fail.


### PR DESCRIPTION
## What

The sidebar's **Homepage** link now prefers a project's registered custom domain over the platform host: for the `iterate` project it links `https://iterate.com/` instead of `https://iterate.iterate.app/`.

- New server fn `getProjectCustomHostnames` (`apps/os/src/lib/project-custom-hostnames.ts`): reverse scan of the ingress hostname directory (`hostname:<host>` KV keys). The directory is used rather than the processor's `customDomains` state because the directory is the routing truth — prd's `iterate.com`/`www.iterate.com` are direct registrations with no domain events behind them, and only signed-in dashboard users can call it.
- Result is sorted apex-most first (fewest labels, then shortest), so `iterate.com` beats `www.iterate.com`.
- `ProjectSidebarGroup` queries it (5-minute staleTime) and falls back to `buildProjectWorkerUrl` when a project has no custom domains — local dev and most projects are unchanged.

## Testing

`pnpm typecheck && pnpm lint && pnpm format` green. The fallback path (no registrations → `[]` → platform host) is the behavior every existing e2e exercises; the custom-domain path was validated against the real prd directory state (both `iterate.com` and `www.iterate.com` resolve to the iterate project record, apex sorts first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI URL selection with project access checks on the new server fn; platform-host fallback unchanged for projects without custom domains.
> 
> **Overview**
> The project sidebar **Homepage** link now uses a project's registered custom domain when one exists, instead of always pointing at the platform host (`<slug>.<base>`).
> 
> A new authenticated server function **`getProjectCustomHostnames`** scans the ingress **`PROJECT_DIRECTORY`** for `hostname:*` keys tied to the project (treated as routing truth over processor state), returns hostnames sorted apex-first, and **`ProjectSidebarGroup`** loads them with a 5-minute React Query cache. It picks the first hostname that **`buildProjectWorkerUrl`** accepts, then falls back to the platform URL when the list is empty.
> 
> Seeded-apps Playwright steps now click the **Continue with iterate** control as a **link** rather than a **button**, matching the auth UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83a59b33e636ac4b49a9b133408945387e0384fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +51 -0 | +38 -0 🟩🟩🟩🟩🟩 |
| UI components | +17 -4 | +13 -4 🟩🟩⬜⬜⬜ |
| Tests | +2 -2 | +2 -2 🟩⬜⬜⬜⬜ |
| **Total** | **+70 -6** | **+53 -6** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between c9993b0 and 83a59b3, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-21T14:18:13.527Z",
      "headSha": "83a59b33e636ac4b49a9b133408945387e0384fe",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-18.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/558265419556781",
      "shortSha": "83a59b3",
      "cleanupDurationMs": 18960,
      "deployDurationMs": 188462,
      "testDurationMs": 187670,
      "testRetries": null,
      "workerSizeKib": 17127.15,
      "workerGzipKib": 4603.97,
      "mainWorkerGzipKib": 4617.21
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-21T14:17:57.310Z",
      "headSha": "83a59b33e636ac4b49a9b133408945387e0384fe",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-18.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/558265419556781",
      "shortSha": "83a59b3",
      "cleanupDurationMs": 2736,
      "deployDurationMs": 20298,
      "testDurationMs": 11552,
      "testRetries": null,
      "workerSizeKib": 3965.81,
      "workerGzipKib": 811.52,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-21T14:17:55.180Z",
      "headSha": "83a59b33e636ac4b49a9b133408945387e0384fe",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-18.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/558265419556781",
      "shortSha": "83a59b3",
      "cleanupDurationMs": 604,
      "deployDurationMs": 6748,
      "testDurationMs": 5750,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `83a59b3` | [https://auth.iterate-preview-18.com](https://auth.iterate-preview-18.com) | 811.5 KiB | 20.3s | 11.6s |  | 2.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/558265419556781) | 2026-07-21T14:17:57.310Z | Preview app released. |
| Dummy Petshop | released | `83a59b3` | [https://dummy-petshop.iterate-preview-18.com](https://dummy-petshop.iterate-preview-18.com) | 198.2 KiB | 6.7s | 5.8s |  | 604ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/558265419556781) | 2026-07-21T14:17:55.180Z | Preview app released. |
| OS | released | `83a59b3` | [https://os.iterate-preview-18.com](https://os.iterate-preview-18.com) | 4.50 MiB (-13.2 KiB vs main) | 188.5s | 187.7s |  | 19.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/558265419556781) | 2026-07-21T14:18:13.527Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->