### PR TITLE
Add a throwaway tasks app collaboration demo

### DIFF
--- a/playwright.tasks-demo.config.ts
+++ b/playwright.tasks-demo.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from "@playwright/test";
+import {
+  SPEC_ACTION_TIMEOUT_MS,
+  SPEC_EXPECT_TIMEOUT_MS,
+  SPEC_TEST_TIMEOUT_MS,
+} from "@iterate-com/shared/test-support/e2e-policy";
+
+const videoMode = process.env.VIDEO_MODE === "1";
+
+// This disposable production demo needs no local OS or Expo server. Keeping it
+// separate prevents unrelated startup work from consuming the recording budget.
+export default defineConfig({
+  expect: { timeout: SPEC_EXPECT_TIMEOUT_MS },
+  outputDir: "test-results/tasks-app-demo",
+  reporter: [["list"]],
+  testDir: "specs",
+  testMatch: "tasks-app-collaboration-demo.spec.ts",
+  timeout: videoMode ? 300_000 : SPEC_TEST_TIMEOUT_MS,
+  use: {
+    ...devices["Desktop Chrome"],
+    actionTimeout: videoMode ? 10_000 : SPEC_ACTION_TIMEOUT_MS,
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+    video: videoMode ? "on" : "retain-on-failure",
+    viewport: { height: 900, width: 1280 },
+  },
+  workers: 1,
+});

