### PR TITLE
Make processor event APIs infer from discriminators

### DIFF
--- a/apps/os/src/domains/integrations/posthog.test.ts
+++ b/apps/os/src/domains/integrations/posthog.test.ts
@@ -101,12 +101,7 @@ describe("first-party PostHog stream integration", () => {
         onPoison: "park",
       },
     });
-    expect(() =>
-      CoreProcessorContract.parseEventInput(
-        "events.iterate.com/stream/subscription-configured",
-        event,
-      ),
-    ).not.toThrow();
+    expect(() => CoreProcessorContract.parseEventInput(event)).not.toThrow();
   });
 
   it("captures the raw durable event with only useful indexed dimensions", async () => {

--- a/apps/os/src/domains/streams/processor-contracts.test.ts
+++ b/apps/os/src/domains/streams/processor-contracts.test.ts
@@ -50,6 +50,27 @@ const AppendDoorContract = defineProcessorContract({
   emits: [],
 });
 
+const ParserInferenceContract = defineProcessorContract({
+  slug: "parser-inference-test",
+  version: "1.0.0",
+  description: "Exercises discriminator inference and parsed output types.",
+  stateSchema: z.object({}),
+  events: {
+    "events.iterate.com/test/number": {
+      payloadSchema: z.object({ value: z.string().transform(Number) }),
+    },
+    "events.iterate.com/test/length": {
+      payloadSchema: z.object({ value: z.string().transform((value) => value.length) }),
+    },
+    "events.iterate.com/test/transient": {
+      ephemeral: true,
+      payloadSchema: z.object({ value: z.string() }),
+    },
+  },
+  consumes: ["events.iterate.com/test/number", "events.iterate.com/test/length"],
+  emits: ["events.iterate.com/test/number", "events.iterate.com/test/transient"],
+});
+
 describe("processor-derived append inputs", () => {
   test("derive required durable inputs from consumes and parse their payload output", () => {
     type Input = ConsumedInput<typeof AppendDoorContract>;
@@ -98,5 +119,65 @@ describe("processor-derived append inputs", () => {
     ).toThrow(
       'Processor "append-door-test" cannot consume ephemeral event "events.iterate.com/test/appendable-input".',
     );
+  });
+});
+
+describe("contract event helpers", () => {
+  test("infer parsed output from the event discriminator", () => {
+    const built = ParserInferenceContract.buildEvent({
+      type: "events.iterate.com/test/number",
+      payload: { value: "42" },
+    });
+    expectTypeOf(built.payload.value).toEqualTypeOf<number>();
+    expect(built.payload.value).toBe(42);
+
+    const parsedInput = ParserInferenceContract.parseEventInput({
+      type: "events.iterate.com/test/length",
+      payload: { value: "four" },
+    });
+    expectTypeOf(parsedInput.payload.value).toEqualTypeOf<number>();
+    expect(parsedInput.payload.value).toBe(4);
+
+    const parsedEvent = ParserInferenceContract.parseEvent({
+      type: "events.iterate.com/test/number",
+      payload: { value: "7" },
+      offset: 1,
+      createdAt: new Date(0).toISOString(),
+      path: "/tests/parser-inference",
+    });
+    expectTypeOf(parsedEvent.payload.value).toEqualTypeOf<number>();
+    expect(parsedEvent.payload.value).toBe(7);
+
+    const consumed = ParserInferenceContract.parseConsumedInput({
+      type: "events.iterate.com/test/length",
+      payload: { value: "three" },
+    });
+    expectTypeOf(consumed.type).toEqualTypeOf<"events.iterate.com/test/length">();
+    expectTypeOf(consumed.payload.value).toEqualTypeOf<number>();
+    expect(consumed.payload.value).toBe(5);
+  });
+
+  test("returns a discriminated union for broadly typed input", () => {
+    const input: StreamEventInput = {
+      type: "events.iterate.com/test/number",
+      payload: { value: "42" },
+    };
+    const parsed = ParserInferenceContract.parseEventInput(input);
+
+    if (parsed.type === "events.iterate.com/test/number") {
+      expectTypeOf(parsed.payload.value).toEqualTypeOf<number>();
+      expect(parsed.payload.value).toBe(42);
+    } else {
+      throw new Error(`unexpected parsed event type: ${parsed.type}`);
+    }
+  });
+
+  test("reflects forced ephemeral defaults in parsed output types", () => {
+    const built = ParserInferenceContract.buildEvent({
+      type: "events.iterate.com/test/transient",
+      payload: { value: "temporary" },
+    });
+    expectTypeOf(built.ephemeral).toEqualTypeOf<true>();
+    expect(built.ephemeral).toBe(true);
   });
 });

--- a/apps/os/src/domains/streams/stream-durable-object.ts
+++ b/apps/os/src/domains/streams/stream-durable-object.ts
@@ -606,18 +606,17 @@ export class StreamDurableObject extends DurableObject<Env> {
       // persisted expressions are NAMES — every delivery re-derives authority
       // from THIS stream's own itx root (project-scoped, or the deployment
       // root for projectId: null streams).
-      const event = CoreProcessorContract.parseEventInput(
-        "events.iterate.com/stream/subscription-configured",
-        args.event,
-      );
-      if (event.payload.delivery.mode === "webhook" && this.name.projectId === null) {
+      const payload = CoreProcessorContract.events[
+        "events.iterate.com/stream/subscription-configured"
+      ].payloadSchema.parse(args.event.payload);
+      if (payload.delivery.mode === "webhook" && this.name.projectId === null) {
         // Webhook POSTs ride the project egress lane (attribution +
         // interception); a global stream has no project to attribute them to.
         throw new Error("webhook subscriptions require a project-scoped stream");
       }
       // An unparseable selector condition must be rejected before it commits,
       // not discovered as a per-event error forever after. (compile throws.)
-      compileEventSelector(event.payload.selector);
+      compileEventSelector(payload.selector);
     }
 
     if (!args.state.paused) return;
@@ -685,7 +684,6 @@ export class StreamDurableObject extends DurableObject<Env> {
   }
 
   #reduceCore(args: { event: StreamEvent; state: CoreProcessorState }): CoreProcessorState {
-    const parse = CoreProcessorContract.parseEvent;
     let next: CoreProcessorState = {
       ...args.state,
       eventCount: args.state.eventCount + 1,
@@ -705,9 +703,13 @@ export class StreamDurableObject extends DurableObject<Env> {
       return this.#reduceCircuitBreaker({ event: args.event, state: next });
     }
 
-    switch (args.event.type) {
+    const event = parseCoreEvent(args.event);
+    if (event === undefined) {
+      return this.#reduceCircuitBreaker({ event: args.event, state: next });
+    }
+
+    switch (event.type) {
       case "events.iterate.com/stream/created": {
-        const event = parse("events.iterate.com/stream/created", args.event);
         if (event.offset !== 1) {
           throw new Error(
             "events.iterate.com/stream/created must be the first event and have offset 1",
@@ -725,7 +727,6 @@ export class StreamDurableObject extends DurableObject<Env> {
       }
 
       case "events.iterate.com/stream/woken": {
-        const event = parse("events.iterate.com/stream/woken", args.event);
         // A new stream incarnation means every previous delivery connection
         // died with the old one. Clearing the roster here is what keeps it
         // truthful without heartbeats: surviving subscribers reconnect and
@@ -734,7 +735,6 @@ export class StreamDurableObject extends DurableObject<Env> {
       }
 
       case "events.iterate.com/stream/paused": {
-        const event = parse("events.iterate.com/stream/paused", args.event);
         return {
           ...next,
           paused: true,
@@ -744,7 +744,6 @@ export class StreamDurableObject extends DurableObject<Env> {
       }
 
       case "events.iterate.com/stream/resumed": {
-        const event = parse("events.iterate.com/stream/resumed", args.event);
         return {
           ...next,
           paused: false,
@@ -754,7 +753,6 @@ export class StreamDurableObject extends DurableObject<Env> {
       }
 
       case "events.iterate.com/stream/configured": {
-        const event = parse("events.iterate.com/stream/configured", args.event);
         const circuitBreaker = event.payload.config.circuitBreaker;
         if (circuitBreaker === undefined) return next;
         return {
@@ -770,7 +768,6 @@ export class StreamDurableObject extends DurableObject<Env> {
       }
 
       case "events.iterate.com/stream/subscriber-connected": {
-        const event = parse("events.iterate.com/stream/subscriber-connected", args.event);
         const { subscriptionKey, subscriber, subscriptionType } = event.payload;
         // Ephemeral connections are runtime facts, not reduced state: their
         // lifetime is the live socket, tracked in #subscribers. Folding them
@@ -794,7 +791,6 @@ export class StreamDurableObject extends DurableObject<Env> {
       }
 
       case "events.iterate.com/stream/subscriber-disconnected": {
-        const event = parse("events.iterate.com/stream/subscriber-disconnected", args.event);
         const { [event.payload.subscriptionKey]: _closed, ...connectionsByKey } =
           next.connectionsByKey;
         return this.#reduceCircuitBreaker({
@@ -804,7 +800,6 @@ export class StreamDurableObject extends DurableObject<Env> {
       }
 
       case "events.iterate.com/stream/subscription-configured": {
-        const event = parse("events.iterate.com/stream/subscription-configured", args.event);
         return this.#reduceCircuitBreaker({
           event: args.event,
           state: {
@@ -825,7 +820,6 @@ export class StreamDurableObject extends DurableObject<Env> {
       }
 
       case "events.iterate.com/stream/subscription-removed": {
-        const event = parse("events.iterate.com/stream/subscription-removed", args.event);
         const { [event.payload.subscriptionKey]: _removed, ...configuredSubscribersByKey } =
           next.configuredSubscribersByKey;
         return this.#reduceCircuitBreaker({
@@ -835,7 +829,6 @@ export class StreamDurableObject extends DurableObject<Env> {
       }
 
       case "events.iterate.com/stream/subscription-parked": {
-        const event = parse("events.iterate.com/stream/subscription-parked", args.event);
         const existing = next.configuredSubscribersByKey[event.payload.subscriptionKey];
         // A parked fact for a since-removed subscription folds to nothing.
         if (existing === undefined) {
@@ -857,7 +850,6 @@ export class StreamDurableObject extends DurableObject<Env> {
       }
 
       case "events.iterate.com/stream/subscription-resumed": {
-        const event = parse("events.iterate.com/stream/subscription-resumed", args.event);
         const existing = next.configuredSubscribersByKey[event.payload.subscriptionKey];
         if (existing === undefined) {
           return this.#reduceCircuitBreaker({ event: args.event, state: next });
@@ -878,11 +870,9 @@ export class StreamDurableObject extends DurableObject<Env> {
       case "events.iterate.com/stream/subscription-cursor-set":
         // The seek itself is a side effect on the spine's cursor row (see
         // #processEvent); the fold only validates and counts the fact.
-        parse("events.iterate.com/stream/subscription-cursor-set", args.event);
         return this.#reduceCircuitBreaker({ event: args.event, state: next });
 
       case "events.iterate.com/stream/child-stream-created": {
-        const event = parse("events.iterate.com/stream/child-stream-created", args.event);
         if (next.path === undefined) {
           return this.#reduceCircuitBreaker({ event: args.event, state: next });
         }
@@ -897,7 +887,6 @@ export class StreamDurableObject extends DurableObject<Env> {
       }
 
       case "events.iterate.com/stream/error-occurred":
-        parse("events.iterate.com/stream/error-occurred", args.event);
         return this.#reduceCircuitBreaker({ event: args.event, state: next });
 
       default:
@@ -922,36 +911,23 @@ export class StreamDurableObject extends DurableObject<Env> {
       return;
     }
 
-    switch (args.event.type) {
+    const event = parseCoreEvent(args.event);
+    if (event === undefined) return;
+
+    switch (event.type) {
       case "events.iterate.com/stream/subscription-configured": {
-        const event = CoreProcessorContract.parseEvent(
-          "events.iterate.com/stream/subscription-configured",
-          args.event,
-        );
         this.#subscribers.onSubscriptionConfigured(event.payload, event.offset);
         return;
       }
       case "events.iterate.com/stream/subscription-removed": {
-        const event = CoreProcessorContract.parseEvent(
-          "events.iterate.com/stream/subscription-removed",
-          args.event,
-        );
         this.#subscribers.onSubscriptionRemoved(event.payload.subscriptionKey);
         return;
       }
       case "events.iterate.com/stream/subscription-resumed": {
-        const event = CoreProcessorContract.parseEvent(
-          "events.iterate.com/stream/subscription-resumed",
-          args.event,
-        );
         this.#subscribers.onResumed(event.payload.subscriptionKey);
         return;
       }
       case "events.iterate.com/stream/subscription-cursor-set": {
-        const event = CoreProcessorContract.parseEvent(
-          "events.iterate.com/stream/subscription-cursor-set",
-          args.event,
-        );
         this.#subscribers.onCursorSet(event.payload.subscriptionKey, event.payload.afterOffset);
         return;
       }
@@ -1505,6 +1481,13 @@ type ReducedCoreEvent = {
   previousState: CoreProcessorState;
   state: CoreProcessorState;
 };
+
+/** Parse only event types owned by the core contract; application events are inert here. */
+function parseCoreEvent(event: StreamEvent) {
+  return Object.hasOwn(CoreProcessorContract.events, event.type)
+    ? CoreProcessorContract.parseEvent(event)
+    : undefined;
+}
 
 function resetCircuitBreaker(
   circuitBreaker: CoreProcessorState["circuitBreaker"],

--- a/apps/os/src/domains/streams/stream-processor.test.ts
+++ b/apps/os/src/domains/streams/stream-processor.test.ts
@@ -364,7 +364,7 @@ describe("contract event-input envelope", () => {
     // Load-bearing: getEventInputSchema is .strict(), so without `ephemeral`
     // in the envelope every processor-lane ephemeral append (the agent's LLM
     // chunks) would throw "Unrecognized key" at parse.
-    const parsed = CounterContract.parseEventInput("events.iterate.com/test/incremented", {
+    const parsed = CounterContract.parseEventInput({
       type: "events.iterate.com/test/incremented",
       ephemeral: true,
       payload: { by: 1 },

--- a/apps/os/src/domains/streams/utils.ts
+++ b/apps/os/src/domains/streams/utils.ts
@@ -1,4 +1,3 @@
-import { buildEvent } from "iterate/processors";
 import type { ItxExpression } from "../../itx/expression.ts";
 import { CoreProcessorContract } from "./core-processor-contract.ts";
 
@@ -60,22 +59,18 @@ export function buildDurableObjectProcessorSubscriptionConfiguredEvent(input: {
   processorSlug: string;
   subscriptionKey?: string;
 }) {
-  return buildEvent({
-    contract: CoreProcessorContract,
-    event: {
-      type: "events.iterate.com/stream/subscription-configured",
-      ...(input.idempotencyKey === undefined ? {} : { idempotencyKey: input.idempotencyKey }),
-      payload: {
-        subscriptionKey:
-          input.subscriptionKey ?? `${input.durableObjectName}#${input.processorSlug}`,
-        delivery: {
-          mode: "wake",
-          expression: [...input.processor, "wakeStreamSubscriber"],
-          // processorSlug rides the delivery explicitly; the wake request
-          // carries it so multi-processor hosts resolve without parsing
-          // anything out of the (opaque) subscription key.
-          processorSlug: input.processorSlug,
-        },
+  return CoreProcessorContract.buildEvent({
+    type: "events.iterate.com/stream/subscription-configured",
+    ...(input.idempotencyKey === undefined ? {} : { idempotencyKey: input.idempotencyKey }),
+    payload: {
+      subscriptionKey: input.subscriptionKey ?? `${input.durableObjectName}#${input.processorSlug}`,
+      delivery: {
+        mode: "wake",
+        expression: [...input.processor, "wakeStreamSubscriber"],
+        // processorSlug rides the delivery explicitly; the wake request
+        // carries it so multi-processor hosts resolve without parsing
+        // anything out of the (opaque) subscription key.
+        processorSlug: input.processorSlug,
       },
     },
   });

--- a/packages/iterate/src/processors/processor-contracts.ts
+++ b/packages/iterate/src/processors/processor-contracts.ts
@@ -164,7 +164,9 @@ type EventFromType<
       infer PayloadOutput,
       unknown
     >
-    ? TypedStreamEvent<Type, PayloadOutput> & { payload: PayloadOutput }
+    ? TypedStreamEvent<Type, PayloadOutput> & { payload: PayloadOutput } & ParsedEphemeralEnvelope<
+          EventDefinitionForType<Events, ProcessorDeps, Type>
+        >
     : never
   : never;
 
@@ -236,8 +238,26 @@ type ParsedInputFromType<
       infer PayloadOutput,
       unknown
     >
-    ? TypedStreamEventInput<Type, PayloadOutput> & { payload: PayloadOutput }
+    ? TypedStreamEventInput<Type, PayloadOutput> & {
+        payload: PayloadOutput;
+      } & ParsedEphemeralEnvelope<EventDefinitionForType<Events, ProcessorDeps, Type>>
     : never
+  : never;
+
+/** Contract-forced ephemeral inputs default to `true` during parsing. */
+type ParsedEphemeralEnvelope<Definition> = Definition extends { ephemeral: true }
+  ? { ephemeral: true }
+  : unknown;
+
+/** A typed builder preserves the supplied envelope while returning parsed payload/default output. */
+type BuiltInputFromEvent<
+  Events extends EventCatalog,
+  ProcessorDeps extends readonly unknown[],
+  Event extends { type: string },
+> = Event extends unknown
+  ? Omit<Event, "payload"> &
+      Pick<ParsedInputFromType<Events, ProcessorDeps, Event["type"]>, "payload"> &
+      ParsedEphemeralEnvelope<EventDefinitionForType<Events, ProcessorDeps, Event["type"]>>
   : never;
 
 /** Parsed durable inputs for a processor's `consumes` tuple. */
@@ -343,21 +363,22 @@ type ProcessorContractBuildEvent<
   > & { type: string },
 >(
   event: Event,
-) => Event;
+) => BuiltInputFromEvent<Events, ProcessorDeps, Event>;
 
-/** `contract.parseEvent(...)`: validate a committed event, optionally narrowed by an explicit type string. */
+/** Resolved contract types compatible with an event's current discriminator type. */
+type ResolvedTypeFromEvent<
+  Events extends EventCatalog,
+  ProcessorDeps extends readonly unknown[],
+  Event extends { type: string },
+> = Extract<ResolvedEventType<Events, ProcessorDeps>, Event["type"]>;
+
+/** `contract.parseEvent(...)`: validate a committed event and infer its output from `event.type`. */
 type ProcessorContractParseEvent<
   Events extends EventCatalog,
   ProcessorDeps extends readonly unknown[],
-> = {
-  <const Type extends ResolvedEventType<Events, ProcessorDeps>>(
-    type: Type,
-    event: StreamEvent,
-  ): EventFromType<Events, ProcessorDeps, Type>;
-  (
-    event: StreamEvent,
-  ): EventFromType<Events, ProcessorDeps, ResolvedEventType<Events, ProcessorDeps>>;
-};
+> = <const Event extends StreamEvent>(
+  event: Event,
+) => EventFromType<Events, ProcessorDeps, ResolvedTypeFromEvent<Events, ProcessorDeps, Event>>;
 
 /**
  * Same as `parseEvent`, but for append inputs that do not yet have an offset or
@@ -371,15 +392,13 @@ type ProcessorContractParseEvent<
 type ProcessorContractParseEventInput<
   Events extends EventCatalog,
   ProcessorDeps extends readonly unknown[],
-> = {
-  <const Type extends ResolvedEventType<Events, ProcessorDeps>>(
-    type: Type,
-    event: StreamEventInput,
-  ): ParsedInputFromType<Events, ProcessorDeps, Type>;
-  (
-    event: StreamEventInput,
-  ): ParsedInputFromType<Events, ProcessorDeps, ResolvedEventType<Events, ProcessorDeps>>;
-};
+> = <const Event extends StreamEventInput>(
+  event: Event,
+) => ParsedInputFromType<
+  Events,
+  ProcessorDeps,
+  ResolvedTypeFromEvent<Events, ProcessorDeps, Event>
+>;
 
 /**
  * `contract.parseConsumedInput(...)`: validate one domain-object append
@@ -389,9 +408,15 @@ type ProcessorContractParseConsumedInput<
   Events extends EventCatalog,
   ProcessorDeps extends readonly unknown[],
   Consumes extends readonly string[],
-> = (
-  event: ConsumedInputFromTypes<Events, ProcessorDeps, Consumes>,
-) => ParsedConsumedInputFromTypes<Events, ProcessorDeps, Consumes>;
+> = <const Event extends ConsumedInputFromTypes<Events, ProcessorDeps, Consumes>>(
+  event: Event,
+) => "*" extends Consumes[number]
+  ? ParsedConsumedInputFromTypes<Events, ProcessorDeps, Consumes>
+  : ParsedConsumedInputFromTypes<
+      Events,
+      ProcessorDeps,
+      readonly Extract<Consumes[number], Event["type"]>[]
+    >;
 
 // =============================================================================
 // Runtime event parsers (bound to this app's event schemas).
@@ -472,14 +497,6 @@ export function getEventInputSchema<
 // =============================================================================
 
 /**
- * Validate an append input against the payload schema resolved from a contract's
- * local `events` plus its `processorDeps`. Used by call sites that hold a
- * contract but not a processor instance (e.g. subscription-configured event
- * builders in `utils.ts`); contracts expose it pre-bound as
- * `contract.buildEvent(...)`.
- */
-
-/**
  * Memoized twins of {@link getEventSchema} / {@link getEventInputSchema} for
  * hot paths. Constructing the zod wrapper per call costs ~20µs (~50x the
  * parse itself), and the reduce/append paths run once per event. Keyed by
@@ -515,29 +532,6 @@ export function cachedEventSchema(args: {
   return cachedSchema(eventSchemaCache, getEventSchema, args);
 }
 
-export function buildEvent<
-  const Contract extends {
-    slug?: string;
-    events: EventCatalog;
-    processorDeps?: readonly unknown[];
-  },
-  const Event extends ResolvedEventInput<Contract> & { type: string },
->(args: { contract: Contract; event: Event }): Event {
-  const eventDefinition = getResolvedEventDefinition({
-    contract: args.contract,
-    eventType: args.event.type,
-  });
-  if (eventDefinition === undefined) {
-    const owner = args.contract.slug == null ? "contract" : `processor "${args.contract.slug}"`;
-    throw new Error(`${owner} cannot build unresolved event "${args.event.type}".`);
-  }
-  return getEventInputSchema({
-    type: args.event.type,
-    payloadSchema: eventDefinition.payloadSchema,
-    ephemeral: eventDefinition.ephemeral,
-  }).parse(args.event) as unknown as Event;
-}
-
 /** Union of append-input shapes for every event a contract can resolve (own + deps). */
 type ResolvedEventInput<Contract> = Contract extends {
   events: EventCatalog;
@@ -548,6 +542,54 @@ type ResolvedEventInput<Contract> = Contract extends {
       ResolvedEventType<ContractEventCatalog<Contract>, ProcessorDepsOf<Contract>>
     >
   : never;
+
+/**
+ * Validate an append input with the payload schema resolved from a processor
+ * contract. Prefer the contract-bound `contract.buildEvent(event)` API, which
+ * carries the same types without repeating the contract in the argument.
+ *
+ * @deprecated Use `contract.buildEvent(event)`.
+ */
+export function buildEvent<
+  const Contract extends {
+    slug?: string;
+    events: EventCatalog;
+    processorDeps?: readonly unknown[];
+  },
+  const Event extends ResolvedEventInput<NoInfer<Contract>> & { type: string },
+>(args: {
+  contract: Contract;
+  event: Event;
+}): BuiltInputFromEvent<ContractEventCatalog<Contract>, ProcessorDepsOf<Contract>, Event> {
+  return parseResolvedEventInput(args.contract, args.event) as BuiltInputFromEvent<
+    ContractEventCatalog<Contract>,
+    ProcessorDepsOf<Contract>,
+    Event
+  >;
+}
+
+function parseResolvedEventInput(
+  contract: {
+    slug?: string;
+    events: EventCatalog;
+    processorDeps?: readonly unknown[];
+  },
+  event: { type: string },
+): unknown {
+  const eventDefinition = getResolvedEventDefinition({
+    contract,
+    eventType: event.type,
+  });
+  if (eventDefinition === undefined) {
+    const owner = contract.slug == null ? "contract" : `processor "${contract.slug}"`;
+    throw new Error(`${owner} cannot build unresolved event "${event.type}".`);
+  }
+  return getEventInputSchema({
+    type: event.type,
+    payloadSchema: eventDefinition.payloadSchema,
+    ephemeral: eventDefinition.ephemeral,
+  }).parse(event);
+}
 
 /**
  * Typed identity for processor contracts: validation plus the pre-bound
@@ -593,10 +635,10 @@ export function defineProcessorContract<
   parseEventInput: ProcessorContractParseEventInput<Events, ProcessorDeps>;
   parseConsumedInput: ProcessorContractParseConsumedInput<Events, ProcessorDeps, Consumes>;
 };
-// The implementation is intentionally untyped (`any` return): the single typed
-// overload above carries the whole contract type; TS cannot relate the
-// generic helper-method shapes to the runtime Object.assign result.
-export function defineProcessorContract(contract: unknown): any {
+// The overload above is the public type. The runtime implementation returns
+// `unknown` because TypeScript cannot relate the generic helper-method shapes
+// to the dynamically validated Object.assign result.
+export function defineProcessorContract(contract: unknown): unknown {
   assertNoLocalProcessorDepEventConflicts(contract);
   assertDefaultStateSchema(contract);
   if (typeof contract !== "object" || contract === null) {
@@ -619,13 +661,10 @@ export function defineProcessorContract(contract: unknown): any {
   };
   return Object.assign(typedContract, {
     buildEvent(event: { type: string }) {
-      return buildEvent({
-        contract: typedContract,
-        event: event as ResolvedEventInput<typeof typedContract> & { type: string },
-      });
+      return parseResolvedEventInput(typedContract, event);
     },
-    parseEvent: makeContractEventParser(typedContract, "parseEvent", getEventSchema),
-    parseEventInput: makeContractEventParser(typedContract, "parseEventInput", getEventInputSchema),
+    parseEvent: makeContractEventParser(typedContract, getEventSchema),
+    parseEventInput: makeContractEventParser(typedContract, getEventInputSchema),
     parseConsumedInput: makeContractConsumedInputParser(typedContract),
   });
 }
@@ -679,18 +718,13 @@ function makeContractConsumedInputParser(contract: {
  */
 function makeContractEventParser(
   contract: { events: EventCatalog; processorDeps?: readonly unknown[] },
-  name: "parseEvent" | "parseEventInput",
   schemaFor: (args: { type: string; payloadSchema: z.ZodType; ephemeral?: boolean }) => {
     parse(value: unknown): unknown;
   },
 ) {
   const parserCache = new Map<string, { parse(value: unknown): unknown }>();
-  return (typeOrEvent: string | { type: string }, maybeEvent?: { type: string }) => {
-    const eventType = typeof typeOrEvent === "string" ? typeOrEvent : typeOrEvent.type;
-    const event = typeof typeOrEvent === "string" ? maybeEvent : typeOrEvent;
-    if (event === undefined) {
-      throw new Error(`Processor "${getProcessorSlug(contract)}" ${name} missing event.`);
-    }
+  return (event: { type: string }) => {
+    const eventType = event.type;
     const eventDefinition = getResolvedEventDefinition({ contract, eventType });
     if (eventDefinition == null) {
       throw new Error(


### PR DESCRIPTION
## Summary

- replace the duplicated `parseEvent(type, event)` and `parseEventInput(type, event)` APIs with single-event parsers that infer the payload from `event.type`
- preserve schema transforms and forced-ephemeral defaults in helper return types, narrow `parseConsumedInput`, and remove the contract implementation `any`
- parse core stream events once before dispatch switches and migrate remaining call sites to the contract-bound helpers
- deprecate the redundant standalone `buildEvent({ contract, event })` API in favor of `contract.buildEvent(event)`

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm test`
- `pnpm --dir packages/iterate build`
- stream-focused suite: 34 files, 372 passing tests, 1 expected failure

No UI changes; screenshots are not applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches synchronous stream append/reduce validation and widely used contract typing; behavior should be equivalent but mistakes in discriminator inference or non-core event handling could affect pre-commit policy and core state folding.
> 
> **Overview**
> **Processor contract helpers** no longer use `parseEvent(type, event)` / `parseEventInput(type, event)`. Callers pass one object; return types are inferred from `event.type`, including Zod **transforms** on payloads and **`ephemeral: true`** defaults on catalog entries. `parseConsumedInput` narrows from the event discriminator; `defineProcessorContract` drops an `any` implementation return. Standalone `buildEvent({ contract, event })` is **deprecated** in favor of `contract.buildEvent(event)`.
> 
> **Stream durable object** core reduce/process paths parse via a shared `parseCoreEvent` (core-owned types only); pre-commit `subscription-configured` validation uses the catalog payload schema directly. **Tests and utilities** (PostHog, subscription builder, processor contract tests) follow the new signatures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b02257cac6da9c8752804a0f2c25b8e0ba0e040b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +137 -125 | +110 -108 🟩🟩🟩🟥🟥 |
| Tests | +83 -7 | +75 -7 🟩🟩⬜⬜⬜ |
| **Total** | **+220 -132** | **+185 -115** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between a999a11 and b02257c, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-21T21:30:19.817Z",
      "headSha": "b02257cac6da9c8752804a0f2c25b8e0ba0e040b",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/525062550557654",
      "shortSha": "b02257c",
      "cleanupDurationMs": 13706,
      "deployDurationMs": 113560,
      "deployedWorkerName": "os-preview-1",
      "deployedWorkerVersion": "167bab71-ba70-4f69-9f3e-0d6089a0eb45",
      "testDurationMs": 188488,
      "testRetries": null,
      "workerSizeKib": 17162.65,
      "workerGzipKib": 4614.41,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 4625.39
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-21T21:30:09.882Z",
      "headSha": "b02257cac6da9c8752804a0f2c25b8e0ba0e040b",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/525062550557654",
      "shortSha": "b02257c",
      "cleanupDurationMs": 3769,
      "deployDurationMs": 19047,
      "deployedWorkerName": "auth-preview-1",
      "deployedWorkerVersion": "9a0e7d32-03b7-4409-b4e8-06d5ced0ee43",
      "testDurationMs": 4783,
      "testRetries": null,
      "workerSizeKib": 3965.97,
      "workerGzipKib": 811.45,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-21T21:30:16.184Z",
      "headSha": "b02257cac6da9c8752804a0f2c25b8e0ba0e040b",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/525062550557654",
      "shortSha": "b02257c",
      "cleanupDurationMs": 10069,
      "deployDurationMs": 45525,
      "deployedWorkerName": "streams-example-app-preview-1",
      "deployedWorkerVersion": "da548ce4-f6e5-4ad9-a6c1-9efca2e6e481",
      "testDurationMs": 60723,
      "testRetries": null,
      "workerSizeKib": 5158.23,
      "workerGzipKib": 1472.94,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-21T21:30:07.115Z",
      "headSha": "b02257cac6da9c8752804a0f2c25b8e0ba0e040b",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/525062550557654",
      "shortSha": "b02257c",
      "cleanupDurationMs": 998,
      "deployDurationMs": 12877,
      "deployedWorkerName": "dummy-petshop-preview-1",
      "deployedWorkerVersion": "2e2e5213-417b-474c-8682-2fb0ca26aafe",
      "testDurationMs": 6202,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "f51b8fff12de09de772cade059bf3d5784e27461+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `b02257c` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 811.5 KiB | 19.0s | 4.8s |  | 3.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/525062550557654) | 2026-07-21T21:30:09.882Z | Preview app released. |
| Dummy Petshop | released | `b02257c` | [https://dummy-petshop.iterate-preview-1.com](https://dummy-petshop.iterate-preview-1.com) | 198.3 KiB | 12.9s | 6.2s |  | 998ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/525062550557654) | 2026-07-21T21:30:07.115Z | Preview app released. |
| OS | released | `b02257c` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 4.51 MiB (-11.0 KiB vs main) | 113.6s | 188.5s |  | 13.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/525062550557654) | 2026-07-21T21:30:19.817Z | Preview app released. |
| Streams Example App | released | `b02257c` | [https://streams.iterate-preview-1.com](https://streams.iterate-preview-1.com) | 1.44 MiB | 45.5s | 60.7s |  | 10.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/525062550557654) | 2026-07-21T21:30:16.184Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->