### PR TITLE
Dispose leaked ITX handle in worker-forwarding E2E

### DIFF
--- a/apps/os/e2e/vitest/itx-subscribe.e2e.test.ts
+++ b/apps/os/e2e/vitest/itx-subscribe.e2e.test.ts
@@ -48,7 +48,7 @@ test("Project stream subscribe can observe project worker processEventBatch forw
                 if (event.type !== "events.iterate.com/stream/child-stream-created") return;
                 if (event.payload.childPath !== TRIGGER_PATH) return;
 
-                const project = await this.env.ITX.get();
+                using project = await this.env.ITX.get();
                 await project.streams.get(OUTPUT_PATH).append({
                   type: FORWARDED_EVENT_TYPE,
                   payload: {


### PR DESCRIPTION
## Summary

Dispose the live project ITX RPC handle created inside the custom dynamic-worker fixture in `itx-subscribe.e2e.test.ts`.

The worker now uses explicit resource management (`using project = await this.env.ITX.get()`), so the handle is released immediately after the forwarded stream append instead of waiting for runtime garbage collection.

## Why this is the flake

The worker-forwarding test has intermittently hit the global 120-second timeout on unrelated branches even though its healthy runtime is about 11–20 seconds.

For the failed PR #2233 attempt:

- the project delivery alarm started at `2026-07-21T22:30:54.957Z` and remained alive for `297,104 ms`;
- after the initial stream/repo work, its only interesting child was the dynamic-worker call, and the alarm then sat open without useful trace activity;
- recovery began as that five-minute invocation ended, and the forwarded output was emitted about 3.4 seconds later;
- the worker build completed in 1.085 seconds, matching the healthy retry, so the bundler was not the tail;
- the same suite window emitted many Cloudflare warnings that RPC stubs had not been disposed and could remain alive until arbitrary garbage collection.

The fixture obtained `env.ITX.get()` without disposing the returned live RPC stub, contrary to the ITX API contract. That lifecycle leak is a high-confidence explanation for the pinned dynamic-worker invocation. This PR fixes the misuse rather than raising the timeout or quarantining a substantive test.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test` — 224 OS unit-test files / 2,118 passing tests, plus all other workspace tests
- Existing-preview focused repeat:
  - preview: PR #2233 / preview 6
  - command: `doppler run --project _shared --config prd -- pnpm preview test-target --pull-request-number 2233 --runner vitest --target e2e/vitest/itx-subscribe.e2e.test.ts --grep 'Project stream subscribe can observe project worker processEventBatch forwarding' --repeat 25`
  - result: **25/25 passed, 0 retries**
  - no deploy and no data erase
  - observed runtime: 10.98–40.14 seconds; all remained below the test budget

### Full preview CI

- Attempt 1 and attempt 2 stopped before E2E because preview 5 still had the retired `os-preview-5-search-index-writes → os-preview-5` Queue consumer from the deleted AI Search system. Cloudflare rejected the now-handler-less OS worker. I removed that exact retired consumer, verified the queue had zero consumers, and then retried the deploy.
- Attempt 3 deployed all three apps successfully. OS deploy took 82.9s, including the full serial container rollout and 23.1s deployment-readiness proof.
- OS E2E passed in 148.9s: 162 passed, 2 expected failures, 3 existing skips.
- The worker-forwarding test changed here passed on its first attempt.
- Three unrelated tests passed on their allowed retry and kept the run green:
  - `fan-out: one un-awaited handle serves multiple pipelined calls (capnweb and workerd lanes)` — first attempt hit the 120s test timeout.
  - `waitrose-session strategy: username/password secret mints on first use, re-mints on 401, session works on the API` — first attempt read `pets` from a null response.
  - `append after idle teardown re-wakes configured subscriber from its checkpoint` — first attempt failed its WebSocket connection.
- The pre-existing TUI lane remained quarantined under [tasks/quarantined-tui-e2e.md](https://github.com/iterate/iterate/blob/479b4c427c649bcbd0519ebafc97fc2c4505f973/tasks/quarantined-tui-e2e.md). This PR adds no quarantine or skip.

No tests are quarantined or newly skipped by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only lifecycle fix in an E2E fixture string; no production runtime behavior changes.
> 
> **Overview**
> The embedded dynamic worker in **`itx-subscribe.e2e.test.ts`** now acquires the project ITX stub with **`using project = await this.env.ITX.get()`** instead of a plain `const`, so the live RPC handle is disposed as soon as the stream append finishes.
> 
> That matches how production workers treat **`env.ITX.get()`** and addresses intermittent **120s** timeouts tied to undisposed stubs pinning long-lived delivery invocations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 479b4c427c649bcbd0519ebafc97fc2c4505f973. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +1 -1 | +1 -1 🟩🟩🟩🟥🟥 |
| **Total** | **+1 -1** | **+1 -1** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 775f90d and 479b4c4, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-22T00:07:14.324Z",
      "headSha": "479b4c427c649bcbd0519ebafc97fc2c4505f973",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/140954123517252",
      "shortSha": "479b4c4",
      "cleanupDurationMs": 12818,
      "deployDurationMs": 82852,
      "deployedWorkerName": "os-preview-5",
      "deployedWorkerVersion": "ecde02fe-d7c5-4138-aeb1-10bef1dc6fb2",
      "testDurationMs": 148944,
      "testRetries": "3 retried: fan-out: one un-awaited handle serves multiple pipelined calls (capnweb and workerd lanes) (vitest x1) — Test timed out in 120000ms. If this is a long-running test, pass a timeout value as the last argument or configure it globally with \"testTimeout\". · waitrose-session strategy: username/password secret mints on first use, re-mints on 401, session works on the API (vitest x1) — Cannot read properties of null (reading 'pets') · append after idle teardown re-wakes configured subscriber from its checkpoint (vitest x1) — WebSocket connection failed.",
      "workerSizeKib": 17149.81,
      "workerGzipKib": 4611.15,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 4622.78
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-22T00:07:04.692Z",
      "headSha": "479b4c427c649bcbd0519ebafc97fc2c4505f973",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/140954123517252",
      "shortSha": "479b4c4",
      "cleanupDurationMs": 3183,
      "deployDurationMs": 17150,
      "deployedWorkerName": "auth-preview-5",
      "deployedWorkerVersion": "a7daa87b-8ce9-4acc-874e-ba52bba3c01c",
      "testDurationMs": 11014,
      "testRetries": null,
      "workerSizeKib": 3965.97,
      "workerGzipKib": 811.59,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-22T00:07:02.262Z",
      "headSha": "479b4c427c649bcbd0519ebafc97fc2c4505f973",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/140954123517252",
      "shortSha": "479b4c4",
      "cleanupDurationMs": 750,
      "deployDurationMs": 6473,
      "deployedWorkerName": "dummy-petshop-preview-5",
      "deployedWorkerVersion": "9363ce47-a996-4a11-89cc-a29625427c08",
      "testDurationMs": 9693,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "31107178ee62c163420c729a8da60663b16c0fec+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `479b4c4` | [https://auth.iterate-preview-5.com](https://auth.iterate-preview-5.com) | 811.6 KiB | 17.1s | 11.0s |  | 3.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/140954123517252) | 2026-07-22T00:07:04.692Z | Preview app released. |
| Dummy Petshop | released | `479b4c4` | [https://dummy-petshop.iterate-preview-5.com](https://dummy-petshop.iterate-preview-5.com) | 198.3 KiB | 6.5s | 9.7s |  | 750ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/140954123517252) | 2026-07-22T00:07:02.262Z | Preview app released. |
| OS | released | `479b4c4` | [https://os.iterate-preview-5.com](https://os.iterate-preview-5.com) | 4.50 MiB (-11.6 KiB vs main) | 82.9s | 148.9s | 3 retried: fan-out: one un-awaited handle serves multiple pipelined calls (capnweb and workerd lanes) (vitest x1) — Test timed out in 120000ms. If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout". · waitrose-session strategy: username/password secret mints on first use, re-mints on 401, session works on the API (vitest x1) — Cannot read properties of null (reading 'pets') · append after idle teardown re-wakes configured subscriber from its checkpoint (vitest x1) — WebSocket connection failed. | 12.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/140954123517252) | 2026-07-22T00:07:14.324Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->
