### PR TITLE
Scope the erase-time DO-binding sweep to the target's own preview slot

### DIFF
--- a/scripts/lib/do-reset.test.ts
+++ b/scripts/lib/do-reset.test.ts
@@ -111,6 +111,54 @@ describe("detachExternalDurableObjectBindings", () => {
     expect(cf.mock.calls.filter(([, init]) => init?.method === "PATCH")).toHaveLength(1);
   });
 
+  test("scans only the target's own slot family plus non-slot workers", async () => {
+    const scanned: string[] = [];
+    const cf = vi.fn(async (path: string) => {
+      scanned.push(path.split("/").at(-2) as string);
+      return { bindings: [] };
+    });
+
+    await detachExternalDurableObjectBindings({
+      ctx: { cf } as never,
+      targetWorkerName: "os-preview-4",
+      targetNamespaceIds: ["target-project"],
+      workerNames: [
+        "os-preview-4",
+        "os-preview-4-typechecker",
+        "auth-preview-4",
+        "os-preview-9",
+        "auth-preview-16-typechecker",
+        "dummy-petshop-preview-19",
+        "captun",
+        "cf-artifact-viewer-dev-jonas",
+      ],
+    });
+
+    expect(scanned.sort()).toEqual([
+      "auth-preview-4",
+      "captun",
+      "cf-artifact-viewer-dev-jonas",
+      "os-preview-4-typechecker",
+    ]);
+  });
+
+  test("a non-slot target still scans every other worker", async () => {
+    const scanned: string[] = [];
+    const cf = vi.fn(async (path: string) => {
+      scanned.push(path.split("/").at(-2) as string);
+      return { bindings: [] };
+    });
+
+    await detachExternalDurableObjectBindings({
+      ctx: { cf } as never,
+      targetWorkerName: "os-prd",
+      targetNamespaceIds: ["target-project"],
+      workerNames: ["os-prd", "os-prd-typechecker", "os-preview-4", "captun"],
+    });
+
+    expect(scanned.sort()).toEqual(["captun", "os-prd-typechecker", "os-preview-4"]);
+  });
+
   test("fails before reset can continue when Cloudflare keeps a target reference", async () => {
     const stale: Settings = {
       bindings: [

--- a/scripts/lib/do-reset.ts
+++ b/scripts/lib/do-reset.ts
@@ -147,6 +147,14 @@ async function forEachWithConcurrency<T>(
  * must never start while Cloudflare still reports a reference to a namespace
  * it is about to retire.
  */
+/** The preview-slot family a worker name belongs to (`os-preview-16` and
+ * `auth-preview-16-typechecker` are both slot 16), or null for every
+ * non-slot name (prd, dev, personal, and unknown workers). */
+export function previewSlotOfWorkerName(workerName: string): number | null {
+  const match = /-preview-(\d+)(?:-|$)/.exec(workerName);
+  return match ? Number(match[1]) : null;
+}
+
 export async function detachExternalDurableObjectBindings(input: {
   ctx: CfContext;
   targetWorkerName: string;
@@ -155,9 +163,20 @@ export async function detachExternalDurableObjectBindings(input: {
 }): Promise<{ workerName: string; removedBindingNames: string[] }[]> {
   const namespaceIds = new Set(input.targetNamespaceIds);
   const detached: { workerName: string; removedBindingNames: string[] }[] = [];
-  const candidates = input.workerNames.filter(
-    (workerName) => workerName !== input.targetWorkerName,
-  );
+  // When the target belongs to a preview slot, workers that clearly belong
+  // to a DIFFERENT slot are skipped: a cross-slot Durable Object binding
+  // would be a platform bug, and settings-scanning every slot's workers is
+  // what exhausts the account's API quota (dozens of GETs per erase, every
+  // preview lane, concurrently — the 429 storms that also starve prd
+  // deploys, since Cloudflare rate-limits per API user). Non-slot names
+  // (prd, dev, personal, unknown) are still swept.
+  const targetSlot = previewSlotOfWorkerName(input.targetWorkerName);
+  const candidates = input.workerNames.filter((workerName) => {
+    if (workerName === input.targetWorkerName) return false;
+    if (targetSlot === null) return true;
+    const slot = previewSlotOfWorkerName(workerName);
+    return slot === null || slot === targetSlot;
+  });
 
   await forEachWithConcurrency(candidates, SETTINGS_SCAN_CONCURRENCY, async (workerName) => {
     const path = `/workers/scripts/${encodeURIComponent(workerName)}/settings`;


### PR DESCRIPTION
## What

`detachExternalDurableObjectBindings` (the safety sweep that detaches other workers' bindings before tombstoning a worker's DO namespaces) settings-scanned **every worker in the account**. On the preview account that's ~100 GETs per erase, twice per lane run, across concurrent lanes — today's observed 429 storms, which also starved **prd** deploys because Cloudflare rate-limits per API user, not per account.

A cross-slot DO binding would be a platform bug, so: when the target is a preview-slot worker, candidates that clearly belong to a **different** slot are skipped. Everything else still gets swept — same-slot workers (sidecars, sibling apps), and all non-slot names (prd, dev, personal, unknown — including any future oddly-named worker, which fails safe into being scanned). Non-slot targets (e.g. `os-prd`) keep the full sweep unchanged.

Evidence from today's failed lanes: the sweep walking `auth-preview-{2,3,6,7,8,9}`, `dummy-petshop-preview-{2,3,4,13..19}`, `streams-example-app-preview-*`, `semaphore-preview-*`, `captun`, `cf-artifact-viewer-dev-jonas`… with 120s Retry-After backoffs, per erase.

## Verification

- scripts suite: 194 passed (two new tests: slot-family scoping incl. sidecar/non-slot coverage; non-slot target keeps full sweep)
- typecheck + lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which workers are scanned before tombstoning DO namespaces; wrong slot logic could miss a cross-slot binding, though that is treated as a platform bug and non-slot/unknown names still fail safe into the sweep.
> 
> **Overview**
> **Narrows the erase-time DO binding safety sweep** so preview-slot targets no longer settings-GET every worker in the account.
> 
> `detachExternalDurableObjectBindings` now uses new `previewSlotOfWorkerName` (parses `-preview-N` from worker names). When the target is a preview slot, workers in a **different** slot are excluded from the candidate list; same-slot siblings (e.g. typecheckers, `auth-preview-4`) and all **non-slot** workers (`prd`, dev, personal, unknown names) are still scanned. Non-slot targets keep the previous behavior (full sweep).
> 
> This cuts Cloudflare API volume during concurrent preview lane erases (the source of 429s that also blocked prd deploys). Two tests lock in slot-family scoping and unchanged full sweep for non-slot targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41a1c2bff61e48752d5b515902bc736dbf57a340. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-21T16:10:32.128Z",
      "headSha": "41a1c2bff61e48752d5b515902bc736dbf57a340",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-10.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/218762479342891",
      "shortSha": "41a1c2b",
      "cleanupDurationMs": 13038,
      "deployDurationMs": 113118,
      "testDurationMs": 205073,
      "testRetries": "2 retried: catalogue example \"dynamic-worker-stateless\" runs identically across runtimes (vitest x1) — example \"dynamic-worker-stateless\" failed in the project-worker runtime: Unable to deserialize cloned data due to invalid or unsupported version. · runs \"journal-is-the-record\" through the project REPL (specs x1) — Error: stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits).",
      "workerSizeKib": 17134.44,
      "workerGzipKib": 4606.74,
      "mainWorkerGzipKib": 4618.68
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-21T16:10:20.225Z",
      "headSha": "41a1c2bff61e48752d5b515902bc736dbf57a340",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-10.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/218762479342891",
      "shortSha": "41a1c2b",
      "cleanupDurationMs": 1132,
      "deployDurationMs": 12710,
      "testDurationMs": 25959,
      "testRetries": null,
      "workerSizeKib": 1915.12,
      "workerGzipKib": 440.96,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-21T16:10:22.856Z",
      "headSha": "41a1c2bff61e48752d5b515902bc736dbf57a340",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-10.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/218762479342891",
      "shortSha": "41a1c2b",
      "cleanupDurationMs": 3761,
      "deployDurationMs": 19567,
      "testDurationMs": 10691,
      "testRetries": null,
      "workerSizeKib": 3965.97,
      "workerGzipKib": 811.51,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-21T16:10:34.239Z",
      "headSha": "41a1c2bff61e48752d5b515902bc736dbf57a340",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-10.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/218762479342891",
      "shortSha": "41a1c2b",
      "cleanupDurationMs": 15141,
      "deployDurationMs": 81144,
      "testDurationMs": 59124,
      "testRetries": null,
      "workerSizeKib": 5161.45,
      "workerGzipKib": 1473.34,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-21T16:10:20.182Z",
      "headSha": "41a1c2bff61e48752d5b515902bc736dbf57a340",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-10.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/218762479342891",
      "shortSha": "41a1c2b",
      "cleanupDurationMs": 1082,
      "deployDurationMs": 5932,
      "testDurationMs": 5803,
      "testRetries": null,
      "workerSizeKib": 1114.39,
      "workerGzipKib": 198.17,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `41a1c2b` | [https://auth.iterate-preview-10.com](https://auth.iterate-preview-10.com) | 811.5 KiB | 19.6s | 10.7s |  | 3.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/218762479342891) | 2026-07-21T16:10:22.856Z | Preview app released. |
| Dummy Petshop | released | `41a1c2b` | [https://dummy-petshop.iterate-preview-10.com](https://dummy-petshop.iterate-preview-10.com) | 198.2 KiB | 5.9s | 5.8s |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/218762479342891) | 2026-07-21T16:10:20.182Z | Preview app released. |
| OS | released | `41a1c2b` | [https://os.iterate-preview-10.com](https://os.iterate-preview-10.com) | 4.50 MiB (-11.9 KiB vs main) | 113.1s | 205.1s | 2 retried: catalogue example "dynamic-worker-stateless" runs identically across runtimes (vitest x1) — example "dynamic-worker-stateless" failed in the project-worker runtime: Unable to deserialize cloned data due to invalid or unsupported version. · runs "journal-is-the-record" through the project REPL (specs x1) — Error: stream-wait-timeout: Timed out waiting for stream event after 60000ms (the public deadline expired while recovery re-armed one-shot waits). | 13.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/218762479342891) | 2026-07-21T16:10:32.128Z | Preview app released. |
| Semaphore | released | `41a1c2b` | [https://semaphore.iterate-preview-10.com](https://semaphore.iterate-preview-10.com) | 441.0 KiB | 12.7s | 26.0s |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/218762479342891) | 2026-07-21T16:10:20.225Z | Preview app released. |
| Streams Example App | released | `41a1c2b` | [https://streams.iterate-preview-10.com](https://streams.iterate-preview-10.com) | 1.44 MiB | 81.1s | 59.1s |  | 15.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/218762479342891) | 2026-07-21T16:10:34.239Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +48 -0 | +42 -0 🟩🟩🟩🟩🟩 |
| CI & scripts | +22 -3 | +11 -3 🟩🟩⬜⬜⬜ |
| **Total** | **+70 -3** | **+53 -3** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between c186612 and 41a1c2b, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->