### PR TITLE
www. on custom hostnames permanent-redirects to the apex

### DIFF
--- a/apps/os/src/ingress.test.ts
+++ b/apps/os/src/ingress.test.ts
@@ -226,6 +226,20 @@ test.for([
     expected: { lane: "project", resolved: { projectId: "prj_custom", appSlug: "someapp" } },
   },
   {
+    name: "www. on a resolving custom hostname permanent-redirects to the apex",
+    config: PREVIEW_CONFIG,
+    resolvers: customHostnameResolvers(),
+    url: "https://www.bla.com/notes?tab=all",
+    expected: { lane: "redirect", location: "https://bla.com/notes?tab=all" },
+  },
+  {
+    name: "www. with nothing behind it still resolves normally",
+    config: PREVIEW_CONFIG,
+    resolvers: customHostnameResolvers(),
+    url: "https://www.unregistered.com/",
+    expected: { lane: "notFound" },
+  },
+  {
     name: "404s non-OS hosts that resolve to nothing",
     config: PREVIEW_CONFIG,
     resolvers: slugResolvers({}),

--- a/apps/os/src/ingress.ts
+++ b/apps/os/src/ingress.ts
@@ -46,6 +46,7 @@ type IngressRoute =
       fetch: { headers: Headers; method: string; url: string };
       resolved: { appSlug: string | null; projectId: string };
     }
+  | { lane: "redirect"; location: string }
   | { lane: "notFound" };
 
 export async function decideIngressRoute(input: {
@@ -97,6 +98,19 @@ export async function decideIngressRoute(input: {
       projectId,
       url: input.url,
     });
+  }
+
+  // `www.` on a custom hostname is an alias, never content: when the host
+  // minus its `www.` label resolves to a project, permanent-redirect there
+  // instead of serving the same pages on two origins (www.garple.com →
+  // garple.com, path and query preserved). Checked before the direct lookup
+  // so an exactly-registered `www.<apex>` also redirects.
+  if (host.startsWith("www.")) {
+    const apex = host.slice("www.".length);
+    const apexTarget = await input.resolvers.projectByHostname(apex);
+    if (apexTarget) {
+      return { lane: "redirect", location: `${url.protocol}//${apex}${url.pathname}${url.search}` };
+    }
   }
 
   const custom = await input.resolvers.projectByHostname(host);

--- a/apps/os/src/worker.ts
+++ b/apps/os/src/worker.ts
@@ -257,6 +257,12 @@ async function apiFetch(
     return response;
   }
 
+  if (route.lane === "redirect") {
+    // 308 keeps the method across the hop (a 301 lets clients downgrade
+    // POST to GET) and is as permanently cacheable as www aliases deserve.
+    return new Response(null, { headers: { location: route.location }, status: 308 });
+  }
+
   if (route.lane === "notFound") {
     return Response.json({ error: "not found" }, { status: 404 });
   }


### PR DESCRIPTION
`www.<host>` on the custom-hostname lane now answers a 308 to `<host>` (path + query preserved) whenever the apex resolves to a project — instead of serving identical content on two origins, which is what `www.iterate.com` was doing after its directory registration. The check runs before the exact lookup, so an exactly-registered `www.<apex>` also redirects; a `www.` host whose remainder resolves to nothing falls through to normal resolution. 308 rather than 301 so methods survive the hop.

Covered by two new table cases in `ingress.test.ts`; `pnpm typecheck && pnpm lint && pnpm test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow ingress behavior change for custom `www.` hosts only; covered by unit tests and no auth or data-path changes.
> 
> **Overview**
> Custom-hostname ingress now treats **`www.<apex>`** as a canonical redirect to the apex when the stripped host resolves to a project, instead of serving duplicate content on two origins.
> 
> **`decideIngressRoute`** gains a **`redirect`** lane: before the exact custom-host lookup, hosts starting with `www.` are checked against `projectByHostname` on the remainder; a hit returns the apex URL with path and query preserved. Registered `www.<apex>` hostnames redirect too; if the apex does not resolve, routing continues as before (e.g. **notFound**).
> 
> The worker answers **`redirect`** with **HTTP 308** and a **`Location`** header so non-GET methods are not downgraded. Two table-driven cases in **`ingress.test.ts`** cover a successful redirect and a `www.` host with no backing project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6861b954c6784c9cef34da4a2ddc13d17a35065b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +20 -0 | +11 -0 🟩🟩🟩🟩⬜ |
| Tests | +14 -0 | +14 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+34 -0** | **+25 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 8763925 and 6861b95, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-21T15:10:30.373Z",
      "headSha": "6861b954c6784c9cef34da4a2ddc13d17a35065b",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/148672365187283",
      "shortSha": "6861b95",
      "cleanupDurationMs": 377829,
      "deployDurationMs": 177070,
      "testDurationMs": 228514,
      "testRetries": "6 retried: runScript caps an in-script sandbox timeout to its absolute deadline and kills the process group (vitest x1) — expected { timedOut: { …(7) } } to match object { timedOut: { exitCode: 124, …(1) } } (5 matching properties omitted from actual) · subscription and subscribe inputs are validated at the door (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · cross-posts do not recursively copy events that are already cross-posted (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · a commented tsconfig still schema-validates (comments are tolerated) (specs x1) — Error: /repos/ide could not be created: Cloudflare API GET /queues?page=1&per_page=100 failed (429): null · toggle a markdown file between Code and its rendered Preview (specs x1) — Error: stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · edit, stage, inspect the Index, and commit through the repo IDE (specs x1) — TimeoutError: locator.click: Timeout 1ms exceeded. Call log: \u001b[2m - waiting for locator('.cm-content')\u001b[22m \u001b[33m If this is a slow operation, update the product code to add a spinner while it's running. This will improve the user experience and buy you more time for this assertion. To add a spin...",
      "workerSizeKib": 17134.51,
      "workerGzipKib": 4606.69,
      "mainWorkerGzipKib": 4618.47
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-21T15:04:15.376Z",
      "headSha": "6861b954c6784c9cef34da4a2ddc13d17a35065b",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/148672365187283",
      "shortSha": "6861b95",
      "cleanupDurationMs": 2830,
      "deployDurationMs": 21300,
      "testDurationMs": 10823,
      "testRetries": null,
      "workerSizeKib": 3965.97,
      "workerGzipKib": 811.62,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-21T15:04:13.233Z",
      "headSha": "6861b954c6784c9cef34da4a2ddc13d17a35065b",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/148672365187283",
      "shortSha": "6861b95",
      "cleanupDurationMs": 685,
      "deployDurationMs": 6693,
      "testDurationMs": 5301,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `6861b95` | [https://auth.iterate-preview-13.com](https://auth.iterate-preview-13.com) | 811.6 KiB | 21.3s | 10.8s |  | 2.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/148672365187283) | 2026-07-21T15:04:15.376Z | Preview app released. |
| Dummy Petshop | released | `6861b95` | [https://dummy-petshop.iterate-preview-13.com](https://dummy-petshop.iterate-preview-13.com) | 198.2 KiB | 6.7s | 5.3s |  | 685ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/148672365187283) | 2026-07-21T15:04:13.233Z | Preview app released. |
| OS | released | `6861b95` | [https://os.iterate-preview-13.com](https://os.iterate-preview-13.com) | 4.50 MiB (-11.8 KiB vs main) | 177.1s | 228.5s | 6 retried: runScript caps an in-script sandbox timeout to its absolute deadline and kills the process group (vitest x1) — expected { timedOut: { …(7) } } to match object { timedOut: { exitCode: 124, …(1) } } (5 matching properties omitted from actual) · subscription and subscribe inputs are validated at the door (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · cross-posts do not recursively copy events that are already cross-posted (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · a commented tsconfig still schema-validates (comments are tolerated) (specs x1) — Error: /repos/ide could not be created: Cloudflare API GET /queues?page=1&per_page=100 failed (429): null · toggle a markdown file between Code and its rendered Preview (specs x1) — Error: stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). · edit, stage, inspect the Index, and commit through the repo IDE (specs x1) — TimeoutError: locator.click: Timeout 1ms exceeded. Call log: [2m - waiting for locator('.cm-content')[22m [33m If this is a slow operation, update the product code to add a spinner while it's running. This will improve the user experience and buy you more time for this assertion. To add a spin... | 377.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/148672365187283) | 2026-07-21T15:10:30.373Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->