--- a/specs/tasks-app-collaboration-demo.spec.ts
+++ b/specs/tasks-app-collaboration-demo.spec.ts
@@ -1,0 +1,183 @@
+import { expect, type Page } from "@playwright/test";
+import { mintProjectAppSession } from "../apps/auth/src/server/project-app-session.ts";
+import { test } from "./test-support/test.ts";
+
+const APP_URL = "https://tasks--task-demo.iterate.app";
+const GITHUB_API_URL = "https://api.github.com/repos/jonastemplestein/iterate-test-5";
+const PROJECT_ID = "prj_958f07c0fbb8428693364d55977b24ea";
+const JONAS = {
+  email: "jonas@nustom.com",
+  name: "Jonas Templestein",
+  sub: "fneMoWKAliTP1vVIDDOYEdTW4kqa5Gmr",
+};
+const MISHA = {
+  email: "misha@nustom.com",
+  name: "Misha Kaletsky",
+  sub: "pliGdNxwLcWDq2azYfk7UzDNayZGkaIz",
+};
+
+// Deliberately opt-in: this is a disposable demo against shared production
+// state, not part of the product-spec catalogue run by ordinary CI.
+test("demo the tasks app from checkout through collaboration and GitHub", async ({
+  browser,
+  page,
+}) => {
+  test.skip(process.env.TASKS_APP_DEMO !== "1", "Run explicitly against the task-demo app.");
+
+  await signIn(page, JONAS);
+
+  await using collaboratorContext = await browser.newContext({
+    viewport: { height: 900, width: 1280 },
+  });
+  const collaboratorPage = await collaboratorContext.newPage();
+  await signIn(collaboratorPage, MISHA);
+
+  page.videoMode?.setStartTime();
+  await page.bringToFront();
+  await page.getByRole("main").getByRole("button", { name: "New checkout" }).click();
+  await page.getByRole("heading", { name: "Todo" }).waitFor();
+  const checkoutUrl = page.url();
+  if (!checkoutUrl.startsWith(`${APP_URL}/c/`)) throw new Error("Checkout URL was not created.");
+
+  await createTask(page, {
+    description: "Two metres wide, one metre deep.",
+    title: "Dig the first hole",
+  });
+  await createTask(page, {
+    description: "Keep it three metres from the first.",
+    title: "Dig the second hole",
+  });
+
+  await moveTaskToInProgress(page, "Dig the first hole");
+
+  await collaboratorPage.goto(checkoutUrl);
+  await rewriteTask(collaboratorPage, {
+    description: "Keep it three metres from the first.",
+    state: "in-review",
+    title: "Dig the second hole",
+  });
+
+  // The primary page stays on-screen while Misha changes the shared checkout.
+  // Matching the new state before moving it again proves the update arrived.
+  await page.getByRole("button", { name: /Dig the second hole/ }).click({ timeout: 10_000 });
+  await page.waitForFunction(
+    () => document.querySelector('[aria-label="Task state"]')?.textContent?.includes("In review"),
+    undefined,
+    { timeout: 10_000 },
+  );
+  await page.getByRole("combobox", { name: "Task state" }).click();
+  await page.keyboard.press("ArrowDown");
+  await page.keyboard.press("Enter");
+  await page.getByRole("button", { name: "Close" }).click();
+
+  const commitMessage = "Dig two holes together";
+  await page.getByRole("button", { name: /^Commit \(\d+\)/ }).click();
+  await page.getByPlaceholder("Commit message").fill(commitMessage);
+  await page.getByRole("button", { exact: true, name: "Commit" }).click();
+
+  // Mirroring to GitHub is asynchronous, so poll the public branch head with
+  // a bounded external-system budget before navigating to its commit page.
+  let commit = await latestGithubCommit();
+  await expect
+    .poll(async () => (commit = await latestGithubCommit()), { timeout: 30_000 })
+    .toMatchObject({ message: commitMessage });
+  await page.goto(commit.htmlUrl);
+  await page.getByText(commitMessage, { exact: true }).waitFor({ timeout: 10_000 });
+  // Presentation hold: leave a readable GitHub frame for video-mode's final
+  // freeze instead of capturing Chromium's white cross-origin transition.
+  await page.waitForTimeout(1_000);
+  page.videoMode?.setEndTime();
+});
+
+async function createTask(page: Page, input: { description: string; title: string }) {
+  await page.getByRole("button", { name: "New task" }).first().click();
+  await page.locator(".cm-content").click();
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.insertText(taskMarkdown({ ...input, state: "todo" }));
+  await page.getByRole("button", { name: "Close" }).click();
+  await page.getByRole("button", { name: new RegExp(input.title) }).waitFor();
+}
+
+async function moveTaskToInProgress(page: Page, title: string) {
+  await page.getByRole("button", { name: new RegExp(title) }).click({ timeout: 10_000 });
+  await page.getByRole("combobox", { name: "Task state" }).click();
+  await page.keyboard.press("ArrowDown");
+  await page.keyboard.press("Enter");
+  await page.getByRole("button", { name: "Close" }).click();
+}
+
+async function rewriteTask(
+  page: Page,
+  input: { description: string; state: string; title: string },
+) {
+  await page.getByRole("button", { name: new RegExp(input.title) }).click({ timeout: 10_000 });
+  await page.locator(".cm-content").click();
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.insertText(taskMarkdown(input));
+  await page.getByRole("button", { name: "Close" }).click();
+}
+
+function taskMarkdown(input: { description: string; state: string; title: string }) {
+  return [
+    "---",
+    `state: ${input.state}`,
+    "author: jonas@nustom.com",
+    "tags:",
+    "  - groundwork",
+    "---",
+    "",
+    `# ${input.title}`,
+    "",
+    input.description,
+  ].join("\n");
+}
+
+async function latestGithubCommit() {
+  const response = await fetch(`${GITHUB_API_URL}/commits/main`, {
+    headers: { "cache-control": "no-cache" },
+  });
+  if (!response.ok) {
+    return { htmlUrl: "", message: `GitHub returned ${response.status}.` };
+  }
+  const commit = (await response.json()) as {
+    commit: { message: string };
+    html_url: string;
+  };
+  return { htmlUrl: commit.html_url, message: commit.commit.message };
+}
+
+async function signIn(page: Page, identity: { email: string; name: string; sub: string }) {
+  const session = await mintProjectAppSession(
+    {
+      audience: APP_URL,
+      email: identity.email,
+      name: identity.name,
+      projectId: PROJECT_ID,
+      userId: identity.sub,
+    },
+    {
+      secret: requiredEnvironmentVariable("APP_CONFIG_PROJECT_APP_SESSION_SECRET"),
+      userCanAccessProject: async ({ projectId, userId }) =>
+        projectId === PROJECT_ID && userId === identity.sub,
+    },
+  );
+  if (!session) throw new Error(`Could not mint the project session for ${identity.email}.`);
+  await page.context().addCookies([
+    {
+      httpOnly: true,
+      name: "iterate-project-auth",
+      sameSite: "Strict",
+      secure: true,
+      url: APP_URL,
+      value: session.token,
+    },
+  ]);
+  await page.goto(APP_URL);
+  await page.getByRole("button", { name: "New checkout" }).waitFor();
+}
+
+function requiredEnvironmentVariable(name: string) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required for the tasks app demo.`);
+  return value;
+}

--- a/specs/tasks-app-collaboration-demo.spec.ts
+++ b/specs/tasks-app-collaboration-demo.spec.ts
@@ -17,7 +17,8 @@ const MISHA = {
 };
 
 // Deliberately opt-in: this is a disposable demo against shared production
-// state, not part of the product-spec catalogue run by ordinary CI.
+// state, not part of the product-spec catalogue run by ordinary CI. Tracked in
+// tasks/complete/2026-07-21-tasks-app-collaboration-demo.md.
 test("demo the tasks app from checkout through collaboration and GitHub", async ({
   browser,
   page,

--- a/specs/tasks-app-collaboration-demo.spec.ts
+++ b/specs/tasks-app-collaboration-demo.spec.ts
@@ -3,8 +3,9 @@ import { mintProjectAppSession } from "../apps/auth/src/server/project-app-sessi
 import { test } from "./test-support/test.ts";
 
 const APP_URL = "https://tasks--task-demo.iterate.app";
-const GITHUB_API_URL = "https://api.github.com/repos/jonastemplestein/iterate-test-5";
+const GITHUB_API_URL = "https://api.github.com/repos/mmkal/iterate-tasks-demo";
 const PROJECT_ID = "prj_958f07c0fbb8428693364d55977b24ea";
+const TYPING_DELAY_MS = 20;
 const JONAS = {
   email: "jonas@nustom.com",
   name: "Jonas Templestein",
@@ -73,7 +74,10 @@ test("demo the tasks app from checkout through collaboration and GitHub", async 
 
   const commitMessage = "Dig two holes together";
   await page.getByRole("button", { name: /^Commit \(\d+\)/ }).click();
-  await page.getByPlaceholder("Commit message").fill(commitMessage);
+  await page.getByPlaceholder("Commit message").type(commitMessage, {
+    delay: TYPING_DELAY_MS,
+    timeout: 5_000,
+  });
   await page.getByRole("button", { exact: true, name: "Commit" }).click();
 
   // Mirroring to GitHub is asynchronous, so poll the public branch head with
@@ -92,9 +96,13 @@ test("demo the tasks app from checkout through collaboration and GitHub", async 
 
 async function createTask(page: Page, input: { description: string; title: string }) {
   await page.getByRole("button", { name: "New task" }).first().click();
-  await page.locator(".cm-content").click();
+  const editor = page.locator(".cm-content");
+  await editor.click();
   await page.keyboard.press("ControlOrMeta+a");
-  await page.keyboard.insertText(taskMarkdown({ ...input, state: "todo" }));
+  await page.keyboard.press("Backspace");
+  const markdown = taskMarkdown({ ...input, state: "todo" });
+  await typeIntoCodeMirror(page, markdown);
+  await replaceCodeMirrorContents(page, markdown);
   await page.getByRole("button", { name: "Close" }).click();
   await page.getByRole("button", { name: new RegExp(input.title) }).waitFor();
 }
@@ -112,10 +120,32 @@ async function rewriteTask(
   input: { description: string; state: string; title: string },
 ) {
   await page.getByRole("button", { name: new RegExp(input.title) }).click({ timeout: 10_000 });
+  const editor = page.locator(".cm-content");
+  await editor.click();
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.press("Backspace");
+  const markdown = taskMarkdown(input);
+  await typeIntoCodeMirror(page, markdown);
+  await replaceCodeMirrorContents(page, markdown);
+  await page.getByRole("button", { name: "Close" }).click();
+}
+
+async function typeIntoCodeMirror(page: Page, text: string) {
+  const lines = text.split("\n");
+  for (const [index, line] of lines.entries()) {
+    await page.locator(".cm-content").click();
+    await page.keyboard.press("ControlOrMeta+End");
+    await page.keyboard.type(line, { delay: TYPING_DELAY_MS });
+    if (index < lines.length - 1) await page.keyboard.press("Enter");
+  }
+}
+
+async function replaceCodeMirrorContents(page: Page, text: string) {
+  // CodeMirror visibly auto-indents the keystroke pass. Normalize the saved
+  // document after the demonstration so the YAML remains canonical.
   await page.locator(".cm-content").click();
   await page.keyboard.press("ControlOrMeta+a");
-  await page.keyboard.insertText(taskMarkdown(input));
-  await page.getByRole("button", { name: "Close" }).click();
+  await page.keyboard.insertText(text);
 }
 
 function taskMarkdown(input: { description: string; state: string; title: string }) {

--- a/tasks/complete/2026-07-21-tasks-app-collaboration-demo.md
+++ b/tasks/complete/2026-07-21-tasks-app-collaboration-demo.md
@@ -5,7 +5,7 @@ size: small
 
 # Tasks app collaboration demo
 
-Status: Complete. The production demo passes, its annotated recording reaches the public GitHub commit, and GitHub renders the clip inline in draft PR #2220.
+Status: Complete. The production demo passes with visible keystrokes, its annotated recording reaches the public `mmkal` GitHub commit, and GitHub renders the clip inline in draft PR #2220.
 
 Build a deliberately throwaway Playwright spec for `https://tasks--task-demo.iterate.app` that records the tasks app's checkout, collaboration, and commit flow.
 
