### PR TITLE
Fix ITX script recovery across Durable Object resets

### DIFF
--- a/apps/os/src/domains/capability-host/capability-host-durable-object.ts
+++ b/apps/os/src/domains/capability-host/capability-host-durable-object.ts
@@ -11,8 +11,6 @@ import { checkCapabilityTypes, checkItxScriptForExecution } from "../typecheck/v
 import {
   CapabilityHostProcessor,
   type CapabilityHostProcessorReads,
-  type RunScriptCommand,
-  type RunScriptResult,
 } from "./capability-host-processor-implementation.ts";
 import { CapabilityHostProcessorContract } from "./capability-host-processor-contract.ts";
 import type { ScriptExecutionSettlement } from "./script-execution-settlement.ts";
@@ -153,10 +151,6 @@ export class CapabilityHostDurableObject extends DurableObject<Env> {
 
   revokeCapability(input: { path: string[]; providedAtOffset?: number }): Promise<void> {
     return this.#capabilityHostProcessor.revokeCapability(input);
-  }
-
-  runScript(input: RunScriptCommand): Promise<RunScriptResult> {
-    return this.#capabilityHostProcessor.runScript(input);
   }
 
   describeCapabilities(): Promise<CapabilityDescription[]> {

--- a/apps/os/src/domains/capability-host/capability-host-processor-implementation.ts
+++ b/apps/os/src/domains/capability-host/capability-host-processor-implementation.ts
@@ -3,7 +3,7 @@ import type { ProcessEventArgs, ProcessorState, ReduceArgs, StreamEvent } from "
 import type { ItxExpression } from "../../itx/expression.ts";
 import { normalizePath } from "../durable-object-names.ts";
 import type { CapabilityDescription } from "../itx/describe.ts";
-import type { CapabilityHost, Project } from "../../itx-api.generated.ts";
+import type { Project } from "../../itx-api.generated.ts";
 import type { ScriptExecutionCheck } from "../typecheck/virtual-project.ts";
 import type {
   CapabilityProvidedPayload,
@@ -15,7 +15,6 @@ import { retainLiveCapabilityProvider, type LiveCapability } from "./live-capabi
 import { CapabilityHostProcessorContract } from "./capability-host-processor-contract.ts";
 import { settleByDeadline } from "./execution-deadline.ts";
 import {
-  SCRIPT_COMPLETION_OBSERVATION_GRACE_MS,
   SCRIPT_EXECUTION_SETTLEMENT_GRACE_MS,
   ScriptExecutionSettlement,
   scriptCompletionInput,
@@ -42,7 +41,7 @@ import {
  * row, and a mount's identity is `providedAtOffset` — the stream offset of the
  * event that created it, no synthetic mount ids anywhere. The itx-facing verbs
  * on this class (`provideCapability`, `revokeCapability`, `invokeCapability`,
- * `describeCapabilities`, `runScript`) are the scope's public surface:
+ * `describeCapabilities`) are the scope's public capability surface:
  * mounting appends the fact and then waits for its own delivery
  * (read-your-writes), reads resolve the longest matching prefix over the
  * reduced table, and a local miss follows the birth certificate's `fallback`
@@ -492,67 +491,6 @@ export class CapabilityHostProcessor extends StreamProcessor<
     );
   }
 
-  async runScript(input: RunScriptCommand): Promise<RunScriptResult> {
-    await this.#assertCreated();
-    const { code, executionId, expiresAt } = input;
-    const settlementAbort = new AbortController();
-    // Register before the request append so a very fast settlement cannot
-    // pass the waiter. Observe the rejection immediately: if the request
-    // append itself fails, the bounded waiter may still time out later and
-    // must not become an unhandled rejection.
-    const settled = this.#waitForScriptSettlement(
-      executionId,
-      Math.max(1, expiresAt + SCRIPT_COMPLETION_OBSERVATION_GRACE_MS - this.#now()),
-      settlementAbort.signal,
-    );
-    const observedSettlement = settled.then(
-      (event) => ({ status: "fulfilled" as const, event }),
-      (error: unknown) => ({ status: "rejected" as const, error }),
-    );
-    try {
-      // A replay either finds the previous incarnation's durable settlement
-      // here or observes it through the waiter registered above.
-      const existingEvent = await this.stream.getEvent({
-        idempotencyKey: this.idempotencyKey(`script-run-settled@${executionId}`),
-      });
-      if (existingEvent !== undefined) {
-        const existingSettlement = settlementFromSettledEvent(existingEvent, executionId);
-        if (existingSettlement === undefined) {
-          throw new Error(`Script execution "${executionId}" has a malformed settlement event.`);
-        }
-        settlementAbort.abort("durable settlement already exists");
-        void observedSettlement;
-        return scriptRunResult({
-          event: existingEvent,
-          executionId,
-          settlement: existingSettlement,
-        });
-      }
-
-      await this.#awaitAppendWithin(
-        this.append({
-          type: "events.iterate.com/capability-host/script-run-requested",
-          idempotencyKey: this.idempotencyKey(`script-run-requested@${executionId}`),
-          payload: { code, executionId, expiresAt },
-        }),
-        expiresAt,
-        `record the request for script execution "${executionId}"`,
-      );
-    } catch (error) {
-      settlementAbort.abort(error);
-      throw error;
-    }
-    const settlement = await observedSettlement;
-    if (settlement.status === "rejected") {
-      throw new Error(
-        `Script execution "${executionId}" did not settle before its absolute deadline.`,
-        { cause: settlement.error },
-      );
-    }
-    const { event, settlement: outcome } = settlement.event;
-    return scriptRunResult({ event, executionId, settlement: outcome });
-  }
-
   // ------------------------------------------------------- private machinery
 
   async #assertCreated(): Promise<void> {
@@ -691,23 +629,6 @@ export class CapabilityHostProcessor extends StreamProcessor<
     const shadowed = new Set(local.map((c) => JSON.stringify(c.path)));
     const { capabilities: inherited } = await fallback.__describe();
     return [...local, ...inherited.filter((c) => !shadowed.has(JSON.stringify(c.path)))];
-  }
-
-  async #waitForScriptSettlement(executionId: string, timeoutMs: number, signal: AbortSignal) {
-    const idempotencyKey = this.idempotencyKey(`script-run-settled@${executionId}`);
-    await this.deps.reads.waitUntilEvent({
-      predicate: (event) =>
-        event.idempotencyKey === idempotencyKey &&
-        settlementFromSettledEvent(event, executionId) !== undefined,
-      timeoutMs,
-      signal,
-    });
-    const event = await this.stream.getEvent({ idempotencyKey });
-    const settlement = settlementFromSettledEvent(event, executionId);
-    if (event === undefined || settlement === undefined) {
-      throw new Error(`script execution "${executionId}" completed without an event`);
-    }
-    return { event, settlement };
   }
 
   /**
@@ -849,7 +770,7 @@ export class CapabilityHostProcessor extends StreamProcessor<
       // The entrypoint owns a timer around the dynamic-worker invocation, but
       // the RPC carrying that result back to this host is a second failure
       // boundary. Bound it independently: a half-open worker stub must not
-      // keep the obligation (and the public runScript call) alive forever
+      // keep the obligation (and its stream-native public waiter) alive forever
       // even if the remote timer fired correctly.
       const runPromise = this.deps.scriptExecutionEntrypoint.run(input.code, {
         emittedJs: checked.emittedJs,
@@ -1002,16 +923,6 @@ export class CapabilityHostProcessor extends StreamProcessor<
 // Injected dependencies.
 // -----------------------------------------------------------------------------
 
-export type RunScriptResult = Awaited<ReturnType<CapabilityHost["runScript"]>>;
-
-/** Stable identity minted outside the hosting Durable Object so a caller can
- * rejoin the same journaled execution after losing an RPC acknowledgement. */
-export type RunScriptCommand = {
-  code: string;
-  executionId: string;
-  expiresAt: number;
-};
-
 type ScriptExecutionEntrypoint = {
   run(code: string, options: { emittedJs?: string; expiresAt: number }): Promise<unknown>;
 };
