### PR TITLE
Record the clone-version failure diagnosis in its task

### DIFF
--- a/tasks/diagnose-workers-rpc-clone-version-failures.md
+++ b/tasks/diagnose-workers-rpc-clone-version-failures.md
@@ -1,5 +1,5 @@
 ---
-state: todo
+state: in-progress
 priority: high
 size: medium
 dependsOn: []
@@ -29,3 +29,56 @@ instrumentation to capture the next occurrence), the failing serialization
 boundary and payload are identified, and the outcome is either fixed or
 modeled with a narrowly bounded, observable recovery justified by the root
 cause. The normal error signal must remain clean.
+
+
+## Diagnosis 2026-07-21 (production burst)
+
+63 occurrences on os-prd, all on 2026-07-21 (zero in the prior 30 days of
+PostHog), all from ONE client, during a Cloudflare runtime/API instability
+window (12:15–14:05 UTC) with prd deploying every 10–20 minutes.
+
+**Throw site, proven from symbolicated frame line:columns**: the Worker
+Loader entrypoint stub fetch — `await entrypoint.fetch(request)` in
+`DynamicWorkerRunner.fetch` (stateless lane). NOT source resolution: the
+failing ray's trace shows `RepoDurableObject.getHead` completing `ok` on the
+same trace before the loader hop threw caller-side ~90ms in.
+
+**Mechanism**: the message is V8's ValueDeserializer wire-format version
+check — it fires only when serializer and deserializer run different runtime
+builds. In the 12:31–12:33 window three DIFFERENT apps/projects (three
+loader cache keys) failed simultaneously through one edge machine: the
+poison is parent-process↔child-process build pairing, not one bad cached
+child. Each error cluster began 3–14 min after a deploy and ENDED at the
+next deploy (three clusters ended within seconds of the next version going
+live) — new parent isolates re-roll the pairing.
+
+**Self-healing**: 1–9 minutes per cluster, capped by deploy cadence; a fresh
+connection escapes immediately, a browser's reused connection stays pinned
+(the serve-error page's 3s polls made one tab re-hit the pair repeatedly —
+since fixed by the page's periodic hard reload).
+
+**The 2026-07-20 preview occurrence** fits the same mechanism one hop over:
+the counter app is the stateful lane, whose post-getHead dispatch is the
+cross-machine DO fetch — mixed workerd builds during staged rollouts produce
+the same receiver-side rejection ("reached getHead, never entered
+StatefulWorkerDurableObject").
+
+**Related but distinct**: the same error string appeared for the restored
+`iterate` project whose config repo predated the post-#2167 SDK surface
+(virtual-module imports the platform no longer ships); healing that repo to
+the current template (a6739397be) stopped those hosts' errors — a stale
+build loading is a second path to the same deserializer rejection.
+
+## Proposed next steps (from the diagnosis)
+
+1. Instrumentation (primary): tag which hop threw in
+   `DynamicWorkerRunner.fetch` (resolve / stateful DO fetch / loader
+   entrypoint fetch) + attach the loader cacheKey before rethrow; log loader
+   cache misses in `loadResolvedWorker`; include hop + cacheKey + rayId in
+   the serve-lane PostHog capture. Answers next time whether fresh children
+   also fail (process-pair mismatch) or only cached ones (cache staleness).
+2. Bounded recovery (optional, stateless lane only): on exactly this
+   message, retry once with a fresh child isolate via a per-isolate
+   generation suffix on the loader cache key. No retry on the stateful hop
+   (cannot change cross-machine pairing); never put the deploy version into
+   the loader cache key (would cold-start every app every deploy).


### PR DESCRIPTION
Docs-only: writes the 2026-07-21 production diagnosis into `tasks/diagnose-workers-rpc-clone-version-failures.md` and flips it to in-progress. Highlights: throw site proven (Worker Loader entrypoint fetch, caller-side), mechanism is V8's serializer wire-version check firing across mismatched parent↔child runtime builds, clusters started after deploys and ended at the next deploy, and the stale-SDK iterate-project incident was a second path to the same error string. Proposed instrumentation and a narrowly bounded stateless-lane recovery are recorded for a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown task documentation only; no runtime or configuration changes.
> 
> **Overview**
> **Documentation-only** update to `tasks/diagnose-workers-rpc-clone-version-failures.md`: task state moves from **todo** to **in-progress**, and a new **Diagnosis 2026-07-21** section captures findings from a production burst (63 errors on one client during deploy instability).
> 
> The write-up pins the throw site to **`DynamicWorkerRunner.fetch`**’s Worker Loader **`entrypoint.fetch`** hop (not repo `getHead` resolution), explains the error as **V8 clone wire-version mismatch** between parent and child runtime builds during staged deploys, and notes cluster timing, self-healing behavior, how the earlier preview incident maps to the stateful DO hop, and a separate stale-SDK **`iterate`** path to the same message.
> 
> It also records **follow-up work**: richer hop/cacheKey/rayId instrumentation and an optional **one-shot stateless-lane retry** with a per-isolate loader cache generation suffix—not broad retries or version-in-cache-key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d3ec1136d4ee11c2148b62f996083696d8750e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Docs | +54 -1 | +44 -1 🟩🟩🟩🟩🟩 |
| **Total** | **+54 -1** | **+44 -1** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 8763925 and 8d3ec11, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->