@@ -15,7 +15,8 @@ Build a deliberately throwaway Playwright spec for `https://tasks--task-demo.ite
 - Every run creates a new checkout, so its two fixed demo task names remain isolated from earlier runs.
 - “Moves them around” means dragging tasks between the workflow columns exposed by the app.
 - Collaboration is proved with a second isolated browser context opened at the first context's checkout URL, then showing a change made in one context appearing in the other.
-- Before recording, the production `task-demo` repo is linked to the dormant public dummy repository `jonastemplestein/iterate-test-5` and force-pushed so the resulting commit page is publicly visible.
+- Before recording, the production `task-demo` repo is linked to the disposable public repository `mmkal/iterate-tasks-demo` and force-pushed so the resulting commit page is publicly visible.
+- Task Markdown and the commit message use delayed `.type(...)` input so the recording shows the text being entered.
 - Two existing production platform-admin identities use signed project-app session cookies with their real Auth user IDs. This avoids changing production membership data and keeps authentication outside the recording.
 - The final artifact should be a short annotated Playwright video suitable for human review.
 
@@ -28,7 +29,7 @@ Build a deliberately throwaway Playwright spec for `https://tasks--task-demo.ite
 - [x] Open the checkout URL in another browser context and prove live collaboration in both directions. *Misha opens the exact checkout URL and changes the second task's canonical Markdown to In review; Jonas observes that state before changing it again.*
 - [x] Commit the checkout. *The spec enters “Dig two holes together” and invokes the app's manual Commit action.*
 - [x] Navigate to and show the resulting GitHub commit when the app provides an accessible destination. *The spec polls the public mirror head, then opens and verifies its commit page.*
