### PR TITLE
Use Doppler for CI telemetry credentials

### DIFF
--- a/.depot/workflows/ci-telemetry.yml
+++ b/.depot/workflows/ci-telemetry.yml
@@ -1,4 +1,9 @@
 name: CI telemetry sync
+permissions:
+  actions: read
+  checks: read
+  contents: read
+  pull-requests: read
 on:
   schedule:
     - cron: "*/15 * * * *"
@@ -14,8 +19,7 @@ jobs:
     timeout-minutes: 10
     env:
       DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
-      DEPOT_CI_TELEMETRY_TOKEN: ${{ secrets.DEPOT_CI_TELEMETRY_TOKEN }}
-      GH_TOKEN: ${{ secrets.ITERATE_BOT_GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ github.token }}
       # The 15-minute cadence rereads 24 hours for outage tolerance. Manual
       # backfills default to seven days and are idempotent.
       CI_TELEMETRY_LOOKBACK_DAYS: "1"
@@ -28,4 +32,10 @@ jobs:
       - name: Reconcile dependencies (baked)
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Backfill GitHub, Depot, and review-bot telemetry
-        run: doppler run --project _shared --config prd -- pnpm tsx scripts/ci/sync-ci-telemetry.ts
+        run: |-
+          set -euo pipefail
+          export DEPOT_CI_TELEMETRY_TOKEN
+          DEPOT_CI_TELEMETRY_TOKEN="$(doppler secrets get DEPOT_CI_TELEMETRY_TOKEN --plain --project _shared --config preview)"
+          doppler run --project _shared --config prd \
+            --preserve-env=DEPOT_CI_TELEMETRY_TOKEN,GITHUB_TOKEN -- \
+            pnpm tsx scripts/ci/sync-ci-telemetry.ts

--- a/.depot/workflows/cloudflare-preview-cleanup.yml
+++ b/.depot/workflows/cloudflare-preview-cleanup.yml
@@ -15,8 +15,8 @@
 # Depot registers automatic triggers when this file is on the default branch —
 # branch-only changes to the `on:` block do not take effect until merged.
 #
-# Secrets (depot ci secrets --org 0p91s0lz49): DOPPLER_TOKEN,
-# ITERATE_BOT_GITHUB_TOKEN.
+# The only Depot secret is DOPPLER_TOKEN. GitHub supplies the job-scoped token;
+# Doppler supplies every other credential.
 #
 # Deliberately NO `paths` filter: a closed PR that once held a slot must always
 # attempt cleanup, even when the final PR diff is empty (full revert) or no
@@ -26,6 +26,10 @@
 # never released preview-1).
 
 name: Cloudflare Preview Cleanup (Depot CI)
+
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   pull_request:
@@ -69,9 +73,9 @@ jobs:
       - name: Preview / cleanup
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.ITERATE_BOT_GITHUB_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |-
           set -euo pipefail
-          doppler run --project _shared --config prd -- pnpm preview cleanup \
+          doppler run --project _shared --config prd --preserve-env=GITHUB_TOKEN -- pnpm preview cleanup \
             --github-token "$GITHUB_TOKEN" \
             --pull-request-number "${{ github.event.pull_request.number }}"

--- a/.depot/workflows/cloudflare-previews.yml
+++ b/.depot/workflows/cloudflare-previews.yml
@@ -21,14 +21,19 @@
 #     --workflow cloudflare-previews.yml --ref <branch> \
 #     --input pull-request-number=<pr>
 #
-# Secrets (depot ci secrets --org 0p91s0lz49): DOPPLER_TOKEN,
-# ITERATE_BOT_GITHUB_TOKEN.
+# The only Depot secret is DOPPLER_TOKEN. GitHub supplies the job-scoped token;
+# Doppler supplies every other credential.
 #
 # Keep the `paths` list below in sync with `cloudflarePreviewSharedPaths` +
 # `cloudflarePreviewAdditionalTriggerPaths` + each app's `paths` in
 # scripts/preview/preview.ts (asserted in scripts/preview/preview.test.ts).
 
 name: Cloudflare Previews (Depot CI)
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: read
 
 # Draft PRs don't claim a preview slot unless they ask — the `preview` label,
 # marking ready for review, or a manual dispatch (dispatch passes
@@ -135,14 +140,14 @@ jobs:
       - name: Preview / deploy + e2e
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.ITERATE_BOT_GITHUB_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
           TEST_TELEMETRY_ARTIFACT_DIR: test-results/ci-telemetry/raw
         run: |-
           set -euo pipefail
           # A manual dispatch is an explicit ask for a fresh preview, so it
           # overrides the draft policy and redeploys even when this exact head
           # was previously cleaned up and recorded as released.
