### PR TITLE
Use fixed stream:append PostHog event for durable stream feed

### DIFF
--- a/apps/os/src/domains/integrations/posthog.test.ts
+++ b/apps/os/src/domains/integrations/posthog.test.ts
@@ -8,7 +8,7 @@ import {
   posthogSubscriptionEvent,
 } from "./posthog.ts";
 
-const posthogEventName = (event: StreamEvent) => `append:${event.type}`;
+const POSTHOG_STREAM_APPEND_EVENT = "stream:append";
 const POSTHOG_SUBSCRIPTION_KEY = "iterate-platform-posthog";
 const jsonBytes = (value: unknown) => new TextEncoder().encode(JSON.stringify(value)).byteLength;
 
@@ -122,7 +122,7 @@ describe("first-party PostHog stream integration", () => {
     expect(requests[0]!.batch).toHaveLength(1);
     const occurrence = requests[0]!.batch[0]!;
     expect(occurrence).toMatchObject({
-      event: posthogEventName(durable),
+      event: POSTHOG_STREAM_APPEND_EVENT,
     });
     expect(occurrence.properties).toEqual({
       $geoip_disable: true,
@@ -163,7 +163,7 @@ describe("first-party PostHog stream integration", () => {
     expect(mixedFetch).toHaveBeenCalledOnce();
     expect(mixed[0]!.batch).toHaveLength(1);
     expect(mixed[0]!.batch[0]).toMatchObject({
-      event: posthogEventName(durable),
+      event: POSTHOG_STREAM_APPEND_EVENT,
       properties: {
         stream_event: durable,
       },
@@ -193,7 +193,7 @@ describe("first-party PostHog stream integration", () => {
 
     const occurrence = requests[0]!.batch[0]!;
     const properties = occurrence.properties as Record<string, unknown>;
-    expect(occurrence.event).toBe(posthogEventName(oversized));
+    expect(occurrence.event).toBe(POSTHOG_STREAM_APPEND_EVENT);
     expect(properties).toMatchObject({
       stream_event_original_json_bytes: jsonBytes(oversized),
       stream_event_truncated: true,
@@ -255,7 +255,7 @@ describe("first-party PostHog stream integration", () => {
     });
     const capturedBirth = requests[0]!.batch[2]!;
     expect(capturedBirth).toMatchObject({
-      event: posthogEventName(created),
+      event: POSTHOG_STREAM_APPEND_EVENT,
       properties: {
         $groups: { project: "prj_123" },
       },
@@ -289,7 +289,7 @@ describe("first-party PostHog stream integration", () => {
     expect(requests[0]!.batch).toHaveLength(1);
     const capturedBirth = requests[0]!.batch[0]!;
     expect(capturedBirth).toMatchObject({
-      event: posthogEventName(created),
+      event: POSTHOG_STREAM_APPEND_EVENT,
     });
     expect(JSON.stringify((capturedBirth.properties as Record<string, unknown>).stream_event)).toBe(
       JSON.stringify(created),

--- a/apps/os/src/domains/integrations/posthog.ts
+++ b/apps/os/src/domains/integrations/posthog.ts
@@ -170,7 +170,11 @@ function posthogEvents(args: {
       offset: event.offset,
     });
     return {
-      event: `append:${event.type}`,
+      // One fixed PostHog event name for every durable stream append. The
+      // committed stream type stays on `stream_event_type` (and inside
+      // `stream_event`) so analytics break down by type without exploding
+      // PostHog's event catalogue.
+      event: "stream:append",
       properties: {
         $geoip_disable: true,
         $groups: groups,
@@ -237,7 +241,7 @@ export async function capturePosthogStreamEventBatch(
     // keeping it observable prevents a future regression from appearing as
     // unexplained time in the parent Stream.append invocation.
     const events = posthogEvents(args);
-    const durableCount = events.filter((event) => event.event.startsWith("append:")).length;
+    const durableCount = events.filter((event) => event.event === "stream:append").length;
     span.setAttribute("iterate.stream.durable_event_count", durableCount);
     // An all-ephemeral delivery (or one that yields no PostHog rows) is a
     // successful no-op — do not fail the subscriber or call the capture API.

--- a/docs/posthog-stream-cost-investigation-2026-07-18.md
+++ b/docs/posthog-stream-cost-investigation-2026-07-18.md
@@ -267,9 +267,10 @@ The practical split is therefore:
 - PostHog for curated product analytics, browser identity, organization/project
   Group Analytics in the browser, and project Group Analytics for durable
   stream activity.
-- Grouped `append:<type>` events while their product value justifies the full
+- Grouped `stream:append` events while their product value justifies the full
   base, identified-event, and Group Analytics cost. Use the native project
-  group for project slicing; type and path are promoted event properties.
+  group for project slicing; type and path are promoted event properties
+  (`stream_event_type`, `stream_path`) rather than encoded into the event name.
 - R2/Iceberg as the better future home if exact long-retention raw history is
   required independently of PostHog.
 
@@ -340,7 +341,8 @@ The enabled staging-only PostHog `Drop Events` transformation is:
 
 - ID: `019f741a-2dd8-0000-61e9-73abda6505fe`
 - Name: `Emergency: drop preview stream events`
-- Filter: `event = 'stream:append' OR event LIKE 'append:%'`
+- Filter: `event = 'stream:append' OR event LIKE 'append:%'` (legacy dual
+  match; production capture is now only `stream:append`)
 - Execution order: `0`
 - Function: `return null`
 
@@ -362,7 +364,7 @@ never modified.
    and traces, not paid organization analytics. Ordinary browser analytics can
    remain separated in the existing development/staging projects.
 3. **Create daily event-volume alerts per PostHog project.** Alert on both total
-   events and `append:%`, with breakdowns by native project group slug,
+   events and `stream:append`, with breakdowns by native project group slug,
    `stream_path`, and `stream_event_type`. A production warning at 50,000/day
    and intervention at 60,000/day leaves headroom below $20/day at the highest
    first-paid combined marginal rates. Non-production stream volume should be

--- a/docs/posthog.md
+++ b/docs/posthog.md
@@ -49,13 +49,16 @@ synthetic projects at CI scale and acknowledge the durable subscription
 without sending those facts to PostHog. Ephemeral events are excluded in both
 the subscription and capture paths.
 
-Every production row is named `append:<type>` and contains the complete
-committed `StreamEvent` under `stream_event`. The only custom properties beside
-that raw event are `stream_event_type`, `stream_path`,
-`stream_event_truncated`, and `stream_event_original_json_bytes`. Nested raw
-fields remain available in HogQL; type and path are promoted because they are
-the common UI filters and breakdowns. The only payload reduction is
-deterministic JSON truncation above 100 KiB.
+Every production row is named `stream:append` and contains the complete
+committed `StreamEvent` under `stream_event`. The committed stream type is
+**not** part of the PostHog event name — it lives on `stream_event_type` (and
+inside the raw event) so the catalogue stays one event while queries still
+filter and break down by type. The only other custom properties beside the raw
+event are `stream_path`, `stream_event_truncated`, and
+`stream_event_original_json_bytes`. Nested raw fields remain available in
+HogQL; type and path are promoted because they are the common UI filters and
+breakdowns. The only payload reduction is deterministic JSON truncation above
+100 KiB.
 
 Machine events do not pretend to have a human actor. They use one stable,
 namespaced distinct ID per deployment/project and carry

--- a/tasks/posthog-observability-gold-path.md
+++ b/tasks/posthog-observability-gold-path.md
@@ -239,7 +239,9 @@ this OS-only subscription.
 
 “All events” means one PostHog occurrence for every non-ephemeral committed row
 still owned by the stream, without a type selector, sampling, success/error
-filter, or payload allowlist. Its event name is `append:<type>`.
+filter, or payload allowlist. Its event name is always `stream:append`; the
+committed stream type is indexed on `stream_event_type` (and nested under
+`stream_event`), not encoded into the PostHog event name.
 The complete committed event is sent under `properties.stream_event`,
 including payload, metadata, source/cross-post provenance, idempotency key,
 ephemerality, offset, commit time, type, and raw path. It remains byte-for-byte
@@ -464,7 +466,7 @@ alarm actions. Possible later operation adapters are:
 - [ ] Only public-batch HTTP acceptance gates the durable cursor; transport
       failures eventually park, and the proof checks PostHog's asynchronous
       ingestion-warning surface without claiming exactly-once indexing.
-- [ ] Each `append:<type>` occurrence contains the complete committed event
+- [ ] Each `stream:append` occurrence contains the complete committed event
       through 100 KiB, with type and path promoted for ordinary UI slicing.
       Larger JSON is visibly and deterministically chopped, with original byte
       size and truncation indexed; no event-field allowlist or sampling exists.


### PR DESCRIPTION
## Summary

- Durable stream export no longer names PostHog events `append:<type>`. Every production durable row is **`stream:append`**.
- The committed stream type stays on **`stream_event_type`** (and inside `stream_event`) so queries filter/break down by type without exploding PostHog’s event catalogue.
- Docs updated (`docs/posthog.md`, gold-path task, cost investigation notes).
- PostHog dashboards already updated out-of-band:
  - [Stream Events — Production](https://eu.posthog.com/project/115112/dashboard/829123) → `stream:append` only
  - [Agent LLM input-token cache](https://eu.posthog.com/project/115112/dashboard/840045) → `stream:append` + `stream_event_type = events.iterate.com/agent/token-usage-reported`

## After merge

Hide/delete legacy `append:*` historical events in PostHog (PostHog has limited per-event-name deletion; plan is hide event definitions + drop residual capture if any).

## Test plan

- [x] Unit tests for `capturePosthogStreamEventBatch` (`apps/os/src/domains/integrations/posthog.test.ts`)
- [ ] CI green
- [ ] After production deploy: confirm new rows land as `stream:append` with `stream_event_type` populated
- [ ] After deploy + merge confirmation: clean up old `append:*` event definitions / residual data

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production PostHog event naming and dashboard queries; payloads and grouping are unchanged, but operators must rely on `stream_event_type` until legacy `append:*` data is cleaned up.
> 
> **Overview**
> Durable stream export no longer creates a separate PostHog event name per stream type (`append:<type>`). **Every** non-ephemeral production row is captured as **`stream:append`**, with the committed type on **`stream_event_type`** (and inside `stream_event`) so HogQL and dashboards can still filter and break down by type without growing PostHog’s event catalogue.
> 
> In `posthog.ts`, durable-count telemetry now keys off `event === "stream:append"` instead of names prefixed with `append:`. Unit tests and docs (`posthog.md`, the gold-path task, and the stream cost investigation) are aligned with the new naming; the staging drop filter still matches legacy `append:%` during transition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be266f62532b05f0c1b37d615b9237e83b5b89cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +6 -2 | +2 -2 🟩⬜⬜⬜⬜ |
| Tests | +6 -6 | +6 -6 🟩🟥⬜⬜⬜ |
| Docs | +20 -13 | +20 -13 🟩🟩🟩🟥🟥 |
| **Total** | **+32 -21** | **+28 -21** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 54985d7 and be266f6, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-22T10:14:57.001Z",
      "headSha": "be266f62532b05f0c1b37d615b9237e83b5b89cf",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/424214429290219",
      "shortSha": "be266f6",
      "cleanupDurationMs": 11439,
      "deployDurationMs": 119779,
      "deployedWorkerName": "os-preview-11",
      "deployedWorkerVersion": "1f5cf2e2-8a4e-4d51-9045-7bee4c35a4a9",
      "testDurationMs": 130335,
      "testRetries": "1 retried: routes seeded apps by host and serves worker-bundler browser assets (vitest x1) — internal error; reference = l551nrg2nq67qgvhqnga2ojp",
      "workerSizeKib": 17150.23,
      "workerGzipKib": 4611.31,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 4623.02
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-22T10:14:48.522Z",
      "headSha": "be266f62532b05f0c1b37d615b9237e83b5b89cf",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/424214429290219",
      "shortSha": "be266f6",
      "cleanupDurationMs": 2957,
      "deployDurationMs": 21459,
      "deployedWorkerName": "auth-preview-11",
      "deployedWorkerVersion": "b8f4bc23-e0a0-4303-8957-86b4855576c9",
      "testDurationMs": 10672,
      "testRetries": null,
      "workerSizeKib": 3965.97,
      "workerGzipKib": 811.66,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-22T10:14:46.175Z",
      "headSha": "be266f62532b05f0c1b37d615b9237e83b5b89cf",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/424214429290219",
      "shortSha": "be266f6",
      "cleanupDurationMs": 609,
      "deployDurationMs": 6341,
      "deployedWorkerName": "dummy-petshop-preview-11",
      "deployedWorkerVersion": "0fa87ee3-6a55-42c3-9f2d-af4fbc0fc106",
      "testDurationMs": 5483,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `be266f6` | [https://auth.iterate-preview-11.com](https://auth.iterate-preview-11.com) | 811.7 KiB | 21.5s | 10.7s |  | 3.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/424214429290219) | 2026-07-22T10:14:48.522Z | Preview app released. |
| Dummy Petshop | released | `be266f6` | [https://dummy-petshop.iterate-preview-11.com](https://dummy-petshop.iterate-preview-11.com) | 198.3 KiB | 6.3s | 5.5s |  | 609ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/424214429290219) | 2026-07-22T10:14:46.175Z | Preview app released. |
| OS | released | `be266f6` | [https://os.iterate-preview-11.com](https://os.iterate-preview-11.com) | 4.50 MiB (-11.7 KiB vs main) | 119.8s | 130.3s | 1 retried: routes seeded apps by host and serves worker-bundler browser assets (vitest x1) — internal error; reference = l551nrg2nq67qgvhqnga2ojp | 11.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/424214429290219) | 2026-07-22T10:14:57.001Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->