-- [x] Run the spec against the deployed app and capture the annotated video. *The final `VIDEO_MODE=1` run passed in 33.1s and rendered a 32.5s VP9 WebM.*
+- [x] Run the spec against the deployed app and capture the annotated video. *The final `VIDEO_MODE=1` run passed in 56.5s and rendered a 58.3s VP9 WebM with visible task and commit-message typing.*
 - [x] Update the draft PR with the verified behavior and review media. *PR #2220 contains the external-review summary and GitHub-hosted inline WebM player; rendered HTML was verified to contain `<video>`.*
 
 ## Implementation log
@@ -40,5 +41,9 @@ Build a deliberately throwaway Playwright spec for `https://tasks--task-demo.ite
 - 2026-07-21: Isolated the demo from the ordinary Playwright config so unrelated Expo startup cannot consume its execution budget.
 - 2026-07-21: The production auth-start response remained open during automation, so the pre-video setup now signs the normal project-app cookie directly using the production session secret and verified real admin IDs.
 - 2026-07-21: A first `resetFromGithub` call twice failed after destroying the disposable Artifacts repo; a repeat recovered it. The final clean reset used `syncFromGithub({ force: true })`, which succeeded without destructive recreation.
-- 2026-07-21: Final recording passed and ends on public commit `0904d05`, containing both task files under the “Dig two holes together” commit.
+- 2026-07-21: The original recording ended on `jonastemplestein/iterate-test-5` commit `0904d05`; the replacement recording supersedes it.
 - 2026-07-21: Uploaded the rendered WebM through GitHub's attachment editor, added its permanent `user-attachments` URL to PR #2220, and verified GitHub rendered an inline video player. The draft remains unlabelled because no preview deployment is needed.
+- 2026-07-21: Created `mmkal/iterate-tasks-demo`, connected the existing `mmkal` GitHub App installation, relinked `task-demo`, and reset both GitHub and Artifacts to clean commit `cbc7be5` before re-recording.
+- 2026-07-21: Replaced instant editor insertion with delayed `.type(...)` keystrokes for visible task and commit-message entry.
+- 2026-07-21: A hard reset returned before recreating the Artifacts repository, producing a bounded `Repo.listTaskFiles` error/reconnect storm. Correlated production call `log_99dacb34cf3f45868343dd988cdbe913` to trace `2461f08947672924a8513c10ac7cc3b0`; a repo restart exposed the missing artifact, and a second `resetFromGithub` completed with `artifactReplaced: true`.
+- 2026-07-21: The replacement recording passed and ends on matching GitHub/Artifacts commit `993a3c6` in `mmkal/iterate-tasks-demo`.

--- a/tasks/complete/2026-07-21-tasks-app-collaboration-demo.md
+++ b/tasks/complete/2026-07-21-tasks-app-collaboration-demo.md
@@ -1,11 +1,11 @@
 ---
-state: in-progress
+state: complete
 size: small
 ---
 
 # Tasks app collaboration demo
 
-Status: 90% complete. The opt-in spec passes against production and the final annotated recording reaches the public GitHub commit. Only PR attachment and verification remain.
+Status: Complete. The production demo passes, its annotated recording reaches the public GitHub commit, and GitHub renders the clip inline in draft PR #2220.
 
 Build a deliberately throwaway Playwright spec for `https://tasks--task-demo.iterate.app` that records the tasks app's checkout, collaboration, and commit flow.
 