-          doppler run --project _shared --config prd -- pnpm preview run \
+          doppler run --project _shared --config prd --preserve-env=GITHUB_TOKEN -- pnpm preview run \
             --github-token "$GITHUB_TOKEN" \
             --pull-request-number "${{ github.event.pull_request.number || inputs.pull-request-number }}" \
             ${{ github.event_name == 'workflow_dispatch' && '--allow-draft --all-apps' || '' }}

--- a/.depot/workflows/deploy-os.yml
+++ b/.depot/workflows/deploy-os.yml
@@ -96,7 +96,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.ITERATE_BOT_GITHUB_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
           APP_SLUG: os
           DEPLOY_LOG_FILE: /tmp/deploy-os.log
         run: |-

--- a/.depot/workflows/loc-report.yml
+++ b/.depot/workflows/loc-report.yml
@@ -1,4 +1,7 @@
 name: LOC report
+permissions:
+  contents: read
+  pull-requests: write
 on:
   pull_request: {}
   workflow_dispatch: {}
@@ -11,7 +14,7 @@ jobs:
       size: 8x32
       image: 0p91s0lz49.registry.depot.dev/iterate-preview-ci:node24-pnpm10-worktree
     env:
-      ITERATE_BOT_GITHUB_TOKEN: ${{ secrets.ITERATE_BOT_GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.depot/workflows/nag.yml
+++ b/.depot/workflows/nag.yml
@@ -1,4 +1,8 @@
 name: Nag about PRs
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 on:
   schedule:
     - cron: "*/15 * * * *"
@@ -21,7 +25,7 @@ jobs:
       image: 0p91s0lz49.registry.depot.dev/iterate-preview-ci:node24-pnpm10-worktree
     env:
       DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
-      ITERATE_BOT_GITHUB_TOKEN: ${{ secrets.ITERATE_BOT_GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.depot/workflows/pr-dashboard.yml
+++ b/.depot/workflows/pr-dashboard.yml
@@ -1,4 +1,9 @@
 name: Daily PR dashboard
+permissions:
+  actions: write
+  contents: read
+  issues: read
+  pull-requests: read
 on:
   pull_request:
     types:
@@ -21,7 +26,7 @@ jobs:
       image: 0p91s0lz49.registry.depot.dev/iterate-preview-ci:node24-pnpm10-worktree
     env:
       DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
-      ITERATE_BOT_GITHUB_TOKEN: ${{ secrets.ITERATE_BOT_GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.depot/workflows/pr-dashboard.yml
+++ b/.depot/workflows/pr-dashboard.yml
@@ -1,6 +1,5 @@
 name: Daily PR dashboard
 permissions:
-  actions: write
   contents: read
   issues: read
   pull-requests: read

--- a/.depot/workflows/preview-e2e-marathon.yml
+++ b/.depot/workflows/preview-e2e-marathon.yml
@@ -8,10 +8,15 @@
 #     --workflow preview-e2e-marathon.yml --ref <branch> \
 #     --input pull-request-number=<pr>
 #
-# Secrets (depot ci secrets --org 0p91s0lz49): DOPPLER_TOKEN,
-# ITERATE_BOT_GITHUB_TOKEN — same as cloudflare-previews.yml.
+# The only Depot secret is DOPPLER_TOKEN. GitHub supplies the job-scoped token;
+# Doppler supplies every other credential.
 
 name: Preview e2e marathon (Depot CI)
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: read
 
 on:
   workflow_dispatch:
@@ -62,7 +67,7 @@ jobs:
       - name: Marathon
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.ITERATE_BOT_GITHUB_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
           TEST_TELEMETRY_ARTIFACT_DIR: test-results/ci-telemetry/raw
           PR_NUMBER: ${{ inputs.pull-request-number }}
           # Empty inputs fall through to the script's own defaults, which the

--- a/.depot/workflows/release.yml
+++ b/.depot/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Create release
         if: steps.check_changes.outputs.commits != '0'
         env:
-          ITERATE_BOT_GITHUB_TOKEN: ${{ secrets.ITERATE_BOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           RELEASE_NAME: ${{ steps.release_info.outputs.release_name }}
           RELEASE_TITLE: ${{ steps.context.outputs.release_title }}
         run: pnpm tsx scripts/ci/create-release.ts

--- a/docs/ci-test-telemetry.md
+++ b/docs/ci-test-telemetry.md
@@ -271,25 +271,37 @@ CI needs a dedicated [Depot organization API token](https://depot.dev/docs/cli/a
 `DEPOT_CI_TELEMETRY_TOKEN`. Depot does not currently expose a read-only token
 limited to CI metrics, so this credential has broad organization API scope.
 Never reuse a developer's personal Depot login token. Create a dedicated token
-named `CI telemetry` in Depot Organization Settings, then store it as a secret
-variant restricted to this repository and workflow. The scheduled job
-intentionally fails if it is missing:
+named `CI telemetry` in Depot Organization Settings, then store it as a masked
+secret in the inheritable Doppler `_shared/preview` base config. Enter the
+value interactively so it does not land in shell history:
 
 ```bash
-read -rs DEPOT_TELEMETRY_VALUE
-printf '%s' "$DEPOT_TELEMETRY_VALUE" | \
-  depot ci secrets set DEPOT_CI_TELEMETRY_TOKEN ci-telemetry \
-    --from-stdin \
-    --org 0p91s0lz49 \
-    --repo iterate/iterate \
-    --workflow ci-telemetry.yml \
-    --description "Dedicated Depot organization API token for historical CI telemetry"
-unset DEPOT_TELEMETRY_VALUE
+doppler --silent secrets set DEPOT_CI_TELEMETRY_TOKEN \
+  --project _shared \
+  --config preview \
+  --visibility masked
 ```
 
-Confirm the variant scope with `depot ci secrets list --org 0p91s0lz49`.
+The scheduled collector reads only that credential from `_shared/preview`,
+then runs the uploader under `_shared/prd`. This split is deliberate:
+`_shared/preview` and `_shared/prd` belong to different PostHog projects, and
+running the whole collector under preview would silently send CI history away
+from the canonical dashboards. The job fails if the Depot credential is
+missing.
+
+`DOPPLER_TOKEN` is the only long-lived secret stored in Depot CI. GitHub API
+calls use the workflow's short-lived `${{ github.token }}` with explicit
+least-privilege permissions; every other credential comes from Doppler. Check
+the invariant without displaying any values:
+
+```bash
+depot ci secrets list --org 0p91s0lz49
+doppler secrets --project _shared --config preview --only-names \
+  | rg DEPOT_CI_TELEMETRY_TOKEN
+```
+
 Rotate or revoke the organization token immediately if it is ever exposed;
-deleting the secret alone does not revoke the token at Depot.
+deleting the Doppler secret alone does not revoke the token at Depot.
 
 Local collection uses `gh` auth and the developer's Depot CLI login:
 

--- a/docs/depot-ci.md
+++ b/docs/depot-ci.md
@@ -119,6 +119,14 @@ non-obvious case: its Depot organization token lives in `_shared/preview`, but
 the collector sends under `_shared/prd` so it reaches the canonical PostHog
 project. See [CI and test telemetry](ci-test-telemetry.md) for the exact setup.
 
+The daily PR dashboard also avoids a hidden token exception: it finds today's
+message and detail reply through Slack history instead of persisting their
+timestamps in a GitHub Actions repository variable. GitHub's variable API
+requires the separate
+[repository `Variables` permission](https://docs.github.com/en/rest/actions/variables#get-a-repository-variable),
+which workflow `GITHUB_TOKEN` permissions cannot request. Do not reintroduce
+`SLACK_PR_DASHBOARD_STATE` or a personal/bot token for that state.
+
 ## Wait For CI
 
 Depot CLI does not currently have a blocking `wait` subcommand. The monitoring

--- a/docs/depot-ci.md
+++ b/docs/depot-ci.md
@@ -12,8 +12,8 @@ runtime logic in normal scripts under `scripts/ci` instead of embedding large
 Historical workflow/job/attempt timing, queueing, CPU/memory utilization, and
 failure-rate analysis lives in PostHog; see
 [CI and test telemetry](ci-test-telemetry.md) for the dashboards, event model,
-scheduled backfill, dedicated Depot organization token and its scope caveat,
-and CLI/MCP queries.
+scheduled backfill, Doppler-managed Depot organization token and its scope
+caveat, and CLI/MCP queries.
 
 ## Quick Links
 
@@ -33,8 +33,9 @@ and CLI/MCP queries.
 - CI scripts: `scripts/ci/*.ts`
 - Custom image:
   `0p91s0lz49.registry.depot.dev/iterate-preview-ci:node24-pnpm10-worktree`
-- Secrets and variables are managed with `depot ci secrets` and `depot ci vars`,
-  not GitHub Actions secrets.
+- `DOPPLER_TOKEN` is the only Depot CI secret. Application and service
+  credentials live in Doppler; GitHub supplies a short-lived job token.
+- Non-secret variables are managed with `depot ci vars`.
 
 The only GitHub Actions workflow left is `.github/workflows/claude-assistant.yml`.
 It is not CI; it exists because Depot CI does not support issue/comment events
@@ -107,9 +108,16 @@ Manage secrets:
 
 ```bash
 depot ci secrets list --org 0p91s0lz49
-printf '%s' "$VALUE" | depot ci secrets add NAME --org 0p91s0lz49
-depot ci secrets remove NAME --org 0p91s0lz49
 ```
+
+The list must contain only `DOPPLER_TOKEN`. Do not copy GitHub, Depot API,
+Cloudflare, Slack, PostHog, or other service credentials into Depot. Put them
+in the appropriate Doppler config; CI reaches them through the bootstrap
+token. GitHub operations use `${{ github.token }}` and workflow-level
+`permissions` instead of a stored bot token. The CI telemetry collector is the
+non-obvious case: its Depot organization token lives in `_shared/preview`, but
+the collector sends under `_shared/prd` so it reaches the canonical PostHog
+project. See [CI and test telemetry](ci-test-telemetry.md) for the exact setup.
 
 ## Wait For CI
 

--- a/scripts/ci/depot-workflows.test.ts
+++ b/scripts/ci/depot-workflows.test.ts
@@ -185,7 +185,6 @@ describe("Depot credential boundaries", () => {
     {
       file: ".depot/workflows/pr-dashboard.yml",
       permissions: {
-        actions: "write",
         contents: "read",
         issues: "read",
         "pull-requests": "read",

--- a/scripts/ci/depot-workflows.test.ts
+++ b/scripts/ci/depot-workflows.test.ts
@@ -27,6 +27,7 @@ type Workflow = {
     "cancel-in-progress": boolean;
   };
   jobs: Record<string, WorkflowJob>;
+  permissions?: Record<string, string>;
   on?: {
     push?: {
       paths?: string[];
@@ -37,6 +38,10 @@ type Workflow = {
 function loadWorkflow(file: string): Workflow {
   return parseYaml(readFileSync(resolve(repoRoot, file), "utf8")) as Workflow;
 }
+
+const depotWorkflowFiles = readdirSync(resolve(repoRoot, ".depot/workflows"))
+  .filter((file) => file.endsWith(".yml"))
+  .map((file) => `.depot/workflows/${file}`);
 
 const deploymentWorkflows = [
   {
@@ -124,6 +129,91 @@ describe("Depot deployment safety", () => {
     expect(workflow.on?.push?.paths).toEqual(
       expect.arrayContaining(["apps/auth/**", "apps/auth-contract/**"]),
     );
+  });
+});
+
+describe("Depot credential boundaries", () => {
+  it("uses DOPPLER_TOKEN as the only stored Depot secret", () => {
+    const secretReferences = depotWorkflowFiles.flatMap((file) => {
+      const contents = readFileSync(resolve(repoRoot, file), "utf8");
+      return [...contents.matchAll(/secrets\.([A-Z0-9_]+)/g)].map((match) => match[1]);
+    });
+
+    expect([...new Set(secretReferences)]).toEqual(["DOPPLER_TOKEN"]);
+  });
+
+  it("uses only GitHub's job-scoped token for GitHub API calls", () => {
+    const tokenAssignments = depotWorkflowFiles.flatMap((file) => {
+      const contents = readFileSync(resolve(repoRoot, file), "utf8");
+      return [...contents.matchAll(/^\s+GITHUB_TOKEN:\s*(.+)$/gm)].map((match) => match[1]);
+    });
+
+    expect(tokenAssignments.length).toBeGreaterThan(0);
+    expect([...new Set(tokenAssignments)]).toEqual(["${{ github.token }}"]);
+  });
+
+  it.each([
+    {
+      file: ".depot/workflows/ci-telemetry.yml",
+      permissions: {
+        actions: "read",
+        checks: "read",
+        contents: "read",
+        "pull-requests": "read",
+      },
+    },
+    {
+      file: ".depot/workflows/cloudflare-preview-cleanup.yml",
+      permissions: { contents: "read", "pull-requests": "write" },
+    },
+    {
+      file: ".depot/workflows/cloudflare-previews.yml",
+      permissions: { contents: "read", "pull-requests": "write", statuses: "read" },
+    },
+    {
+      file: ".depot/workflows/deploy-os.yml",
+      permissions: { contents: "read", deployments: "write", statuses: "write" },
+    },
+    {
+      file: ".depot/workflows/loc-report.yml",
+      permissions: { contents: "read", "pull-requests": "write" },
+    },
+    {
+      file: ".depot/workflows/nag.yml",
+      permissions: { contents: "read", issues: "write", "pull-requests": "write" },
+    },
+    {
+      file: ".depot/workflows/pr-dashboard.yml",
+      permissions: {
+        actions: "write",
+        contents: "read",
+        issues: "read",
+        "pull-requests": "read",
+      },
+    },
+    {
+      file: ".depot/workflows/preview-e2e-marathon.yml",
+      permissions: { contents: "read", "pull-requests": "write", statuses: "read" },
+    },
+    {
+      file: ".depot/workflows/release.yml",
+      permissions: { contents: "write" },
+    },
+  ])("$file grants only its required GitHub permissions", ({ file, permissions }) => {
+    expect(loadWorkflow(file).permissions).toEqual(permissions);
+  });
+
+  it("loads the Depot telemetry token from preview without changing the PostHog config", () => {
+    const workflow = loadWorkflow(".depot/workflows/ci-telemetry.yml");
+    const collector = workflow.jobs.sync.steps?.find((step) =>
+      step.run?.includes("scripts/ci/sync-ci-telemetry.ts"),
+    );
+
+    expect(collector?.run).toContain(
+      "doppler secrets get DEPOT_CI_TELEMETRY_TOKEN --plain --project _shared --config preview",
+    );
+    expect(collector?.run).toContain("doppler run --project _shared --config prd");
+    expect(collector?.run).toContain("--preserve-env=DEPOT_CI_TELEMETRY_TOKEN,GITHUB_TOKEN");
   });
 });
 

--- a/scripts/ci/github.ts
+++ b/scripts/ci/github.ts
@@ -5,9 +5,9 @@ import { Octokit } from "@octokit/rest";
 import { markdownAnnotator } from "../../packages/shared/src/dev/markdown-annotator.ts";
 
 export function getOctokit() {
-  const auth = process.env.ITERATE_BOT_GITHUB_TOKEN || process.env.GITHUB_TOKEN;
+  const auth = process.env.GITHUB_TOKEN;
   if (!auth) {
-    throw new Error("GITHUB_TOKEN or ITERATE_BOT_GITHUB_TOKEN is required");
+    throw new Error("GITHUB_TOKEN is required");
   }
   return new Octokit({ auth });
 }

--- a/scripts/ci/pr-dashboard.test.ts
+++ b/scripts/ci/pr-dashboard.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { findDashboardState } from "./pr-dashboard.ts";
+
+describe("findDashboardState", () => {
+  it("paginates today's Slack history and finds the dashboard detail reply", async () => {
+    const history = vi
+      .fn()
+      .mockResolvedValueOnce({
+        messages: [{ ts: "newer", text: "another CI message" }],
+        response_metadata: { next_cursor: "next-page" },
+      })
+      .mockResolvedValueOnce({
+        messages: [
+          {
+            bot_id: "ci-bot",
+            text: "*PR dashboard 22nd July* — 2 opened (details in thread)",
+            ts: "dashboard",
+          },
+        ],
+        response_metadata: {},
+      });
+    const replies = vi.fn().mockResolvedValue({
+      messages: [
+        { bot_id: "ci-bot", text: "parent", ts: "dashboard" },
+        { bot_id: "ci-bot", text: "details", ts: "details", thread_ts: "dashboard" },
+      ],
+    });
+    const slack = { conversations: { history, replies } } as unknown as Parameters<
+      typeof findDashboardState
+    >[0];
+
+    await expect(
+      findDashboardState(slack, {
+        channel: "ci-channel",
+        heading: "*PR dashboard 22nd July*",
+        today: "2026-07-22",
+      }),
+    ).resolves.toEqual({ ts: "dashboard", detailsTs: "details" });
+    expect(history).toHaveBeenNthCalledWith(1, {
+      channel: "ci-channel",
+      cursor: undefined,
+      limit: 100,
+      oldest: "1784678400",
+    });
+    expect(history).toHaveBeenNthCalledWith(2, {
+      channel: "ci-channel",
+      cursor: "next-page",
+      limit: 100,
+      oldest: "1784678400",
+    });
+    expect(replies).toHaveBeenCalledWith({ channel: "ci-channel", limit: 100, ts: "dashboard" });
+  });
+
+  it("returns null when today's Slack history contains no dashboard", async () => {
+    const replies = vi.fn();
+    const slack = {
+      conversations: {
+        history: vi.fn().mockResolvedValue({ messages: [], response_metadata: {} }),
+        replies,
+      },
+    } as unknown as Parameters<typeof findDashboardState>[0];
+
+    await expect(
+      findDashboardState(slack, {
+        channel: "ci-channel",
+        heading: "*PR dashboard 22nd July*",
+        today: "2026-07-22",
+      }),
+    ).resolves.toBeNull();
+    expect(replies).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/ci/pr-dashboard.ts
+++ b/scripts/ci/pr-dashboard.ts
@@ -9,7 +9,6 @@ export async function updatePrDashboard() {
   const repo = getRepo();
   const isTest = getEventName() !== "pull_request";
   const channel = isTest ? slackChannelIds["#misha-test"] : slackChannelIds["#ci"];
-  const stateVariableName = isTest ? "SLACK_PR_DASHBOARD_STATE_TEST" : "SLACK_PR_DASHBOARD_STATE";
   const dryRun = !process.env.CI;
 
   const now = new Date();
@@ -107,24 +106,7 @@ export async function updatePrDashboard() {
     blocks: chunkSlackBlocks(lines),
   };
   const slack = getSlackClient();
-  type State = { date: string; channel: string; ts: string; details_ts?: string };
-  const state: State | null = await github.rest.actions
-    .getRepoVariable({ ...repo, name: stateVariableName })
-    .then((res) => JSON.parse(res.data.value) as State)
-    .catch((error: { status?: number }) => {
-      if (error.status === 404) return null;
-      throw error;
-    });
-
-  const writeState = async (newState: State) => {
-    const value = JSON.stringify(newState);
-    await github.rest.actions
-      .updateRepoVariable({ ...repo, name: stateVariableName, value })
-      .catch(async (error: { status?: number }) => {
-        if (error.status !== 404) throw error;
-        await github.rest.actions.createRepoVariable({ ...repo, name: stateVariableName, value });
-      });
-  };
+  const state = await findDashboardState(slack, { channel, heading, today });
   const postDetailsInThread = async (parentTs: string) => {
     const details = await slack.chat.postMessage({
       ...detailsPayload,
@@ -134,7 +116,7 @@ export async function updatePrDashboard() {
     return details.ts;
   };
 
-  if (state && state.date === today && state.channel === channel) {
+  if (state) {
     const updated = await slack.chat
       .update({ channel, ts: state.ts, text: summaryText, blocks: [] })
       .catch((error) => {
@@ -143,13 +125,13 @@ export async function updatePrDashboard() {
       });
     if (updated) {
       const detailsUpdated =
-        state.details_ts &&
-        (await slack.chat.update({ ...detailsPayload, ts: state.details_ts }).catch((error) => {
+        state.detailsTs &&
+        (await slack.chat.update({ ...detailsPayload, ts: state.detailsTs }).catch((error) => {
           console.warn("details chat.update failed, re-posting in thread:", error);
           return null;
         }));
       if (!detailsUpdated) {
-        await writeState({ ...state, details_ts: await postDetailsInThread(state.ts) });
+        await postDetailsInThread(state.ts);
       }
       console.log(`Updated existing dashboard message ${state.ts}`);
       return;
@@ -159,8 +141,44 @@ export async function updatePrDashboard() {
   const message = await slack.chat.postMessage({ channel, text: summaryText });
   if (!message.ts) throw new Error("No ts in postMessage response");
   const detailsTs = await postDetailsInThread(message.ts);
-  await writeState({ date: today, channel, ts: message.ts, details_ts: detailsTs });
   console.log(`Posted new dashboard message ${message.ts} (details ${detailsTs})`);
+}
+
+/** Find today's dashboard in Slack itself, avoiding a second mutable state store. */
+export async function findDashboardState(
+  slack: ReturnType<typeof getSlackClient>,
+  input: { channel: string; heading: string; today: string },
+): Promise<{ ts: string; detailsTs?: string } | null> {
+  const oldest = String(Date.parse(`${input.today}T00:00:00.000Z`) / 1_000);
+  let cursor: string | undefined;
+  for (;;) {
+    const history = await slack.conversations.history({
+      channel: input.channel,
+      cursor,
+      limit: 100,
+      oldest,
+    });
+    const parent = history.messages?.find(
+      (message) => message.ts && message.text?.startsWith(`${input.heading} —`),
+    );
+    if (parent?.ts) {
+      const replies = await slack.conversations.replies({
+        channel: input.channel,
+        limit: 100,
+        ts: parent.ts,
+      });
+      const details = replies.messages?.find(
+        (message) =>
+          message.ts !== parent.ts &&
+          ((parent.bot_id && message.bot_id === parent.bot_id) ||
+            (parent.user && message.user === parent.user)),
+      );
+      return { ts: parent.ts, ...(details?.ts ? { detailsTs: details.ts } : {}) };
+    }
+
+    cursor = history.response_metadata?.next_cursor || undefined;
+    if (!cursor) return null;
+  }
 }
 
 function chunkSlackBlocks(lines: string[]) {

--- a/scripts/ci/report-worker-size.ts
+++ b/scripts/ci/report-worker-size.ts
@@ -10,7 +10,7 @@
  * Env: APP_SLUG, DEPLOY_LOG_FILE, DEPLOY_SHA (the checked-out sha that was
  * actually deployed — NOT the workflow trigger's GITHUB_SHA, which diverges
  * on a workflow_dispatch with a custom ref), GITHUB_REPOSITORY, and
- * GITHUB_TOKEN / ITERATE_BOT_GITHUB_TOKEN.
+ * GITHUB_TOKEN.
  */
 import { readFileSync } from "node:fs";
 import { isMainModule } from "../../packages/shared/src/dev/is-main-module.ts";

--- a/scripts/ci/sync-ci-telemetry.ts
+++ b/scripts/ci/sync-ci-telemetry.ts
@@ -322,9 +322,9 @@ async function depotEvents(): Promise<PostHogEvent[]> {
       "DEPOT_CI_TELEMETRY_TOKEN is required for Depot timing and utilization telemetry",
     );
   }
-  // Developer runs may use the Depot CLI's local login. CI uses a dedicated
-  // organization API token scoped to this repository and workflow as a Depot
-  // CI secret; Depot does not currently offer a read-only metrics token.
+  // Developer runs may use the Depot CLI's local login. CI loads a dedicated
+  // organization API token from Doppler _shared/preview; Depot does not
+  // currently offer a read-only metrics token.
   const environment = token ? { ...process.env, DEPOT_TOKEN: token } : process.env;
   const list = await depotJson<Array<{ workflow_id: string; status: string; created_at: string }>>(
     [

--- a/scripts/preview/e2e-policy.test.ts
+++ b/scripts/preview/e2e-policy.test.ts
@@ -184,6 +184,11 @@ describe("watchdogs the shell can't import stay in sync", () => {
       "group: cloudflare-previews-${{ inputs.pull-request-number }}",
     );
     expect(marathonWorkflow).toContain("cancel-in-progress: false");
+    expect(
+      source.match(
+        /doppler run --project _shared --config prd --preserve-env=GITHUB_TOKEN -- pnpm preview/g,
+      ),
+    ).toHaveLength(2);
     // Uncounted priming runs are a masking layer; every run counts.
     expect(marathonWorkflow).not.toContain("warmup-runs");
   });

--- a/scripts/preview/flake-hunt-loop.sh
+++ b/scripts/preview/flake-hunt-loop.sh
@@ -90,7 +90,7 @@ while [ "$run" -le "$RUNS" ]; do
 
   echo "run $run/$RUNS: deploying the full fleet (attempt $attempt)"
   run_with_watchdog "$RUN_TIMEOUT_SECS" "$deploy_log" \
-    doppler run --project _shared --config prd -- pnpm preview deploy --all-apps --allow-draft \
+    doppler run --project _shared --config prd --preserve-env=GITHUB_TOKEN -- pnpm preview deploy --all-apps --allow-draft \
     --pull-request-number "$PR_NUMBER"
   deploy_exit=$?
 
@@ -115,7 +115,7 @@ while [ "$run" -le "$RUNS" ]; do
 
   echo "run $run/$RUNS: running every e2e lane in parallel (${remaining}s watchdog remaining)"
   run_with_watchdog "$remaining" "$test_log" \
-    doppler run --project _shared --config prd -- pnpm preview test \
+    doppler run --project _shared --config prd --preserve-env=GITHUB_TOKEN -- pnpm preview test \
     --pull-request-number "$PR_NUMBER"
   test_exit=$?
 


### PR DESCRIPTION
## Summary

- make `DOPPLER_TOKEN` the only secret referenced by Depot workflows
- replace the long-lived GitHub bot token with each job's ephemeral `${{ github.token }}` and explicit least-privilege permissions
- load `DEPOT_CI_TELEMETRY_TOKEN` from Doppler `_shared/preview` while keeping PostHog delivery under `_shared/prd`
- derive daily PR dashboard state from Slack history instead of GitHub repository variables
- document the credential boundary and enforce it with workflow regression tests

## Why

Depot CI already has everything it needs through its Doppler bootstrap token and GitHub's job-scoped token. Keeping GitHub and Depot API credentials as additional Depot secrets duplicates secret management and leaves long-lived credentials where ephemeral or Doppler-managed credentials work.

`_shared/preview` and `_shared/prd` point at different PostHog projects, so the collector intentionally fetches only the Depot credential from preview and runs ingestion under prd. This avoids silently splitting the canonical telemetry dataset.

## Verification

- `pnpm install && pnpm typecheck && pnpm lint && pnpm exec oxfmt --check . && pnpm test`
- bounded live collector dry run: GitHub Actions, GitHub reviews, and Depot sources all succeeded (68 normalized events)
- dispatched branch telemetry workflow completed successfully and collected 1,711 idempotent events
- `depot ci secrets list --org 0p91s0lz49` contains only `DOPPLER_TOKEN`
- `DEPOT_CI_TELEMETRY_TOKEN` is present in Doppler `_shared/preview` and inherited by preview configs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication for preview deploy/cleanup, releases, and telemetry collection; misconfigured permissions or Doppler env preservation could break PR automation or split telemetry, though regression tests and documented invariants reduce that risk.
> 
> **Overview**
> **Depot CI workflows** now treat **`DOPPLER_TOKEN`** as the only stored Depot secret and use **`${{ github.token }}`** with explicit workflow **`permissions`** instead of a long-lived bot token. Preview, cleanup, marathon, release, LOC report, nag, and deploy paths pass **`--preserve-env=GITHUB_TOKEN`** into Doppler so the job token is not overwritten.
> 
> The **CI telemetry** job loads **`DEPOT_CI_TELEMETRY_TOKEN`** from Doppler **`_shared/preview`** but still runs ingestion under **`_shared/prd`** so PostHog events stay on the canonical project.
> 
> **`scripts/ci/github.ts`** requires **`GITHUB_TOKEN`** only. The **daily PR dashboard** drops GitHub repository-variable state and **`findDashboardState`** rediscovers today’s Slack parent and thread reply via paginated history.
> 
> **Docs** describe the credential boundary; **`depot-workflows.test.ts`** adds regression tests for secrets, token source, permissions, and the telemetry Doppler split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45f24ac4f579126bf5abcfd536caca3c6a9e1517. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +167 -0 | +154 -0 🟩🟩🟩🟩🟩 |
| CI & scripts | +104 -51 | +94 -46 🟩🟩🟩🟥🟥 |
| Docs | +48 -20 | +43 -20 🟩🟥⬜⬜⬜ |
| **Total** | **+319 -71** | **+291 -66** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between b12cc06 and 45f24ac, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-22T06:15:13.151Z",
      "headSha": "45f24ac4f579126bf5abcfd536caca3c6a9e1517",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/580827144728560",
      "shortSha": "45f24ac",
      "cleanupDurationMs": 17953,
      "deployDurationMs": 67479,
      "deployedWorkerName": "os-preview-12",
      "deployedWorkerVersion": "22963abe-60e7-4037-9e99-7bdf388d7fa3",
      "workerSizeKib": 17150.31,
      "workerGzipKib": 4611.29,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 4622.9
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-22T06:14:56.326Z",
      "headSha": "64dde735e174d5c3badf99d2815a249711da6aa2",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/304022096953957",
      "shortSha": "64dde73",
      "cleanupDurationMs": 1126,
      "deployDurationMs": 12155,
      "deployedWorkerName": "semaphore-preview-12",
      "deployedWorkerVersion": "26f9ead0-c208-4462-89fe-0ab155d663f9",
      "testDurationMs": 21322,
      "testRetries": null,
      "workerSizeKib": 1915.22,
      "workerGzipKib": 440.99,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-22T06:14:58.391Z",
      "headSha": "45f24ac4f579126bf5abcfd536caca3c6a9e1517",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/580827144728560",
      "shortSha": "45f24ac",
      "cleanupDurationMs": 3190,
      "deployDurationMs": 16503,
      "deployedWorkerName": "auth-preview-12",
      "deployedWorkerVersion": "7d7db1fe-5b6f-4aec-b3ba-f2849c9b4e97",
      "workerSizeKib": 3965.97,
      "workerGzipKib": 811.4,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-22T06:15:08.447Z",
      "headSha": "64dde735e174d5c3badf99d2815a249711da6aa2",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/304022096953957",
      "shortSha": "64dde73",
      "cleanupDurationMs": 13243,
      "deployDurationMs": 95735,
      "deployedWorkerName": "streams-example-app-preview-12",
      "deployedWorkerVersion": "e3575d93-6515-42ed-b838-c99b8bb0972e",
      "testDurationMs": 59214,
      "testRetries": null,
      "workerSizeKib": 5149.26,
      "workerGzipKib": 1470.62,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-22T06:14:56.282Z",
      "headSha": "45f24ac4f579126bf5abcfd536caca3c6a9e1517",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/580827144728560",
      "shortSha": "45f24ac",
      "cleanupDurationMs": 1074,
      "deployDurationMs": 51,
      "deployedWorkerName": "dummy-petshop-preview-12",
      "deployedWorkerVersion": "7bd09004-d5c5-4e91-a0d3-579b94cd5c44",
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `45f24ac` | [https://auth.iterate-preview-12.com](https://auth.iterate-preview-12.com) | 811.4 KiB | 16.5s |  |  | 3.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/580827144728560) | 2026-07-22T06:14:58.391Z | Preview app released. |
| Dummy Petshop | released | `45f24ac` | [https://dummy-petshop.iterate-preview-12.com](https://dummy-petshop.iterate-preview-12.com) | 198.3 KiB | 51ms |  |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/580827144728560) | 2026-07-22T06:14:56.282Z | Preview app released. |
| OS | released | `45f24ac` | [https://os.iterate-preview-12.com](https://os.iterate-preview-12.com) | 4.50 MiB (-11.6 KiB vs main) | 67.5s |  |  | 18.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/580827144728560) | 2026-07-22T06:15:13.151Z | Preview app released. |
| Semaphore | released | `64dde73` | [https://semaphore.iterate-preview-12.com](https://semaphore.iterate-preview-12.com) | 441.0 KiB | 12.2s | 21.3s |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/304022096953957) | 2026-07-22T06:14:56.326Z | Preview app released. |
| Streams Example App | released | `64dde73` | [https://streams.iterate-preview-12.com](https://streams.iterate-preview-12.com) | 1.44 MiB | 95.7s | 59.2s |  | 13.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/304022096953957) | 2026-07-22T06:15:08.447Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->