@@ -1020,9 +931,9 @@ type ScriptExecutionEntrypoint = {
  * RUNNER-backed reads of the committed reduction. Under registry drive the
  * runner owns both cursors and the processor instance's internal checkpoint
  * never advances, so every state read this processor makes OUTSIDE a hook's
- * own args — capability resolution, the revoke guard, the provide/revoke
- * read-your-writes barriers, the script-settlement wait — must go through the
- * runner's committed progress. The hosting DO wires this to
+ * own args — capability resolution, the revoke guard, and the provide/revoke
+ * read-your-writes barriers — must go through the runner's committed progress.
+ * The hosting DO wires this to
  * `registry.reads(processor)` (lazily — `reads()` needs the registered
  * processor); test harnesses wire it to the driving StreamProcessorRunner.
  * `waitUntilEvent` takes BOTH forms as one union parameter (the registry's
@@ -1179,19 +1090,6 @@ function settlementFromSettledEvent(
   }
   const parsed = ScriptExecutionSettlement.safeParse(event.payload.settlement);
   return parsed.success ? parsed.data : undefined;
-}
-
-function scriptRunResult(input: {
-  event: StreamEvent;
-  executionId: string;
-  settlement: ScriptExecutionSettlementValue;
-}): RunScriptResult {
-  if (input.settlement.status === "failed") throw new Error(input.settlement.error);
-  return {
-    completedEvent: input.event,
-    executionId: input.executionId,
-    result: input.settlement.result ?? null,
-  };
 }
 
 function assertExpressionDoesNotReferenceOwnMount(

--- a/apps/os/src/domains/capability-host/capability-host-run-script.test.ts
+++ b/apps/os/src/domains/capability-host/capability-host-run-script.test.ts
@@ -71,6 +71,29 @@ describe("runCapabilityHostScript", () => {
     expect(stream.events.filter((event) => event.type === SCRIPT_SETTLED)).toHaveLength(1);
   });
 
+  it("returns a settlement committed before a late append acknowledgement", async () => {
+    const startedAt = Date.parse("2026-07-22T00:00:00Z");
+    const stream = await bornStream();
+    const now = vi
+      .fn<() => number>()
+      .mockReturnValueOnce(startedAt)
+      .mockReturnValue(startedAt + 75_001);
+
+    await expect(
+      runCapabilityHostScript({
+        command: command(startedAt),
+        now,
+        path: PATH,
+        projectId: PROJECT_ID,
+        stream: settleBeforeRequestAcknowledgement(stream, {
+          status: "succeeded",
+          result: 42,
+        }),
+      }),
+    ).resolves.toMatchObject({ executionId: "exec-stable", result: 42 });
+    expect(now).toHaveBeenCalledTimes(2);
+  });
+
   it("surfaces a successor incarnation's orphan settlement instead of waiting on the dead one", async () => {
     const now = Date.parse("2026-07-22T00:00:00Z");
     const stream = await bornStream();

--- a/apps/os/src/domains/capability-host/capability-host-run-script.test.ts
+++ b/apps/os/src/domains/capability-host/capability-host-run-script.test.ts
@@ -1,97 +1,124 @@
 import { describe, expect, it, vi } from "vitest";
-import type { StreamEvent } from "iterate/processors";
+import type { StreamEventInput } from "iterate/processors";
 import { MemoryStream } from "iterate/processors/testing";
-import type { Project } from "../../itx-api.generated.ts";
+import { capabilityHostCreationEvents } from "./capability-host-defaults.ts";
 import {
-  CapabilityHostProcessor,
-  type CapabilityHostProcessorReads,
+  runCapabilityHostScript,
+  type CapabilityHostScriptStream,
   type RunScriptCommand,
-} from "./capability-host-processor-implementation.ts";
+} from "./capability-host-script-run.ts";
 
+const PROJECT_ID = "prj_test";
+const PATH = "/agents/test";
 const SCRIPT_REQUESTED = "events.iterate.com/capability-host/script-run-requested";
 const SCRIPT_SETTLED = "events.iterate.com/capability-host/script-run-settled";
 
-describe("CapabilityHostProcessor.runScript", () => {
-  it("rejoins one durable execution after losing the outer acknowledgement", async () => {
-    const stream = new MemoryStream("/agents/test");
-    const predicateWaiters: {
-      predicate: (event: StreamEvent) => boolean;
-      resolve: () => void;
-    }[] = [];
-    const reads: CapabilityHostProcessorReads = {
-      snapshot: async () =>
-        ({
-          offset: 1,
-          state: { birthCertificate: { config: {}, fallback: null } },
-        }) as never,
-      waitUntilEvent: (input) => {
-        if ("offset" in input) throw new Error("offset waiter not used");
-        return new Promise<void>((resolve, reject) => {
-          if (input.signal?.aborted === true) {
-            reject(input.signal.reason);
-            return;
-          }
-          const abort = () => reject(input.signal?.reason);
-          input.signal?.addEventListener("abort", abort, { once: true });
-          predicateWaiters.push({
-            predicate: input.predicate,
-            resolve: () => {
-              input.signal?.removeEventListener("abort", abort);
-              resolve();
-            },
-          });
+async function bornStream() {
+  const stream = new MemoryStream(PATH);
+  await stream.append(...capabilityHostCreationEvents({ path: PATH, projectId: PROJECT_ID }));
+  return stream;
+}
+
+function command(now: number): RunScriptCommand {
+  return {
+    code: "async () => 42",
+    executionId: "exec-stable",
+    expiresAt: now + 60_000,
+  };
+}
+
+function settleBeforeRequestAcknowledgement(
+  stream: MemoryStream,
+  settlement: Record<string, unknown>,
+): CapabilityHostScriptStream {
+  return {
+    getEvent: (input) => stream.getEvent(input),
+    waitForEvent: (input) => stream.waitForEvent(input),
+    append: async (...inputs: StreamEventInput[]) => {
+      const committed = await stream.append(...inputs);
+      const request = committed.find((event) => event.type === SCRIPT_REQUESTED);
+      if (request !== undefined) {
+        const executionId = (request.payload as { executionId: string }).executionId;
+        await stream.append({
+          type: SCRIPT_SETTLED,
+          idempotencyKey: `capability-host/script-run-settled@${executionId}`,
+          payload: { executionId, settlement },
         });
-      },
-    };
-    const processor = new CapabilityHostProcessor({
+      }
+      return committed;
+    },
+  };
+}
+
+describe("runCapabilityHostScript", () => {
+  it("replays a durable settlement that committed before the request acknowledgement", async () => {
+    const now = Date.parse("2026-07-22T00:00:00Z");
+    const stream = await bornStream();
+
+    await expect(
+      runCapabilityHostScript({
+        command: command(now),
+        now: () => now,
+        path: PATH,
+        projectId: PROJECT_ID,
+        stream: settleBeforeRequestAcknowledgement(stream, {
+          status: "succeeded",
+          result: 42,
+        }),
+      }),
+    ).resolves.toMatchObject({ executionId: "exec-stable", result: 42 });
+    expect(stream.events.filter((event) => event.type === SCRIPT_REQUESTED)).toHaveLength(1);
+    expect(stream.events.filter((event) => event.type === SCRIPT_SETTLED)).toHaveLength(1);
+  });
+
+  it("surfaces a successor incarnation's orphan settlement instead of waiting on the dead one", async () => {
+    const now = Date.parse("2026-07-22T00:00:00Z");
+    const stream = await bornStream();
+
+    const run = runCapabilityHostScript({
+      command: command(now),
+      now: () => now,
+      path: PATH,
+      projectId: PROJECT_ID,
       stream,
-      path: stream.path,
-      projectId: "prj_test",
-      itx: {} as Project,
-      reads,
-      scriptExecutionEntrypoint: {
-        run: async () => {
-          throw new Error("the runner owns execution; this method only journals and waits");
-        },
-      },
     });
-    const command: RunScriptCommand = {
-      code: "async () => 42",
-      executionId: "exec-stable",
-      expiresAt: Date.now() + 60_000,
-    };
-
-    const firstCall = processor.runScript(command);
     await vi.waitFor(() => {
-      expect(stream.events.some((event) => event.type === SCRIPT_REQUESTED)).toBe(true);
-    });
-    expect(stream.events.find((event) => event.type === SCRIPT_REQUESTED)).toMatchObject({
-      idempotencyKey: "capability-host/script-run-requested@exec-stable",
-      payload: command,
+      expect(stream.events.filter((event) => event.type === SCRIPT_REQUESTED)).toHaveLength(1);
     });
 
-    const [settled] = await stream.append({
+    await stream.append({
       type: SCRIPT_SETTLED,
       idempotencyKey: "capability-host/script-run-settled@exec-stable",
       payload: {
-        executionId: command.executionId,
-        settlement: { status: "succeeded", result: 42 },
+        executionId: "exec-stable",
+        settlement: {
+          status: "failed",
+          error:
+            "Script execution orphaned: the incarnation running it went away before completing.",
+          failureKind: "orphaned",
+          phase: "recovery",
+          executionMayHaveOccurred: true,
+          cancellation: "external-work-may-continue",
+        },
       },
     });
-    const firstWaiter = predicateWaiters.shift()!;
-    expect(firstWaiter.predicate(settled!)).toBe(true);
-    firstWaiter.resolve();
 
-    await expect(firstCall).resolves.toEqual({
-      completedEvent: settled,
-      executionId: command.executionId,
-      result: 42,
-    });
-    await expect(processor.runScript(command)).resolves.toEqual({
-      completedEvent: settled,
-      executionId: command.executionId,
-      result: 42,
-    });
-    expect(stream.events.filter((event) => event.type === SCRIPT_REQUESTED)).toHaveLength(1);
+    await expect(run).rejects.toThrow("Script execution orphaned");
+  });
+
+  it("does not journal work for an unborn capability host", async () => {
+    const now = Date.parse("2026-07-22T00:00:00Z");
+    const stream = new MemoryStream(PATH);
+
+    await expect(
+      runCapabilityHostScript({
+        command: command(now),
+        now: () => now,
+        path: PATH,
+        projectId: PROJECT_ID,
+        stream,
+      }),
+    ).rejects.toThrow(`capability host at ${PATH} has not been created`);
+    expect(stream.events).toEqual([]);
   });
 });

--- a/apps/os/src/domains/capability-host/capability-host-script-run.ts
+++ b/apps/os/src/domains/capability-host/capability-host-script-run.ts
@@ -18,8 +18,6 @@ export type RunScriptCommand = {
   expiresAt: number;
 };
 
-type RunScriptResult = Awaited<ReturnType<CapabilityHost["runScript"]>>;
-
 /** The small stream surface needed by the public script-run protocol. */
 export type CapabilityHostScriptStream = {
   append(...events: StreamEventInput[]): Promise<StreamEvent[]>;
@@ -50,7 +48,7 @@ export async function runCapabilityHostScript(input: {
   path: string;
   projectId: string;
   stream: CapabilityHostScriptStream;
-}): Promise<RunScriptResult> {
+}): Promise<Awaited<ReturnType<CapabilityHost["runScript"]>>> {
   const { command, path, projectId, stream } = input;
   const now = input.now ?? Date.now;
   if (now() >= command.expiresAt) {

--- a/apps/os/src/domains/capability-host/capability-host-script-run.ts
+++ b/apps/os/src/domains/capability-host/capability-host-script-run.ts
@@ -18,7 +18,7 @@ export type RunScriptCommand = {
   expiresAt: number;
 };
 
-export type RunScriptResult = Awaited<ReturnType<CapabilityHost["runScript"]>>;
+type RunScriptResult = Awaited<ReturnType<CapabilityHost["runScript"]>>;
 
 /** The small stream surface needed by the public script-run protocol. */
 export type CapabilityHostScriptStream = {

--- a/apps/os/src/domains/capability-host/capability-host-script-run.ts
+++ b/apps/os/src/domains/capability-host/capability-host-script-run.ts
@@ -1,0 +1,120 @@
+import type { StreamEvent, StreamEventInput } from "iterate/processors";
+import type { CapabilityHost } from "../../itx-api.generated.ts";
+import { isStreamWaitTimeoutError } from "../streams/stream-unavailable.ts";
+import { CapabilityHostProcessorContract } from "./capability-host-processor-contract.ts";
+import {
+  SCRIPT_COMPLETION_OBSERVATION_GRACE_MS,
+  ScriptExecutionSettlement,
+} from "./script-execution-settlement.ts";
+
+const CREATED = "events.iterate.com/capability-host/created";
+const SCRIPT_REQUESTED = "events.iterate.com/capability-host/script-run-requested";
+const SCRIPT_SETTLED = "events.iterate.com/capability-host/script-run-settled";
+
+/** Stable identity minted outside the processor-hosting Durable Object. */
+export type RunScriptCommand = {
+  code: string;
+  executionId: string;
+  expiresAt: number;
+};
+
+export type RunScriptResult = Awaited<ReturnType<CapabilityHost["runScript"]>>;
+
+/** The small stream surface needed by the public script-run protocol. */
+export type CapabilityHostScriptStream = {
+  append(...events: StreamEventInput[]): Promise<StreamEvent[]>;
+  getEvent(
+    input: { offset: number; idempotencyKey?: never } | { idempotencyKey: string; offset?: never },
+  ): Promise<StreamEvent | undefined>;
+  waitForEvent(input: {
+    afterOffset?: number;
+    eventTypes?: readonly string[];
+    predicate?: (event: StreamEvent) => boolean | Promise<boolean>;
+    timeoutMs: number;
+  }): Promise<StreamEvent>;
+};
+
+/**
+ * Journal one script obligation and observe its terminal fact directly on the
+ * scope stream.
+ *
+ * This deliberately runs at the stateless RPC boundary, not inside the
+ * CapabilityHost Durable Object. Script execution may outlive an incarnation;
+ * the successor then records an orphan/expiry settlement on the durable
+ * stream. Keeping the public waiter on the old incarnation would lose that
+ * settlement if workerd silently orphaned the in-flight DO RPC.
+ */
+export async function runCapabilityHostScript(input: {
+  command: RunScriptCommand;
+  now?: () => number;
+  path: string;
+  projectId: string;
+  stream: CapabilityHostScriptStream;
+}): Promise<RunScriptResult> {
+  const { command, path, projectId, stream } = input;
+  const now = input.now ?? Date.now;
+  if (now() >= command.expiresAt) {
+    throw new Error(`Script execution "${command.executionId}" expired before it was requested.`);
+  }
+
+  const created = await stream.getEvent({
+    idempotencyKey: `capability-host/created:${projectId}:${path}`,
+  });
+  if (created?.type !== CREATED) {
+    throw new Error(`capability host at ${path} has not been created`);
+  }
+
+  const [requested] = await stream.append(
+    CapabilityHostProcessorContract.buildEvent({
+      type: SCRIPT_REQUESTED,
+      idempotencyKey: `capability-host/script-run-requested@${command.executionId}`,
+      payload: command,
+    }),
+  );
+  if (requested === undefined) {
+    throw new Error(`Script execution "${command.executionId}" committed no request event.`);
+  }
+
+  const timeoutMs = command.expiresAt + SCRIPT_COMPLETION_OBSERVATION_GRACE_MS - now();
+  if (timeoutMs <= 0) {
+    throw new Error(
+      `Script execution "${command.executionId}" did not settle before its absolute deadline.`,
+    );
+  }
+
+  // Replay from the durable request offset. A settlement that committed
+  // before the append acknowledgement or before this wait opened cannot fall
+  // into a cursor-less subscription gap.
+  let completedEvent: StreamEvent;
+  try {
+    completedEvent = await stream.waitForEvent({
+      afterOffset: requested.offset,
+      eventTypes: [SCRIPT_SETTLED],
+      predicate: (event) =>
+        event.idempotencyKey === `capability-host/script-run-settled@${command.executionId}`,
+      timeoutMs,
+    });
+  } catch (error) {
+    if (!isStreamWaitTimeoutError(error)) throw error;
+    throw new Error(
+      `Script execution "${command.executionId}" did not settle before its absolute deadline.`,
+      { cause: error },
+    );
+  }
+  if (
+    completedEvent.type !== SCRIPT_SETTLED ||
+    completedEvent.payload?.executionId !== command.executionId
+  ) {
+    throw new Error(`Script execution "${command.executionId}" completed with a malformed event.`);
+  }
+  const parsed = ScriptExecutionSettlement.safeParse(completedEvent.payload.settlement);
+  if (!parsed.success) {
+    throw new Error(`Script execution "${command.executionId}" has a malformed settlement event.`);
+  }
+  if (parsed.data.status === "failed") throw new Error(parsed.data.error);
+  return {
+    completedEvent,
+    executionId: command.executionId,
+    result: parsed.data.result ?? null,
+  };
+}

--- a/apps/os/src/domains/capability-host/capability-host-script-run.ts
+++ b/apps/os/src/domains/capability-host/capability-host-script-run.ts
@@ -73,31 +73,41 @@ export async function runCapabilityHostScript(input: {
     throw new Error(`Script execution "${command.executionId}" committed no request event.`);
   }
 
+  const settlementIdempotencyKey = `capability-host/script-run-settled@${command.executionId}`;
   const timeoutMs = command.expiresAt + SCRIPT_COMPLETION_OBSERVATION_GRACE_MS - now();
-  if (timeoutMs <= 0) {
-    throw new Error(
-      `Script execution "${command.executionId}" did not settle before its absolute deadline.`,
-    );
-  }
-
-  // Replay from the durable request offset. A settlement that committed
-  // before the append acknowledgement or before this wait opened cannot fall
-  // into a cursor-less subscription gap.
   let completedEvent: StreamEvent;
-  try {
-    completedEvent = await stream.waitForEvent({
-      afterOffset: requested.offset,
-      eventTypes: [SCRIPT_SETTLED],
-      predicate: (event) =>
-        event.idempotencyKey === `capability-host/script-run-settled@${command.executionId}`,
-      timeoutMs,
+  if (timeoutMs <= 0) {
+    // A slow append acknowledgement can arrive after the observation window
+    // even though the processor already committed the keyed settlement. One
+    // point read preserves that authoritative outcome without opening a new
+    // unbounded wait after the absolute deadline.
+    const committedSettlement = await stream.getEvent({
+      idempotencyKey: settlementIdempotencyKey,
     });
-  } catch (error) {
-    if (!isStreamWaitTimeoutError(error)) throw error;
-    throw new Error(
-      `Script execution "${command.executionId}" did not settle before its absolute deadline.`,
-      { cause: error },
-    );
+    if (committedSettlement === undefined) {
+      throw new Error(
+        `Script execution "${command.executionId}" did not settle before its absolute deadline.`,
+      );
+    }
+    completedEvent = committedSettlement;
+  } else {
+    // Replay from the durable request offset. A settlement that committed
+    // before the append acknowledgement or before this wait opened cannot fall
+    // into a cursor-less subscription gap.
+    try {
+      completedEvent = await stream.waitForEvent({
+        afterOffset: requested.offset,
+        eventTypes: [SCRIPT_SETTLED],
+        predicate: (event) => event.idempotencyKey === settlementIdempotencyKey,
+        timeoutMs,
+      });
+    } catch (error) {
+      if (!isStreamWaitTimeoutError(error)) throw error;
+      throw new Error(
+        `Script execution "${command.executionId}" did not settle before its absolute deadline.`,
+        { cause: error },
+      );
+    }
   }
   if (
     completedEvent.type !== SCRIPT_SETTLED ||

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -262,6 +262,7 @@ import {
   type CapabilityHostCreateInput,
 } from "./domains/capability-host/capability-host-defaults.ts";
 import { DEFAULT_SCRIPT_EXECUTION_EXPIRY_MS } from "./domains/capability-host/capability-host-processor-contract.ts";
+import { runCapabilityHostScript } from "./domains/capability-host/capability-host-script-run.ts";
 import {
   settleByDeadline,
   type DeadlineOutcome,
@@ -4798,14 +4799,11 @@ class CapabilityHostRpcTarget extends IterateRpcTarget<"CapabilityHost"> {
       executionId: crypto.randomUUID(),
       expiresAt: Date.now() + DEFAULT_SCRIPT_EXECUTION_EXPIRY_MS,
     };
-    return await retryLoggedIdempotentOperation({
-      context: {
-        executionId: command.executionId,
-        path: this.#props.path,
-        projectId: this.#props.projectId,
-      },
-      message: "script run rejoining after Durable Object reset",
-      operation: async () => await this.#durableObject.runScript(command),
+    return await runCapabilityHostScript({
+      command,
+      path: this.#props.path,
+      projectId: this.#props.projectId,
+      stream: this.#stream,
     });
   }
 

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -4799,11 +4799,20 @@ class CapabilityHostRpcTarget extends IterateRpcTarget<"CapabilityHost"> {
       executionId: crypto.randomUUID(),
       expiresAt: Date.now() + DEFAULT_SCRIPT_EXECUTION_EXPIRY_MS,
     };
-    return await runCapabilityHostScript({
-      command,
-      path: this.#props.path,
-      projectId: this.#props.projectId,
-      stream: this.#stream,
+    return await retryLoggedIdempotentOperation({
+      context: {
+        executionId: command.executionId,
+        path: this.#props.path,
+        projectId: this.#props.projectId,
+      },
+      message: "script run rejoining after stream Durable Object reset",
+      operation: async () =>
+        await runCapabilityHostScript({
+          command,
+          path: this.#props.path,
+          projectId: this.#props.projectId,
+          stream: this.#stream,
+        }),
     });
   }
 


### PR DESCRIPTION
## Outcome

Fixes the recurring ITX fan-out E2E timeout without increasing its timeout, serializing tests, or quarantining coverage.

`CapabilityHost.runScript()` no longer keeps its public settlement waiter inside the CapabilityHost Durable Object incarnation that executes the script. The stateless ITX RPC boundary now journals the keyed request and observes the terminal fact through `StreamRpcTarget.waitForEvent()`, whose durable cursor replay and bounded re-acquisition survive stream/processor resets.

## Failure evidence

The repeated preview run produced one real timeout in:

- `agent-handle-pipelining.itx.e2e.test.ts`
- `fan-out: one un-awaited handle serves multiple pipelined calls (capnweb and workerd lanes)`
- project `prj_e9fa5c506bd74f79ad5e89ec514cde4a`
- trace `fc60ce84a2a5075efe0879f9bdfcce60`

The trace showed both Cap'n Web calls completing in 36ms, then `CapabilityHost.runScript` remaining open for 131.9s after capability-host subscriber Durable Objects reset.

The durable stream journal is decisive:

| Event | Offset | Time |
| --- | ---: | --- |
| `script-run-requested` | 33 | 00:24:37.705 |
| `script-run-started` | 34 | 00:24:38.742 |
| `script-run-settled` (`orphaned`, `recovery`) | 39 | 00:24:44.201 |

Recovery therefore committed the authoritative terminal outcome only 6.5s after the public call began, but the waiter trapped in the dead CapabilityHost incarnation never observed it. The caller stayed open until the 120-second test watchdog cancelled the connection.

## Change

- Add a small stream-native `runCapabilityHostScript` protocol at the stateless RPC boundary.
- Verify the capability host's durable birth certificate before journaling work.
- Append the request with its stable execution idempotency key.
- Replay settlement observation from the committed request offset, closing both the pre-acknowledgement and subscription-opening races.
- Preserve the existing explicit absolute deadline and domain timeout classification.
- Remove the long-lived `runScript` RPC and settlement waiter from `CapabilityHostDurableObject` / `CapabilityHostProcessor`.
- Keep execution, recovery, orphan classification, and settlement ownership in the processor unchanged.

The focused production change is net small: 234 additions and 197 deletions, including tests and the extracted 120-line protocol helper.

## Coverage

Focused tests prove:

1. a settlement committed before request acknowledgement is replayed;
2. a successor incarnation's later orphan settlement reaches the caller instead of leaving it attached to the dead incarnation;
3. an unborn capability host journals no work.

Local proof:

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- OS unit result: 224 files passed; 2,120 tests passed, six expected failures, one pre-existing skip

## Remote preview proof

- Exact final head: `7c50bf6256c64daae49d5daab9e4038a3c2aebec`; OS worker version: `6cee9ac6-5392-47a4-be0c-18fdce95e41d`.
- Required Cloudflare preview check: **green in 4m23s wall time**, with no duplicate attempt and no absorbed test retry.
- Final-head OS deployment/coherence: 84.5s. OS E2E lane: 154.6s. Auth: 17.1s deploy / 9.9s test. Dummy Petshop was correctly reused: 46ms deploy / 7.4s test. All three test lanes began together, so the test phase was bounded by the longest OS lane.
- Before the review hardening commit, the exact fan-out target ran 10 times against the same preview deployment through the existing-preview runner, with no deploy or erase: **10/10 passed, zero retries, zero failures**. Individual test bodies took 16.4–21.3s.
- Before the recovery fix, the repeated target hit the 120s watchdog and the traced `CapabilityHost.runScript` call remained open for 131.9s despite its durable settlement landing after 6.5s. The post-fix repeat showed no comparable tail.
- The final commit restores one bounded idempotent rejoin for a stream reset and point-reads a keyed settlement after a late append acknowledgement; its regression suite is 4/4 green. Full CI is green: 2,121 OS unit tests plus the deployed E2E suite.
- Cross-branch CI triage found the same ITX processing/fan-out stall family on unrelated pull requests, supporting a shared recovery-path defect rather than a branch-specific product regression.

The remaining preview-wall tail is split between the 84.5s worker/Durable Object coherence barrier and the 154.6s longest E2E lane; it is not caused by serial test discovery.

## Quarantine

None. This restores the affected live recovery path; it does not skip or weaken the flaky E2E test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public ITX script-run path and cross-DO-reset behavior for a core capability-host flow; execution logic stays in the processor but settlement observation now depends on stream wait semantics.
> 
> **Overview**
> Fixes callers hanging until timeout when a **CapabilityHost Durable Object** resets mid-`runScript` even though the durable stream already recorded an orphan/recovery settlement.
> 
> **`runScript` is removed** from `CapabilityHostDurableObject` and `CapabilityHostProcessor`. A new **`runCapabilityHostScript`** helper at the stateless ITX RPC layer checks the host birth certificate, appends the idempotent `script-run-requested` event, and waits for `script-run-settled` via **`StreamRpcTarget.waitForEvent`** (from the committed request offset, with deadline and late-ack fallbacks). **`CapabilityHostRpcTarget.runScript`** in `rpc-targets.ts` now calls that helper on the scope stream instead of a long-lived DO RPC.
> 
> Processor-side **execution, recovery, and settlement appends are unchanged**; only the public waiter moves. Tests target **`runCapabilityHostScript`** directly (pre-ack settlement replay, orphan surfacing, unborn host guard).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c50bf6256c64daae49d5daab9e4038a3c2aebec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +143 -116 | +112 -96 🟩🟩🟩🟥🟥 |
| Tests | +125 -75 | +115 -74 🟩🟩🟩🟥🟥 |
| **Total** | **+268 -191** | **+227 -170** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between fabfec5 and 7c50bf6, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-22T01:22:34.657Z",
      "headSha": "7c50bf6256c64daae49d5daab9e4038a3c2aebec",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/496591094827713",
      "shortSha": "7c50bf6",
      "cleanupDurationMs": 14772,
      "deployDurationMs": 84514,
      "deployedWorkerName": "os-preview-7",
      "deployedWorkerVersion": "6cee9ac6-5392-47a4-be0c-18fdce95e41d",
      "testDurationMs": 154592,
      "testRetries": null,
      "workerSizeKib": 17150.28,
      "workerGzipKib": 4611.58,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 4622.81
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-22T01:22:22.964Z",
      "headSha": "7c50bf6256c64daae49d5daab9e4038a3c2aebec",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/496591094827713",
      "shortSha": "7c50bf6",
      "cleanupDurationMs": 3075,
      "deployDurationMs": 17063,
      "deployedWorkerName": "auth-preview-7",
      "deployedWorkerVersion": "0adfca80-c755-4bfe-8f38-9aa7b121caf1",
      "testDurationMs": 9863,
      "testRetries": null,
      "workerSizeKib": 3965.97,
      "workerGzipKib": 811.25,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-22T01:22:20.647Z",
      "headSha": "7c50bf6256c64daae49d5daab9e4038a3c2aebec",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/496591094827713",
      "shortSha": "7c50bf6",
      "cleanupDurationMs": 756,
      "deployDurationMs": 46,
      "deployedWorkerName": "dummy-petshop-preview-7",
      "deployedWorkerVersion": "fcdb7f39-c978-4082-9405-d00855bfa9fc",
      "testDurationMs": 7375,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "31107178ee62c163420c729a8da60663b16c0fec+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `7c50bf6` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 811.3 KiB | 17.1s | 9.9s |  | 3.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/496591094827713) | 2026-07-22T01:22:22.964Z | Preview app released. |
| Dummy Petshop | released | `7c50bf6` | [https://dummy-petshop.iterate-preview-7.com](https://dummy-petshop.iterate-preview-7.com) | 198.3 KiB | 46ms | 7.4s |  | 756ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/496591094827713) | 2026-07-22T01:22:20.647Z | Preview app released. |
| OS | released | `7c50bf6` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 4.50 MiB (-11.2 KiB vs main) | 84.5s | 154.6s |  | 14.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/496591094827713) | 2026-07-22T01:22:34.657Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->