### PR TITLE
Prove post-builder preview stability

### DIFF
--- a/apps/os/e2e/vitest/itx-agents.e2e.test.ts
+++ b/apps/os/e2e/vitest/itx-agents.e2e.test.ts
@@ -768,7 +768,12 @@ test("Project worker processEventBatch receives events from every project stream
   const crossPosted = project.streams.get("/cross-posted");
   const copied = crossPosted.waitForEvent({
     eventTypes: ["events.iterate.com/test/cross-posted"],
-    timeoutMs: 30_000,
+    // A fresh commit deliberately exercises the cold project-worker build.
+    // Durable feed handoff preserves delivery, but two consecutive preview
+    // runs exceeded the old 30s client deadline before the worker cross-posted.
+    // Keep enough headroom to observe that delivery while the follow-up task
+    // reduces the cold-path tail and restores the tighter budget.
+    timeoutMs: 100_000,
   });
 
   const [sourceEvent] = await project.streams.get(sourcePath).append({

--- a/apps/os/e2e/vitest/live-capability-websocket.e2e.test.ts
+++ b/apps/os/e2e/vitest/live-capability-websocket.e2e.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "vitest";
 import WebSocket from "ws";
 import { adminSecret, buildUrl, withItxSession } from "./test-helpers.ts";
 
-// THE DESIRED BEHAVIOR (not yet implemented — see `test.fails` below): a live
+// THE DESIRED BEHAVIOR (not yet implemented — see the quarantined spec below): a live
 // capability whose `fetch(request)` upgrades WebSockets, provided over Cap'n
 // Web from this vitest process, serves a project app host end to end:
 //
@@ -17,10 +17,11 @@ import { adminSecret, buildUrl, withItxSession } from "./test-helpers.ts";
 // tunnels the socket across the Cap'n Web session as a stream pair
 // (websocket-streams.ts), but it materializes a real WebSocket at the session
 // endpoint, and the internal workerd RPC hops between there and the app
-// isolate refuse to serialize it. The passing test below pins that exact
-// boundary; the failing test is the specification. When the mesh learns to
-// carry the socket (e.g. by staying in stream-pair form until the fetch-lane
-// exit), the `test.fails` flips and this file is the to-do list.
+// isolate refuse to serialize it. The preserved specs below pin that boundary
+// and the desired behavior. Both are quarantined because the boundary probe
+// deterministically kills the shared OS isolate after catching its expected
+// error; restoration is owned by
+// tasks/quarantined-live-capability-websocket-e2e.md.
 
 /** The WebSocket surface the fork's tunnel needs on the provider side
  * (`WebSocketLike` in capnweb's websocket-streams.ts). Node has no
@@ -60,7 +61,8 @@ export default class LiveWsApp extends WorkerEntrypoint<{ ITX: ItxBinding }> {
 }
 `;
 
-test("the boundary, pinned: a socket-carrying Response dies crossing the worker mesh", async () => {
+// Quarantined with tasks/quarantined-live-capability-websocket-e2e.md.
+test.skip("the boundary, pinned: a socket-carrying Response dies crossing the worker mesh", async () => {
   const marker = crypto.randomUUID().slice(0, 8);
 
   using session = withItxSession();
@@ -100,10 +102,9 @@ test("the boundary, pinned: a socket-carrying Response dies crossing the worker 
   expect(outcome).toContain('Could not serialize object of type "WebSocket"');
 });
 
-test.fails(
+// Quarantined with tasks/quarantined-live-capability-websocket-e2e.md.
+test.skip(
   "DESIRED: a live-capability fetch handler serves WebSockets at an app host",
-  // Vitest retries the deliberately failing body before it inverts the result
-  // for `fails`; retrying cannot heal this documented mesh limitation.
   { retry: 0, timeout: 150_000 },
   async () => {
     const marker = crypto.randomUUID().slice(0, 8);

--- a/apps/os/src/components/repo-ide/repo-ide.tsx
+++ b/apps/os/src/components/repo-ide/repo-ide.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useCallback } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useNavigate, useSearch } from "@tanstack/react-router";
+import { useNavigate, useRouterState, useSearch } from "@tanstack/react-router";
 import {
   FilesIcon,
   GitBranchIcon,
@@ -19,6 +19,7 @@ import {
   ResizablePanelGroup,
 } from "@iterate-com/ui/components/resizable";
 import { toast } from "@iterate-com/ui/components/sonner";
+import { Spinner } from "@iterate-com/ui/components/spinner";
 import { useItx, useItxQuery } from "iterate/sdk/itx/react";
 import { isBinaryRepoPath } from "./repo-file-kinds.ts";
 import { localFileToBase64, pickLocalFile } from "./local-file.ts";
@@ -46,6 +47,7 @@ import {
 export function RepoIde({ projectId, repoPath }: { projectId: string; repoPath: string }) {
   const itx = useItx();
   const queryClient = useQueryClient();
+  const routePending = useRouterState({ select: (state) => state.isLoading });
   const files = useItxQuery({
     key: ["repo-files", projectId, repoPath],
     query: (itx) => itx.repos.get(repoPath).listFiles(),
@@ -220,7 +222,17 @@ export function RepoIde({ projectId, repoPath }: { projectId: string; repoPath: 
   });
 
   return (
-    <div className="flex min-h-0 min-w-0 flex-1 flex-row">
+    <div className="relative flex min-h-0 min-w-0 flex-1 flex-row">
+      {routePending ? (
+        <div
+          className="pointer-events-none absolute top-2 right-2 z-20 flex items-center gap-1.5 rounded border bg-background/95 px-2 py-1 text-xs text-muted-foreground shadow-sm"
+          data-spinner="true"
+          role="status"
+        >
+          <Spinner className="size-3.5" />
+          Updating view...
+        </div>
+      ) : null}
       {/* vscode-style activity strip: Files / Source control / History / GitHub. */}
       <div className="flex shrink-0 flex-col items-center gap-1 border-r px-1 py-2">
         <Button

--- a/docs/ci-preview-performance.md
+++ b/docs/ci-preview-performance.md
@@ -115,6 +115,10 @@ serially because they intentionally share one warm container.
 - `[preview:os] lane start/finish` lines show the four overlapping OS lanes.
 - The managed preview block in the PR body records per-app deploy duration,
   test duration, and consumed retries.
+- The reporting tail remains part of the end-to-end budget. Test events are
+  packed into size-bounded PostHog batches (5 MB of encoded events, below the
+  20 MB request limit), so telemetry volume does not turn into one serial HTTP
+  round trip per 100 events.
 
 Use at least three unchanged warm-slot runs when changing concurrency. A single
 green run proves neither the tail nor the retry rate. Classify every retry and

--- a/docs/preview-e2e-flake-hunt.md
+++ b/docs/preview-e2e-flake-hunt.md
@@ -81,10 +81,36 @@ Round-8 run ledger:
 | Proof                    | Revision                                   | Accepted runs | Retries | Outcome                                     |
 | ------------------------ | ------------------------------------------ | ------------: | ------: | ------------------------------------------- |
 | Pre-round normal preview | `a0380f8d078ddab6a825f9a070b2a8f433d5e7e4` |          0/25 |       1 | Passed in 5m20s; cross-project stream retry |
+| Round-8 marathon 1       | `e301520145a6259a743a3e300366a0a53689a009` |          0/25 |       2 | Functional pass; rejected at 311s           |
 
-The dedicated round-8 PR dispatches the canonical Depot workflow for every
-attempt. Its immutable head, workflow IDs, timings, and retry counts will be
-recorded here without replacing normal preview CI with a custom runner.
+The first round-8 attempt was [Depot run
+`3jp43c0dbg`](https://depot.dev/orgs/0p91s0lz49/workflows/vxd3v2n769?job=xjm4379s33&attempt=lp5zq2dfp4).
+Every test eventually passed, but the proof stopped because the workflow took
+311 seconds and absorbed two retries. OS deployed in 101.7 seconds and its e2e
+lane took 152.6 seconds. Vitest passed 48 files, with 2 skipped, in 86.15
+seconds; Playwright passed 63 cases in 146 seconds.
+
+The project-worker cross-post case again exhausted its 30-second stream wait
+before passing on retry, reaching 62.79 seconds across both attempts. This
+second consecutive occurrence establishes a cold-build delivery tail rather
+than a one-off test failure. The test still exercises a fresh worker build and
+is not quarantined; its public delivery budget is temporarily 100 seconds, and
+`tasks/reduce-project-worker-cross-post-tail.md` tracks instrumentation,
+latency reduction, and restoration of the tighter budget.
+
+The other retry was the markdown-preview Playwright spec. The network trace
+showed the parent project route's identity `beforeLoad` taking 1.79 seconds
+after the Preview search-param navigation. The test selected Code while that
+first transition was still settling; `.cm-content` remained absent for roughly
+1.3 seconds, then the editor was fully rendered in the failure screenshot
+about 100 milliseconds after the action deadline. The IDE now renders a
+visible, `data-spinner`-marked status while TanStack Router is loading. This
+exposes the real product wait and lets the normal spinner-aware action deadline
+cover it; the substantial markdown editing and sanitization spec remains
+active.
+
+This head therefore contributes zero accepted runs. The next immutable head
+starts a new 0/25 streak through the same canonical Depot workflow.
 
 ## Round 7 (2026-07-21, post-#2226 and #2227)
 

--- a/docs/preview-e2e-flake-hunt.md
+++ b/docs/preview-e2e-flake-hunt.md
@@ -82,6 +82,7 @@ Round-8 run ledger:
 | ------------------------ | ------------------------------------------ | ------------: | ------: | ------------------------------------------- |
 | Pre-round normal preview | `a0380f8d078ddab6a825f9a070b2a8f433d5e7e4` |          0/25 |       1 | Passed in 5m20s; cross-project stream retry |
 | Round-8 marathon 1       | `e301520145a6259a743a3e300366a0a53689a009` |          0/25 |       2 | Functional pass; rejected at 311s           |
+| Round-8 marathon 2       | `c2a695fac7279da1b3b9bb64512a2d08d20aa576` |          0/25 |       0 | Clean pass; rejected at 311s                |
 
 The first round-8 attempt was [Depot run
 `3jp43c0dbg`](https://depot.dev/orgs/0p91s0lz49/workflows/vxd3v2n769?job=xjm4379s33&attempt=lp5zq2dfp4).
@@ -111,6 +112,24 @@ active.
 
 This head therefore contributes zero accepted runs. The next immutable head
 starts a new 0/25 streak through the same canonical Depot workflow.
+
+The next canonical attempt on that head was [Depot run
+`w9sc1f40ds`](https://depot.dev/orgs/0p91s0lz49/workflows/s5sm8wx775?job=xl2nzs4w1s&attempt=jf9f0zg4z2).
+It was the first complete zero-retry pass in this round: all 48 runnable OS
+Vitest files and all 63 Playwright cases passed on their first attempt. OS
+deployed in 116.2 seconds and its e2e lane passed in 146.9 seconds (Vitest
+113.08 seconds; Playwright 2.3 minutes). The strict proof still rejected it
+because dispatch creation through completion took 311 seconds.
+
+Reporting accounted for the avoidable final tail: normalization produced
+6,865 PostHog events, then the uploader sent 69 fixed 100-event batches
+strictly sequentially, consuming 12.9 seconds before artifact collection.
+The uploader now packs events by encoded size, with a conservative 5 MB event
+payload budget beneath PostHog's 20 MB batch-request limit. The preceding
+5,906-event artifact packs into three requests instead of 60 while preserving
+every deterministic event UUID and the existing per-batch bounded retry. The
+next immutable head again starts at 0/25; only a canonical Depot run can prove
+the real reporting and whole-workflow reduction.
 
 ## Round 7 (2026-07-21, post-#2226 and #2227)
 

--- a/docs/preview-e2e-flake-hunt.md
+++ b/docs/preview-e2e-flake-hunt.md
@@ -83,6 +83,7 @@ Round-8 run ledger:
 | Pre-round normal preview | `a0380f8d078ddab6a825f9a070b2a8f433d5e7e4` |          0/25 |       1 | Passed in 5m20s; cross-project stream retry |
 | Round-8 marathon 1       | `e301520145a6259a743a3e300366a0a53689a009` |          0/25 |       2 | Functional pass; rejected at 311s           |
 | Round-8 marathon 2       | `c2a695fac7279da1b3b9bb64512a2d08d20aa576` |          0/25 |       0 | Clean pass; rejected at 311s                |
+| Round-8 marathon 3       | `723f73067c13fa52512593f9e2952ffc91618ef2` |          0/25 |      19 | Shared-isolate cancellation; rejected       |
 
 The first round-8 attempt was [Depot run
 `3jp43c0dbg`](https://depot.dev/orgs/0p91s0lz49/workflows/vxd3v2n769?job=xjm4379s33&attempt=lp5zq2dfp4).
@@ -128,8 +129,29 @@ The uploader now packs events by encoded size, with a conservative 5 MB event
 payload budget beneath PostHog's 20 MB batch-request limit. The preceding
 5,906-event artifact packs into three requests instead of 60 while preserving
 every deterministic event UUID and the existing per-batch bounded retry. The
-next immutable head again starts at 0/25; only a canonical Depot run can prove
-the real reporting and whole-workflow reduction.
+next canonical run, [Depot run
+`h95t4wvm5n`](https://depot.dev/orgs/0p91s0lz49/workflows/vsm4b78r2d?job=gtxq2vksbg&attempt=ppp78dt78z),
+confirmed the real upload tail fell by roughly 10 seconds. The complete check
+still took 312 seconds and absorbed 19 Vitest retries, all from one synchronized
+`Peer closed WebSocket: 1006` wave; every retry passed.
+
+Cloudflare traces identified one causal test rather than 19 independent
+flakes. The live-capability WebSocket boundary probe caught its expected
+serialization error and reported a pass, then the runtime canceled that
+session's root `GET /api` because the Worker had hung and would never generate
+a response. Three isolated apparent passes reproduced the hidden runtime
+cancellation three times out of three. Because every Vitest file correctly
+runs in parallel against the same OS deployment, that isolate cancellation
+severed unrelated sessions across otherwise-independent projects.
+
+Both cases in `live-capability-websocket.e2e.test.ts` are explicitly
+quarantined under
+`tasks/quarantined-live-capability-websocket-e2e.md`. The causal boundary case
+is deterministically runtime-fatal; the second was a `test.fails` that stopped
+on an unrelated stale-template assertion and therefore provided no active
+coverage. Ordinary live capabilities, project-app WebSockets, and all other OS
+Vitest files remain enabled. This quarantine resets the immutable head and the
+accepted streak to 0/25; only a canonical Depot run can restart it.
 
 ## Round 7 (2026-07-21, post-#2226 and #2227)
 

--- a/docs/preview-e2e-flake-hunt.md
+++ b/docs/preview-e2e-flake-hunt.md
@@ -52,6 +52,40 @@ normal telemetry; if the workstation sleeps or exits, no running test is
 misclassified and no later run is silently counted. Resume by explicitly
 starting a new proof—accepted streaks are never inferred across ledgers.
 
+## Round 8 (2026-07-22, post-#2251)
+
+This is a fresh proof from `origin/main` at
+`cd5f4a67b9df5bc05fd2e38fe5ea9eda63bd6e7b`, including the cold worker-build
+handoff from #2251 and the fixed durable-stream telemetry from #2249. It
+inherits no streak: the accepted-run counter starts at zero.
+
+The final #2251 head, `a0380f8d078ddab6a825f9a070b2a8f433d5e7e4`,
+passed its normal preview check on the first workflow attempt. The complete
+check took 5m20s. OS deployment was the critical deployment lane at 148.9s,
+while OS e2e took 133.7s: Playwright passed 63/63 tests in 2.1m and Vitest
+passed 48 files, with 2 skipped, in 78.98s. This is useful green baseline
+evidence but not an accepted marathon run because it exceeded five minutes
+and absorbed one Vitest retry.
+
+The retried case was `Project worker processEventBatch receives events from
+every project stream and can cross-post`. Its first attempt reached the
+30-second stream-wait watchdog and its retry passed, bringing the case to
+59.18s. This first occurrence is recorded rather than quarantining a
+substantial concurrency test from one observation. Any recurrence in this
+round rejects the run and triggers diagnosis; a test shown to be independently
+flaky or pathologically slow will be fixed or quarantined with a tracking task
+under the normal testing policy.
+
+Round-8 run ledger:
+
+| Proof                    | Revision                                   | Accepted runs | Retries | Outcome                                     |
+| ------------------------ | ------------------------------------------ | ------------: | ------: | ------------------------------------------- |
+| Pre-round normal preview | `a0380f8d078ddab6a825f9a070b2a8f433d5e7e4` |          0/25 |       1 | Passed in 5m20s; cross-project stream retry |
+
+The dedicated round-8 PR dispatches the canonical Depot workflow for every
+attempt. Its immutable head, workflow IDs, timings, and retry counts will be
+recorded here without replacing normal preview CI with a custom runner.
+
 ## Round 7 (2026-07-21, post-#2226 and #2227)
 
 This is a fresh proof from `origin/main` at

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -25,6 +25,17 @@ hook/body/module/import timing, Node attempts, and standalone smoke phases.
 > Its live e2e is explicitly skipped and restoration is owned by
 > [`tasks/quarantined-cloudflare-artifacts-event-delivery.md`](../tasks/quarantined-cloudflare-artifacts-event-delivery.md).
 
+> [!CAUTION]
+> **🔥 LIVE-CAPABILITY WEBSOCKET MESH E2E IS QUARANTINED.** Its boundary
+> probe caught the expected serialization failure and reported a pass, then
+> deterministically caused the Workers runtime to cancel the shared OS isolate.
+> In the fully parallel suite that severed 19 unrelated ITX sessions with
+> WebSocket code 1006. The two explicit skips cover only the known-unsupported
+> Node live-capability → internal Worker mesh WebSocket upgrade; ordinary live
+> capabilities, project-app WebSockets, and all other OS e2e coverage remain
+> active. Evidence and restoration criteria live in
+> [`tasks/quarantined-live-capability-websocket-e2e.md`](../tasks/quarantined-live-capability-websocket-e2e.md).
+
 ## Philosophy
 
 Six principles carry this system. They are conscious design — most trace

--- a/scripts/ci/posthog-events.test.ts
+++ b/scripts/ci/posthog-events.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "vitest";
-import { systemEvent } from "./posthog-events.ts";
+import { postHogEventBatches, systemEvent, type PostHogEvent } from "./posthog-events.ts";
 
 it("uses a stable top-level PostHog UUID for retry and replay deduplication", () => {
   const first = systemEvent("ci test finished", "stable-source-occurrence", "ci-test:1", {});
@@ -13,3 +13,39 @@ it("uses a stable top-level PostHog UUID for retry and replay deduplication", ()
   );
   expect(first.properties.$insert_id).toBe("stable-source-occurrence");
 });
+
+it("packs capture batches by encoded payload size", () => {
+  const events = [
+    eventWithPayload("a", "1234"),
+    eventWithPayload("b", "5678"),
+    eventWithPayload("c", "9"),
+  ];
+  const oneEventBytes = Buffer.byteLength(JSON.stringify(events[0]));
+
+  expect(postHogEventBatches(events, oneEventBytes * 2 + 1)).toEqual([
+    [events[0], events[1]],
+    [events[2]],
+  ]);
+});
+
+it("keeps an individually oversized event intact for an explicit API failure", () => {
+  const event = eventWithPayload("oversized", "1234567890");
+  expect(postHogEventBatches([event], 1)).toEqual([[event]]);
+});
+
+it.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1])(
+  "rejects an invalid capture batch byte budget (%s)",
+  (budget) => {
+    expect(() => postHogEventBatches([], budget)).toThrow(
+      "PostHog batch event budget must be a positive safe integer",
+    );
+  },
+);
+
+function eventWithPayload(id: string, payload: string): PostHogEvent {
+  return {
+    event: "ci test finished",
+    uuid: id,
+    properties: { distinct_id: `ci-test:${id}`, payload },
+  };
+}

--- a/scripts/ci/posthog-events.ts
+++ b/scripts/ci/posthog-events.ts
@@ -7,6 +7,12 @@ export type PostHogEvent = {
   properties: Record<string, unknown>;
 };
 
+// PostHog accepts batch request bodies up to 20 MB. Keep our event payload at
+// one quarter of that ceiling so the API key/envelope and future event-shape
+// growth retain generous headroom, while avoiding one HTTP round trip per 100
+// test events (the preview suite currently emits roughly 7,000 per run).
+const POSTHOG_BATCH_EVENT_BUDGET_BYTES = 5_000_000;
+
 export function readPostHogConfig(environment = process.env): { apiKey: string; host: string } {
   const raw = environment.APP_CONFIG_POSTHOG?.trim();
   if (!raw) throw new Error("APP_CONFIG_POSTHOG is required for CI telemetry");
@@ -23,8 +29,7 @@ export function readPostHogConfig(environment = process.env): { apiKey: string; 
 
 /** Delivers deterministic system events. Callers supply stable identities for backfill safety. */
 export async function sendPostHogEvents(events: PostHogEvent[], config = readPostHogConfig()) {
-  for (let offset = 0; offset < events.length; offset += 100) {
-    const batch = events.slice(offset, offset + 100);
+  for (const batch of postHogEventBatches(events)) {
     let lastError: unknown;
     for (let attempt = 0; attempt < 3; attempt += 1) {
       try {
@@ -45,6 +50,32 @@ export async function sendPostHogEvents(events: PostHogEvent[], config = readPos
     }
     if (lastError) throw new Error("PostHog CI telemetry delivery failed", { cause: lastError });
   }
+}
+
+export function postHogEventBatches(
+  events: readonly PostHogEvent[],
+  eventBudgetBytes = POSTHOG_BATCH_EVENT_BUDGET_BYTES,
+): PostHogEvent[][] {
+  if (!Number.isSafeInteger(eventBudgetBytes) || eventBudgetBytes <= 0) {
+    throw new TypeError("PostHog batch event budget must be a positive safe integer");
+  }
+
+  const batches: PostHogEvent[][] = [];
+  let batch: PostHogEvent[] = [];
+  let batchBytes = 0;
+  for (const event of events) {
+    const eventBytes = Buffer.byteLength(JSON.stringify(event));
+    const separatorBytes = batch.length === 0 ? 0 : 1;
+    if (batch.length > 0 && batchBytes + separatorBytes + eventBytes > eventBudgetBytes) {
+      batches.push(batch);
+      batch = [];
+      batchBytes = 0;
+    }
+    batch.push(event);
+    batchBytes += (batch.length === 1 ? 0 : 1) + eventBytes;
+  }
+  if (batch.length > 0) batches.push(batch);
+  return batches;
 }
 
 export function systemEvent(

--- a/tasks/quarantined-live-capability-websocket-e2e.md
+++ b/tasks/quarantined-live-capability-websocket-e2e.md
@@ -1,0 +1,74 @@
+---
+state: todo
+priority: high
+size: large
+tags: [ci, e2e, websocket, capnweb, cloudflare, quarantine]
+---
+
+# Restore the live-capability WebSocket e2e
+
+The two live-capability WebSocket cases were quarantined on 2026-07-22 while
+landing PR #2253. The passing boundary probe catches the known
+`Could not serialize object of type "WebSocket"` failure, but the damaged
+Cap'n Web session then causes the Cloudflare Workers runtime to cancel the
+shared OS isolate. That turns one apparent pass into a synchronized wave of
+unrelated `Peer closed WebSocket: 1006` retries across the fully parallel
+Vitest suite.
+
+## Evidence
+
+- Canonical Depot run
+  [`h95t4wvm5n`](https://depot.dev/orgs/0p91s0lz49/workflows/vsm4b78r2d?job=gtxq2vksbg&attempt=ppp78dt78z)
+  passed functionally in 312 seconds but absorbed 19 Vitest retries. Every
+  first attempt started in the same 277-millisecond launch wave and failed
+  because its OS WebSocket closed with code 1006; every retry passed.
+- Cloudflare account `376ef7ed81b0573f93524de763666c15`, service
+  `os-preview-16`, version `84f6e838-5bc1-47f4-9f60-0ae1476da3fa`, trace
+  `d160e356f5fbb1c964364b552d9bd028` identifies the causal session. It created
+  `live-ws-pin-6baafa0d`, caught the expected live-capability `Function.call`
+  error at `2026-07-22T11:24:05.339Z`, then the runtime canceled the root
+  `GET /api` span 110 milliseconds later because the Worker had hung and
+  would never generate a response.
+- Three isolated invocations all appeared green in 9–10 seconds with no test
+  retry, but all three emitted the same hidden runtime cancellation. Their
+  unique projects were `live-ws-pin-94a63f00`, `live-ws-pin-41239ac2`, and
+  `live-ws-pin-ba08c636`; the cancellations landed at 11:39:53.756Z,
+  11:40:04.743Z, and 11:40:15.211Z respectively.
+- The `DESIRED` case was a `test.fails`, so any exception counted as success.
+  An isolated invocation stopped at its stale router-template anchor before
+  attempting the WebSocket dispatch. It therefore provided no active coverage
+  while still provisioning a complete project.
+
+## Quarantined behavior
+
+- CI no longer exercises a Node-provided live capability returning an
+  upgrading WebSocket `Response` through the internal Worker mesh.
+- Ordinary live capabilities, HTTP `Request`/`Response` capability dispatch,
+  project-app WebSockets, Cap'n Web transport coverage, and every other OS
+  Vitest file remain active and fully parallel.
+- Both preserved cases are explicit `test.skip` calls in
+  `apps/os/e2e/vitest/live-capability-websocket.e2e.test.ts`; no discovery or
+  title filter hides them.
+
+## Work
+
+- Minimize the failure in the Cap'n Web WebSocket-stream bridge and identify
+  which serialized socket resource, reverse RPC target, or disposal promise
+  remains live after workerd rejects the internal RPC hop.
+- Make the unsupported response fail in a bounded way that closes every
+  stream/stub and cannot cancel the serving isolate or sibling sessions.
+- Update the seeded router patch in the desired-behavior case and replace
+  `test.fails` with an assertion that can only pass for the intended outcome.
+- Implement the actual socket-carrying mesh behavior, or permanently model the
+  unsupported boundary without invoking a runtime-fatal path.
+
+## Exit criteria
+
+- The boundary case runs repeatedly against a real preview with no Worker
+  runtime cancellation, unexplained error log, leaked RPC stub, or sibling
+  WebSocket disconnect.
+- The desired case reaches the project app host and passes as an ordinary test
+  only when bidirectional frames survive the complete mesh.
+- Both explicit skips are removed.
+- At least 25 consecutive canonical, fully parallel preview runs complete with
+  zero absorbed retries and no correlated WebSocket-close wave.

--- a/tasks/reduce-project-worker-cross-post-tail.md
+++ b/tasks/reduce-project-worker-cross-post-tail.md
@@ -1,0 +1,41 @@
+---
+state: todo
+priority: high
+size: medium
+tags: [ci, e2e, performance, workers, streams]
+---
+
+# Reduce the cold project-worker cross-post delivery tail
+
+The production-shaped e2e case `Project worker processEventBatch receives
+events from every project stream and can cross-post` commits a unique worker,
+appends to a fresh child stream, and proves the project-wide worker feed can
+cross-post that event. Two consecutive preview workflows exhausted its
+30-second public stream-wait deadline before passing on the repository's one
+retry:
+
+- PR #2251's final preview: 59.18 seconds across both attempts.
+- PR #2253 Depot run `3jp43c0dbg`: 62.79 seconds across both attempts.
+
+The durable cold-build handoff preserves the event, but the combined commit,
+build, feed-delivery, and worker-start tail is too close to the former budget.
+The e2e wait is temporarily 100 seconds so this substantial coverage remains
+active without converting healthy delayed delivery into a retry.
+
+## Work
+
+- Record separate timings for repo commit, coordinator handoff, bundle cache
+  lookup or build, feed redelivery, dynamic Worker startup, cross-post append,
+  and feed acknowledgement.
+- Correlate cold and warm samples with Worker traces and the existing build and
+  stream telemetry under the normal fully parallel preview load.
+- Remove the dominant cold-path or contention latency without weakening the
+  fresh-worker and fresh-child-stream coverage.
+
+## Exit criteria
+
+- The case passes on its first attempt in at least 25 consecutive canonical
+  preview runs.
+- Its cold-path p99 delivery completes within 30 seconds with no unexplained
+  errors, stalled feeds, duplicate processing, or leaked builds.
+- Restore the public stream-wait deadline from 100 seconds to 30 seconds.


### PR DESCRIPTION
## Goal

Make the ordinary full preview deploy-plus-e2e path fast and reliable, then prove it through the same Depot CI CLI route used by pull requests. The strict evidence target is 25 consecutive full-fleet runs under five minutes with zero absorbed retries; the practical performance target remains roughly 3½ minutes.

The marathon script only dispatches `cloudflare-previews.yml` through Depot and reads its retained artifacts. It does not bypass the real runner, GitHub checks, preview lease, PostHog telemetry, test discovery, or retry policy.

## What this PR changes

- Keeps every Vitest file discoverable and running in parallel; there is no file-level serialization or hand-written shard list.
- Temporarily gives the production-shaped project-worker cross-post assertion a 100-second public wait budget while `tasks/reduce-project-worker-cross-post-tail.md` tracks reducing its cold-path tail and restoring the 30-second budget.
- Exposes TanStack Router pending state as a visible `data-spinner` overlay so Playwright waits for genuine Code/Preview navigation work instead of racing an empty editor.
- Packs CI telemetry by encoded payload size (5 MB/event batch beneath PostHog's 20 MB request limit), replacing fixed 100-event batches while preserving deterministic event IDs and bounded retries.
- Quarantines exactly two live-capability WebSocket mesh cases that are independently proven pathological, with their bodies preserved and a task-backed restoration contract.

This PR contains none of the removed sandbox-builder or AI Search implementation. It relies on current `main`'s worker-bundler architecture and the already-removed AI Search path.

## 🔥 Unrelated pathological e2e quarantined

**The two cases in `apps/os/e2e/vitest/live-capability-websocket.e2e.test.ts` are now explicit `test.skip` calls. No other newly discovered test is skipped.**

The first case looked green because it caught the expected `Could not serialize object of type "WebSocket"` error. Cloudflare then canceled its root `/api` request because the Worker had hung and would never generate a response. In the fully parallel suite that one isolate-level failure severed 19 unrelated ITX WebSockets with code 1006; all 19 passed on their one ordinary retry.

The second case was already `test.fails`. Its isolated run died at a stale router-template assertion before attempting WebSocket dispatch, yet Vitest inverted that unrelated failure into a pass. It therefore provided no active proof.

Three focused invocations of the first case produced three apparent passes and three hidden runtime cancellations. The canonical causal trace is `d160e356f5fbb1c964364b552d9bd028` on `os-preview-16`, version `84f6e838-5bc1-47f4-9f60-0ae1476da3fa`: the expected capability error landed at `2026-07-22T11:24:05.339Z`, followed 110 ms later by the runtime cancellation.

Restoration evidence, scope, work, and exit criteria are in [`tasks/quarantined-live-capability-websocket-e2e.md`](https://github.com/iterate/iterate/blob/agent/e2e-flake-athon-5/tasks/quarantined-live-capability-websocket-e2e.md). Ordinary live capabilities, HTTP capability dispatch, project-app WebSockets, Cap'n Web transport tests, and the 19 collateral tests remain enabled and parallel.

## Canonical performance evidence

### Current head — ordinary CI green

- [Depot workflow](https://depot.dev/orgs/0p91s0lz49/workflows/np8n0k9v8m?job=0pj4mkndt4&attempt=h9kk2xv283)
- complete GitHub check: **passed in 5m7s**
- OS deploy: 102.2 seconds
- OS e2e: 174.4 seconds
- Vitest: 143.94 seconds after two project-worker feed tests used their ordinary retry
- Playwright: all 63 cases passed after one subscription-state case used its ordinary retry
- absorbed retries: 3; normal CI correctly remained green
- the prior synchronized 19-test `Peer closed WebSocket: 1006` wave did not recur

This is the requested first successful full e2e proof on the final head, so the PR is mergeable. It is not a strict-marathon acceptance: 5m7s exceeds five minutes and its three retries keep the immutable-head streak at 0/25. The result moves the remaining tail away from the toxic WebSocket probe and onto project-worker feed acknowledgement plus one browser subscription-state race.

### Pre-quarantine diagnostic run

Latest completed full run before the quarantine:

- [Depot run `h95t4wvm5n`](https://depot.dev/orgs/0p91s0lz49/workflows/vsm4b78r2d?job=gtxq2vksbg&attempt=ppp78dt78z)
- functional result: green in 312 seconds; strict result: rejected for 19 absorbed retries and exceeding 300 seconds
- OS deploy: 129.8 seconds
- deployment readiness within that path: approximately 89 seconds
- OS e2e: 142 seconds
- Vitest: 75.91 seconds
- Playwright: 63 cases passed in approximately 2.2 minutes
- telemetry upload: approximately 3.6 seconds, down by roughly 10 seconds from the preceding canonical run

Vitest files already overlap, and the OS e2e phase is approximately the maximum of the Vitest and Playwright lanes rather than their sum. The final run confirms that the 19-test isolate-cancellation wave is gone. Its 102.2-second deploy plus 174.4-second OS e2e tail shows the next work belongs in deployment/readiness and the two slow project-worker feed paths—not in serializing test files.

## Retry diagnoses retained as coverage

### Cold project-worker cross-post delivery

The ITX case commits a unique worker, appends to a fresh child stream, and proves the project-wide worker feed cross-posts the event. Two previews exceeded the former 30-second public stream deadline before passing on retry. The test remains active; only its assertion budget is temporarily 100 seconds. The task requires phase-level instrumentation, cold-path p99 reduction, 25 first-attempt passes, and restoration of the tighter budget.

### Markdown Code/Preview navigation

The Playwright trace showed parent-route identity work taking 1.79 seconds while the test selected Code. CodeMirror appeared about 100 ms after the old action budget expired. The UI now reports real router pending work to users and to the existing spinner-aware Playwright budget; the substantive editing/sanitization/navigation test remains active with no timeout override.

## Local validation on head `6666be8a9337eb99317a3ad5572932a3f9a13b8b`

- `pnpm --filter @iterate-com/os test`: 225 files passed; 2,127 tests passed, 6 expected failures, 1 pre-existing unit skip
- `pnpm --filter @iterate-com/os typecheck`
- `pnpm --dir lint test -- dated-skips.test.ts`: 5 files / 23 tests passed, including the quarantine-policy check
- `pnpm exec oxlint apps/os/e2e/vitest/live-capability-websocket.e2e.test.ts`: zero warnings/errors
- `pnpm exec oxfmt --check` on the changed source/docs
- `git diff --check`

## Proof state

Head `6666be8a9337eb99317a3ad5572932a3f9a13b8b` passed the complete ordinary Depot preview once in **5m7s**, with all fleet tests green after three bounded retries. This satisfies the requested normal-CI merge gate. The separate strict streak remains **0/25** because that proof rejects retries and runs over five minutes.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect preview CI timing, quarantine two specialized e2e specs, and add a small UI loading state; PostHog batching is CI-only with unit tests, but the websocket quarantine removes active coverage until the capnweb/isolate issue is fixed.
> 
> **Overview**
> Targets **Round 8** of the 25-run preview stability proof: fixes that showed up as marathon rejections (311s wall time, absorbed retries) without weakening the main e2e coverage.
> 
> **Reporting tail:** CI PostHog upload no longer sends ~70 sequential 100-event HTTP batches. Events are packed with `postHogEventBatches` using a **5 MB** encoded payload budget (under PostHog’s 20 MB limit), cutting the reporting phase by roughly **10 seconds** on ~7k-event runs while keeping deterministic UUIDs and per-batch retries.
> 
> **Product / Playwright:** The repo IDE shows an **“Updating view…”** overlay with `data-spinner` while TanStack Router is pending, so Code/Preview navigation exposes real loading instead of a blank panel that tripped spinner-aware deadlines.
> 
> **E2e budgets & quarantine:** The cold **project-worker cross-post** stream wait is temporarily **100s** (was 30s) with `tasks/reduce-project-worker-cross-post-tail.md` tracking restoration. Both **live-capability WebSocket mesh** specs are explicit **`test.skip`** quarantines—the boundary probe passed but **canceled the shared Workers isolate**, causing a fleet-wide `Peer closed WebSocket: 1006` wave; restoration is in `tasks/quarantined-live-capability-websocket-e2e.md`. Docs record Round 8 evidence and the new testing caution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6666be8a9337eb99317a3ad5572932a3f9a13b8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| UI components | +14 -2 | +14 -2 🟩⬜⬜⬜⬜ |
| Tests | +53 -11 | +35 -4 🟩⬜⬜⬜⬜ |
| CI & scripts | +33 -2 | +26 -2 🟩⬜⬜⬜⬜ |
| Docs | +231 -0 | +198 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+331 -15** | **+273 -8** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between cd5f4a6 and 6666be8, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->