### PR TITLE
Keep worker status visible under strict CSP

### DIFF
--- a/apps/os/docs/dynamic-worker-dispatch.md
+++ b/apps/os/docs/dynamic-worker-dispatch.md
@@ -141,16 +141,23 @@ Successful repo-backed fetches carry platform-authored
 removes any value user code tried to spoof before stamping this header.
 Project ingress uses it to inject the small **Iterate overlay** into HTML
 documents (HTMLRewriter, appended before `</body>`). Injection is skipped for
-non-documents, encoded bodies, responses with CSP, and responses opting out
-through `x-iterate-overlay`; the seeded basic apps intentionally omit CSP so
-the floating corner mark remains visible. The same streaming transform adds
-an inverted Iterate favicon at document end when the app has no `rel=icon`
-link anywhere in its document. Its reserved same-origin asset lives at
+non-documents, encoded bodies, and responses opting out through
+`x-iterate-overlay`. The live overlay is scriptless declarative shadow DOM;
+native details/summary provides its click-open panel. For a CSP-protected
+document, ingress generates a per-response nonce, authorizes it only in the
+style directive governing elements (in every header or meta policy), and puts
+it on the overlay's isolated stylesheet. When styles fall back to
+`default-src`, ingress copies those sources into a new `style-src` directive
+before adding the nonce; the nonce never enters `default-src`, where it could
+also become script permission. It never adds `unsafe-inline` or a new host
+source. The same streaming transform adds an
+inverted Iterate favicon at document end when the app has no `rel=icon` link
+anywhere in its document. Its reserved same-origin asset lives at
 `/.iterate/favicon.svg`, so normal self-only CSPs accept it without embedding
 the full SVG in every document. On the `/prj_<id>` path lane, the link keeps
 that browser-visible prefix while dispatch serves the rewritten project path.
-CSP and overlay opt-out affect the script widget, not the favicon fallback; an
-app-provided icon always wins. See `worker-serve-overlay.ts`.
+Overlay opt-out does not affect the favicon fallback; an app-provided icon
+always wins. See `worker-serve-overlay.ts`.
 
 ## Live capabilities and WebSockets: the specification, and today's boundary
 