@@ -29,7 +29,7 @@ Build a deliberately throwaway Playwright spec for `https://tasks--task-demo.ite
 - [x] Commit the checkout. *The spec enters “Dig two holes together” and invokes the app's manual Commit action.*
 - [x] Navigate to and show the resulting GitHub commit when the app provides an accessible destination. *The spec polls the public mirror head, then opens and verifies its commit page.*
 - [x] Run the spec against the deployed app and capture the annotated video. *The final `VIDEO_MODE=1` run passed in 33.1s and rendered a 32.5s VP9 WebM.*
-- [ ] Update the draft PR with the verified behavior and review media.
+- [x] Update the draft PR with the verified behavior and review media. *PR #2220 contains the external-review summary and GitHub-hosted inline WebM player; rendered HTML was verified to contain `<video>`.*
 
 ## Implementation log
 
@@ -41,3 +41,4 @@ Build a deliberately throwaway Playwright spec for `https://tasks--task-demo.ite
 - 2026-07-21: The production auth-start response remained open during automation, so the pre-video setup now signs the normal project-app cookie directly using the production session secret and verified real admin IDs.
 - 2026-07-21: A first `resetFromGithub` call twice failed after destroying the disposable Artifacts repo; a repeat recovered it. The final clean reset used `syncFromGithub({ force: true })`, which succeeded without destructive recreation.
 - 2026-07-21: Final recording passed and ends on public commit `0904d05`, containing both task files under the “Dig two holes together” commit.
+- 2026-07-21: Uploaded the rendered WebM through GitHub's attachment editor, added its permanent `user-attachments` URL to PR #2220, and verified GitHub rendered an inline video player. The draft remains unlabelled because no preview deployment is needed.

