### PR TITLE
Await reflected agent messages in e2e

### DIFF
--- a/apps/os/e2e/vitest/itx-agents.e2e.test.ts
+++ b/apps/os/e2e/vitest/itx-agents.e2e.test.ts
@@ -191,6 +191,14 @@ test("Agent scripts can send web-chat messages (with file attachments) and call 
     predicate: (event) => event.payload?.message === "string form with files",
     timeoutMs: 30_000,
   });
+  const reflectedFilesReply = agent.stream.waitForEvent({
+    eventTypes: [AGENT_CONTEXT_ADDED_TYPE],
+    predicate: (event) =>
+      event.payload?.role === "assistant" &&
+      event.payload.content ===
+        "The assistant sent this visible web-chat message: string form with files",
+    timeoutMs: 30_000,
+  });
   const scriptSettled = agent.stream.waitForEvent({
     eventTypes: ["events.iterate.com/capability-host/script-run-settled"],
     timeoutMs: 30_000,
@@ -225,6 +233,7 @@ test("Agent scripts can send web-chat messages (with file attachments) and call 
     },
   });
   await scriptSettled;
+  const reflectedFilesEvent = await reflectedFilesReply;
 
   const events = await agent.stream.getEvents();
   expect(events).toEqual(
@@ -246,15 +255,8 @@ test("Agent scripts can send web-chat messages (with file attachments) and call 
     ]),
   );
 
-  const reflectedFilesReply = events.find(
-    (event) =>
-      event.type === AGENT_CONTEXT_ADDED_TYPE &&
-      event.payload?.role === "assistant" &&
-      event.payload.content ===
-        "The assistant sent this visible web-chat message: string form with files",
-  );
-  expect(reflectedFilesReply?.payload).toMatchObject({ role: "assistant" });
-  expect(reflectedFilesReply?.payload).not.toHaveProperty("llmRequestOffset");
+  expect(reflectedFilesEvent.payload).toMatchObject({ role: "assistant" });
+  expect(reflectedFilesEvent.payload).not.toHaveProperty("llmRequestOffset");
 });
 
 test("Agent create replays its earlier birth and setup events through its subscriptions", async () => {


### PR DESCRIPTION
## Summary

- register the reflected assistant-context listener before the agent script runs
- await that exact event before asserting its payload
- remove the racy post-settlement stream snapshot lookup

## Why

The same test failed on PRs #2205 and #2223 with `expected undefined to match object { role: "assistant" }`. It waited for the two visible web messages and `script-run-settled`, then immediately fetched a stream snapshot and assumed the separately reflected assistant-context event had already arrived. Script settlement does not establish that ordering.

This change waits for the behavior the test actually requires. It adds no sleep, retry, timeout increase, product fallback, or quarantine, and it leaves the rest of the event snapshot coverage intact.

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm exec oxfmt --check apps/os/e2e/vitest/itx-agents.e2e.test.ts`
- [x] `pnpm exec oxlint apps/os/e2e/vitest/itx-agents.e2e.test.ts`
- [x] `pnpm --dir apps/os typecheck`
- [ ] full preview deploy and e2e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production behavior; reduces CI flake risk.
> 
> **Overview**
> Fixes a **flaky ordering assumption** in the agent web-chat e2e test that sent messages with file attachments and asserted on a separately reflected `AGENT_CONTEXT_ADDED` assistant message.
> 
> The test now **registers `waitForEvent` for that reflected context event before the script runs**, then awaits it after `script-run-settled`. Assertions use the awaited event instead of scanning a post-settlement `getEvents()` snapshot, because settlement does not guarantee the reflection event has landed yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 679c6360fa9f956f33b187b784ed4947fab065ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +11 -9 | +11 -9 🟩🟩🟩🟥🟥 |
| **Total** | **+11 -9** | **+11 -9** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 2de2b7e and 679c636, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-21T22:23:17.505Z",
      "headSha": "679c6360fa9f956f33b187b784ed4947fab065ae",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/130380383879607",
      "shortSha": "679c636",
      "cleanupDurationMs": 11197,
      "deployDurationMs": 99619,
      "deployedWorkerName": "os-preview-11",
      "deployedWorkerVersion": "4d3aa5a7-070e-4fa5-a3ce-a2cd55f5f969",
      "testDurationMs": 154048,
      "testRetries": null,
      "workerSizeKib": 17162.06,
      "workerGzipKib": 4614.31,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 4625.2
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-21T22:23:09.049Z",
      "headSha": "679c6360fa9f956f33b187b784ed4947fab065ae",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/130380383879607",
      "shortSha": "679c636",
      "cleanupDurationMs": 2738,
      "deployDurationMs": 20793,
      "deployedWorkerName": "auth-preview-11",
      "deployedWorkerVersion": "c91bfca9-8d63-4a8f-9be8-dd47773fddda",
      "testDurationMs": 12306,
      "testRetries": null,
      "workerSizeKib": 3965.97,
      "workerGzipKib": 811.47,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-21T22:23:07.077Z",
      "headSha": "679c6360fa9f956f33b187b784ed4947fab065ae",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/130380383879607",
      "shortSha": "679c636",
      "cleanupDurationMs": 764,
      "deployDurationMs": 5777,
      "deployedWorkerName": "dummy-petshop-preview-11",
      "deployedWorkerVersion": "a67aeb43-9377-4fba-b02f-a88bc55cc4ef",
      "testDurationMs": 5266,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "31107178ee62c163420c729a8da60663b16c0fec+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `679c636` | [https://auth.iterate-preview-11.com](https://auth.iterate-preview-11.com) | 811.5 KiB | 20.8s | 12.3s |  | 2.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/130380383879607) | 2026-07-21T22:23:09.049Z | Preview app released. |
| Dummy Petshop | released | `679c636` | [https://dummy-petshop.iterate-preview-11.com](https://dummy-petshop.iterate-preview-11.com) | 198.3 KiB | 5.8s | 5.3s |  | 764ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/130380383879607) | 2026-07-21T22:23:07.077Z | Preview app released. |
| OS | released | `679c636` | [https://os.iterate-preview-11.com](https://os.iterate-preview-11.com) | 4.51 MiB (-10.9 KiB vs main) | 99.6s | 154.0s |  | 11.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/130380383879607) | 2026-07-21T22:23:17.505Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->