--- a/apps/os/e2e/vitest/project-ingress.e2e.test.ts
+++ b/apps/os/e2e/vitest/project-ingress.e2e.test.ts
@@ -184,7 +184,7 @@ test("routes seeded apps by host and serves worker-bundler browser assets", asyn
   expect(guestbookHtml).toContain(
     '<script type="module" src="/apps/guestbook/client.js"></script>',
   );
-  expect(guestbookHtml).toContain("__iterateWorkerOverlay");
+  expect(guestbookHtml).toContain("data-iterate-worker-overlay");
   const guestbookClient = await fetchApp(`guestbook--${slug}`, {
     path: "/apps/guestbook/client.js",
   });

--- a/apps/os/e2e/vitest/worker-build-overlay.e2e.test.ts
+++ b/apps/os/e2e/vitest/worker-build-overlay.e2e.test.ts
@@ -42,9 +42,10 @@ test(
       "a successful worker build",
     );
     const homepage = await healthy.response.text();
+    const overlayMarker = "data-iterate-worker-overlay";
     expect(homepage).toContain("Hello from your iterate project worker");
-    expect(homepage).toContain("__iterateWorkerOverlay");
-    expect(homepage.indexOf("__iterateWorkerOverlay")).toBeGreaterThan(homepage.indexOf("<body"));
+    expect(homepage).toContain(overlayMarker);
+    expect(homepage.indexOf(overlayMarker)).toBeGreaterThan(homepage.indexOf("<body"));
 
     const original = await project.repo.readFile({ path: "worker.ts" });
     expect(original?.content).toContain("export default class ProjectWorker");

--- a/apps/os/src/domains/workers/worker-serve-overlay.test.ts
+++ b/apps/os/src/domains/workers/worker-serve-overlay.test.ts
@@ -7,6 +7,7 @@ import {
   withWorkerCommit,
 } from "./worker-serve-info.ts";
 import {
+  allowStyleNonceInCsp,
   relIncludesIcon,
   WORKER_DEFAULT_FAVICON_PATH,
   workerDefaultFaviconHtml,
@@ -63,6 +64,15 @@ describe("workerOverlayDecision", () => {
     expect(workerOverlayDecision(documentRequest, htmlResponse())).toBe(commitOid);
   });
 
+  test("injects for CSP-protected HTML because the transform authorizes only its style", () => {
+    expect(
+      workerOverlayDecision(
+        documentRequest,
+        htmlResponse({ "content-security-policy": "default-src 'none'" }),
+      ),
+    ).toBe(commitOid);
+  });
+
   test.each([
     [
       "no serve header",
@@ -70,7 +80,6 @@ describe("workerOverlayDecision", () => {
     ],
     ["non-HTML response", htmlResponse({ "content-type": "application/json" })],
     ["overlay opt-out", htmlResponse({ [OVERLAY_OPT_OUT_HEADER]: "off" })],
-    ["a page with its own CSP", htmlResponse({ "content-security-policy": "default-src 'self'" })],
     ["empty commit", htmlResponse({ [WORKER_SERVE_HEADER]: "" })],
     ["a pre-encoded body we cannot parse", htmlResponse({ "content-encoding": "gzip" })],
   ])("stays out of %s", (_name, response) => {
@@ -94,6 +103,56 @@ describe("workerOverlayDecision", () => {
     });
     expect(workerOverlayDecision(subresource, htmlResponse())).toBeNull();
     expect(workerOverlayDecision(documentRequest, htmlResponse())).not.toBeNull();
+  });
+});
+
+describe("CSP-safe worker overlay styles", () => {
+  const nonce = "c3Atc2FmZS1ub25jZQ";
+  const source = `'nonce-${nonce}'`;
+
+  test("authorizes one nonce through the directive that governs style elements", () => {
+    expect(allowStyleNonceInCsp("default-src 'none'; img-src 'self'", nonce)).toBe(
+      `default-src 'none'; img-src 'self'; style-src 'none' ${source}`,
+    );
+    expect(allowStyleNonceInCsp("default-src 'none'; style-src 'self'", nonce)).toBe(
+      `default-src 'none'; style-src 'self' ${source}`,
+    );
+    expect(
+      allowStyleNonceInCsp(
+        "default-src 'none'; style-src 'self'; style-src-elem https://styles.example",
+        nonce,
+      ),
+    ).toBe(`default-src 'none'; style-src 'self'; style-src-elem https://styles.example ${source}`);
+  });
+
+  test("updates every independently enforced policy", () => {
+    expect(
+      allowStyleNonceInCsp("default-src 'none', default-src 'self'; style-src 'none'", nonce),
+    ).toBe(
+      `default-src 'none'; style-src 'none' ${source}, default-src 'self'; style-src 'none' ${source}`,
+    );
+  });
+
+  test("never exposes its style nonce through the script fallback", () => {
+    const policy = allowStyleNonceInCsp("default-src 'none'; img-src 'self'", nonce);
+    expect(policy).toContain(`style-src 'none' ${source}`);
+    expect(policy).toContain("default-src 'none'");
+    expect(policy).not.toContain(`default-src 'none' ${source}`);
+  });
+
+  test("does not restrict a policy that leaves styles unrestricted or duplicate the nonce", () => {
+    expect(allowStyleNonceInCsp("img-src 'none'; connect-src 'self'", nonce)).toBe(
+      "img-src 'none'; connect-src 'self'",
+    );
+    expect(allowStyleNonceInCsp(`style-src 'none' ${source}`, nonce)).toBe(
+      `style-src 'none' ${source}`,
+    );
+  });
+
+  test("rejects a nonce that is unsafe to place in CSP and HTML", () => {
+    expect(() => allowStyleNonceInCsp("default-src 'none'", `bad'; style-src *`)).toThrow(
+      "Invalid CSP nonce",
+    );
   });
 });
 
@@ -128,11 +187,17 @@ describe("user-space favicon", () => {
 });
 
 describe("workerOverlayHtml", () => {
-  test("carries the iterate mark and the serve info", () => {
-    const html = workerOverlayHtml({ commitOid, kind: "live" });
+  test("carries the Iterate mark and serve info in a scriptless shadow component", () => {
+    const html = workerOverlayHtml(
+      { commitOid, kind: "live" },
+      { styleNonce: "c3Atc2FmZS1ub25jZQ" },
+    );
     expect(html).toContain('viewBox="0 0 500 500"');
-    expect(html).toContain('"c0ffee1234"');
+    expect(html).toContain("c0ffee1");
     expect(html).toContain('data-kind="live"');
+    expect(html).toContain('<template shadowrootmode="open">');
+    expect(html).toContain('<style nonce="c3Atc2FmZS1ub25jZQ">');
+    expect(html).not.toContain("<script");
   });
 
   test("loading and error states carry the ring, the spinner marker, and the red color", () => {
@@ -144,21 +209,20 @@ describe("workerOverlayHtml", () => {
     expect(failed).toContain('data-kind="buildFailed"');
     expect(failed).not.toContain('data-spinner="true"');
     expect(failed).toContain("#dc2626");
-    // Failure details start visible; everything else keeps the menu closed.
-    expect(failed).toContain('<div id="panel">');
-    expect(building).toContain('<div id="panel" hidden>');
+    // Failure details start visible; everything else keeps the native details closed.
+    expect(failed).toContain('<details id="details" open>');
+    expect(building).toContain('<details id="details">');
     // The live badge never shows the ring machinery as active state.
     expect(workerOverlayHtml({ commitOid, kind: "live" })).not.toContain('data-spinner="true"');
   });
 
-  test("serve metadata cannot break out of the script element", () => {
+  test("serve metadata cannot break out of the static component markup", () => {
     const html = workerOverlayHtml({
-      commitOid: 'evil</script><script>alert("x")</script>',
-      kind: "live",
+      kind: "buildFailed",
+      message: 'evil</script><script>alert("x")</script>',
     });
-    // Only the fragment's own tags — the payload's are <-escaped inert.
-    expect(html.match(/<\/script>/g)).toHaveLength(1);
-    expect(html).toContain("\\u003c/script>");
+    expect(html).not.toContain("<script");
+    expect(html).toContain("evil&lt;/script&gt;&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;");
   });
 });
 
@@ -192,9 +256,9 @@ describe("workerBuildFailedResponse", () => {
     expect(response.headers.get(WORKER_BUILD_FAILED_HEADER)).toBe("1");
     expect(response.headers.get(OVERLAY_OPT_OUT_HEADER)).toBe("1");
     const body = await response.text();
-    // The message rides the state JSON <-escaped and lands via textContent.
+    // The message is HTML-escaped before it enters the static component.
     expect(body).toContain("Could not resolve");
-    expect(body).toContain("\\u003cb>zod\\u003c/b>");
+    expect(body).toContain("&lt;b&gt;zod&lt;/b&gt;");
     expect(body).not.toContain("<b>zod</b>");
     expect(body).toContain("then reload this page");
     expect(body).not.toContain("const poll = async");

--- a/apps/os/src/domains/workers/worker-serve-overlay.ts
+++ b/apps/os/src/domains/workers/worker-serve-overlay.ts
@@ -69,6 +69,72 @@ function escapeHtml(text: string): string {
     .replaceAll('"', "&quot;");
 }
 
+const CSP_NONCE_PATTERN = /^[A-Za-z0-9_-]+$/u;
+
+/**
+ * Authorize one platform-injected style in every independently enforced CSP
+ * policy. The nonce is added to the most specific directive that controls
+ * style elements; policies that do not restrict styles stay untouched. When
+ * styles inherit from default-src, copy that fallback into a new style-src
+ * directive before adding the nonce. Adding a style nonce to default-src
+ * would also authorize scripts whenever script-src is absent.
+ *
+ * This deliberately never adds unsafe-inline, a host source, or script
+ * permission. Combining 'none' with a nonce is valid CSP: 'none' is ignored
+ * only for the one element presenting that unguessable nonce.
+ */
+export function allowStyleNonceInCsp(policyList: string, nonce: string): string {
+  if (!CSP_NONCE_PATTERN.test(nonce)) throw new Error("Invalid CSP nonce.");
+  const nonceSource = `'nonce-${nonce}'`;
+  return policyList
+    .split(",")
+    .map((policy) => {
+      const directives = policy
+        .split(";")
+        .map((directive) => directive.trim())
+        .filter(Boolean);
+      const names = directives.map((directive) => directive.split(/\s+/u, 1)[0]?.toLowerCase());
+      const target = names.includes("style-src-elem")
+        ? "style-src-elem"
+        : names.includes("style-src")
+          ? "style-src"
+          : null;
+      if (target !== null) {
+        return directives
+          .map((directive, index) => {
+            if (names[index] !== target) return directive;
+            const sources = directive.split(/\s+/u);
+            return sources.includes(nonceSource) ? directive : `${directive} ${nonceSource}`;
+          })
+          .join("; ");
+      }
+
+      const defaultSourceIndex = names.indexOf("default-src");
+      if (defaultSourceIndex === -1) return directives.join("; ");
+      const defaultSources = directives[defaultSourceIndex]
+        .split(/\s+/u)
+        .slice(1)
+        .filter((source) => source !== nonceSource);
+      return [...directives, `style-src ${[...defaultSources, nonceSource].join(" ")}`].join("; ");
+    })
+    .join(", ");
+}
+
+function randomCspNonce(): string {
+  let binary = "";
+  for (const byte of crypto.getRandomValues(new Uint8Array(18))) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/u, "");
+}
+
+function allowOverlayStyleInHeaders(headers: Headers, nonce: string): void {
+  for (const name of ["content-security-policy", "content-security-policy-report-only"]) {
+    const policy = headers.get(name);
+    if (policy !== null) headers.set(name, allowStyleNonceInCsp(policy, nonce));
+  }
+}
+
 /** Everything the corner widget can say. */
 type WorkerOverlayState =
   | { kind: "buildFailed"; message: string }
@@ -102,37 +168,34 @@ function overlayText(state: WorkerOverlayState): { status: string; tip: string }
 }
 
 /**
- * The corner widget: one inline script mounts the mark in a shadow root so
- * application CSS cannot reach it. Used verbatim by both lanes — injected
- * into served documents (live) and mounted on the stand-in pages (building /
- * buildFailed / serveError). States drive a tracing ring around the badge
- * (animated while something is happening, static red on a terminal failure),
- * a hover tooltip, and a click-open menu carrying status + details.
+ * The corner widget is static HTML/CSS in a declarative shadow root: app CSS
+ * cannot reach it, native details/summary owns click-open behavior, and even
+ * script-src 'none' or Trusted Types pages can display it. A per-response
+ * style nonce is supplied when ingress injects it into CSP-protected HTML.
+ * The same fragment mounts directly on platform stand-in pages.
  */
-export function workerOverlayHtml(state: WorkerOverlayState): string {
-  // U+003C escaping keeps any "</script>" (or "<!--") inside failure messages
-  // inert; U+2028/2029 stay out of the source for pre-ES2019 parsers.
-  const stateJson = JSON.stringify({ ...state, ...overlayText(state) })
-    .replaceAll("<", "\\u003c")
-    .replaceAll("\u2028", "\\u2028")
-    .replaceAll("\u2029", "\\u2029");
+export function workerOverlayHtml(
+  state: WorkerOverlayState,
+  options: { styleNonce?: string } = {},
+): string {
+  const text = overlayText(state);
+  const short = state.kind === "live" ? state.commitOid.slice(0, 7) : "";
+  const tip = short ? `${text.tip} (${short})` : text.tip;
+  const nonceAttribute = options.styleNonce ? ` nonce="${escapeHtml(options.styleNonce)}"` : "";
   const isBusy = state.kind === "building" || state.kind === "serveError";
-  // Failure details must not hide behind a click — error states start with
-  // the menu open (the badge still toggles it away).
   const startOpen = state.kind === "buildFailed" || state.kind === "serveError";
-  return `<script>(() => {
-  if (window.__iterateWorkerOverlay) return;
-  window.__iterateWorkerOverlay = true;
-  const state = ${stateJson};
-  const host = document.createElement("div");
-  host.style.cssText = "position:fixed;bottom:16px;right:16px;z-index:2147483647";
-  const root = host.attachShadow({ mode: "open" });
-  root.innerHTML = \`<style>
-    :host { all: initial; }
+  const detail =
+    state.kind === "buildFailed" ? `<pre id="detail">${escapeHtml(state.message)}</pre>` : "";
+  return `<iterate-worker-status data-iterate-worker-overlay>
+  <template shadowrootmode="open">
+  <style${nonceAttribute}>
+    :host { all: initial !important; display: block !important; position: fixed !important; bottom: 16px !important; right: 16px !important; z-index: 2147483647 !important; }
     #widget { position: relative; font: 12px/1.5 ui-sans-serif, system-ui, sans-serif; }
-    #badge { display: block; position: relative; width: 34px; height: 34px; padding: 0; border: 0; background: none; cursor: pointer; opacity: .55; transition: opacity .15s; }
+    #details { margin: 0; padding: 0; }
+    #badge { display: block; position: relative; width: 34px; height: 34px; padding: 0; border: 0; background: none; cursor: pointer; opacity: .55; transition: opacity .15s; list-style: none; }
+    #badge::-webkit-details-marker { display: none; }
     #badge .mark { display: block; width: 100%; height: 100%; border-radius: 22.37%; box-shadow: 0 2px 10px rgba(0,0,0,.35); }
-    #badge:hover, #widget:not([data-kind="live"]) #badge { opacity: 1; }
+    #badge:hover, #details[open] #badge, #widget:not([data-kind="live"]) #badge { opacity: 1; }
     #ring { display: none; position: absolute; inset: -5px; width: 44px; height: 44px; color: #0a0a0a; }
     #ring rect { stroke-dasharray: 30 70; animation: trace 1.2s linear infinite; }
     [data-kind="building"] #ring, [data-kind="serveError"] #ring, [data-kind="buildFailed"] #ring { display: block; }
@@ -142,46 +205,28 @@ export function workerOverlayHtml(state: WorkerOverlayState): string {
     @keyframes trace { to { stroke-dashoffset: -100; } }
     @keyframes pulse { 50% { opacity: 0.45; } }
     #tip { display: none; position: absolute; bottom: 46px; right: 0; padding: 4px 8px; background: #0a0a0a; color: #fafafa; border-radius: 6px; white-space: nowrap; pointer-events: none; }
-    #widget:hover:not([data-open="true"]) #tip { display: block; }
+    #widget:hover #tip { display: block; }
+    #details[open] ~ #tip { display: none; }
     #panel { position: absolute; bottom: 46px; right: 0; width: 320px; padding: 12px 14px; background: #0a0a0a; color: #fafafa; border: 1px solid #262626; border-radius: 10px; box-shadow: 0 8px 24px rgba(0,0,0,.45); }
     #panel header { display: flex; justify-content: space-between; color: #a3a3a3; margin-bottom: 4px; }
     #panel pre { margin: 8px 0 0; padding: 8px 10px; background: #171717; border: 1px solid #262626; border-radius: 8px; color: #fca5a5; font: 11px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; white-space: pre-wrap; word-break: break-word; max-height: 40vh; overflow: auto; }
   </style>
-  <div id="widget" data-kind="${state.kind}"${isBusy ? ' data-spinner="true"' : ""}${startOpen ? ' data-open="true"' : ""}>
-    <div id="tip" role="tooltip"></div>
-    <div id="panel"${startOpen ? "" : " hidden"}>
-      <header><span>iterate worker</span><span id="meta"></span></header>
-      <div id="status"></div>
-      <pre id="detail" hidden></pre>
-    </div>
-    <button id="badge" aria-label="iterate worker status">
-      <svg id="ring" viewBox="0 0 44 44" fill="none" aria-hidden="true"><rect x="1.5" y="1.5" width="41" height="41" rx="12" stroke="currentColor" stroke-width="2.5" pathLength="100" stroke-linecap="round" /></svg>
-      ${ITERATE_MARK_SVG}
-    </button>
-  </div>\`;
-  const short = state.commitOid ? state.commitOid.slice(0, 7) : "";
-  root.getElementById("tip").textContent = short ? state.tip + " (" + short + ")" : state.tip;
-  root.getElementById("status").textContent = state.status;
-  const meta = root.getElementById("meta");
-  if (state.kind === "building") {
-    const started = Date.now();
-    setInterval(() => { meta.textContent = Math.round((Date.now() - started) / 1000) + "s"; }, 1000);
-  } else {
-    meta.textContent = short;
-  }
-  if (state.message) {
-    const detail = root.getElementById("detail");
-    detail.hidden = false;
-    detail.textContent = state.message;
-  }
-  const widget = root.getElementById("widget");
-  const panel = root.getElementById("panel");
-  root.getElementById("badge").addEventListener("click", () => {
-    panel.hidden = !panel.hidden;
-    widget.dataset.open = String(!panel.hidden);
-  });
-  document.body.appendChild(host);
-})();</script>`;
+  <div id="widget" data-kind="${state.kind}"${isBusy ? ' data-spinner="true"' : ""}>
+    <details id="details"${startOpen ? " open" : ""}>
+      <summary id="badge" aria-label="iterate worker status">
+        <svg id="ring" viewBox="0 0 44 44" fill="none" aria-hidden="true"><rect x="1.5" y="1.5" width="41" height="41" rx="12" stroke="currentColor" stroke-width="2.5" pathLength="100" stroke-linecap="round" /></svg>
+        ${ITERATE_MARK_SVG}
+      </summary>
+      <div id="panel">
+        <header><span>iterate worker</span><span id="meta">${escapeHtml(short)}</span></header>
+        <div id="status">${escapeHtml(text.status)}</div>
+        ${detail}
+      </div>
+    </details>
+    <div id="tip" role="tooltip">${escapeHtml(tip)}</div>
+  </div>
+  </template>
+</iterate-worker-status>`;
 }
 
 /**
@@ -317,34 +362,51 @@ export function workerOverlayDecision(request: Request, response: Response): str
   const commitOid = workerHtmlDocumentCommit(request, response);
   if (commitOid === null) return null;
   if (response.headers.has(OVERLAY_OPT_OUT_HEADER)) return null;
-  // A page with its own CSP likely forbids the inline overlay script. The
-  // favicon remains eligible: an app can override it with any rel=icon link.
-  if (response.headers.has("content-security-policy")) return null;
   return commitOid;
 }
 
 /**
  * Ingress's one call: dress a project-worker response in the platform's
  * user-space chrome. HTML documents get the default favicon at document end
- * unless the app supplied one anywhere, plus (when allowed) the widget before
- * </body>. HTMLRewriter keeps the transformation streaming; everything else
- * passes through untouched.
+ * unless the app supplied one anywhere, plus the scriptless widget before
+ * </body>. A random style nonce is authorized in response-header and meta
+ * CSPs, without granting any script capability. HTMLRewriter keeps the
+ * transformation streaming; everything else passes through untouched.
  */
 export function applyProjectWorkerOverlay(request: Request, response: Response): Response {
   if (workerHtmlDocumentCommit(request, response) === null) return response;
   const commitOid = workerOverlayDecision(request, response);
   const urlPrefix = request.headers.get("x-iterate-url-prefix") ?? "";
+  const styleNonce = commitOid === null ? null : randomCspNonce();
   let hasFavicon = false;
+  let hasOverlay = false;
   const rewriter = new HTMLRewriter()
     .on("link", {
       element(element) {
         hasFavicon ||= relIncludesIcon(element.getAttribute("rel"));
       },
     })
+    .on("meta", {
+      element(element) {
+        if (styleNonce === null) return;
+        if (
+          element.getAttribute("http-equiv")?.trim().toLowerCase() !== "content-security-policy"
+        ) {
+          return;
+        }
+        const policy = element.getAttribute("content");
+        if (policy !== null) {
+          element.setAttribute("content", allowStyleNonceInCsp(policy, styleNonce));
+        }
+      },
+    })
     .on("body", {
       element(element) {
-        if (commitOid !== null) {
-          element.append(workerOverlayHtml({ commitOid, kind: "live" }), { html: true });
+        if (commitOid !== null && styleNonce !== null && !hasOverlay) {
+          element.append(workerOverlayHtml({ commitOid, kind: "live" }, { styleNonce }), {
+            html: true,
+          });
+          hasOverlay = true;
         }
       },
     })
@@ -356,10 +418,18 @@ export function applyProjectWorkerOverlay(request: Request, response: Response):
         if (!hasFavicon) {
           end.append(workerDefaultFaviconHtml(urlPrefix), { html: true });
         }
+        // Malformed/minimal HTML need not contain an explicit body. The
+        // document-end fallback keeps the platform status present there too.
+        if (commitOid !== null && styleNonce !== null && !hasOverlay) {
+          end.append(workerOverlayHtml({ commitOid, kind: "live" }, { styleNonce }), {
+            html: true,
+          });
+        }
       },
     });
   const transformed = rewriter.transform(response);
   const out = new Response(transformed.body, transformed);
+  if (styleNonce !== null) allowOverlayStyleInHeaders(out.headers, styleNonce);
   // The transform changes byte length, and fetch already decompressed the
   // upstream body — a copied length header would lie about this body.
   out.headers.delete("content-length");

--- a/specs/seeded-apps.spec.ts
+++ b/specs/seeded-apps.spec.ts
@@ -102,11 +102,27 @@ test("the seeded internal app authenticates a real project member", async ({ bas
   // already signed in to OS. The auth partial owns the request and renders
   // the form on the app's own origin.
   const internalUrl = appUrl("internal", slug, baseURL!);
+  const signInResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url() === internalUrl &&
+      response.request().resourceType() === "document" &&
+      response.headers()["content-security-policy"]?.includes("default-src 'none'") === true,
+    { timeout: 120_000 },
+  );
   await page.goto(internalUrl);
   // A named app's first use may still need its own cold worker start. The
   // platform's building page is visible progress; 120s matches hello above.
   await page.getByRole("heading", { name: "Sign in to Iterate" }).waitFor({ timeout: 120_000 });
   await page.getByText("This app is available to project members.").waitFor();
+  const signInResponse = await signInResponsePromise;
+  const overlay = page.locator("iterate-worker-status[data-iterate-worker-overlay]");
+  await overlay.waitFor({ state: "visible" });
+  expect(await overlay.locator("script").count()).toBe(0);
+  const overlayNonce = await overlay
+    .locator("style")
+    .evaluate((style: HTMLStyleElement) => style.nonce);
+  expect(overlayNonce).not.toBe("");
+  expect(signInResponse.headers()["content-security-policy"]).toContain(`'nonce-${overlayNonce}'`);
 
   // This follows app -> OS -> app callback. OS reuses the iterate_session
   // cookie installed by the signup flow; the callback redeems a fragment token


### PR DESCRIPTION
## Why

Protected `internal--<project>` requests are intercepted by OS authentication before they reach the project worker. Those responses use a strict Content Security Policy, and project ingress previously skipped the worker-status overlay whenever CSP was present.

## What changed

- Render the worker-status badge as scriptless declarative shadow DOM with native `details` / `summary` interaction.
- Generate a fresh 144-bit nonce per transformed response and authorize only the injected shadow stylesheet.
- Apply the narrow style-policy rewrite to enforced headers, report-only headers, and CSP meta policies.
- Preserve the existing overlay opt-out and independent default-favicon fallback.
- Cover strict internal-app authentication in the deployed browser suite.

## Security

The transform never adds script permission, `unsafe-inline`, or a host source. When styles inherit from `default-src`, ingress copies the existing fallback sources into a new `style-src` directive and adds the nonce there; the nonce never enters `default-src` or the script fallback. Static overlay metadata is HTML-escaped.

## Verification

- `pnpm typecheck`
- `pnpm lint` (zero warnings)
- 25 focused worker-overlay tests
- Preview browser coverage asserts that the strict-CSP internal-app sign-in shows the overlay, contains no overlay script, and authorizes exactly its stylesheet nonce

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HTML ingress and CSP rewriting on project-app documents, including auth pages with `default-src 'none'`, though the rewrite is narrowly limited to authorizing one style nonce and does not add script sources.
> 
> **Overview**
> **Project ingress no longer skips the worker-status overlay when a page has CSP.** The corner badge is now **scriptless declarative shadow DOM** (`iterate-worker-status`, `data-iterate-worker-overlay`) with native **`details`/`summary`** for the panel instead of `__iterateWorkerOverlay` inline script.
> 
> On CSP-protected HTML, **`applyProjectWorkerOverlay`** mints a per-response style nonce, rewrites **enforced/report-only CSP headers** and **CSP meta** via new **`allowStyleNonceInCsp`** (nonce only on `style-src` / `style-src-elem`, or a derived `style-src` from `default-src`—never widening script), and applies that nonce to the overlay stylesheet. Injection still falls back at document end when there is no `<body>`.
> 
> Docs, unit tests (CSP edge cases), e2e marker updates, and a Playwright check on the strict-CSP **internal** sign-in page assert the overlay is visible with **zero scripts** and a matching CSP nonce.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59c2ceef2ec07b1df948238badee8253e1f8911d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +140 -70 | +112 -55 🟩🟩🟩🟥🟥 |
| Tests | +99 -18 | +90 -15 🟩🟩🟩⬜⬜ |
| Docs | +14 -7 | +14 -7 🟩⬜⬜⬜⬜ |
| **Total** | **+253 -95** | **+216 -77** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between b3dd32c and 59c2cee, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-21T16:06:34.757Z",
      "headSha": "59c2ceef2ec07b1df948238badee8253e1f8911d",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/586861817372584",
      "shortSha": "59c2cee",
      "cleanupDurationMs": 16535,
      "deployDurationMs": 97230,
      "testDurationMs": 232932,
      "testRetries": "4 retried: catalogue example \"stream-cross-post\" runs identically across runtimes (vitest x1) — example \"stream-cross-post\" failed in the run-script runtime: stream-wait-timeout: Timed out waiting for stream event after 10000ms (the public deadline expired while recovery re-armed one-shot waits). · agent create installs only generic machinery; later events configure it (vitest x1) — Durable Object storage operation exceeded timeout which caused object to be reset. · crossPostTo copies matching events with source provenance (vitest x1) — stream-unavailable: Durable Object storage operation exceeded timeout which caused object to be reset. · Worker build pipeline bundles multi-file TypeScript inline sources (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits).",
      "workerSizeKib": 17136.2,
      "workerGzipKib": 4607.2,
      "mainWorkerGzipKib": 4618.68
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-21T16:06:20.878Z",
      "headSha": "59c2ceef2ec07b1df948238badee8253e1f8911d",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/586861817372584",
      "shortSha": "59c2cee",
      "cleanupDurationMs": 2653,
      "deployDurationMs": 32751,
      "testDurationMs": 11604,
      "testRetries": null,
      "workerSizeKib": 3965.97,
      "workerGzipKib": 811.34,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-21T16:06:18.807Z",
      "headSha": "59c2ceef2ec07b1df948238badee8253e1f8911d",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/586861817372584",
      "shortSha": "59c2cee",
      "cleanupDurationMs": 581,
      "deployDurationMs": 6118,
      "testDurationMs": 5704,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `59c2cee` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 811.3 KiB | 32.8s | 11.6s |  | 2.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/586861817372584) | 2026-07-21T16:06:20.878Z | Preview app released. |
| Dummy Petshop | released | `59c2cee` | [https://dummy-petshop.iterate-preview-2.com](https://dummy-petshop.iterate-preview-2.com) | 198.2 KiB | 6.1s | 5.7s |  | 581ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/586861817372584) | 2026-07-21T16:06:18.807Z | Preview app released. |
| OS | released | `59c2cee` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 4.50 MiB (-11.5 KiB vs main) | 97.2s | 232.9s | 4 retried: catalogue example "stream-cross-post" runs identically across runtimes (vitest x1) — example "stream-cross-post" failed in the run-script runtime: stream-wait-timeout: Timed out waiting for stream event after 10000ms (the public deadline expired while recovery re-armed one-shot waits). · agent create installs only generic machinery; later events configure it (vitest x1) — Durable Object storage operation exceeded timeout which caused object to be reset. · crossPostTo copies matching events with source provenance (vitest x1) — stream-unavailable: Durable Object storage operation exceeded timeout which caused object to be reset. · Worker build pipeline bundles multi-file TypeScript inline sources (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). | 16.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/586861817372584) | 2026-07-21T16:06:34.757Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->