### PR TITLE
Fail fast on processor catch-up Durable Object resets

### DIFF
--- a/apps/os/src/domains/streams/stream-processor-rpc-target.test.ts
+++ b/apps/os/src/domains/streams/stream-processor-rpc-target.test.ts
@@ -463,6 +463,27 @@ describe("StreamProcessorRpcTarget", () => {
     await target.snapshot();
     expect(catchUpBeforeSnapshot).toHaveBeenCalledOnce();
   });
+
+  it("tags a processor lifecycle reset before RPC strips its retryable flag", async () => {
+    const lifecycleReset = Object.assign(
+      new Error(
+        "Internal error while starting up Durable Object storage caused object to be reset",
+      ),
+      { retryable: true },
+    );
+    const reads: ProcessorReads<{ seen: number }> = {
+      getRuntimeState: async () => ({ snapshot: { offset: 0, state: { seen: 0 } } }),
+      snapshot: async () => ({ offset: 0, state: { seen: 0 } }),
+      waitUntilEvent: async () => {
+        throw lifecycleReset;
+      },
+    };
+    const target = new StreamProcessorRpcTarget(reads);
+
+    await expect(target.waitUntilProcessed({ offset: 8, timeoutMs: 75_000 })).rejects.toThrow(
+      "stream-unavailable: Internal error while starting up Durable Object storage caused object to be reset",
+    );
+  });
 });
 
 describe("ProcessorRelayRpcTarget", () => {
@@ -654,12 +675,11 @@ describe("ProcessorRelayRpcTarget", () => {
     expect(acquisitions).toBe(1);
   });
 
-  it("shares one waitUntilProcessed timeout across a lifecycle retry", async () => {
+  it("shares one waitUntilProcessed timeout across a serialized availability retry", async () => {
     let now = 1_000;
     const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
-    const lifecycleReset = Object.assign(
-      new Error("Durable Object reset because its code was updated."),
-      { durableObjectReset: true },
+    const lifecycleReset = new Error(
+      "stream-unavailable: Durable Object reset because its code was updated.",
     );
     const waits: { offset: number; timeoutMs?: number }[] = [];
     const processor = {

--- a/apps/os/src/domains/streams/stream-processor-runner.test.ts
+++ b/apps/os/src/domains/streams/stream-processor-runner.test.ts
@@ -148,6 +148,7 @@ function makeJournal(homePath = HOME) {
   /** EVERY append attempt, deduped or not — the at-least-once evidence. */
   const attempts: { path: string; event: StreamEventInput; deduped: boolean }[] = [];
   const failNext = new Map<string, Error>();
+  let failNextRead: Error | undefined;
   let createdAtClock = 0;
 
   const rowsFor = (path: string): StreamEvent[] => {
@@ -201,6 +202,11 @@ function makeJournal(homePath = HOME) {
         const limit = args?.limit ?? 500;
         return {
           next: () => {
+            if (failNextRead !== undefined) {
+              const error = failNextRead;
+              failNextRead = undefined;
+              return Promise.reject(error);
+            }
             const page = rowsFor(path)
               .filter(
                 (row) =>
@@ -236,6 +242,9 @@ function makeJournal(homePath = HOME) {
     },
     failNextAppendTo(path: string, error: Error) {
       failNext.set(path, error);
+    },
+    failNextReadWith(error: Error) {
+      failNextRead = error;
     },
   };
 }
@@ -1323,6 +1332,41 @@ describe("StreamProcessorRunner.waitUntilEvent", () => {
     expect(snapshot.offset).toBe(committed.offset);
     expect(snapshot.state.open).toContain("ryw");
     expect(harness.store.record?.processing.acknowledgedThroughOffset).toBe(committed.offset);
+  });
+
+  it("offset form rejects a failed self-pull promptly instead of parking until its timeout", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const controller = new AbortController();
+    try {
+      const harness = makeHarness();
+      const storageReset = new Error(
+        "Internal error while starting up Durable Object storage caused object to be reset",
+      );
+      harness.journal.failNextReadWith(storageReset);
+
+      const waiting = harness.runner.waitUntilEvent({
+        offset: 8,
+        timeoutMs: 75_000,
+        signal: controller.signal,
+      });
+      const outcome = await Promise.race([
+        waiting.then(
+          () => ({ status: "resolved" as const }),
+          (error: unknown) => ({ error, status: "rejected" as const }),
+        ),
+        tick().then(() => ({ status: "still-parked" as const })),
+      ]);
+
+      // Always settle the old implementation's parked promise so a red test
+      // leaves neither a timer nor an unhandled rejection behind.
+      controller.abort();
+      await waiting.catch(() => undefined);
+
+      expect(outcome).toEqual({ error: storageReset, status: "rejected" });
+    } finally {
+      controller.abort();
+      consoleError.mockRestore();
+    }
   });
 });
 

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -6241,7 +6241,11 @@ export class StreamProcessorRpcTarget<State, PublicState = State>
     // operation. Awaiting catchUpBeforeSnapshot here first made timeoutMs
     // dishonest: a stuck catch-up could hold this call forever before the
     // timed waiter even existed.
-    await this.#reads.waitUntilEvent(input);
+    // This is the last local hop before capnweb strips workerd's lifecycle
+    // flags. Preserve the explicit availability classification so the outer
+    // relay can re-dial the replacement DO exactly once. Application errors
+    // pass through unchanged.
+    await this.#reads.waitUntilEvent(input).catch(rethrowStreamUnavailable);
   }
 }
 

--- a/packages/iterate/src/processors/stream-processor-runner.ts
+++ b/packages/iterate/src/processors/stream-processor-runner.ts
@@ -474,20 +474,17 @@ export class StreamProcessorRunner<
       // frames — no double-drive against a concurrent live frame, because
       // redelivered offsets dedupe against the acknowledged cursor — and
       // resolves the waiter through the ordinary frame commit. A genuinely
-      // future offset stays parked for delivery. Pull failures are logged, not
-      // rethrown: the waiter stays valid (a later frame still resolves it) and
-      // `timeoutMs` stays the caller's bound.
-      this.catchUp().catch((error: unknown) => {
-        console.error(
-          `stream processor "${this.driver.contract.slug}" waitUntilEvent(offset ${offset}) ` +
-            `self-pull failed; the waiter stays parked for delivery`,
-          error,
-        );
+      // future offset stays parked for delivery after a successful pull. A
+      // failed pull is authoritative, however: settle this wait immediately
+      // so the caller can apply its bounded availability retry instead of
+      // hiding the failure behind the full wait timeout.
+      void this.catchUp().catch((error: unknown) => {
+        reached.reject(error);
       });
-      return await reached;
+      return await reached.promise;
     }
     const { predicate, signal, timeoutMs } = args;
-    await this.#parkEventWaiter({ kind: "predicate", predicate }, { signal, timeoutMs });
+    await this.#parkEventWaiter({ kind: "predicate", predicate }, { signal, timeoutMs }).promise;
   }
 
   /** Release delivery resources. Idempotent; a disposed runner rejects new work. */
@@ -1040,9 +1037,10 @@ export class StreamProcessorRunner<
       | { kind: "predicate"; predicate: (event: StreamEvent) => boolean }
       | { kind: "offset"; offset: number },
     opts: { signal?: AbortSignal; timeoutMs?: number },
-  ): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-      const waiter: EventWaiter = { ...match, reject, resolve, signal: opts.signal };
+  ): { promise: Promise<void>; reject: (error: unknown) => void } {
+    let waiter!: EventWaiter;
+    const promise = new Promise<void>((resolve, reject) => {
+      waiter = { ...match, reject, resolve, signal: opts.signal };
       this.#eventWaiters.add(waiter);
       if (opts.timeoutMs !== undefined) {
         waiter.timer = setTimeout(() => {
@@ -1061,6 +1059,10 @@ export class StreamProcessorRunner<
         if (opts.signal.aborted) waiter.abortListener();
       }
     });
+    return {
+      promise,
+      reject: (error: unknown) => this.#settleEventWaiter(waiter, { error }),
+    };
   }
 
   #settleEventWaiter(


### PR DESCRIPTION
## Outcome

A transient Durable Object storage reset during a processor's read-your-writes catch-up no longer gets swallowed behind the full 75-second waitUntilProcessed timeout.

- A failed self-pull now rejects its exact parked offset waiter immediately.
- The processor RPC boundary preserves the existing explicit stream-unavailable classification before capnweb strips workerd's lifecycle flags.
- The isolate relay then obtains a fresh processor facade and retries exactly once under the original public deadline.
- A successful pull that has not reached a genuinely future offset still parks normally.
- This adds no retry loop, timeout increase, test quarantine, or CI-only exception.

## Why this is a cross-branch infrastructure flake

The recent-CI audit found the same project-birth barrier failing in unrelated tests and unrelated projects:

- PR #2225, [Depot attempt z2dlv5dl0f](https://depot.dev/orgs/0p91s0lz49/workflows/n6lv6hnmr0?job=g2778g26th&attempt=z2dlv5dl0f): three Vitest cases and one Playwright setup all timed out at exactly offset 8; every retry passed. OS e2e took 171.1 seconds.
- PR #2231, [Depot attempt 0nz7jjsrgt](https://depot.dev/orgs/0p91s0lz49/workflows/x5qcwsqnrj?job=3vpzvr98qc&attempt=0nz7jjsrgt): streams.e2e timed out at exactly offset 8; its retry passed. OS e2e took 159.7 seconds.

Cloudflare telemetry for 2026-07-21 21:45–22:05 UTC confirms this was one platform incident, not independent assertion flakes:

- 269 Internal error while starting up Durable Object storage caused object to be reset events
- 8 preview services
- 28 Durable Object IDs
- 119 distinct Cloudflare references
- 248 Project Durable Object events and 20 Stream Durable Object events

The decisive application trace was:

> stream processor "project" waitUntilEvent(offset 8) self-pull failed; the waiter stays parked for delivery

That policy converted each immediately known infrastructure failure into a guaranteed 75-second tail. The caller already had the correct bounded fresh-incarnation retry; it simply could not see the failure.

Cloudflare query evidence: aggregate run 4pgpqxgexxltbq3txiu9410i; focused trace run 0dp0qiqovvymi125l3mk74q6.

## Implementation

StreamProcessorRunner.waitUntilEvent({ offset }) now owns a cancellable waiter handle. If its serialized self-pull fails, that handle settles with the original error and removes the timer/listeners. Ordinary frame commits and genuine future-offset delivery retain their previous semantics.

StreamProcessorRpcTarget.waitUntilProcessed applies rethrowStreamUnavailable at the final local boundary. Lifecycle failures retain their retryable wire classification; application errors preserve identity and are never retried. ProcessorRelayRpcTarget already limits this recovery to one re-dial and keeps both attempts inside one timeout.

## Verification

- Regression demonstrated red before the fix: the injected storage reset remained still-parked.
- The same regression is green after the fix and settles in 3 ms.
- Runner + RPC relay suites: 49/49 pass.
- Twenty concurrent executions of both affected suites: 20/20 pass (980 test cases total).
- Full monorepo pnpm test: pass; OS alone reports 224 files, 2,123 pass, 6 expected failures, 1 existing skip.
- pnpm typecheck: pass.
- pnpm lint: pass.
- pnpm format:check: pass.
- pnpm knip: pass.

## Production-shaped preview proof

The exact PR head `4b349be1ab9220b2dad82a00ae00ce3a79729da8` passed its first and only preview attempt: [Depot job gmsg8zjdxn](https://depot.dev/orgs/0p91s0lz49/workflows/lzj6sdl3j8?job=gmsg8zjdxn).

- All four deploys passed; the critical-path OS deploy took 111.5 seconds.
- All four end-to-end lanes started in parallel and passed: OS 155.6 seconds, streams example 56.4 seconds, auth 10.3 seconds, dummy petshop 5.8 seconds.
- OS Vitest: 48 files passed, 2 existing skips; 162 tests passed, 2 expected failures, 3 existing skips.
- OS Playwright and the remaining deployed suites passed.
- No test retry was emitted, and none of the cross-branch 75-second offset-8 stalls recurred.
- The complete preview check took 5m15s. This is above the 5-minute target: the remaining critical path is the 111.5-second OS deploy followed by the 155.6-second OS lane, not this eliminated failure tail.

## Testing / quarantine note

No test was quarantined or newly skipped. The cross-branch failures above are unrelated victim tests sharing one infrastructure path, so skipping each victim would hide the common defect and substantially reduce coverage. Preview e2e remains the production-shaped acceptance proof for this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes read-your-writes wait and RPC error propagation on the stream processor path; behavior is narrower (fail-fast vs full timeout) but affects timing and retry visibility for DO lifecycle failures.
> 
> **Overview**
> Fixes CI flakes where a **Durable Object storage reset** during processor read-your-writes catch-up was logged and ignored, leaving `waitUntilProcessed` parked for the full **75s** timeout even though the failure was already known.
> 
> **`StreamProcessorRunner.waitUntilEvent({ offset })`** now exposes a cancellable waiter from `#parkEventWaiter`. If the serialized **`catchUp()`** self-pull fails, that waiter is **rejected with the original error** right away; a successful pull that has not reached a future offset still parks as before.
> 
> **`StreamProcessorRpcTarget.waitUntilProcessed`** applies **`rethrowStreamUnavailable`** on the last local hop so lifecycle/`retryable` failures stay classified as **`stream-unavailable`** before capnweb strips workerd flags, enabling the existing **one re-dial** relay retry under the same public deadline.
> 
> Tests cover prompt rejection on injected storage reset, RPC tagging of lifecycle resets, and relay timeout sharing when the error is already `stream-unavailable`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b349be1ab9220b2dad82a00ae00ce3a79729da8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +21 -15 | +13 -12 🟩🟥⬜⬜⬜ |
| Tests | +68 -4 | +60 -4 🟩🟩🟩🟩🟩 |
| **Total** | **+89 -19** | **+73 -16** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 2edc539 and 4b349be, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-22T02:08:26.837Z",
      "headSha": "4b349be1ab9220b2dad82a00ae00ce3a79729da8",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/333238112161424",
      "shortSha": "4b349be",
      "cleanupDurationMs": 12420,
      "deployDurationMs": 111510,
      "deployedWorkerName": "os-preview-2",
      "deployedWorkerVersion": "79cf0956-85d0-49b3-8958-e3975350a41c",
      "testDurationMs": 155606,
      "testRetries": null,
      "workerSizeKib": 17150.3,
      "workerGzipKib": 4611.2,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 4623.09
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-22T02:08:17.594Z",
      "headSha": "4b349be1ab9220b2dad82a00ae00ce3a79729da8",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/333238112161424",
      "shortSha": "4b349be",
      "cleanupDurationMs": 3174,
      "deployDurationMs": 20218,
      "deployedWorkerName": "auth-preview-2",
      "deployedWorkerVersion": "ff0045a2-4dc9-4484-af4f-961af7d23e5d",
      "testDurationMs": 10257,
      "testRetries": null,
      "workerSizeKib": 3965.97,
      "workerGzipKib": 811.46,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-22T02:08:23.906Z",
      "headSha": "4b349be1ab9220b2dad82a00ae00ce3a79729da8",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/333238112161424",
      "shortSha": "4b349be",
      "cleanupDurationMs": 9485,
      "deployDurationMs": 88478,
      "deployedWorkerName": "streams-example-app-preview-2",
      "deployedWorkerVersion": "075f94af-e3fe-4ffd-aa80-8eb339c93f2f",
      "testDurationMs": 56362,
      "testRetries": null,
      "workerSizeKib": 5149.2,
      "workerGzipKib": 1470.63,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-22T02:08:15.216Z",
      "headSha": "4b349be1ab9220b2dad82a00ae00ce3a79729da8",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/333238112161424",
      "shortSha": "4b349be",
      "cleanupDurationMs": 792,
      "deployDurationMs": 5852,
      "deployedWorkerName": "dummy-petshop-preview-2",
      "deployedWorkerVersion": "3104b7fd-864a-4d24-b1bf-3f4bb6af327d",
      "testDurationMs": 5821,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `4b349be` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 811.5 KiB | 20.2s | 10.3s |  | 3.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/333238112161424) | 2026-07-22T02:08:17.594Z | Preview app released. |
| Dummy Petshop | released | `4b349be` | [https://dummy-petshop.iterate-preview-2.com](https://dummy-petshop.iterate-preview-2.com) | 198.3 KiB | 5.9s | 5.8s |  | 792ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/333238112161424) | 2026-07-22T02:08:15.216Z | Preview app released. |
| OS | released | `4b349be` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 4.50 MiB (-11.9 KiB vs main) | 111.5s | 155.6s |  | 12.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/333238112161424) | 2026-07-22T02:08:26.837Z | Preview app released. |
| Streams Example App | released | `4b349be` | [https://streams.iterate-preview-2.com](https://streams.iterate-preview-2.com) | 1.44 MiB | 88.5s | 56.4s |  | 9.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/333238112161424) | 2026-07-22T02:08:23.906Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->
