### PR TITLE
Avoid installing Iterate CLI dependencies in userspace builds

### DIFF
--- a/patches/@cloudflare__worker-bundler@0.2.1.patch
+++ b/patches/@cloudflare__worker-bundler@0.2.1.patch
@@ -2,7 +2,7 @@ diff --git a/dist/installer-Ns4ivVf5.js b/dist/installer-Ns4ivVf5.js
 index 0220df7c889d58e6a670214eb1b6e1aa10215b2f..47627a3aad06d1de1f732ed48ccdf7e82197805a 100644
 --- a/dist/installer-Ns4ivVf5.js
 +++ b/dist/installer-Ns4ivVf5.js
-@@ -75,20 +75,32 @@ async function installPackage(name, versionRange, result, fileSystem, installedP
+@@ -75,20 +75,40 @@ async function installPackage(name, versionRange, result, fileSystem, installedP
  	if (existing) return existing;
  	const installPromise = (async () => {
  		try {
@@ -44,9 +44,18 @@ index 0220df7c889d58e6a670214eb1b6e1aa10215b2f..47627a3aad06d1de1f732ed48ccdf7e8
  			result.installed.push(`${name}@${version}`);
 -			const packageFiles = await fetchPackageFiles(name, versionMetadata);
  			for (const [filePath, content] of Object.entries(packageFiles)) fileSystem.write(`node_modules/${name}/${filePath}`, content);
- 			const deps = versionMetadata.dependencies ?? {};
+-			const deps = versionMetadata.dependencies ?? {};
++			// Temporary until Iterate publishes its SDK separately: userspace workers
++			// must not install the CLI dependency graph for SDK-only imports.
++			const dependencies = versionMetadata.dependencies ?? {};
++			const deps = name === "iterate" ? Object.fromEntries(Object.entries(dependencies).filter(([dependency]) => [
++				"@iterate-com/capnweb",
++				"@tanstack/react-query",
++				"react",
++				"zod"
++			].includes(dependency))) : dependencies;
  			await Promise.all(Object.entries(deps).map(([depName, depVersion]) => installPackage(depName, depVersion, result, fileSystem, installedPackages, inProgress, registry)));
-@@ -104,6 +116,25 @@ async function installPackage(name, versionRange, result, fileSystem, installedP
+@@ -104,6 +124,25 @@ async function installPackage(name, versionRange, result, fileSystem, installedP
  		inProgress.delete(name);
  	}
  }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,7 @@ patchedDependencies:
     hash: e05b6e0e968dd85c546197511b6b7bdeaf9f4449572e4a143d90d5d31008fb40
     path: patches/@better-auth__oauth-provider@1.6.9.patch
   '@cloudflare/worker-bundler@0.2.1':
-    hash: d2bb8caf8f458739322f7e885d1dae5c152accfc58d5812f0097897843f293db
+    hash: 73256eb6fd3dcae81991c5c1730c823d847cb51938ee0cdb524018a167f938c9
     path: patches/@cloudflare__worker-bundler@0.2.1.patch
   '@cloudflare/workers-types@4.20260621.1':
     hash: ae8908e1d45f2ea02ffeabf1230701598cc2878240ef700403ff76df72677af2
@@ -539,7 +539,7 @@ importers:
         version: 0.3.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@tanstack/ai@0.10.2)(ai@6.0.159(zod@4.3.6))(zod@4.3.6)
       '@cloudflare/worker-bundler':
         specifier: 0.2.1
-        version: 0.2.1(patch_hash=d2bb8caf8f458739322f7e885d1dae5c152accfc58d5812f0097897843f293db)
+        version: 0.2.1(patch_hash=73256eb6fd3dcae81991c5c1730c823d847cb51938ee0cdb524018a167f938c9)
       '@codemirror/autocomplete':
         specifier: ^6.20.1
         version: 6.20.1
@@ -14306,7 +14306,7 @@ snapshots:
       - utf-8-validate
       - workerd
 
-  '@cloudflare/worker-bundler@0.2.1(patch_hash=d2bb8caf8f458739322f7e885d1dae5c152accfc58d5812f0097897843f293db)':
+  '@cloudflare/worker-bundler@0.2.1(patch_hash=73256eb6fd3dcae81991c5c1730c823d847cb51938ee0cdb524018a167f938c9)':
     dependencies:
       '@typescript/vfs': 1.6.4(typescript@6.0.3)
       es-module-lexer: 2.1.0

--- a/tasks/separate-iterate-sdk-package.md
+++ b/tasks/separate-iterate-sdk-package.md
@@ -18,12 +18,25 @@ runtime dependency graph even when it imports a narrow SDK subpath such as
 This is particularly expensive for userspace apps. The dynamic worker builder
 installs a package and all of its declared runtime dependencies before esbuild
 can tree-shake unused exports. A guestbook client that only needs LiveState
-therefore also downloads the CLI, OpenTUI, ORPC, and other unrelated dependency
-trees. Subpath exports cannot fix this because npm dependencies are declared
-for the whole package, not per export.
+therefore also downloads Clack, trpc-cli, ORPC, and other unrelated CLI
+dependency trees. OpenTUI is now optional and is not traversed by the current
+worker-bundler installer, but it still belongs on the CLI side of the eventual
+package boundary. Subpath exports cannot fix the underlying problem because npm
+dependencies are declared for the whole package, not per export.
 
-PR #2167 applies a tactical cleanup by correctly classifying optional TUI and
-type-only dependencies. The durable fix is a real package boundary.
+PR #2167 applied a tactical cleanup by correctly classifying optional TUI and
+type-only dependencies. Until this task lands, the existing worker-bundler
+patch also contains a deliberately gross workaround: when the package being
+installed is named `iterate`, the installer follows only a hard-coded SDK
+dependency allowlist (`@iterate-com/capnweb`, `@tanstack/react-query`, `react`,
+and `zod`). This avoids downloading the known CLI graph during dynamic app
+builds without pretending to provide import-aware package installation.
+
+The allowlist does not change the published manifest or solve the package
+boundary. A new SDK runtime dependency must be added to the allowlist or the
+userspace build will fail, deliberately and visibly. Remove the allowlist and
+the worker-bundler patch as part of this task once seeded apps install the real
+SDK artifact.
 
 ## Goal
 
@@ -71,12 +84,17 @@ select the exact pkg.pr.new artifact for a preview PR head.
   policy; they must not silently fall back to an unrelated moving version.
 - The package must install through conventional npm-compatible semantics. Do
   not teach worker-bundler to lazily approximate a package manager or maintain
-  an application-specific transitive-dependency allowlist.
+  an application-specific transitive-dependency allowlist. The temporary
+  `iterate` allowlist described above is explicitly technical debt to delete,
+  not part of the target design.
 
 ## Acceptance criteria
 
 - [ ] A freshly packed SDK has no dependencies on OpenTUI, Clack, ORPC,
       trpc-cli, Octokit, or CLI-only Node packages.
+- [ ] Remove the hard-coded `iterate` dependency allowlist from the
+      worker-bundler patch; installing the SDK follows its complete published
+      dependency graph normally.
 - [ ] The guestbook and todo templates consume the published SDK through their
       existing `iterate/...` imports with no virtual-module copies or CDN
       imports.


### PR DESCRIPTION
## Summary

Follow-up to #2167: make cold userspace app builds stop downloading Iterate's CLI dependency graph when the app only imports SDK subpaths.

This extends our existing `@cloudflare/worker-bundler` patch with one deliberately narrow rule:

- every package except `iterate` still installs its complete published `dependencies`
- `iterate` installs only the currently required SDK runtime dependencies:
  - `@iterate-com/capnweb`
  - `@tanstack/react-query`
  - `react`
  - `zod`

The lockfile only changes the worker-bundler patch hash. The separate-SDK task now documents this workaround, its failure mode, and its required deletion.

## Why this is necessary

The first production request to the newly seeded guestbook returned our intentional `503 worker_building` response because the browser build budget is 1.5 seconds. The correlated build completed successfully in 5.532 seconds, but worker-bundler made 67 package requests:

- 1 request for the exact `pkg.pr.new` Iterate tarball selected through `APP_CONFIG_ITERATE_SDK_PACKAGE_SPEC`
- 66 requests to the npm registry
- the downloaded graph included unrelated CLI dependencies such as Clack, trpc-cli, ORPC, Commander, and their transitives

esbuild can tree-shake exports only after worker-bundler has recursively installed the package's complete declared dependency graph, so SDK subpath imports cannot avoid that download cost by themselves.

A focused installation of the same exact `pkg.pr.new` artifact with this patch completed in 1.15 seconds with 11 HTTP requests and six installed packages:

- `iterate`
- `@iterate-com/capnweb`
- `@tanstack/react-query`
- `@tanstack/query-core`
- `react`
- `zod`

There were no warnings and no Clack, ORPC, trpc-cli, or OpenTUI packages.

This local result is not an apples-to-apples Cloudflare production latency benchmark, but it proves the installer now follows the intended dramatically smaller graph.

## Deliberate grossness and ownership

@mmkal, you are going to inherit removing this workaround as part of the separate Iterate SDK package work. It is intentionally gross, but it was necessary to make userspace cold builds much faster now instead of waiting for the package split.

The important constraints are recorded in `tasks/separate-iterate-sdk-package.md`:

- this does not change or repair the published `iterate` manifest
- this is not import-aware installation and must not become a general worker-bundler feature
- a new Iterate SDK runtime dependency must be added to the allowlist or userspace builds fail visibly
- the allowlist must be deleted once seeded apps install a real SDK artifact with a naturally lean dependency graph

The allowlist is intentional: unlike a denylist, an unexpected new dependency does not silently reintroduce the CLI graph.

## Validation

- `pnpm install --frozen-lockfile --offline`
- exact `pkg.pr.new` artifact installed through worker-bundler: 11 requests, six packages, zero warnings, zero forbidden CLI/TUI packages
- `pnpm exec vitest run src/worker-bundler.test.ts src/domains/workers/build-backend.test.ts`: 12 tests passed
- staged-file formatting hook passed

No generated-code unit tests were added.

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Docs | +25 -7 | +23 -6 🟩🟩🟩🟩🟥 |
| Other | +12 -3 | +12 -3 🟩🟩🟥⬜⬜ |
| Generated | +3 -3 | +3 -3 🟩⬜⬜⬜⬜ |
| **Total** | **+40 -13** | **+38 -12** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 7f729ba and e378375, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the patched installer used for all userspace worker builds; the `iterate`-only allowlist can break builds if SDK dependencies grow without updating the list, though that failure mode is intentional.
> 
> **Overview**
> Userspace dynamic builds were timing out because worker-bundler recursively installed the full `iterate` manifest (CLI graph) before esbuild could tree-shake SDK subpath imports. This PR extends the existing **`@cloudflare/worker-bundler`** patch so installs named **`iterate`** follow a hard-coded SDK allowlist—`@iterate-com/capnweb`, `@tanstack/react-query`, `react`, and `zod`—while every other package still gets its full published `dependencies`. The patch also adds **direct HTTP(S) tarball** dependency specs with `package.json` validation, which supports exact `pkg.pr.new` artifacts from preview config.
> 
> **`tasks/separate-iterate-sdk-package.md`** is updated to treat the allowlist as explicit technical debt: new SDK runtime deps must be added to the list or builds fail visibly, and the allowlist must be removed when a lean SDK artifact ships. The lockfile only refreshes the worker-bundler patch hash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3783756dccb63ed13c220294f9a779a784b4931. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->