### PR TITLE
Add config-repo reset script

### DIFF
--- a/apps/os/scripts/cli.ts
+++ b/apps/os/scripts/cli.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { createBuiltInPrompts, createCli, isAgent, yamlTableConsoleLogger } from "trpc-cli";
 import { isMainModule } from "@iterate-com/shared/dev/is-main-module";
 
+export * as configRepo from "./reset-config-repo.ts";
 export * as dev from "./dev.ts";
 export * as itx from "./itx.ts";
 export * as session from "./session.ts";

--- a/apps/os/scripts/reset-config-repo.ts
+++ b/apps/os/scripts/reset-config-repo.ts
@@ -1,0 +1,117 @@
+// `pnpm cli config-repo reset --project <slug-or-id>` — overwrite a project's
+// config repo (`/repos/config`) so its tree matches the CURRENT template at
+// apps/os/config-repo-template. Run it from `apps/os`; the active Doppler
+// config supplies the OS deployment URL and its matching admin secret:
+//
+//   doppler run --config prd -- pnpm cli config-repo reset --project iterate
+//
+// It seeds the exact same file map a freshly created project on this
+// deployment would get (`projectRepoSeedFiles`, including the `iterate` SDK
+// spec swap), then commits ONE batch that writes every template file and
+// deletes anything the project still carries that the template no longer
+// ships. Config-repo commits land on main and redeploy the project worker
+// automatically, so the reset takes effect on the next build — no extra step.
+
+import process from "node:process";
+
+import { cloudflareWorkerVersionOverrideHeaders } from "@iterate-com/shared/test-support/cloudflare-worker-version-overrides";
+import { connectItx } from "iterate/node";
+
+import { projectRepoSeedFiles } from "../src/domains/repos/project-repo-seed.ts";
+import { readDevServerInfo } from "./lib/dev-server-info.ts";
+
+type ResetOptions = {
+  /** Project slug or `prj_` ID whose `/repos/config` to reset. */
+  project: string;
+  /**
+   * The `iterate` package spec to bake into the seeded `package.json`. Defaults
+   * to the deployment's own `APP_CONFIG_ITERATE_SDK_PACKAGE_SPEC` (unset on prd
+   * → the template's `@main` pkg.pr.new build), so a reset matches exactly what
+   * a new project on this deployment would install.
+   */
+  sdkSpec?: string;
+  /** Commit message. Defaults to a descriptive template-reset line. */
+  message?: string;
+  /** Print the plan (files to write / delete) without committing. */
+  dryRun?: boolean;
+  /** OS base URL. Defaults to APP_CONFIG_BASE_URL or the live local dev server. */
+  baseUrl?: string;
+};
+
+/**
+ * Reset one project's config repo to the current template. Destructive by
+ * design: the project's own edits under `/repos/config` are discarded. Use
+ * `--dry-run` first to see exactly which paths will be written and deleted.
+ */
+export async function reset(options: ResetOptions) {
+  const project = options.project?.trim();
+  if (!project) throw new Error("--project <slug-or-id> is required.");
+
+  // Match the deployment's seed exactly. On prd this env var is unset, so the
+  // template ships its canonical `iterate@main` spec; preview passes the
+  // PR-head build. An explicit `--sdk-spec` overrides both.
+  const sdkSpec =
+    options.sdkSpec?.trim() || process.env.APP_CONFIG_ITERATE_SDK_PACKAGE_SPEC?.trim() || undefined;
+  const templateFiles = projectRepoSeedFiles(sdkSpec);
+  const templatePaths = new Set(templateFiles.map((file) => file.path));
+
+  const connection = adminConnection(options);
+  using session = connectItx(connection);
+  const repo = session.projects.get(project).repo;
+
+  // Everything the project currently has under /repos/config. Anything not in
+  // the template is scheduled for deletion so the tree ends up byte-for-byte
+  // the template, not a union of old and new files.
+  const { commitOid, paths: currentPaths } = await repo.listFiles();
+  const deletes = currentPaths
+    .filter((path) => !templatePaths.has(path))
+    .map((path) => ({ path, delete: true as const }));
+  const writes = templateFiles.map(({ path, content }) => ({ path, content }));
+  const changes = [...writes, ...deletes];
+
+  const plan = {
+    project,
+    fromCommit: commitOid,
+    sdkSpec: sdkSpec ?? "(template default: iterate@main)",
+    writes: writes.length,
+    deletes: deletes.map((change) => change.path),
+  };
+
+  if (options.dryRun) {
+    process.stdout.write(`${JSON.stringify({ dryRun: true, ...plan }, null, 2)}\n`);
+    process.exit(0);
+  }
+
+  const result = await repo.commitFiles({
+    message: options.message?.trim() || "Reset config repo to template",
+    changes,
+  });
+
+  process.stdout.write(`${JSON.stringify({ ...plan, result }, null, 2)}\n`);
+
+  // The Cap'n Web WebSocket would otherwise keep the process alive.
+  process.exit(0);
+}
+
+// Same admin-secret connection every CLI itx command builds: the secret stays
+// in this Node process and authenticates to the deployment's `/api` surface.
+function adminConnection(options: { baseUrl?: string }) {
+  const baseUrl =
+    options.baseUrl?.trim() ||
+    process.env.APP_CONFIG_BASE_URL?.trim() ||
+    readDevServerInfo(new URL("..", import.meta.url).pathname, {
+      requireLive: true,
+    })?.baseUrl.replace(/\/+$/, "");
+  if (!baseUrl) {
+    throw new Error(
+      "No base URL: pass --base-url, set APP_CONFIG_BASE_URL, or start the local dev server.",
+    );
+  }
+  const secret = process.env.APP_CONFIG_ADMIN_API_SECRET?.trim() ?? "";
+  if (!secret) throw new Error("APP_CONFIG_ADMIN_API_SECRET is required.");
+  return {
+    auth: { type: "admin-secret" as const, secret },
+    baseUrl,
+    headers: cloudflareWorkerVersionOverrideHeaders(process.env),
+  };
+}


