### PR TITLE
Avoid reloading the repo route for IDE view changes

### DIFF
--- a/apps/os/src/routes/_app/projects/$projectSlug/repos/$.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/repos/$.tsx
@@ -34,6 +34,10 @@ export const Route = createFileRoute("/_app/projects/$projectSlug/repos/$")({
       project: context.project,
       streamBreadcrumb: streamBreadcrumb(context.project, repoPathFromSplat(params._splat)),
     }),
+  // The loader depends on the project and repo path, never the IDE's URL-owned
+  // view state. Keep Code/Preview and sidebar search-param changes synchronous
+  // instead of re-running the project breadcrumb server function.
+  shouldReload: false,
   component: ProjectRepoDetailContent,
 });
 

--- a/specs/repo-ide-svg-index-preview.spec.ts
+++ b/specs/repo-ide-svg-index-preview.spec.ts
@@ -1,3 +1,4 @@
+import { expect } from "@playwright/test";
 import { connectAdminItx } from "./test-support/forged-session.ts";
 import { test } from "./test-support/test.ts";
 import { openRepoTreeFile } from "./test-support/repo-tree.ts";
@@ -38,8 +39,14 @@ test("toggle an svg file between Code and its sandboxed Preview", async ({
   // Preview renders the svg in the sandboxed iframe (same srcdoc lane as html).
   await page.getByRole("tab", { name: "Preview" }).click({ timeout: 10_000 });
   const preview = page.locator('iframe[title="HTML preview"]');
-  await preview.waitFor();
-  await preview.and(page.locator('[srcdoc*="<circle"]')).waitFor();
+  // The tab changes URL-owned view state through a React transition while the
+  // usable Code pane remains on screen. There is intentionally no loading
+  // spinner, so assert the bounded eventual render rather than treating the
+  // transition as a missing product loading state.
+  // oxlint-disable-next-line iterate/spec-restricted-syntax -- React retains the usable Code pane during this search-state transition, so there is intentionally no spinner for locator.waitFor to follow.
+  await expect(preview).toBeVisible();
+  // oxlint-disable-next-line iterate/spec-restricted-syntax -- same bounded search-state transition; this assertion also proves the rendered iframe contains the SVG source.
+  await expect(preview).toHaveAttribute("srcdoc", /<circle/);
 });
 
 test("preview a staged snapshot from the readonly Index view", async ({


### PR DESCRIPTION
## Summary

- stop the repo IDE route loader from re-running for URL-owned view-state changes such as Code/Preview and sidebar toggles
- use a bounded Playwright web-first assertion for the retained-content React transition
- keep the existing behavioral coverage: the SVG iframe must become visible and its `srcdoc` must contain the SVG source

## Why

The first strict preview flakeathon run was rejected because `repo-ide-svg-index-preview.spec.ts` passed only on retry. Its trace showed:

1. the Preview click updated the browser URL to `preview=true`
2. TanStack re-ran the route breadcrumb project server function even though that loader uses only the project and repo path
3. React retained the usable Code pane during the transition, so no spinner was present
4. middlewright correctly took its no-spinner fail-fast path before the iframe rendered

`shouldReload: false` is appropriate for this route because TanStack match identity includes the interpolated path. A project or repo-path navigation creates a new pending match and still runs the loader; only same-path search-state changes reuse its existing data.

No test is skipped or quarantined by this PR.

## Evidence

- Historical PostHog test telemetry: the exact SVG toggle had one retry across roughly 56 executions; the HTML and Markdown siblings had none
- Original strict run: [Depot workflow](https://depot.dev/orgs/0p91s0lz49/workflows/2jnlpjpnpz), rejected at run 1 with one absorbed retry
- Original trace: the click started an unnecessary `_serverFn` request after the URL changed; that request was then aborted
- PR preview: [Depot workflow](https://depot.dev/orgs/0p91s0lz49/workflows/lxqr26fpnt) passed in 4m27s
  - OS e2e passed in 135.9s
  - Playwright passed 63/63 in 129s with zero retries
  - the exact SVG toggle passed first attempt in 20.2s; its staged-index sibling passed first attempt in 18.6s
- Retry-disabled pressure test against the deployed PR code: 20/20 passed in 55.0s with ten workers, comprising ten repetitions of both tests in the SVG/index spec
  - affected SVG transition: 10/10, zero retries
  - one 47.7s total tail was 39.5s project-fixture creation; the entire remainder of that test was 8.3s
- Earlier retry-disabled pressure test against the original failing preview also passed 20/20; the affected SVG transition is therefore 20/20 across the two pressure runs, in addition to the full-suite PR pass

## Verification

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (OS: 224 files, 2,123 passed, 6 expected failures, 1 existing skip)
- `doppler run --project os --config preview_15 -- env CI=1 pnpm spec specs/repo-ide-svg-index-preview.spec.ts --project=web --repeat-each=10 --workers=10 --retries=0` (20/20 passed against the original failing preview)
- `doppler run --project os --config preview_10 -- env CI=1 pnpm spec specs/repo-ide-svg-index-preview.spec.ts --project=web --repeat-each=10 --workers=10 --retries=0` (20/20 passed against the deployed PR code)

All CI checks are green and the sole review thread was answered and resolved.

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->