### PR TITLE
Mint the avatar URL (image) into project-app-session claims

### DIFF
--- a/apps/auth-contract/src/worker.ts
+++ b/apps/auth-contract/src/worker.ts
@@ -52,6 +52,8 @@ export type MintProjectAppSessionInput = {
   /** Display identity baked into the claims for the app behind the proxy
    * (presence, authorship). Carries no authority — userId is the principal. */
   email?: string;
+  /** Avatar URL, same display-only status as email/name. */
+  image?: string;
   name?: string;
   projectId: string;
   userId: string;

--- a/apps/auth/src/server/project-app-session.test.ts
+++ b/apps/auth/src/server/project-app-session.test.ts
@@ -80,7 +80,14 @@ describe("project app sessions", () => {
   it("bakes optional display identity into the claims and still validates", async () => {
     const userCanAccessProject = async () => true;
     const issued = await mintProjectAppSession(
-      { audience, projectId, userId: "usr_one", email: "one@example.com", name: "One Person" },
+      {
+        audience,
+        projectId,
+        userId: "usr_one",
+        email: "one@example.com",
+        image: "https://example.com/one.png",
+        name: "One Person",
+      },
       { secret, userCanAccessProject },
     );
     assert.ok(issued);
@@ -89,6 +96,7 @@ describe("project app sessions", () => {
       Buffer.from(issued.token.split(".")[1]!, "base64url").toString("utf8"),
     ) as Record<string, unknown>;
     assert.equal(payload.email, "one@example.com");
+    assert.equal(payload.image, "https://example.com/one.png");
     assert.equal(payload.name, "One Person");
     assert.equal(payload.userId, "usr_one");
 
@@ -101,7 +109,7 @@ describe("project app sessions", () => {
 
     // …and blank display fields stay out of the claims entirely.
     const bare = await mintProjectAppSession(
-      { audience, projectId, userId: "usr_one", email: "", name: "  " },
+      { audience, projectId, userId: "usr_one", email: "", image: " ", name: "  " },
       { secret, userCanAccessProject },
     );
     assert.ok(bare);
@@ -109,6 +117,7 @@ describe("project app sessions", () => {
       Buffer.from(bare.token.split(".")[1]!, "base64url").toString("utf8"),
     ) as Record<string, unknown>;
     assert.equal("email" in bareClaims, false);
+    assert.equal("image" in bareClaims, false);
     assert.equal("name" in bareClaims, false);
   });
 });

--- a/apps/auth/src/server/project-app-session.ts
+++ b/apps/auth/src/server/project-app-session.ts
@@ -16,6 +16,7 @@ const ProjectAppSessionClaims = z
     email: z.string().trim().min(1).max(320).optional(),
     exp: z.number().int(),
     iat: z.number().int(),
+    image: z.string().trim().min(1).max(2048).optional(),
     name: z.string().trim().min(1).max(256).optional(),
     projectId: z.string().trim().min(1).max(256),
     type: z.literal("project-app-session"),
@@ -48,6 +49,7 @@ export async function mintProjectAppSession(
       {
         audience: input.audience,
         ...(input.email === undefined ? {} : { email: input.email }),
+        ...(input.image === undefined ? {} : { image: input.image }),
         ...(input.name === undefined ? {} : { name: input.name }),
         projectId: input.projectId,
         type: "project-app-session",
@@ -92,6 +94,7 @@ function parseMintInput(input: MintProjectAppSessionInput) {
   return {
     audience: parseAudience(input.audience),
     email: optionalDisplayField(input.email, 320),
+    image: optionalDisplayField(input.image, 2048),
     name: optionalDisplayField(input.name, 256),
     projectId: z.string().trim().min(1).max(256).parse(input.projectId),
     userId: z.string().trim().min(1).max(256).parse(input.userId),

--- a/apps/os/src/auth/project-auth.ts
+++ b/apps/os/src/auth/project-auth.ts
@@ -160,7 +160,7 @@ export async function handleProjectAuthStart(input: {
   mintSession(input: MintProjectAppSessionInput): Promise<{ token: string } | null>;
   request: Request;
   resolveProjectId(targetUrl: string): Promise<string | null>;
-  session: { userId: string; email?: string; name?: string } | null;
+  session: { userId: string; email?: string; image?: string; name?: string } | null;
 }): Promise<Response> {
   if (input.request.method !== "GET") return methodNotAllowed("GET");
   const requestUrl = new URL(input.request.url);
@@ -192,6 +192,7 @@ export async function handleProjectAuthStart(input: {
     issued = await input.mintSession({
       audience: target.origin,
       email: input.session.email,
+      image: input.session.image,
       name: input.session.name,
       projectId,
       userId: input.session.userId,

--- a/apps/os/src/routes/api.$.ts
+++ b/apps/os/src/routes/api.$.ts
@@ -21,6 +21,7 @@ export const Route = createFileRoute("/api/$")({
               ? {
                   userId: context.iterateAuthSession.user.id,
                   email: context.iterateAuthSession.user.email || undefined,
+                  image: context.iterateAuthSession.user.picture || undefined,
                   name: context.iterateAuthSession.user.name || undefined,
                 }
               : null,


### PR DESCRIPTION
Follow-up to #2193: adds an optional `image` claim (the better-auth/OIDC `picture` URL) to project-app-session tokens, so remote apps behind the config-worker proxy can render real avatar images in presence UIs straight off the use-verified token — the tasks app already consumes it (AvatarImage with colored-initials fallback).

- Display-only like email/name: no authority, `userId` stays the principal.
- Strict claims schema gains the optional field; blank values stay out of the payload; pre-rollout tokens keep validating (test extended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only JWT claim extension with backward-compatible validation; no authz or session principal changes.
> 
> **Overview**
> Adds an optional **`image`** display claim to project-app-session JWTs so proxied project apps can show avatar URLs from the verified token (same non-authoritative role as `email`/`name`; **`userId`** remains the principal).
> 
> Auth minting accepts **`image`** on the contract and strict Zod claims (max 2048, omitted when blank). OS **`/api/project-auth/start`** forwards **`iterateAuthSession.user.picture`** as **`image`** when minting. Tests assert the claim is embedded and that whitespace-only values are stripped from the payload; older tokens without **`image`** still validate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9edce4c0545f03088b9e59b17627ad542f67bb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +8 -1 | +7 -1 🟩🟩🟩⬜⬜ |
| Tests | +11 -2 | +11 -2 🟩🟩🟩🟩🟥 |
| **Total** | **+19 -3** | **+18 -3** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 3e0675d and c9edce4, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->