### PR TITLE
Preview: skip an unchanged dummy-petshop deploy

### DIFF
--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -351,6 +351,7 @@ async function deployPreviewApps({
       async (app) => {
         return await deployPreviewAppWithStatus({
           app,
+          existingEntry: current.state.apps[app.slug] ?? null,
           commandEnvironment: {
             ...runtime.commandEnvironment,
             // apps/os/scripts/deploy.ts turns this into
@@ -1366,6 +1367,14 @@ export type CloudflarePreviewApp = {
     projectHostnameBases?: string[];
   };
   paths: string[];
+  /**
+   * Skip this app's deploy when the slot already serves an identical build: a
+   * prior recorded "deployed" entry whose publicUrl matches this slot and
+   * whose fingerprint (git object ids of these paths at HEAD) is unchanged.
+   * For fixture apps that almost never change (dummy-petshop) — the app's
+   * e2e smoke still runs against the existing worker.
+   */
+  contentFingerprintPaths?: string[];
   /** Apps co-selected so this app deploys and tests against one coherent head. */
   previewDependencies?: CloudflarePreviewAppSlug[];
   /**
@@ -1905,6 +1914,9 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
       return { baseUrl: env.baseUrl };
     },
     paths: ["apps/dummy-petshop/**"],
+    // The fixture's content barely ever changes; envs.ts rides along because
+    // it decides the generated wrangler routes.
+    contentFingerprintPaths: ["apps/dummy-petshop", "envs.ts"],
     previewReadyUrlPath: "/",
     previewTestBaseUrlEnvVar: "PETSHOP_BASE_URL",
     previewTestCommandArgs: ["pnpm", "test:e2e"],
@@ -2007,6 +2019,8 @@ export const CloudflarePreviewAppEntry = z.object({
   workerSizeKib: z.number().nonnegative().finite().nullable().optional(),
   /** Wrangler-reported gzip size of the deployed worker, in KiB. */
   workerGzipKib: z.number().nonnegative().finite().nullable().optional(),
+  /** Content fingerprint of the deployed sources (contentFingerprintPaths). */
+  deployedFingerprint: z.string().trim().min(1).nullable().optional(),
   /**
    * Main's deployed gzip size in KiB at deploy time, read from the
    * `worker-size/<app>` commit status main deploys publish — the baseline for
@@ -3501,10 +3515,29 @@ async function releaseLeaseDespiteTeardownFailure(input: {
   }
 }
 
+/** Git object ids of the app's fingerprint paths at HEAD — content-addressed,
+ * so an unchanged fixture app can skip its deploy entirely. */
+function previewAppContentFingerprint(
+  app: PreviewAppRuntime,
+  repositoryRoot: string,
+): string | null {
+  if (!app.contentFingerprintPaths?.length) return null;
+  return execFileSync(
+    "git",
+    ["rev-parse", ...app.contentFingerprintPaths.map((path) => `HEAD:${path}`)],
+    { cwd: repositoryRoot, encoding: "utf8" },
+  )
+    .trim()
+    .split("\n")
+    .join("+");
+}
+
 async function deployPreviewAppWithStatus(input: {
   app: PreviewAppRuntime;
   commandEnvironment: NodeJS.ProcessEnv;
   dopplerConfig: string;
+  /** This app's entry from the PR's recorded state, for the unchanged-skip. */
+  existingEntry: CloudflarePreviewAppEntry | null;
   /** Main's published size baseline for this app, when one exists. */
   mainWorkerSize: WorkerSizeInfo | null;
   pullRequestHeadSha: string;
@@ -3552,6 +3585,7 @@ async function deployPreviewApp(input: {
   app: PreviewAppRuntime;
   commandEnvironment: NodeJS.ProcessEnv;
   dopplerConfig: string;
+  existingEntry: CloudflarePreviewAppEntry | null;
   mainWorkerSize: WorkerSizeInfo | null;
   pullRequestHeadSha: string;
   repositoryRoot: string;
@@ -3574,6 +3608,29 @@ async function deployPreviewApp(input: {
     shortSha: input.pullRequestHeadSha.slice(0, 7),
     updatedAt: new Date().toISOString(),
   } as const;
+
+  const fingerprint = previewAppContentFingerprint(input.app, input.repositoryRoot);
+  if (
+    fingerprint !== null &&
+    input.existingEntry?.status === "deployed" &&
+    input.existingEntry.publicUrl === appConfig.baseUrl &&
+    input.existingEntry.deployedFingerprint === fingerprint
+  ) {
+    // Same slot, same content, last run fully green: the worker already
+    // serving is byte-identical to what this deploy would upload. Skip the
+    // wrangler/Cloudflare-API round trip; the e2e smoke still verifies it.
+    logPreview(
+      `deploy skipped: ${input.app.slug} unchanged since ${input.existingEntry.shortSha ?? "the recorded deploy"} on this slot (fingerprint ${fingerprint.slice(0, 12)}…)`,
+    );
+    return CloudflarePreviewAppEntry.parse({
+      ...baseEntry,
+      deployedFingerprint: fingerprint,
+      workerSizeKib: input.existingEntry.workerSizeKib ?? null,
+      workerGzipKib: input.existingEntry.workerGzipKib ?? null,
+      mainWorkerGzipKib: input.existingEntry.mainWorkerGzipKib ?? null,
+      status: "awaiting-tests",
+    });
+  }
 
   const deployResult = await runPreviewDeployCommand({
     app: input.app,
@@ -3641,6 +3698,7 @@ async function deployPreviewApp(input: {
   return CloudflarePreviewAppEntry.parse({
     ...baseEntry,
     ...sizeFields,
+    deployedFingerprint: fingerprint,
     status: "awaiting-tests",
   });
 }

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -3614,13 +3614,25 @@ async function deployPreviewApp(input: {
     fingerprint !== null &&
     input.existingEntry?.status === "deployed" &&
     input.existingEntry.publicUrl === appConfig.baseUrl &&
-    input.existingEntry.deployedFingerprint === fingerprint
+    input.existingEntry.deployedFingerprint === fingerprint &&
+    // The record alone is not proof the worker still answers — this app may
+    // be selected precisely because the not-serving sweep found it dead
+    // (selectRecordedGreenAppsNotServing), e.g. after a slot erase. Skip only
+    // when every readiness URL answers right now.
+    (
+      await Promise.all(
+        resolvePreviewReadinessUrls({
+          publicUrl: appConfig.baseUrl,
+          readyUrlPath: input.app.previewReadyUrlPath,
+        }).map((url) => probePreviewAppServingOnce(url)),
+      )
+    ).every((probe) => probe.ok)
   ) {
-    // Same slot, same content, last run fully green: the worker already
-    // serving is byte-identical to what this deploy would upload. Skip the
-    // wrangler/Cloudflare-API round trip; the e2e smoke still verifies it.
+    // Same slot, same content, last run fully green, worker answering: what
+    // is serving is byte-identical to what this deploy would upload. Skip
+    // the wrangler/Cloudflare-API round trip; the e2e smoke still verifies it.
     logPreview(
-      `deploy skipped: ${input.app.slug} unchanged since ${input.existingEntry.shortSha ?? "the recorded deploy"} on this slot (fingerprint ${fingerprint.slice(0, 12)}…)`,
+      `deploy skipped: ${input.app.slug} unchanged since ${input.existingEntry.shortSha ?? "the recorded deploy"} on this slot and serving (fingerprint ${fingerprint.slice(0, 12)}…)`,
     );
     return CloudflarePreviewAppEntry.parse({
       ...baseEntry,


### PR DESCRIPTION
dummy-petshop is co-selected as an OS preview dependency, so it redeployed on virtually every preview run even though its content almost never changes — wrangler + Cloudflare-API round trips against the same account rate limit that preview runs contend for (today's 429 storms made that vivid).

Apps can now declare `contentFingerprintPaths`. Before deploying, the fingerprint (git object ids of those paths at `HEAD`, so it covers every committed change under them) is compared against the PR's recorded entry; when the entry is fully green (`deployed`), points at this same slot (`publicUrl` matches the resolved base URL — this subsumes slot-move detection), and the fingerprint is identical, the deploy is skipped and the recorded worker keeps serving. The app's own e2e smoke still runs against it, so evidence stays fresh at the current head, and the OS lane's `PETSHOP_BASE_URL` dependency resolution keeps working (the skip entry carries the current head SHA).

Any content change, slot move, or prior non-green state redeploys exactly as before. Only dummy-petshop opts in (`apps/dummy-petshop` + `envs.ts`, the latter because it decides generated wrangler routes).

`pnpm typecheck && pnpm lint && pnpm format` green; `scripts` preview suite 126/126.

Related: #2169 removes the queue/event-subscription control-plane calls from repo creation — together these are the two main self-inflicted contributors to the account's API rate-limit pressure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Orchestration-only change in preview scripts with conservative guards (deployed status, URL match, live probes); only dummy-petshop opts in, and e2e still runs after a skip.
> 
> **Overview**
> Preview deploy can now **skip wrangler** for apps that declare `contentFingerprintPaths` when the PR already has a fully green (`deployed`) record on the **same slot** (`publicUrl`), the **git object ids** of those paths at `HEAD` match the stored `deployedFingerprint`, and **readiness probes** succeed right now (so a dead worker after slot erase still redeploys).
> 
> **dummy-petshop** is the only opt-in today (`apps/dummy-petshop` + `envs.ts`), cutting repeated Cloudflare API traffic when OS preview runs pull it in as a dependency. Skipped runs still advance the entry to `awaiting-tests` at the current head and keep size metadata; a real deploy persists `deployedFingerprint` on success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 087a7f933ba43e409e09b58c42f1aaea19c5da00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-21T18:43:41.767Z",
      "headSha": "087a7f933ba43e409e09b58c42f1aaea19c5da00",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/182735726109471",
      "shortSha": "087a7f9",
      "cleanupDurationMs": 13790,
      "deployDurationMs": 129245,
      "testDurationMs": 201769,
      "testRetries": "1 retried: agent replies to a browser chat message in the feed (specs x1) — TimeoutError: locator.waitFor: Timeout 30000ms exceeded. Call log: \u001b[2m - waiting for locator('[data-testid=\"agent-feed-message\"][data-kind=\"assistant\"]').filter({ hasText: 'kumquat' }).first() to be visible\u001b[22m",
      "workerSizeKib": 17133.76,
      "workerGzipKib": 4606.04,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 4618.99
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-21T18:43:29.196Z",
      "headSha": "087a7f933ba43e409e09b58c42f1aaea19c5da00",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/182735726109471",
      "shortSha": "087a7f9",
      "cleanupDurationMs": 1216,
      "deployDurationMs": 20520,
      "testDurationMs": 30694,
      "testRetries": null,
      "workerSizeKib": 1915.12,
      "workerGzipKib": 440.96,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-21T18:43:34.533Z",
      "headSha": "087a7f933ba43e409e09b58c42f1aaea19c5da00",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/182735726109471",
      "shortSha": "087a7f9",
      "cleanupDurationMs": 6551,
      "deployDurationMs": 18239,
      "testDurationMs": 11285,
      "testRetries": null,
      "workerSizeKib": 3965.97,
      "workerGzipKib": 811.63,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-21T18:43:38.526Z",
      "headSha": "087a7f933ba43e409e09b58c42f1aaea19c5da00",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/182735726109471",
      "shortSha": "087a7f9",
      "cleanupDurationMs": 10541,
      "deployDurationMs": 93773,
      "testDurationMs": 65607,
      "testRetries": null,
      "workerSizeKib": 5161.45,
      "workerGzipKib": 1473.34,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-21T18:43:29.141Z",
      "headSha": "087a7f933ba43e409e09b58c42f1aaea19c5da00",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/182735726109471",
      "shortSha": "087a7f9",
      "cleanupDurationMs": 1153,
      "deployDurationMs": 425,
      "testDurationMs": 5447,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "deployedFingerprint": "8603144e09cd783dbe2a943f192d10cf72fdb573+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `087a7f9` | [https://auth.iterate-preview-11.com](https://auth.iterate-preview-11.com) | 811.6 KiB | 18.2s | 11.3s |  | 6.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/182735726109471) | 2026-07-21T18:43:34.533Z | Preview app released. |
| Dummy Petshop | released | `087a7f9` | [https://dummy-petshop.iterate-preview-11.com](https://dummy-petshop.iterate-preview-11.com) | 198.2 KiB | 425ms | 5.4s |  | 1.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/182735726109471) | 2026-07-21T18:43:29.141Z | Preview app released. |
| OS | released | `087a7f9` | [https://os.iterate-preview-11.com](https://os.iterate-preview-11.com) | 4.50 MiB (-12.9 KiB vs main) | 129.2s | 201.8s | 1 retried: agent replies to a browser chat message in the feed (specs x1) — TimeoutError: locator.waitFor: Timeout 30000ms exceeded. Call log: [2m - waiting for locator('[data-testid="agent-feed-message"][data-kind="assistant"]').filter({ hasText: 'kumquat' }).first() to be visible[22m | 13.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/182735726109471) | 2026-07-21T18:43:41.767Z | Preview app released. |
| Semaphore | released | `087a7f9` | [https://semaphore.iterate-preview-11.com](https://semaphore.iterate-preview-11.com) | 441.0 KiB | 20.5s | 30.7s |  | 1.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/182735726109471) | 2026-07-21T18:43:29.196Z | Preview app released. |
| Streams Example App | released | `087a7f9` | [https://streams.iterate-preview-11.com](https://streams.iterate-preview-11.com) | 1.44 MiB | 93.8s | 65.6s |  | 10.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/182735726109471) | 2026-07-21T18:43:38.526Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| CI & scripts | +70 -0 | +48 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+70 -0** | **+48 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 2fc9426 and 087a7f9, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->