### PR TITLE
Run focused tests against existing previews

### DIFF
--- a/docs/dev-environments.md
+++ b/docs/dev-environments.md
@@ -456,6 +456,31 @@ These share the PR's slot and PR-body state with CI (ownership lives in the
 semaphore), so a local run renews (never fights) the slot CI claimed for the
 same PR.
 
+For a focused flake hunt, reuse the exact OS deployment and run one test file
+repeatedly without deploying, erasing the slot, or changing the PR's recorded
+full-suite result:
+
+```bash
+# Vitest target paths are relative to apps/os.
+GITHUB_TOKEN="$(gh auth token)" doppler run --project _shared --config prd --preserve-env=GITHUB_TOKEN -- \
+  pnpm preview test-target --pull-request-number 1234 --runner vitest \
+  --target e2e/vitest/itx-agents.e2e.test.ts \
+  --grep "Agent scripts can send web-chat messages" --repeat 25
+
+# Playwright target paths are relative to the repository root.
+GITHUB_TOKEN="$(gh auth token)" doppler run --project _shared --config prd --preserve-env=GITHUB_TOKEN -- \
+  pnpm preview test-target --pull-request-number 1234 --runner playwright \
+  --target specs/repo-ide.spec.ts --grep "discarding a new file" --repeat 25
+```
+
+Each repeat is a fresh runner invocation against the same immutable Worker
+versions and has CI's single test-level retry enabled. Absorbed retries remain
+visible in the per-run output and final summary. All requested samples run so
+the summary preserves the failure rate, then the command exits nonzero if any
+sample failed. The PR must still own its slot and OS plus its test dependencies
+must be recorded at the PR's current head; otherwise the command refuses and
+tells you to deploy first.
+
 ### Story 3: pin a PR to a slot
 
 `preview assign` says "this PR shall have this slot" (or whatever is free)

--- a/docs/preview-e2e-flake-hunt.md
+++ b/docs/preview-e2e-flake-hunt.md
@@ -24,6 +24,13 @@ reliable fix, recorded below; a failure resets the consecutive-green counter.
 `scripts/preview/flake-hunt-loop.sh` drives the loop and writes a machine-readable
 per-run duration and retry ledger.
 
