### PR TITLE
Hide empty Recently Active Agents on project home

### DIFF
--- a/apps/os/src/components/project-dashboard.tsx
+++ b/apps/os/src/components/project-dashboard.tsx
@@ -3,7 +3,6 @@ import { Link } from "@tanstack/react-router";
 import { useLiveState } from "iterate/sdk/itx/react";
 import { ArrowRightIcon } from "lucide-react";
 import { buttonVariants } from "@iterate-com/ui/components/button";
-import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@iterate-com/ui/components/empty";
 import { NewAgentComposer } from "~/components/new-agent-composer.tsx";
 import {
   AGENT_DISPLAY_STATE_PRESENTATION,
@@ -20,8 +19,8 @@ const CLOCK_TICK_MS = 15_000;
 
 /**
  * Project home for ready projects: start a new thread, continue from a few
- * recent agents. No page title — the shell breadcrumb carries context, the
- * composer placeholder says what to do.
+ * recent agents when any exist. No page title — the shell breadcrumb carries
+ * context, the composer placeholder says what to do.
  */
 export function ProjectDashboard({
   projectId,
@@ -43,7 +42,6 @@ export function ProjectDashboard({
     [agentsState],
   );
   const nowMs = useTickingNowMs(CLOCK_TICK_MS);
-  const agentsLoading = agentsState === undefined;
 
   return (
     <main className="flex min-h-full flex-1 flex-col p-4 md:p-8" data-testid="project-dashboard">
@@ -62,31 +60,22 @@ export function ProjectDashboard({
 
         <NewAgentComposer projectId={projectId} projectSlug={projectSlug} />
 
-        <section className="flex flex-col gap-3" aria-labelledby="recent-agents-heading">
-          <div className="flex items-baseline justify-between gap-3">
-            <h2 id="recent-agents-heading" className="text-base font-medium tracking-tight">
-              Recently Active Agents
-            </h2>
-            <Link
-              to="/projects/$projectSlug/agents"
-              params={{ projectSlug }}
-              search={{}}
-              className="text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
-            >
-              See all
-            </Link>
-          </div>
+        {recent.length > 0 ? (
+          <section className="flex flex-col gap-3" aria-labelledby="recent-agents-heading">
+            <div className="flex items-baseline justify-between gap-3">
+              <h2 id="recent-agents-heading" className="text-base font-medium tracking-tight">
+                Recently Active Agents
+              </h2>
+              <Link
+                to="/projects/$projectSlug/agents"
+                params={{ projectSlug }}
+                search={{}}
+                className="text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+              >
+                See all
+              </Link>
+            </div>
 
-          {agentsLoading ? (
-            <p className="py-6 text-sm text-muted-foreground">Loading agents…</p>
-          ) : recent.length === 0 ? (
-            <Empty>
-              <EmptyHeader>
-                <EmptyTitle>No agents yet</EmptyTitle>
-                <EmptyDescription>Message a new agent above to start one.</EmptyDescription>
-              </EmptyHeader>
-            </Empty>
-          ) : (
             <ul className="grid gap-2 sm:grid-cols-2" data-testid="recent-agents-list">
               {recent.map((agent) => (
                 <li key={agent.path}>
@@ -94,8 +83,8 @@ export function ProjectDashboard({
                 </li>
               ))}
             </ul>
-          )}
-        </section>
+          </section>
+        ) : null}
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary

- Project home (`/projects/<slug>`) no longer shows the **Recently Active Agents** section when there are no agents.
- The empty "No agents yet / Message a new agent above" block was redundant under the composer; the section only appears once there is at least one recent agent.

## Test plan

- [ ] Open a project with zero agents → only the composer (and optional Continue onboarding) shows; no empty agents section
- [ ] Open a project with agents → Recently Active Agents + See all still appear with cards
- [ ] Create the first agent from the composer → recent list appears after agents exist

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change on the project dashboard; no API, routing, or agent-selection logic changes.
> 
> **Overview**
> Project home no longer renders the **Recently Active Agents** block unless there is at least one recent agent.
> 
> The section is gated on `recent.length > 0`, so projects with no agents (or while agent live state is still loading and `recent` is treated as empty) only see the composer and optional **Continue onboarding** link. The **Loading agents…** copy and the **No agents yet** empty state under that heading were removed as redundant with the composer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7516eac5db478389fa24bb2e5b12f83d66b170b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| UI components | +19 -30 | +17 -28 🟩🟩🟥🟥🟥 |
| **Total** | **+19 -30** | **+17 -28** 🟩🟩🟥🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between a999a11 and 7516eac, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-21T21:37:45.079Z",
      "headSha": "7516eac5db478389fa24bb2e5b12f83d66b170b0",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/546552535355042",
      "shortSha": "7516eac",
      "cleanupDurationMs": 10847,
      "deployDurationMs": 134166,
      "deployedWorkerName": "os-preview-2",
      "deployedWorkerVersion": "e5d4ac52-dc33-4632-bffc-6e79e9958572",
      "testDurationMs": 214887,
      "testRetries": "1 retried: repl-examples.spec.ts › itx REPL catalogue examples › runs \"stream-cross-post\" through the project REPL › web (playwright x1) — Error: REPL entry errored: Error: RPC session was shut down by disposing the main stub at me.shutdown (https://os.iterate-preview-2.com/assets/dist-C53yZodz.js:1:40863) at pe.dispose (https://os.iterate-preview-2.com/assets/dist-C53yZodz.js:1:40140) at Proxy.<anonymous> (https://os.iterate-previe...",
      "workerSizeKib": 17163.96,
      "workerGzipKib": 4614.41,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 4625.39
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-21T21:37:37.491Z",
      "headSha": "7516eac5db478389fa24bb2e5b12f83d66b170b0",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/546552535355042",
      "shortSha": "7516eac",
      "cleanupDurationMs": 3257,
      "deployDurationMs": 22312,
      "deployedWorkerName": "auth-preview-2",
      "deployedWorkerVersion": "7765e0b3-8209-487d-8c09-7d7351078fea",
      "testDurationMs": 14060,
      "testRetries": null,
      "workerSizeKib": 3965.97,
      "workerGzipKib": 811.27,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-21T21:37:34.877Z",
      "headSha": "7516eac5db478389fa24bb2e5b12f83d66b170b0",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/546552535355042",
      "shortSha": "7516eac",
      "cleanupDurationMs": 637,
      "deployDurationMs": 5822,
      "deployedWorkerName": "dummy-petshop-preview-2",
      "deployedWorkerVersion": "9fe0e797-591c-44b6-b4c7-2d42fecaf240",
      "testDurationMs": 6008,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "f51b8fff12de09de772cade059bf3d5784e27461+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `7516eac` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 811.3 KiB | 22.3s | 14.1s |  | 3.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/546552535355042) | 2026-07-21T21:37:37.491Z | Preview app released. |
| Dummy Petshop | released | `7516eac` | [https://dummy-petshop.iterate-preview-2.com](https://dummy-petshop.iterate-preview-2.com) | 198.3 KiB | 5.8s | 6.0s |  | 637ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/546552535355042) | 2026-07-21T21:37:34.877Z | Preview app released. |
| OS | released | `7516eac` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 4.51 MiB (-11.0 KiB vs main) | 134.2s | 214.9s | 1 retried: repl-examples.spec.ts › itx REPL catalogue examples › runs "stream-cross-post" through the project REPL › web (playwright x1) — Error: REPL entry errored: Error: RPC session was shut down by disposing the main stub at me.shutdown (https://os.iterate-preview-2.com/assets/dist-C53yZodz.js:1:40863) at pe.dispose (https://os.iterate-preview-2.com/assets/dist-C53yZodz.js:1:40140) at Proxy.<anonymous> (https://os.iterate-previe... | 10.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/546552535355042) | 2026-07-21T21:37:45.079Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->