### PR TITLE
Detach retired AI Search queue consumers during deploy

### DIFF
--- a/apps/os/scripts/deploy.test.ts
+++ b/apps/os/scripts/deploy.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../scripts/lib/deploy-helpers.ts";
 import {
   assertPreviewPetshopIntegrationConfigured,
-  detachRetiredArtifactEventQueueConsumer,
+  detachRetiredWorkerQueueConsumers,
   isExactOsProjectMiss,
   posthogBuildEnv,
   resolveOsContainerDeployArgs,
@@ -19,9 +19,9 @@ import {
 
 const secretName = "APP_CONFIG_ITERATE_AUTH__SERVICE_TOKEN";
 
-describe("retired Artifact event Queue consumer", () => {
+describe("retired Worker Queue consumers", () => {
   it.each(["script", "script_name"] as const)(
-    "detaches only the legacy consumer for this Worker when Cloudflare returns %s",
+    "detaches only this Worker's retired consumers when Cloudflare returns %s",
     async (workerField) => {
       const calls: Array<{ init?: RequestInit; path: string }> = [];
       const cf = async <T>(path: string, init?: RequestInit): Promise<T> => {
@@ -33,26 +33,54 @@ describe("retired Artifact event Queue consumer", () => {
           })) as T;
         }
         if (path === "/queues?per_page=100&page=2") {
-          return [{ queue_id: "queue-id", queue_name: "os-preview-4-events" }] as T;
+          return [
+            { queue_id: "events-queue-id", queue_name: "os-preview-4-events" },
+            {
+              queue_id: "search-queue-id",
+              queue_name: "os-preview-4-search-index-writes",
+            },
+          ] as T;
         }
-        if (path === "/queues/queue-id/consumers") {
+        if (path === "/queues/events-queue-id/consumers") {
           return [
             { consumer_id: "other-consumer", script: "other", type: "worker" },
-            { consumer_id: "consumer-id", [workerField]: "os-preview-4", type: "worker" },
+            {
+              consumer_id: "events-consumer-id",
+              [workerField]: "os-preview-4",
+              type: "worker",
+            },
+          ] as T;
+        }
+        if (path === "/queues/search-queue-id/consumers") {
+          return [
+            { consumer_id: "http-consumer", type: "http_pull" },
+            {
+              consumer_id: "search-consumer-id",
+              [workerField]: "os-preview-4",
+              type: "worker",
+            },
           ] as T;
         }
         return undefined as T;
       };
 
       await expect(
-        detachRetiredArtifactEventQueueConsumer({ cf, workerName: "os-preview-4" }),
-      ).resolves.toBe("detached");
+        detachRetiredWorkerQueueConsumers({ cf, workerName: "os-preview-4" }),
+      ).resolves.toEqual([
+        { queueName: "os-preview-4-events", status: "detached" },
+        { queueName: "os-preview-4-search-index-writes", status: "detached" },
+      ]);
       expect(calls).toEqual([
         { path: "/queues?per_page=100&page=1", init: undefined },
         { path: "/queues?per_page=100&page=2", init: undefined },
-        { path: "/queues/queue-id/consumers", init: undefined },
+        { path: "/queues/events-queue-id/consumers", init: undefined },
+        { path: "/queues/search-queue-id/consumers", init: undefined },
         {
-          path: "/queues/queue-id/consumers/consumer-id",
+          path: "/queues/events-queue-id/consumers/events-consumer-id",
+          init: { method: "DELETE" },
+        },
+        {
+          path: "/queues/search-queue-id/consumers/search-consumer-id",
           init: { method: "DELETE" },
         },
       ]);
@@ -64,15 +92,18 @@ describe("retired Artifact event Queue consumer", () => {
     const cf = async <T>(path: string): Promise<T> => {
       calls.push(path);
       if (path === "/queues?per_page=100&page=1") {
-        return [{ queue_id: "queue-id", queue_name: "os-preview-4-events" }] as T;
+        return [{ queue_id: "events-queue-id", queue_name: "os-preview-4-events" }] as T;
       }
       return [] as T;
     };
 
     await expect(
-      detachRetiredArtifactEventQueueConsumer({ cf, workerName: "os-preview-4" }),
-    ).resolves.toBe("absent");
-    expect(calls).toEqual(["/queues?per_page=100&page=1", "/queues/queue-id/consumers"]);
+      detachRetiredWorkerQueueConsumers({ cf, workerName: "os-preview-4" }),
+    ).resolves.toEqual([
+      { queueName: "os-preview-4-events", status: "absent" },
+      { queueName: "os-preview-4-search-index-writes", status: "absent" },
+    ]);
+    expect(calls).toEqual(["/queues?per_page=100&page=1", "/queues/events-queue-id/consumers"]);
   });
 });
 

--- a/apps/os/scripts/deploy.ts
+++ b/apps/os/scripts/deploy.ts
@@ -59,8 +59,11 @@ import { ensureR2Bucket } from "./ensure-resources.ts";
 import { ensureInboundEmailRouting } from "./email-routing-resources.ts";
 
 const PREVIEW_PETSHOP_CONFIG = "APP_CONFIG_INTEGRATIONS__PETSHOP";
-const RETIRED_ARTIFACT_EVENTS_QUEUE_SUFFIX = "-events";
 const RETIRED_QUEUE_PAGE_SIZE = 100;
+const RETIRED_WORKER_QUEUE_CONSUMERS = [
+  { label: "Artifact event", suffix: "-events" },
+  { label: "AI Search index-write", suffix: "-search-index-writes" },
+] as const;
 
 const RetiredQueue = z.object({
   queue_id: z.string(),
@@ -74,51 +77,60 @@ const RetiredQueueConsumer = z.object({
 });
 
 /**
- * Cloudflare refuses a handler-less Worker upload while the previous Queue
- * consumer still targets that script. Detach only that exact retired
- * consumer before the first post-quarantine deploy; later deploys are a
- * read-only no-op. The queue and its producer subscriptions are deliberately
- * left for the audited one-off cleanup tracked by the quarantine task.
+ * Cloudflare refuses a handler-less Worker upload while a previous Queue
+ * consumer still targets that script. Detach only the exact consumers left
+ * behind by retired features; later deploys are read-only no-ops. The queues
+ * themselves are deliberately left for separately audited resource cleanup.
  */
-export async function detachRetiredArtifactEventQueueConsumer(input: {
+export async function detachRetiredWorkerQueueConsumers(input: {
   cf: <T = unknown>(path: string, init?: RequestInit) => Promise<T>;
   workerName: string;
-}): Promise<"absent" | "detached"> {
-  const queueName = `${input.workerName}${RETIRED_ARTIFACT_EVENTS_QUEUE_SUFFIX}`;
-  let queue: z.infer<typeof RetiredQueue> | undefined;
-  for (let page = 1; queue === undefined; page += 1) {
+}): Promise<Array<{ queueName: string; status: "absent" | "detached" }>> {
+  const retiredQueues = RETIRED_WORKER_QUEUE_CONSUMERS.map(({ label, suffix }) => ({
+    label,
+    queueName: `${input.workerName}${suffix}`,
+  }));
+  const queueNames = new Set(retiredQueues.map(({ queueName }) => queueName));
+  const queuesByName = new Map<string, z.infer<typeof RetiredQueue>>();
+  for (let page = 1; queuesByName.size < queueNames.size; page += 1) {
     const queues = z
       .array(RetiredQueue)
       .parse(await input.cf(`/queues?per_page=${RETIRED_QUEUE_PAGE_SIZE}&page=${page}`));
-    queue = queues.find((candidate) => candidate.queue_name === queueName);
+    for (const queue of queues) {
+      if (queueNames.has(queue.queue_name)) queuesByName.set(queue.queue_name, queue);
+    }
     if (queues.length < RETIRED_QUEUE_PAGE_SIZE) break;
   }
-  if (!queue) {
-    console.log(`retired Artifact event Queue absent: ${queueName}`);
-    return "absent";
-  }
 
-  const consumers = z
-    .array(RetiredQueueConsumer)
-    .parse(await input.cf(`/queues/${encodeURIComponent(queue.queue_id)}/consumers`));
-  const consumer = consumers.find(
-    (candidate) =>
-      candidate.type === "worker" &&
-      (candidate.script === input.workerName || candidate.script_name === input.workerName),
-  );
-  if (!consumer) {
-    console.log(`retired Artifact event Queue consumer absent: ${queueName}`);
-    return "absent";
-  }
+  return Promise.all(
+    retiredQueues.map(async ({ label, queueName }) => {
+      const queue = queuesByName.get(queueName);
+      if (!queue) {
+        console.log(`retired ${label} Queue absent: ${queueName}`);
+        return { queueName, status: "absent" } as const;
+      }
 
-  await input.cf(
-    `/queues/${encodeURIComponent(queue.queue_id)}/consumers/${encodeURIComponent(consumer.consumer_id)}`,
-    { method: "DELETE" },
+      const consumers = z
+        .array(RetiredQueueConsumer)
+        .parse(await input.cf(`/queues/${encodeURIComponent(queue.queue_id)}/consumers`));
+      const consumer = consumers.find(
+        (candidate) =>
+          candidate.type === "worker" &&
+          (candidate.script === input.workerName || candidate.script_name === input.workerName),
+      );
+      if (!consumer) {
+        console.log(`retired ${label} Queue consumer absent: ${queueName}`);
+        return { queueName, status: "absent" } as const;
+      }
+
+      await input.cf(
+        `/queues/${encodeURIComponent(queue.queue_id)}/consumers/${encodeURIComponent(consumer.consumer_id)}`,
+        { method: "DELETE" },
+      );
+      console.log(`detached retired ${label} Queue consumer: ${queueName} -> ${input.workerName}`);
+      return { queueName, status: "detached" } as const;
+    }),
   );
-  console.log(
-    `detached retired Artifact event Queue consumer: ${queueName} -> ${input.workerName}`,
-  );
-  return "detached";
 }
 
 /** Preview OS always runs its first-party integration proof against the
@@ -295,7 +307,7 @@ export default async function deploy(
       // an existing deployment: Cloudflare retains its consumer and rejects
       // the handler-less upload. This exact, idempotent detach is the rollout
       // migration; it never creates or reconciles subscriptions.
-      await detachRetiredArtifactEventQueueConsumer({
+      await detachRetiredWorkerQueueConsumers({
         cf: ctx.cf,
         workerName: ctx.env.osWorkerName,
       });


### PR DESCRIPTION
## Summary

- detach the exact OS Worker consumers left behind by retired Artifact event delivery and AI Search before each deploy
- discover both retired queues in one paginated Cloudflare queue scan, then inspect/delete their consumers in parallel
- leave the queues and every unrelated consumer untouched; subsequent deploys are read-only no-ops

## Why

After AI Search was removed in #2146, a recycled preview slot still had an os-preview-5-search-index-writes consumer targeting os-preview-5. Cloudflare rejected the handler-less Worker upload with code 11001 (Queue handler is missing), so preview E2E never started. Manually detaching that exact consumer unblocked #2238 and proved the stale control-plane state was the blocker.

This extends the existing deployment migration for the retired -events consumer to the retired -search-index-writes consumer, so every preview slot and production heal automatically on its next deploy.

## Safety

The cleanup is deliberately narrow: it resolves only <worker>-events and <worker>-search-index-writes, selects only type=worker consumers whose script/script_name exactly equals the deployed Worker, and deletes only those consumer IDs. It does not delete queues, wildcard resources, producer bindings, pull consumers, or consumers belonging to another Worker.

## Local proof

- pnpm typecheck
- pnpm lint
- pnpm format:check
- pnpm test (all workspaces; apps/os: 224 files, 2,118 passing, 6 expected failures, 1 skip)
- focused apps/os scripts/deploy.test.ts: 17 passing

## Preview proof

- Attempt 1 reached the new migration on preview-4: it detached the exact retired Artifact event consumer and found the retired AI Search queue absent. OS then failed before tests because Cloudflare returned transient code 10013 while deploying the unchanged worker-bundler sidecar. This was unrelated to this change and is preserved here rather than hidden.
- Attempt 2 was an explicit manual dispatch after classifying that failure. All five app deploys passed; OS deployed in 78.7s and the full parallel test phase passed in 154.5s. OS Vitest reported 162 passed, 2 expected failures, and 3 existing skips; OS Playwright reported 63 passed. No absorbed retries were reported.
- Existing skips were unchanged by this PR: quarantined Artifact event delivery, the opt-in exact Codex WebSocket proof, and the already-skipped WebSocket waitForEvent cleanup case. This PR added no quarantine.
- The earlier preview-5 incident remains the destructive-path evidence: removing the exact stale os-preview-5-search-index-writes consumer changed Wrangler from code 11001 failure to a successful OS deploy on #2238. The unit test exercises that same exact-name and exact-Worker deletion path automatically.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Pre-deploy DELETE calls against Cloudflare queue consumers are deployment-critical; scope is narrow (two known queue names, exact Worker match) but mistakes could affect live preview/prod rollouts.
> 
> **Overview**
> Extends the existing deploy-time Cloudflare queue consumer migration so it no longer only clears **Artifact event** (`-events`) bindings—it also detaches **AI Search index-write** (`-search-index-writes`) consumers that can block Wrangler upload with “Queue handler is missing” after those features were removed from the Worker.
> 
> `detachRetiredArtifactEventQueueConsumer` is replaced by **`detachRetiredWorkerQueueConsumers`**, which walks a fixed list of retired queue suffixes, resolves queue IDs in one paginated scan, then inspects and deletes only `type=worker` consumers whose `script` / `script_name` matches the deploying Worker. It returns per-queue `absent` / `detached` status; queues themselves are left in place. The deploy `prepare` step now calls the renamed helper unchanged in intent.
> 
> Tests cover dual-queue detach (including `script` vs `script_name`), ignoring unrelated consumers, and idempotent no-op when queues or consumers are already gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43fae0bf79a13fa2f287e41c4a54c0c953f6e47f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +45 -14 | +45 -14 🟩🟩🟩🟥⬜ |
| CI & scripts | +48 -36 | +43 -31 🟩🟩🟩🟥🟥 |
| **Total** | **+93 -50** | **+88 -45** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 78e0ab3 and 43fae0b, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-22T00:19:29.350Z",
      "headSha": "43fae0bf79a13fa2f287e41c4a54c0c953f6e47f",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/572156225504644",
      "shortSha": "43fae0b",
      "cleanupDurationMs": 12432,
      "deployDurationMs": 78660,
      "deployedWorkerName": "os-preview-4",
      "deployedWorkerVersion": "feb94051-5d56-4d71-8a5c-a46930876474",
      "testDurationMs": 154451,
      "testRetries": null,
      "workerSizeKib": 17149.81,
      "workerGzipKib": 4611.15,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 4622.74
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-22T00:19:20.650Z",
      "headSha": "43fae0bf79a13fa2f287e41c4a54c0c953f6e47f",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/572156225504644",
      "shortSha": "43fae0b",
      "cleanupDurationMs": 3729,
      "deployDurationMs": 15562,
      "deployedWorkerName": "auth-preview-4",
      "deployedWorkerVersion": "258d7603-6cdc-4e1d-a8fd-cd29615e369b",
      "testDurationMs": 3645,
      "testRetries": null,
      "workerSizeKib": 3965.97,
      "workerGzipKib": 811.33,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-22T00:19:17.845Z",
      "headSha": "43fae0bf79a13fa2f287e41c4a54c0c953f6e47f",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/572156225504644",
      "shortSha": "43fae0b",
      "cleanupDurationMs": 922,
      "deployDurationMs": 6200,
      "deployedWorkerName": "dummy-petshop-preview-4",
      "deployedWorkerVersion": "96db2641-6eb2-41bf-aebd-7227c81bc801",
      "testDurationMs": 5703,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "31107178ee62c163420c729a8da60663b16c0fec+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-22T00:19:17.846Z",
      "headSha": "43fae0bf79a13fa2f287e41c4a54c0c953f6e47f",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/572156225504644",
      "shortSha": "43fae0b",
      "cleanupDurationMs": 921,
      "deployDurationMs": 13684,
      "deployedWorkerName": "semaphore-preview-4",
      "deployedWorkerVersion": "f442b787-8d57-449e-a3ae-774fb51eb07c",
      "testDurationMs": 21909,
      "testRetries": null,
      "workerSizeKib": 1915.22,
      "workerGzipKib": 440.99,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-22T00:19:30.326Z",
      "headSha": "43fae0bf79a13fa2f287e41c4a54c0c953f6e47f",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/572156225504644",
      "shortSha": "43fae0b",
      "cleanupDurationMs": 13397,
      "deployDurationMs": 58535,
      "deployedWorkerName": "streams-example-app-preview-4",
      "deployedWorkerVersion": "947cf8d4-7158-4c75-ae66-4f53f5cb328e",
      "testDurationMs": 55921,
      "testRetries": null,
      "workerSizeKib": 5145.89,
      "workerGzipKib": 1469.77,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `43fae0b` | [https://auth.iterate-preview-4.com](https://auth.iterate-preview-4.com) | 811.3 KiB | 15.6s | 3.6s |  | 3.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/572156225504644) | 2026-07-22T00:19:20.650Z | Preview app released. |
| Dummy Petshop | released | `43fae0b` | [https://dummy-petshop.iterate-preview-4.com](https://dummy-petshop.iterate-preview-4.com) | 198.3 KiB | 6.2s | 5.7s |  | 922ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/572156225504644) | 2026-07-22T00:19:17.845Z | Preview app released. |
| OS | released | `43fae0b` | [https://os.iterate-preview-4.com](https://os.iterate-preview-4.com) | 4.50 MiB (-11.6 KiB vs main) | 78.7s | 154.5s |  | 12.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/572156225504644) | 2026-07-22T00:19:29.350Z | Preview app released. |
| Semaphore | released | `43fae0b` | [https://semaphore.iterate-preview-4.com](https://semaphore.iterate-preview-4.com) | 441.0 KiB | 13.7s | 21.9s |  | 921ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/572156225504644) | 2026-07-22T00:19:17.846Z | Preview app released. |
| Streams Example App | released | `43fae0b` | [https://streams.iterate-preview-4.com](https://streams.iterate-preview-4.com) | 1.44 MiB | 58.5s | 55.9s |  | 13.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/572156225504644) | 2026-07-22T00:19:30.326Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->