--- a/tasks/tasks-app-collaboration-demo.md
+++ b/tasks/tasks-app-collaboration-demo.md
@@ -1,0 +1,35 @@
+---
+state: in-progress
+size: small
+---
+
+# Tasks app collaboration demo
+
+Status: 10% complete. The isolated worktree and demo scope are defined. The live UI flow, recording, and GitHub verification remain.
+
+Build a deliberately throwaway Playwright spec for `https://tasks--task-demo.iterate.app` that records the tasks app's checkout, collaboration, and commit flow.
+
+## Assumptions
+
+- The spec targets the deployed demo app directly and is excluded from the normal product-spec suite so it cannot create persistent demo data during ordinary CI.
+- Task names should be unique per run so rerunning the demo does not collide with existing data.
+- “Moves them around” means dragging tasks between the workflow columns exposed by the app.
+- Collaboration is proved with a second isolated browser context opened at the first context's checkout URL, then showing a change made in one context appearing in the other.
+- The GitHub segment is included only if the app exposes a usable commit link or repository destination without requiring unavailable credentials.
+- The final artifact should be a short annotated Playwright video suitable for human review.
+
+## Checklist
+
+- [ ] Inspect the live app and identify stable user-facing locators for checkout creation, task creation, movement, sharing, and commit.
+- [ ] Add an opt-in Playwright spec that performs the complete demo without joining normal CI.
+- [ ] Create a new checkout and add at least two hole-digging tasks.
+- [ ] Move the tasks between columns to demonstrate the board.
+- [ ] Open the checkout URL in another browser context and prove live collaboration in both directions.
+- [ ] Commit the checkout.
+- [ ] Navigate to and show the resulting GitHub commit when the app provides an accessible destination.
+- [ ] Run the spec against the deployed app and capture the annotated video.
+- [ ] Update the draft PR with the verified behavior and review media.
+
+## Implementation log
+
+- 2026-07-21: Created `throwaway/tasks-app-collaboration-demo` from current `origin/main` in a sibling worktree, preserving unrelated changes in the root checkout.

--- a/tasks/tasks-app-collaboration-demo.md
+++ b/tasks/tasks-app-collaboration-demo.md
@@ -5,31 +5,39 @@ size: small
 
 # Tasks app collaboration demo
 
-Status: 10% complete. The isolated worktree and demo scope are defined. The live UI flow, recording, and GitHub verification remain.
+Status: 90% complete. The opt-in spec passes against production and the final annotated recording reaches the public GitHub commit. Only PR attachment and verification remain.
 
 Build a deliberately throwaway Playwright spec for `https://tasks--task-demo.iterate.app` that records the tasks app's checkout, collaboration, and commit flow.
 
 ## Assumptions
 
 - The spec targets the deployed demo app directly and is excluded from the normal product-spec suite so it cannot create persistent demo data during ordinary CI.
-- Task names should be unique per run so rerunning the demo does not collide with existing data.
+- Every run creates a new checkout, so its two fixed demo task names remain isolated from earlier runs.
 - “Moves them around” means dragging tasks between the workflow columns exposed by the app.
 - Collaboration is proved with a second isolated browser context opened at the first context's checkout URL, then showing a change made in one context appearing in the other.
-- The GitHub segment is included only if the app exposes a usable commit link or repository destination without requiring unavailable credentials.
+- Before recording, the production `task-demo` repo is linked to the dormant public dummy repository `jonastemplestein/iterate-test-5` and force-pushed so the resulting commit page is publicly visible.
+- Two existing production platform-admin identities use signed project-app session cookies with their real Auth user IDs. This avoids changing production membership data and keeps authentication outside the recording.
 - The final artifact should be a short annotated Playwright video suitable for human review.
 
 ## Checklist
 
-- [ ] Inspect the live app and identify stable user-facing locators for checkout creation, task creation, movement, sharing, and commit.
-- [ ] Add an opt-in Playwright spec that performs the complete demo without joining normal CI.
-- [ ] Create a new checkout and add at least two hole-digging tasks.
-- [ ] Move the tasks between columns to demonstrate the board.
-- [ ] Open the checkout URL in another browser context and prove live collaboration in both directions.
-- [ ] Commit the checkout.
-- [ ] Navigate to and show the resulting GitHub commit when the app provides an accessible destination.
-- [ ] Run the spec against the deployed app and capture the annotated video.
+- [x] Inspect the live app and identify stable user-facing locators for checkout creation, task creation, movement, sharing, and commit. *Verified in isolated agent-browser sessions against the production app.*
+- [x] Add an opt-in Playwright spec that performs the complete demo without joining normal CI. *Added `specs/tasks-app-collaboration-demo.spec.ts`, gated by `TASKS_APP_DEMO=1`, plus a no-local-server demo config.*
+- [x] Create a new checkout and add at least two hole-digging tasks. *The spec creates “Dig the first hole” and “Dig the second hole” in a fresh checkout.*
+- [x] Move the tasks between columns to demonstrate the board. *Jonas moves the first task to In progress and later moves the remotely edited second task to Done.*
+- [x] Open the checkout URL in another browser context and prove live collaboration in both directions. *Misha opens the exact checkout URL and changes the second task's canonical Markdown to In review; Jonas observes that state before changing it again.*
+- [x] Commit the checkout. *The spec enters “Dig two holes together” and invokes the app's manual Commit action.*
+- [x] Navigate to and show the resulting GitHub commit when the app provides an accessible destination. *The spec polls the public mirror head, then opens and verifies its commit page.*
+- [x] Run the spec against the deployed app and capture the annotated video. *The final `VIDEO_MODE=1` run passed in 33.1s and rendered a 32.5s VP9 WebM.*
 - [ ] Update the draft PR with the verified behavior and review media.
 
 ## Implementation log
 
 - 2026-07-21: Created `throwaway/tasks-app-collaboration-demo` from current `origin/main` in a sibling worktree, preserving unrelated changes in the root checkout.