+Once a failing test is isolated, use `pnpm preview test-target` to run its
+Vitest file or Playwright spec repeatedly against the PR's already-deployed
+preview. It does not deploy, erase, or overwrite the full-suite result; see
+[Dev environments → Story 2](dev-environments.md#story-2-run-what-ci-runs-locally)
+for exact commands. This focused loop is diagnostic only: the accepted streak
+still consists of complete deploy-plus-e2e runs on Depot.
+
 The trustworthy count runs **in Depot CI, not on a workstation** (a laptop
 sleeping mid-loop produced hours of phantom "degradation" — see the lab note):
 `.depot/workflows/preview-e2e-marathon.yml` runs that same loop on Depot infra,

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -54,6 +54,7 @@ const {
   resolvePreviewOsContainerRollout,
   resolvePreviewReadinessUrls,
   resolvePreviewTestBaseUrlEnvironment,
+  resolvePreviewTestTargetPlan,
   resolvePreviewTestWorkerVersionOverrides,
   selectExpiredLeasesForGc,
   selectPreviewAppsForPullRequest,
@@ -603,6 +604,45 @@ describe("auth preview root secrets", () => {
 });
 
 describe("preview test commands", () => {
+  test("builds a focused Vitest invocation from the OS app", () => {
+    expect(
+      resolvePreviewTestTargetPlan({
+        grep: "Agent scripts can send web-chat messages",
+        repositoryRoot: repoRoot,
+        runner: "vitest",
+        target: "e2e/vitest/itx-agents.e2e.test.ts",
+      }),
+    ).toEqual({
+      args: [
+        "e2e",
+        "--project",
+        "node",
+        "e2e/vitest/itx-agents.e2e.test.ts",
+        "--testNamePattern",
+        "Agent scripts can send web-chat messages",
+      ],
+      command: "pnpm",
+      telemetryFile: resolve(repoRoot, "test-results/preview-target-vitest.json"),
+      workingDirectory: resolve(repoRoot, "apps/os"),
+    });
+  });
+
+  test("builds a focused Playwright invocation from the repository root", () => {
+    expect(
+      resolvePreviewTestTargetPlan({
+        grep: "discarding a new file",
+        repositoryRoot: repoRoot,
+        runner: "playwright",
+        target: "specs/repo-ide.spec.ts",
+      }),
+    ).toEqual({
+      args: ["spec", "specs/repo-ide.spec.ts", "--grep", "discarding a new file"],
+      command: "pnpm",
+      telemetryFile: resolve(repoRoot, "test-results/playwright-results.json"),
+      workingDirectory: repoRoot,
+    });
+  });
+
   test("normalizes OS preview artifacts before Depot upload", () => {
     const workflow = readFileSync(
       resolve(repoRoot, ".depot/workflows/cloudflare-previews.yml"),

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -200,12 +200,9 @@ export async function testTarget(options: TestTargetOptions) {
     apps: recorded.apps,
     headSha: context.pullRequestHeadSha,
   });
-  const versionedAppSlugs = [
-    app.slug,
-    ...Object.keys(app.previewTestDependencyBaseUrlEnvVars ?? {}).map((slug) =>
-      CloudflarePreviewAppSlug.parse(slug),
-    ),
-  ];
+  // Match the full preview lane: RPC-only dependencies such as auth need an
+  // exact version pin even though they do not contribute a public base URL.
+  const versionedAppSlugs = expandPreviewDependencies([app.slug]);
   const workerVersionOverrides = resolvePreviewTestWorkerVersionOverrides({
     apps: recorded.apps,
     appSlugs: versionedAppSlugs,

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -1,11 +1,11 @@
 import { execFileSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { promises as dns } from "node:dns";
-import { readFile } from "node:fs/promises";
+import { mkdir, readFile, rm } from "node:fs/promises";
 import { userInfo } from "node:os";
 import { request as httpRequest } from "node:http";
 import { request as httpsRequest } from "node:https";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { Octokit } from "@octokit/rest";
 import { z } from "zod";
 import {
@@ -137,6 +137,150 @@ export async function test(options: PullRequestCommandOptions = {}) {
   return await withPreviewE2eTelemetry(context, runtime, "test", (telemetry) =>
     testPreviewApps({ context, runtime, telemetry }),
   );
+}
+
+type TestTargetOptions = PullRequestCommandOptions & {
+  /** Test runner to invoke against the deployed OS preview. */
+  runner: PreviewTestTargetRunner;
+  /** Test file path, relative to the repository root for Playwright or apps/os for Vitest. */
+  target: string;
+  /** Optional test-name pattern passed to the selected runner. */
+  grep?: string;
+  /** Number of independent sequential invocations against the same deployment. Defaults to 1. */
+  repeat?: number;
+};
+
+/**
+ * Run one OS Vitest file or Playwright spec against an already-deployed PR
+ * preview. This renews the existing lease but never deploys, erases data, or
+ * marks the app's full preview suite green.
+ */
+export async function testTarget(options: TestTargetOptions) {
+  const selection = z
+    .object({
+      grep: z.string().trim().min(1).optional(),
+      repeat: z.number().int().min(1).max(100).default(1),
+      runner: z.enum(["vitest", "playwright"]),
+      target: z.string().trim().min(1),
+    })
+    .parse(options);
+  const { context, runtime } = await resolvePreviewCommandSetup(options);
+  const recorded = (await readCloudflarePreviewState(context)).state;
+  const holder = pullRequestHolder(context.pullRequestNumber);
+  const semaphore = runtime.createPreviewSemaphoreResourceClient();
+  const displaySlot = recorded.environmentConfigLease;
+  const environmentConfigLease =
+    (await adoptLeaseHeldBySemaphore({
+      holder,
+      leaseMs: defaultPreviewLeaseMs,
+      preferSlug: displaySlot?.slug ?? null,
+      semaphore,
+    })) ??
+    (await retakeRecordedSlotIfFree({
+      holder,
+      leaseMs: defaultPreviewLeaseMs,
+      recordedSlug: displaySlot?.slug ?? null,
+      semaphore,
+    }));
+  if (!environmentConfigLease) {
+    throw new Error(
+      `Cannot run a targeted preview test: PR #${context.pullRequestNumber} does not hold its recorded preview slot. Run preview deploy first.`,
+    );
+  }
+
+  const app = cloudflarePreviewApps.os;
+  const entry = recorded.apps.os;
+  if (!canRunPreviewTests(entry) || entry?.headSha !== context.pullRequestHeadSha) {
+    throw new Error(
+      `Cannot run a targeted preview test: OS is not recorded as deployed at head ${context.pullRequestHeadSha.slice(0, 7)}. Run preview deploy first.`,
+    );
+  }
+  const baseUrlEnvironment = resolvePreviewTestBaseUrlEnvironment({
+    app,
+    apps: recorded.apps,
+    headSha: context.pullRequestHeadSha,
+  });
+  const versionedAppSlugs = [
+    app.slug,
+    ...Object.keys(app.previewTestDependencyBaseUrlEnvVars ?? {}).map((slug) =>
+      CloudflarePreviewAppSlug.parse(slug),
+    ),
+  ];
+  const workerVersionOverrides = resolvePreviewTestWorkerVersionOverrides({
+    apps: recorded.apps,
+    appSlugs: versionedAppSlugs,
+    dopplerConfig: environmentConfigLease.dopplerConfig,
+    headSha: context.pullRequestHeadSha,
+  });
+  const plan = resolvePreviewTestTargetPlan({
+    ...selection,
+    repositoryRoot: runtime.repositoryRoot,
+  });
+  await mkdir(dirname(plan.telemetryFile), { recursive: true });
+
+  let passed = 0;
+  let retries = 0;
+  const failures: string[] = [];
+  for (let iteration = 1; iteration <= selection.repeat; iteration += 1) {
+    await rm(plan.telemetryFile, { force: true });
+    logPreview(
+      `target test ${iteration}/${selection.repeat}: ${selection.runner} ${selection.target}${selection.grep ? ` matching ${JSON.stringify(selection.grep)}` : ""} against ${entry.publicUrl}`,
+    );
+    const result = await runCommand({
+      args: [
+        "run",
+        "--project",
+        app.dopplerProject,
+        "--config",
+        environmentConfigLease.dopplerConfig,
+        "--",
+        "env",
+        "CI=true",
+        `${E2E_CLOUDFLARE_WORKERS_VERSION_OVERRIDES_ENV}=${workerVersionOverrides}`,
+        `E2E_RETRY_TELEMETRY_FILE=${plan.telemetryFile}`,
+        ...baseUrlEnvironment,
+        plan.command,
+        ...plan.args,
+      ],
+      command: "doppler",
+      environment: runtime.commandEnvironment,
+      signal: runtime.signal,
+      workingDirectory: plan.workingDirectory,
+    });
+    const summary = await readTestTelemetryLane(`targeted ${selection.runner}`, () =>
+      selection.runner === "vitest"
+        ? readVitestTestTelemetry(plan.telemetryFile, "targeted vitest", runtime.repositoryRoot)
+        : readPlaywrightTestTelemetry(
+            plan.telemetryFile,
+            "targeted playwright",
+            runtime.repositoryRoot,
+          ),
+    );
+    announceRetryTelemetry("os target", summary);
+    retries += summary.retried.reduce((total, test) => total + test.retryCount, 0);
+    const failure =
+      previewTestFailureMessage({ result, retrySummary: summary }) ??
+      (summary.collectionErrors.length
+        ? `Structured test telemetry was incomplete: ${summary.collectionErrors.join("; ")}`
+        : null);
+    if (failure) {
+      failures.push(`run ${iteration}: ${failure}`);
+      console.error(`[preview] target test failed: ${failure}`);
+    } else {
+      passed += 1;
+      console.error(`[preview] target test passed: run ${iteration}/${selection.repeat}`);
+    }
+  }
+
+  logPreview(
+    `target tests finished: ${passed}/${selection.repeat} passed, ${failures.length} failed, ${retries} retries; deployment was reused without deploy or erase`,
+  );
+  if (failures.length > 0) {
+    throw new Error(
+      `${failures.length}/${selection.repeat} targeted preview test runs failed:\n${failures.join("\n")}`,
+    );
+  }
+  return { ok: true as const, passed, repeat: selection.repeat, retries };
 }
 
 /**
@@ -521,6 +665,42 @@ function resolvePreviewTestBaseUrlEnvironment({
     }
     return `${environmentVariable}=${entry.publicUrl}`;
   });
+}
+
+type PreviewTestTargetRunner = "vitest" | "playwright";
+
+function resolvePreviewTestTargetPlan(input: {
+  grep?: string;
+  repositoryRoot: string;
+  runner: PreviewTestTargetRunner;
+  target: string;
+}) {
+  const target = input.target.trim();
+  if (!target || target.startsWith("-")) {
+    throw new Error("A test target must be a non-empty path, not a CLI option.");
+  }
+
+  if (input.runner === "vitest") {
+    return {
+      args: [
+        "e2e",
+        "--project",
+        "node",
+        target,
+        ...(input.grep ? ["--testNamePattern", input.grep] : []),
+      ],
+      command: "pnpm",
+      telemetryFile: resolve(input.repositoryRoot, "test-results/preview-target-vitest.json"),
+      workingDirectory: resolve(input.repositoryRoot, "apps/os"),
+    };
+  }
+
+  return {
+    args: ["spec", target, ...(input.grep ? ["--grep", input.grep] : [])],
+    command: "pnpm",
+    telemetryFile: resolve(input.repositoryRoot, "test-results/playwright-results.json"),
+    workingDirectory: input.repositoryRoot,
+  };
 }
 
 function resolvePreviewTestWorkerVersionOverrides(input: {
@@ -6277,6 +6457,7 @@ export const previewInternals = {
   resolvePreviewOsContainerRollout,
   resolvePreviewReadinessUrls,
   resolvePreviewTestBaseUrlEnvironment,
+  resolvePreviewTestTargetPlan,
   resolvePreviewTestWorkerVersionOverrides,
   selectPreviewAppsForPullRequest,
   selectPreviewAppsNeedingRetry,


### PR DESCRIPTION
## Summary

- add `pnpm preview test-target` for one OS Vitest file or one root Playwright spec
- repeat the target against the exact already-deployed PR preview without deploying, erasing data, or overwriting the full-suite PR result
- retain the normal single CI test retry and report every absorbed retry plus the aggregate pass/fail rate
- document the focused flake-hunting workflow and keep the full Depot pipeline as the only accepted marathon proof

## Why

A full preview deploy and complete e2e suite is the right merge proof, but it is an expensive diagnostic loop once a failure has already been isolated. This command reuses the PR slot that CI already owns, validates that OS and its dependencies are recorded at the current head, and pins requests to those exact immutable Worker versions. That makes 25 or more samples of one suspected test practical without turning each sample into another deployment.

The command deliberately runs each sample as a fresh sequential runner invocation. Samples do not overlap and accidentally create a new pressure test; each still uses the same CI profile and its one test-level retry. All requested samples complete before the aggregate command fails, so a flake hunt records the actual observed failure rate rather than stopping at the first red sample.

## Safety contract

- requires the PR to still own its semaphore lease
- requires OS and every test dependency to be deployed at the exact current PR head
- uses the recorded preview URLs plus exact Worker-version overrides
- never deploys, erases preview data, or changes the recorded app test status
- treats missing structured telemetry as a failure

## Test plan

- Local gate passed: `pnpm install --frozen-lockfile`, `pnpm typecheck`, `pnpm lint`, `pnpm format`, `pnpm test`, and `pnpm preview test-target --help`.
- [Exact-head full preview attempt 2](https://depot.dev/orgs/0p91s0lz49/workflows/sc49j7x9nc?job=nmnrf6mk49&attempt=zjmlms8r6c) passed: OS deploy 90.9s, Vitest 78s, Playwright 154s, and the complete OS e2e lane 161.6s.
- Focused Vitest proof reused the existing preview and ran the exact previously failing `itx-egress` case twice: 2/2 passed in 14s and 13s, with zero retries, deploys, or erases.
- Focused Playwright proof reused the same preview and ran `repo-ide.spec.ts` matching `discarding a new file confirms before permanently removing it`: 1/1 passed in 29s, with zero retries, deploys, or erases.

### Unrelated flake evidence

[Full preview attempt 1](https://depot.dev/orgs/0p91s0lz49/workflows/sc49j7x9nc?job=nmnrf6mk49&attempt=0x0h2813sq) was contaminated by post-readiness Cloudflare rollout churn: `a repeated refresh event before its snapshot cannot resurrect material` failed both allowed attempts with `Durable Object reset because its code was updated`; nine other unrelated Vitest tests consumed retries, several with the same reset/network-loss signature, and Playwright absorbed one `agent-chat` retry. The exact red test then passed 2/2 against the unchanged deployment, without redeploying. Attempt 2 passed the full suite while absorbing one DO-storage retry and one initial WebSocket-connection retry.

Cross-branch evidence shows the exact `itx-egress` test passing in at least 24 other usable preview logs and the code-update reset occurring across unrelated tests in this rollout-contaminated run. No victim test was newly skipped or quarantined by this PR; the existing TUI quarantine is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches preview orchestration and live preview test execution (lease, version pins, Doppler), but deliberately avoids deploy/erase/PR status updates and gates on slot ownership and head-aligned deployments.
> 
> **Overview**
> Adds **`pnpm preview test-target`** so engineers can run one OS Vitest file or one root Playwright spec many times against a PR preview that is **already deployed**, without paying for another full deploy or erasing slot data.
> 
> The command **renews the semaphore lease** like other preview flows but **refuses** to run unless the PR still owns its slot and OS (plus RPC test dependencies such as auth) are recorded at the **current PR head**. Each sample is a fresh `doppler run` with `CI=true`, the same preview base URLs, and **exact Worker version overrides** as the full preview test lane; it does **not** deploy, erase, or update the PR’s full-suite test status.
> 
> **`resolvePreviewTestTargetPlan`** maps `--runner vitest|playwright`, `--target`, and optional `--grep` into the right `pnpm` invocation (Vitest paths under `apps/os`, Playwright under repo root) and telemetry file paths. The repeat loop (up to 100) runs every requested sample, surfaces absorbed CI retries in logs, then exits nonzero with an aggregate failure rate if any sample failed.
> 
> Docs in **dev-environments** and **preview-e2e-flake-hunt** describe the workflow; unit tests cover the Vitest and Playwright plan builders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 978aec3861bc45520d905eb3e25d37295cfd9339. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +40 -0 | +38 -0 🟩⬜⬜⬜⬜ |
| CI & scripts | +180 -2 | +160 -2 🟩🟩🟩🟩🟩 |
| Docs | +32 -0 | +27 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+252 -2** | **+225 -2** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between ed36ba3 and 978aec3, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->