### PR DESCRIPTION
## What

Adds `pnpm cli config-repo reset --project <slug-or-id>` — a small CLI script that overwrites a project's config repo (`/repos/config`) so its tree matches the **current template** at `apps/os/config-repo-template`.

```bash
doppler run --config prd -- pnpm cli config-repo reset --project iterate
```

## How

It reuses `projectRepoSeedFiles(...)` — the exact file map (including the `iterate` SDK-spec swap) a **freshly created project on that deployment** would seed with — so a reset is just a re-seed, not a hand-rolled copy. Then it commits **one** batch that:

- writes every template file, and
- deletes anything the project still carries that the template no longer ships,

so the tree ends up byte-for-byte the template rather than a union of old and new files. Config-repo commits land on `main` and redeploy the project worker automatically, so the reset takes effect on the next build.

- Defaults the SDK spec to the deployment's own `APP_CONFIG_ITERATE_SDK_PACKAGE_SPEC` (unset on prd → the template's `iterate@main` build; preview passes its PR-head build), overridable with `--sdk-spec`.
- `--dry-run` prints the write/delete plan without committing.
- Works against any project/deployment over the standard admin-secret itx connection (same shape as `pnpm cli itx` / `session`).

## Already run against prd

Applied to the `iterate` prd project (config-repo commit `cff3cc174`): 13 files brought in line with the template, 0 stale files to delete. A follow-up run reports `noChanges: true` — idempotent, the repo now matches the template exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The command overwrites live project config repos and auto-redeploys workers, but it is admin-gated, supports dry-run, and reuses the same seed path as project creation.
> 
> **Overview**
> Adds **`pnpm cli config-repo reset --project <slug-or-id>`** so operators can force a project's `/repos/config` tree to match the current `config-repo-template`, discarding any custom edits there.
> 
> The new `reset-config-repo` script builds the file set via **`projectRepoSeedFiles`** (same as new-project seeding, including deployment **`APP_CONFIG_ITERATE_SDK_PACKAGE_SPEC`** / optional **`--sdk-spec`**), lists existing repo paths over the standard **admin-secret itx** connection, then commits one batch that **writes every template file** and **deletes paths** no longer in the template. **`--dry-run`** prints the write/delete plan as JSON without committing; successful commits trigger the usual config-repo redeploy on the next build.
> 
> `cli.ts` re-exports the module as **`configRepo`** so trpc-cli exposes the `config-repo reset` subcommand alongside existing `itx` / `session` tooling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f1093af12a50e4a2d8532752e6b257e6743302a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| CI & scripts | +118 -0 | +67 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+118 -0** | **+67 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between a61f8c8 and 6f1093a, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-22T06:13:03.100Z",
      "headSha": "6f1093af12a50e4a2d8532752e6b257e6743302a",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/342909323738953",
      "shortSha": "6f1093a",
      "cleanupDurationMs": 11042,
      "deployDurationMs": 131667,
      "deployedWorkerName": "os-preview-8",
      "deployedWorkerVersion": "a77ba9b3-b15d-44ea-a719-9f3ada443e9c",
      "testDurationMs": 130147,
      "testRetries": "1 retried: catalogue example \"dynamic-worker-stateful\" runs identically across runtimes (vitest x1) — example \"dynamic-worker-stateful\" failed in the project-worker runtime: Unable to deserialize cloned data due to invalid or unsupported version.",
      "workerSizeKib": 17150.31,
      "workerGzipKib": 4611.29,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 4622.9
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-22T06:12:54.777Z",
      "headSha": "6f1093af12a50e4a2d8532752e6b257e6743302a",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/342909323738953",
      "shortSha": "6f1093a",
      "cleanupDurationMs": 2716,
      "deployDurationMs": 20513,
      "deployedWorkerName": "auth-preview-8",
      "deployedWorkerVersion": "aaa6f5e7-dada-4c6e-bb14-469a57588afd",
      "testDurationMs": 10199,
      "testRetries": null,
      "workerSizeKib": 3965.97,
      "workerGzipKib": 811.35,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-22T06:12:52.655Z",
      "headSha": "6f1093af12a50e4a2d8532752e6b257e6743302a",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/342909323738953",
      "shortSha": "6f1093a",
      "cleanupDurationMs": 591,
      "deployDurationMs": 5744,
      "deployedWorkerName": "dummy-petshop-preview-8",
      "deployedWorkerVersion": "1c27352d-da4a-4a98-9bf6-0991c403f00c",
      "testDurationMs": 6366,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `6f1093a` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 811.4 KiB | 20.5s | 10.2s |  | 2.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/342909323738953) | 2026-07-22T06:12:54.777Z | Preview app released. |
| Dummy Petshop | released | `6f1093a` | [https://dummy-petshop.iterate-preview-8.com](https://dummy-petshop.iterate-preview-8.com) | 198.3 KiB | 5.7s | 6.4s |  | 591ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/342909323738953) | 2026-07-22T06:12:52.655Z | Preview app released. |
| OS | released | `6f1093a` | [https://os.iterate-preview-8.com](https://os.iterate-preview-8.com) | 4.50 MiB (-11.6 KiB vs main) | 131.7s | 130.1s | 1 retried: catalogue example "dynamic-worker-stateful" runs identically across runtimes (vitest x1) — example "dynamic-worker-stateful" failed in the project-worker runtime: Unable to deserialize cloned data due to invalid or unsupported version. | 11.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/342909323738953) | 2026-07-22T06:13:03.100Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->