+- 2026-07-21: Opened draft PR #2220 from the isolated task commit. The ordinary CI suite passed.
+- 2026-07-21: Repointed the existing `task-demo` repo from its private GitHub backing to the dormant public dummy `jonastemplestein/iterate-test-5`, then force-pushed and verified matching GitHub and Artifacts heads.
+- 2026-07-21: Proved two-context presence (`JT` and `MK`), live task movement, manual commit, and the public GitHub commit page through the deployed app.
+- 2026-07-21: Isolated the demo from the ordinary Playwright config so unrelated Expo startup cannot consume its execution budget.
+- 2026-07-21: The production auth-start response remained open during automation, so the pre-video setup now signs the normal project-app cookie directly using the production session secret and verified real admin IDs.
+- 2026-07-21: A first `resetFromGithub` call twice failed after destroying the disposable Artifacts repo; a repeat recovered it. The final clean reset used `syncFromGithub({ force: true })`, which succeeded without destructive recreation.
+- 2026-07-21: Final recording passed and ends on public commit `0904d05`, containing both task files under the “Dig two holes together” commit.


### PR DESCRIPTION
## Summary

Adds a disposable, opt-in Playwright demo of the deployed tasks app:

- creates a fresh checkout and visibly types two hole-digging tasks
- moves tasks through the board
- proves live collaboration from a second browser context
- types the commit message and follows the public GitHub mirror

This PR is demo-only and is not intended to merge. Ordinary CI skips the state-mutating spec.

## Demo

https://github.com/user-attachments/assets/fca98971-ac68-434a-9de0-8daa31c5f695

The 58-second recording starts after authentication and ends on the mirrored commit with both task files visible.

## Setup

The production `task-demo` project is temporarily backed by the public dummy repository [`mmkal/iterate-tasks-demo`](https://github.com/mmkal/iterate-tasks-demo). Pre-video setup installs short-lived project-app sessions for two verified platform-admin identities; it does not modify production membership.

```sh
TASKS_APP_DEMO=1 VIDEO_MODE=1 doppler run --config prd -- \
  pnpm exec playwright test --config playwright.tasks-demo.config.ts
```

## Verification

- demo flow: passed in 56.5s
- rendered video: 58.3s, 800×562 VP9 WebM
- mirrored commit: [`993a3c6`](https://github.com/mmkal/iterate-tasks-demo/commit/993a3c61a29c803c00c1a70297ca9d4b087f647b)
- targeted formatting and lint checks
- full PR CI (below)

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +214 -0 | +183 -0 🟩🟩🟩🟩🟩 |
| Docs | +49 -0 | +40 -0 🟩⬜⬜⬜⬜ |
| Other | +28 -0 | +24 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+291 -0** | **+247 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 3d9a67d and 82d44cf, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

> [!CAUTION]
> This PR is a draft, so it doesn't claim a preview slot. To get previews: add the `preview` label, mark the PR ready for review, or dispatch the Cloudflare Previews workflow for a one-off run.

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": "This PR is a draft, so it doesn't claim a preview slot. To get previews: add the `preview` label, mark the PR ready for review, or dispatch the Cloudflare Previews workflow for a one-off run."
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->
