### PR TITLE
Measure preview deployment phases in CI telemetry

### DIFF
--- a/docs/ci-test-telemetry.md
+++ b/docs/ci-test-telemetry.md
@@ -176,16 +176,19 @@ dimensions, never separate event families.
 | execution           | workflow/run/attempt/job URLs, runner provider, preview slot, test project             |
 | identity            | stable artifact, test-run, logical-test, and execution IDs                             |
 
-| Event                          | Grain                                  | Evidence                                                                                                                             |
-| ------------------------------ | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `ci test run started/finished` | runner or orchestration operation      | status, wall duration, test/failure/retry/module/lane counts, incomplete-telemetry flag                                              |
-| `ci test lane finished`        | app/lane command                       | status, exit code, wall duration, collection errors and incomplete-telemetry flag                                                    |
-| `ci test finished`             | logical test                           | source location, raw state, expected outcome, total/body/hooks/schedule time, timeout, retries, heap, tags, annotations, first error |
-| `ci test attempt finished`     | concrete attempt                       | index, state, duration, schedule delay, worker, attachments, stdout/stderr bytes, error                                              |
-| `ci test phase finished`       | explicit operation or Playwright step  | nested title, category, start/duration, source, attachments, error                                                                   |
-| `ci test module finished`      | Vitest module                          | environment, prepare, collect, setup, import, queue, and execution timing                                                            |
-| `ci test import finished`      | imported module within a Vitest module | self and total import duration                                                                                                       |
-| `ci test telemetry finalized`  | one finalizer job                      | expected/observed/missing workspaces and runner sources, incomplete artifacts, runner-event count, final status                      |
+| Event                            | Grain                                  | Evidence                                                                                                                             |
+| -------------------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `ci test run started/finished`   | runner or orchestration operation      | status, wall duration, test/failure/retry/module/lane counts, incomplete-telemetry flag                                              |
+| `ci test lane finished`          | app/lane command                       | status, exit code, wall duration, collection errors and incomplete-telemetry flag                                                    |
+| `ci test finished`               | logical test                           | source location, raw state, expected outcome, total/body/hooks/schedule time, timeout, retries, heap, tags, annotations, first error |
+| `ci test attempt finished`       | concrete attempt                       | index, state, duration, schedule delay, worker, attachments, stdout/stderr bytes, error                                              |
+| `ci test phase finished`         | explicit operation or Playwright step  | nested title, category, start/duration, source, attachments, error                                                                   |
+| `ci test module finished`        | Vitest module                          | environment, prepare, collect, setup, import, queue, and execution timing                                                            |
+| `ci test import finished`        | imported module within a Vitest module | self and total import duration                                                                                                       |
+| `ci test telemetry finalized`    | one finalizer job                      | expected/observed/missing workspaces and runner sources, incomplete artifacts, runner-event count, final status                      |
+| `ci deploy run started/finished` | preview deployment operation           | status, total wall duration, preview slot, and bounded error                                                                         |
+| `ci deploy lane finished`        | one preview app deployment             | app wall duration, Worker identity, and config/command/readiness/reuse-proof timings                                                 |
+| `ci deploy phase finished`       | one measured app-deploy phase          | phase name and duration, app, slot, status, and immutable Worker identity                                                            |
 
 `attempt_detail` is `complete` when all attempts are present and
 `aggregate-only` when only the runner's aggregate retry count/duration exists.
@@ -455,8 +458,8 @@ SELECT properties.telemetry_source AS telemetry_source,
   argMax(toInt(properties.event_count), timestamp) AS event_count,
   argMax(properties.telemetry_sync_id, timestamp) AS telemetry_sync_id,
   argMax(properties.collector_head_sha, timestamp) AS collector_head_sha,
-  argMax(properties.error_name, timestamp) AS error_name,
-  argMax(properties.error_message, timestamp) AS error_message
+  nullIf(argMax(ifNull(properties.error_name, ''), timestamp), '') AS error_name,
+  nullIf(argMax(ifNull(properties.error_message, ''), timestamp), '') AS error_message
 FROM events
 WHERE event = 'ci telemetry source sync finished'
   AND timestamp >= now() - INTERVAL 7 DAY
@@ -468,6 +471,12 @@ ORDER BY telemetry_source
 Expect one fresh row each for `github-actions`, `github-reviews`, and `depot`.
 Do not trust a provider's downstream tiles when its row is missing, failed, or
 older than 30 minutes.
+
+The `ifNull` inside `argMax` is load-bearing: ClickHouse skips null aggregate
+arguments, so a plain `argMax(properties.error_message, timestamp)` can attach
+an older failure to the latest healthy row. Converting null to an empty string
+before aggregation and back afterwards makes the error fields belong to the
+same latest observation as the status.
 
 `telemetry_incomplete = true` means reporter shutdown did not finish and the
 dataset may omit test details, or an expected runner artifact is wholly absent.

--- a/packages/shared/src/test-support/ci-telemetry.ts
+++ b/packages/shared/src/test-support/ci-telemetry.ts
@@ -137,6 +137,31 @@ const TestTelemetryLane = z.object({
   collectionErrors: z.array(z.string()),
 });
 
+const DeploymentTelemetryLane = z.object({
+  app: z.string().min(1),
+  previewSlot: z.string().optional(),
+  status: z.enum(["passed", "failed"]),
+  durationMs: z.number().nonnegative(),
+  finishedAt: Timestamp.optional(),
+  configDurationMs: z.number().nonnegative().nullable().optional(),
+  commandDurationMs: z.number().nonnegative().nullable().optional(),
+  readinessDurationMs: z.number().nonnegative().nullable().optional(),
+  reuseProofDurationMs: z.number().nonnegative().nullable().optional(),
+  workerName: z.string().nullable().optional(),
+  workerVersion: z.string().nullable().optional(),
+});
+
+const DeploymentTelemetry = z.object({
+  deploymentKind: z.string().min(1),
+  status: z.enum(["passed", "failed", "skipped"]),
+  startedAt: Timestamp,
+  finishedAt: Timestamp,
+  durationMs: z.number().nonnegative(),
+  previewSlot: z.string().optional(),
+  error: TestTelemetryError.optional(),
+  lanes: z.array(DeploymentTelemetryLane),
+});
+
 /**
  * Durable, runner-independent input to the CI telemetry finalizer. Reporters
  * only write this artifact; they never know about PostHog or network delivery.
@@ -175,6 +200,8 @@ export const TestTelemetryArtifact = z.object({
     durationMs: z.number().nonnegative(),
     error: TestTelemetryError.optional(),
   }),
+  /** Optional deployment evidence recorded by an orchestration artifact. */
+  deployment: DeploymentTelemetry.optional(),
   lanes: z.array(TestTelemetryLane),
   tests: z.array(TestTelemetryRecord),
   modules: z.array(ModuleTelemetryRecord),
@@ -189,6 +216,8 @@ export type TestTelemetryAttempt = z.infer<typeof TestTelemetryAttempt>;
 export type TestTelemetryRecord = z.infer<typeof TestTelemetryRecord>;
 export type ModuleTelemetryRecord = z.infer<typeof ModuleTelemetryRecord>;
 export type TestTelemetryLane = z.infer<typeof TestTelemetryLane>;
+export type DeploymentTelemetry = z.infer<typeof DeploymentTelemetry>;
+export type DeploymentTelemetryLane = z.infer<typeof DeploymentTelemetryLane>;
 
 /** Convert an arbitrary runner/orchestrator failure into the shared JSON-safe shape. */
 export function normalizeTestTelemetryError(

--- a/scripts/ci/test-telemetry-events.ts
+++ b/scripts/ci/test-telemetry-events.ts
@@ -47,6 +47,7 @@ export function testTelemetryEvents(artifact: TestTelemetryArtifact): PostHogEve
       { status: "running" },
       artifact.run.startedAt,
     ),
+    ...deploymentTelemetryEvents(artifact),
   ];
   for (const [laneIndex, lane] of artifact.lanes.entries()) {
     events.push(
@@ -276,6 +277,103 @@ export function testTelemetryEvents(artifact: TestTelemetryArtifact): PostHogEve
         error_message: artifact.run.error?.message.slice(0, 2_000),
       },
       artifact.run.finishedAt,
+    ),
+  );
+  return events;
+}
+
+function deploymentTelemetryEvents(artifact: TestTelemetryArtifact): PostHogEvent[] {
+  const deployment = artifact.deployment;
+  if (!deployment) return [];
+
+  const distinctId = `ci-deploy:${artifact.ci.workflowRunId}:${artifact.ci.workflowRunAttempt}:${artifact.artifactId}`;
+  const common = {
+    artifact_schema_version: artifact.artifactSchemaVersion,
+    artifact_id: artifact.artifactId,
+    artifact_producer: artifact.producer,
+    deployment_kind: deployment.deploymentKind,
+    ...ciProperties(artifact),
+  };
+  const event = (
+    name: string,
+    identity: string,
+    properties: Record<string, unknown>,
+    timestamp: string,
+  ) =>
+    systemEvent(
+      name,
+      `${distinctId}:${identity}`,
+      distinctId,
+      { ...common, ...properties },
+      timestamp,
+    );
+
+  const events: PostHogEvent[] = [
+    event(
+      "ci deploy run started",
+      "run-started",
+      {
+        lane: "preview",
+        preview_slot: deployment.previewSlot,
+        status: "running",
+      },
+      deployment.startedAt,
+    ),
+  ];
+  for (const [laneIndex, lane] of deployment.lanes.entries()) {
+    const laneCommon = {
+      scope: "app",
+      app: lane.app,
+      preview_slot: lane.previewSlot ?? deployment.previewSlot,
+      status: lane.status,
+      worker_name: lane.workerName,
+      worker_version: lane.workerVersion,
+    };
+    events.push(
+      event(
+        "ci deploy lane finished",
+        `lane:${laneIndex}`,
+        {
+          ...laneCommon,
+          duration_ms: lane.durationMs,
+          config_duration_ms: lane.configDurationMs,
+          command_duration_ms: lane.commandDurationMs,
+          readiness_duration_ms: lane.readinessDurationMs,
+          reuse_proof_duration_ms: lane.reuseProofDurationMs,
+        },
+        lane.finishedAt ?? deployment.finishedAt,
+      ),
+    );
+    for (const [phaseName, durationMs] of [
+      ["config", lane.configDurationMs],
+      ["command", lane.commandDurationMs],
+      ["readiness", lane.readinessDurationMs],
+      ["reuse proof", lane.reuseProofDurationMs],
+    ] as const) {
+      if (durationMs == null) continue;
+      events.push(
+        event(
+          "ci deploy phase finished",
+          `lane:${laneIndex}:phase:${phaseName}`,
+          { ...laneCommon, phase_name: phaseName, duration_ms: durationMs },
+          lane.finishedAt ?? deployment.finishedAt,
+        ),
+      );
+    }
+  }
+  events.push(
+    event(
+      "ci deploy run finished",
+      "run-finished",
+      {
+        lane: "preview",
+        preview_slot: deployment.previewSlot,
+        status: deployment.status,
+        duration_ms: deployment.durationMs,
+        error_name: deployment.error?.name,
+        error_message: deployment.error?.message.slice(0, 2_000),
+      },
+      deployment.finishedAt,
     ),
   );
   return events;

--- a/scripts/ci/upload-test-telemetry.test.ts
+++ b/scripts/ci/upload-test-telemetry.test.ts
@@ -159,6 +159,54 @@ it("transmogrifies one runner-independent artifact into the shared PostHog event
   });
 });
 
+it("normalizes retained preview deployment evidence without reporter network I/O", () => {
+  const events = testTelemetryEvents({
+    ...artifact,
+    deployment: {
+      deploymentKind: "cloudflare-preview",
+      status: "passed",
+      startedAt: "2026-07-21T09:58:00.000Z",
+      finishedAt: "2026-07-21T10:00:00.000Z",
+      durationMs: 120_000,
+      previewSlot: "preview-3",
+      lanes: [
+        {
+          app: "os",
+          previewSlot: "preview-3",
+          status: "passed",
+          durationMs: 115_500,
+          finishedAt: "2026-07-21T09:59:58.000Z",
+          configDurationMs: 500,
+          commandDurationMs: 42_900,
+          readinessDurationMs: 72_100,
+          workerName: "os-preview-3",
+          workerVersion: "11111111-1111-4111-8111-111111111111",
+        },
+      ],
+    },
+  });
+  const deploymentEvents = events.filter(({ event }) => event.startsWith("ci deploy "));
+
+  expect(deploymentEvents.map(({ event }) => event)).toEqual([
+    "ci deploy run started",
+    "ci deploy lane finished",
+    "ci deploy phase finished",
+    "ci deploy phase finished",
+    "ci deploy phase finished",
+    "ci deploy run finished",
+  ]);
+  expect(deploymentEvents[1]).toMatchObject({
+    timestamp: "2026-07-21T09:59:58.000Z",
+    properties: {
+      app: "os",
+      command_duration_ms: 42_900,
+      readiness_duration_ms: 72_100,
+      worker_name: "os-preview-3",
+      worker_version: "11111111-1111-4111-8111-111111111111",
+    },
+  });
+});
+
 it("keeps raw and normalized JSON for replay while dry-run skips delivery", async () => {
   const root = mkdtempSync(join(tmpdir(), "test-telemetry-finalizer-"));
   writeTestTelemetryArtifact(artifact, { TEST_TELEMETRY_ARTIFACT_DIR: join(root, "raw") });

--- a/scripts/ci/upload-test-telemetry.test.ts
+++ b/scripts/ci/upload-test-telemetry.test.ts
@@ -209,7 +209,20 @@ it("normalizes retained preview deployment evidence without reporter network I/O
 
 it("keeps raw and normalized JSON for replay while dry-run skips delivery", async () => {
   const root = mkdtempSync(join(tmpdir(), "test-telemetry-finalizer-"));
-  writeTestTelemetryArtifact(artifact, { TEST_TELEMETRY_ARTIFACT_DIR: join(root, "raw") });
+  writeTestTelemetryArtifact(
+    {
+      ...artifact,
+      deployment: {
+        deploymentKind: "cloudflare-preview",
+        status: "passed",
+        startedAt: "2026-07-21T09:58:00.000Z",
+        finishedAt: "2026-07-21T10:00:00.000Z",
+        durationMs: 120_000,
+        lanes: [],
+      },
+    },
+    { TEST_TELEMETRY_ARTIFACT_DIR: join(root, "raw") },
+  );
 
   const result = await finalizeTestTelemetry({ artifactRoot: root, dryRun: true });
 
@@ -218,7 +231,7 @@ it("keeps raw and normalized JSON for replay while dry-run skips delivery", asyn
     readFileSync(join(root, "normalized", "posthog-events.json"), "utf8"),
   ) as { schemaVersion: number; events: unknown[] };
   expect(normalized.schemaVersion).toBe(2);
-  expect(normalized.events).toHaveLength(10);
+  expect(normalized.events).toHaveLength(12);
   expect(normalized.events.at(-1)).toMatchObject({
     event: "ci test telemetry finalized",
     properties: { status: "passed", telemetry_incomplete: false, runner_event_count: 9 },

--- a/scripts/ci/upload-test-telemetry.ts
+++ b/scripts/ci/upload-test-telemetry.ts
@@ -42,7 +42,10 @@ export async function finalizeTestTelemetry(options: {
   if (loaded.length === 0 && !options.cancelled) {
     throw new Error(`No test telemetry artifacts found below ${rawDirectory}`);
   }
-  const runnerEvents = loaded.flatMap(({ artifact }) => testTelemetryEvents(artifact));
+  const telemetryEvents = loaded.flatMap(({ artifact }) => testTelemetryEvents(artifact));
+  const runnerEventCount = telemetryEvents.filter(({ event }) =>
+    event.startsWith("ci test "),
+  ).length;
   const completeness = analyzeTestTelemetryCompleteness(
     loaded.map(({ artifact }) => artifact),
     options.expectedWorkspaces ?? [],
@@ -58,7 +61,7 @@ export async function finalizeTestTelemetry(options: {
     primaryArtifact,
   } = completeness;
   const events = [
-    ...runnerEvents,
+    ...telemetryEvents,
     ...(primaryArtifact
       ? [
           testTelemetryFinalizerEvent({
@@ -73,7 +76,7 @@ export async function finalizeTestTelemetry(options: {
             observedArtifactSourceCount: observedArtifactSources.length,
             observedWorkspaceCount: observedWorkspaces.length,
             primaryArtifact,
-            runnerEventCount: runnerEvents.length,
+            runnerEventCount,
           }),
         ]
       : []),

--- a/scripts/preview/e2e-telemetry.test.ts
+++ b/scripts/preview/e2e-telemetry.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, it } from "vitest";
-import type { TestTelemetryArtifact } from "@iterate-com/shared/test-support/ci-telemetry";
+import { TestTelemetryArtifact } from "@iterate-com/shared/test-support/ci-telemetry";
 import { PreviewE2eTelemetryArtifact } from "./e2e-telemetry.ts";
 
 it("stores orchestration timing separately from runner artifacts", () => {
@@ -44,6 +44,19 @@ it("stores orchestration timing separately from runner artifacts", () => {
       },
     ],
   });
+  telemetry.deployRunStarted();
+  telemetry.deployAppFinished({
+    app: "os",
+    slot: "preview-3",
+    status: "passed",
+    durationMs: 12_000,
+    configDurationMs: 500,
+    commandDurationMs: 4_000,
+    readinessDurationMs: 7_500,
+    workerName: "os-preview-3",
+    workerVersion: "11111111-1111-4111-8111-111111111111",
+  });
+  telemetry.deployRunFinished({ status: "passed", durationMs: 12_500, slot: "preview-3" });
   telemetry.appFinished({
     app: "os",
     slot: "preview_3",
@@ -56,7 +69,9 @@ it("stores orchestration timing separately from runner artifacts", () => {
   });
   telemetry.runFinished({ status: "passed", durationMs: 22_000 });
 
-  expect(telemetry.artifactForTest()).toMatchObject({
+  const completedArtifact = telemetry.artifactForTest();
+  expect(() => TestTelemetryArtifact.parse(completedArtifact)).not.toThrow();
+  expect(completedArtifact).toMatchObject({
     artifactSchemaVersion: 1,
     producer: "preview-e2e-orchestrator",
     ci: {
@@ -76,6 +91,24 @@ it("stores orchestration timing separately from runner artifacts", () => {
       },
     ],
     run: { status: "passed", durationMs: 22_000 },
+    deployment: {
+      deploymentKind: "cloudflare-preview",
+      status: "passed",
+      durationMs: 12_500,
+      previewSlot: "preview-3",
+      lanes: [
+        {
+          app: "os",
+          previewSlot: "preview-3",
+          durationMs: 12_000,
+          configDurationMs: 500,
+          commandDurationMs: 4_000,
+          readinessDurationMs: 7_500,
+          workerName: "os-preview-3",
+          workerVersion: "11111111-1111-4111-8111-111111111111",
+        },
+      ],
+    },
     tests: [],
     modules: [],
     lanes: [

--- a/scripts/preview/e2e-telemetry.test.ts
+++ b/scripts/preview/e2e-telemetry.test.ts
@@ -47,6 +47,7 @@ it("stores orchestration timing separately from runner artifacts", () => {
   telemetry.deployRunStarted();
   telemetry.deployAppFinished({
     app: "os",
+    finishedAt: "2026-07-21T12:00:12.000Z",
     slot: "preview-3",
     status: "passed",
     durationMs: 12_000,
@@ -99,6 +100,7 @@ it("stores orchestration timing separately from runner artifacts", () => {
       lanes: [
         {
           app: "os",
+          finishedAt: "2026-07-21T12:00:12.000Z",
           previewSlot: "preview-3",
           durationMs: 12_000,
           configDurationMs: 500,
@@ -134,6 +136,7 @@ it("retains the preview slot when deployment fails after an app lane completes",
   telemetry.deployRunStarted();
   telemetry.deployAppFinished({
     app: "os",
+    finishedAt: "2026-07-21T12:00:12.000Z",
     slot: "preview-3",
     status: "failed",
     durationMs: 12_000,

--- a/scripts/preview/e2e-telemetry.test.ts
+++ b/scripts/preview/e2e-telemetry.test.ts
@@ -121,3 +121,38 @@ it("stores orchestration timing separately from runner artifacts", () => {
   });
   rmSync(artifactDirectory, { recursive: true });
 });
+
+it("retains the preview slot when deployment fails after an app lane completes", () => {
+  const artifactDirectory = mkdtempSync(join(tmpdir(), "preview-e2e-telemetry-"));
+  const telemetry = new PreviewE2eTelemetryArtifact({
+    environment: { TEST_TELEMETRY_ARTIFACT_DIR: artifactDirectory },
+    headSha: "abcdef0123456789",
+    operation: "deploy",
+    pullRequestNumber: 42,
+    runUrl: null,
+  });
+  telemetry.deployRunStarted();
+  telemetry.deployAppFinished({
+    app: "os",
+    slot: "preview-3",
+    status: "failed",
+    durationMs: 12_000,
+  });
+  telemetry.deployRunFinished({
+    status: "failed",
+    durationMs: 12_500,
+    error: new Error("readiness failed"),
+  });
+  telemetry.runFinished({
+    status: "failed",
+    durationMs: 12_500,
+    error: new Error("readiness failed"),
+  });
+
+  expect(telemetry.artifactForTest().deployment).toMatchObject({
+    status: "failed",
+    previewSlot: "preview-3",
+    error: { message: "readiness failed" },
+  });
+  rmSync(artifactDirectory, { recursive: true });
+});

--- a/scripts/preview/e2e-telemetry.ts
+++ b/scripts/preview/e2e-telemetry.ts
@@ -112,13 +112,20 @@ export class PreviewE2eTelemetryArtifact {
   }) {
     const finishedAt = new Date().toISOString();
     const startedAtMs = this.deploymentStartedAtMs ?? Date.now() - input.durationMs;
+    const laneSlots = new Set(
+      this.deploymentLanes
+        .map(({ previewSlot }) => previewSlot)
+        .filter((previewSlot): previewSlot is string => previewSlot !== undefined),
+    );
+    const inferredSlot = laneSlots.size === 1 ? laneSlots.values().next().value : undefined;
+    const previewSlot = input.slot ?? inferredSlot;
     this.deploymentResult = {
       deploymentKind: "cloudflare-preview",
       status: input.status,
       startedAt: new Date(startedAtMs).toISOString(),
       finishedAt,
       durationMs: input.durationMs,
-      ...(input.slot ? { previewSlot: input.slot } : {}),
+      ...(previewSlot ? { previewSlot } : {}),
       ...(input.error ? { error: normalizeTestTelemetryError(input.error) } : {}),
       lanes: this.deploymentLanes,
     };

--- a/scripts/preview/e2e-telemetry.ts
+++ b/scripts/preview/e2e-telemetry.ts
@@ -79,6 +79,7 @@ export class PreviewE2eTelemetryArtifact {
 
   deployAppFinished(input: {
     app: string;
+    finishedAt: string;
     slot?: string;
     status: "passed" | "failed";
     durationMs: number;
@@ -94,7 +95,7 @@ export class PreviewE2eTelemetryArtifact {
       ...(input.slot ? { previewSlot: input.slot } : {}),
       status: input.status,
       durationMs: input.durationMs,
-      finishedAt: new Date().toISOString(),
+      finishedAt: input.finishedAt,
       configDurationMs: input.configDurationMs,
       commandDurationMs: input.commandDurationMs,
       readinessDurationMs: input.readinessDurationMs,

--- a/scripts/preview/e2e-telemetry.ts
+++ b/scripts/preview/e2e-telemetry.ts
@@ -4,6 +4,8 @@ import {
   testTelemetryArtifactId,
   writeTestTelemetryArtifact,
   writeTestTelemetryFailureSentinel,
+  type DeploymentTelemetry,
+  type DeploymentTelemetryLane,
   type TestTelemetryArtifact,
   type TestTelemetryArtifactSource,
   type TestTelemetryLane,
@@ -13,7 +15,7 @@ type RunContext = {
   branch?: string;
   environment: NodeJS.ProcessEnv;
   headSha: string;
-  operation: "test" | "run";
+  operation: "deploy" | "test" | "run";
   pullRequestNumber: number;
   runUrl: string | null;
 };
@@ -32,7 +34,10 @@ export class PreviewE2eTelemetryArtifact {
   };
   private readonly environment: NodeJS.ProcessEnv;
   private readonly expectedArtifactSources: TestTelemetryArtifactSource[] = [];
+  private readonly deploymentLanes: DeploymentTelemetryLane[] = [];
   private readonly lanes: TestTelemetryLane[] = [];
+  private deploymentResult: DeploymentTelemetry | null = null;
+  private deploymentStartedAtMs: number | null = null;
   private runResult: TestTelemetryArtifact["run"] | null = null;
   private startedAtMs = Date.now();
 
@@ -66,6 +71,57 @@ export class PreviewE2eTelemetryArtifact {
     // If the orchestrator is killed, the finalizer can still prove which
     // runner artifacts should have appeared instead of accepting their silence.
     this.writeFailureSentinel();
+  }
+
+  deployRunStarted() {
+    this.deploymentStartedAtMs = Date.now();
+  }
+
+  deployAppFinished(input: {
+    app: string;
+    slot?: string;
+    status: "passed" | "failed";
+    durationMs: number;
+    configDurationMs?: number | null;
+    commandDurationMs?: number | null;
+    readinessDurationMs?: number | null;
+    reuseProofDurationMs?: number | null;
+    workerName?: string | null;
+    workerVersion?: string | null;
+  }) {
+    this.deploymentLanes.push({
+      app: input.app,
+      ...(input.slot ? { previewSlot: input.slot } : {}),
+      status: input.status,
+      durationMs: input.durationMs,
+      finishedAt: new Date().toISOString(),
+      configDurationMs: input.configDurationMs,
+      commandDurationMs: input.commandDurationMs,
+      readinessDurationMs: input.readinessDurationMs,
+      reuseProofDurationMs: input.reuseProofDurationMs,
+      workerName: input.workerName,
+      workerVersion: input.workerVersion,
+    });
+  }
+
+  deployRunFinished(input: {
+    status: "passed" | "failed" | "skipped";
+    durationMs: number;
+    slot?: string;
+    error?: unknown;
+  }) {
+    const finishedAt = new Date().toISOString();
+    const startedAtMs = this.deploymentStartedAtMs ?? Date.now() - input.durationMs;
+    this.deploymentResult = {
+      deploymentKind: "cloudflare-preview",
+      status: input.status,
+      startedAt: new Date(startedAtMs).toISOString(),
+      finishedAt,
+      durationMs: input.durationMs,
+      ...(input.slot ? { previewSlot: input.slot } : {}),
+      ...(input.error ? { error: normalizeTestTelemetryError(input.error) } : {}),
+      lanes: this.deploymentLanes,
+    };
   }
 
   appFinished(input: {
@@ -144,6 +200,7 @@ export class PreviewE2eTelemetryArtifact {
       context: this.context,
       expectedArtifactSources: this.expectedArtifactSources,
       run: this.runResult,
+      ...(this.deploymentResult ? { deployment: this.deploymentResult } : {}),
       lanes: this.lanes,
       tests: [],
       modules: [],

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -125,7 +125,11 @@ async function resolvePreviewCommandSetup(options: PullRequestCommandOptions) {
  */
 export async function deploy(options: DeployCommandOptions = {}) {
   const { context, runtime } = await resolvePreviewCommandSetup(options);
-  return await deployPreviewApps({ context, options, runtime });
+  return await withPreviewE2eTelemetry(context, runtime, "deploy", (telemetry) =>
+    measurePreviewDeployRun(telemetry, () =>
+      deployPreviewApps({ context, options, runtime, telemetry }),
+    ),
+  );
 }
 
 /**
@@ -298,7 +302,9 @@ export async function testTarget(options: TestTargetOptions) {
 export async function run(options: DeployCommandOptions = {}) {
   const { context, runtime } = await resolvePreviewCommandSetup(options);
   return await withPreviewE2eTelemetry(context, runtime, "run", async (telemetry) => {
-    const deployResult = await deployPreviewApps({ context, options, runtime });
+    const deployResult = await measurePreviewDeployRun(telemetry, () =>
+      deployPreviewApps({ context, options, runtime, telemetry }),
+    );
     if ("skippedReason" in deployResult && deployResult.skippedReason === "draft") {
       return deployResult;
     }
@@ -312,7 +318,7 @@ export async function run(options: DeployCommandOptions = {}) {
 async function withPreviewE2eTelemetry<T>(
   context: PullRequestPreviewContext,
   runtime: PreviewRuntime,
-  operation: "test" | "run",
+  operation: "deploy" | "test" | "run",
   execute: (telemetry: PreviewE2eTelemetryArtifact) => Promise<T>,
 ): Promise<T> {
   const telemetry = new PreviewE2eTelemetryArtifact({
@@ -353,20 +359,61 @@ async function withPreviewE2eTelemetry<T>(
   return result;
 }
 
+async function measurePreviewDeployRun<T>(
+  telemetry: PreviewE2eTelemetryArtifact,
+  execute: () => Promise<T>,
+): Promise<T> {
+  const startedAt = Date.now();
+  telemetry.deployRunStarted();
+  try {
+    const result = await execute();
+    telemetry.deployRunFinished({
+      status: previewOperationWasSkipped(result) ? "skipped" : "passed",
+      durationMs: Date.now() - startedAt,
+      slot: previewResultSlot(result),
+    });
+    return result;
+  } catch (error) {
+    telemetry.deployRunFinished({
+      status: "failed",
+      durationMs: Date.now() - startedAt,
+      error,
+    });
+    throw error;
+  }
+}
+
 function previewOperationWasSkipped(result: unknown) {
   return (
     typeof result === "object" && result !== null && "skipped" in result && result.skipped === true
   );
 }
 
+function previewResultSlot(result: unknown): string | undefined {
+  if (typeof result !== "object" || result === null || !("state" in result)) return undefined;
+  const state = result.state;
+  if (typeof state !== "object" || state === null || !("environmentConfigLease" in state)) {
+    return undefined;
+  }
+  const lease = state.environmentConfigLease;
+  return typeof lease === "object" &&
+    lease !== null &&
+    "slug" in lease &&
+    typeof lease.slug === "string"
+    ? lease.slug
+    : undefined;
+}
+
 async function deployPreviewApps({
   context,
   options,
   runtime,
+  telemetry,
 }: {
   context: PullRequestPreviewContext;
   options: DeployCommandOptions;
   runtime: PreviewRuntime;
+  telemetry: PreviewE2eTelemetryArtifact;
 }) {
   logPreview(
     `deploy for PR #${context.pullRequestNumber} (head ${context.pullRequestHeadSha.slice(0, 7)}) — holder ${pullRequestHolder(context.pullRequestNumber)}, semaphore ${defaultSemaphoreBaseUrl}`,
@@ -604,6 +651,18 @@ async function deployPreviewApps({
 
     for (const entry of entries) {
       accumulatedEntries[entry.appSlug] = entry;
+      telemetry.deployAppFinished({
+        app: entry.appSlug,
+        slot: environmentConfigLease.slug,
+        status: entry.status === "awaiting-tests" ? "passed" : "failed",
+        durationMs: entry.deployDurationMs ?? 0,
+        configDurationMs: entry.deployConfigDurationMs,
+        commandDurationMs: entry.deployCommandDurationMs,
+        readinessDurationMs: entry.deployReadinessDurationMs,
+        reuseProofDurationMs: entry.deployReuseProofDurationMs,
+        workerName: entry.deployedWorkerName,
+        workerVersion: entry.deployedWorkerVersion,
+      });
     }
     const update = await updatePreviewState(context, (state) => ({
       ...state,
@@ -2478,6 +2537,14 @@ export const CloudflarePreviewAppEntry = z.object({
   shortSha: z.string().trim().min(1).nullable().optional(),
   cleanupDurationMs: z.number().nonnegative().finite().nullable().optional(),
   deployDurationMs: z.number().nonnegative().finite().nullable().optional(),
+  /** Time spent resolving the Doppler-backed public URL and Worker identity. */
+  deployConfigDurationMs: z.number().nonnegative().finite().nullable().optional(),
+  /** Time spent in the app's build, Cloudflare mutation, and app-level smoke command. */
+  deployCommandDurationMs: z.number().nonnegative().finite().nullable().optional(),
+  /** Time from a successful deploy command to exact-version readiness. */
+  deployReadinessDurationMs: z.number().nonnegative().finite().nullable().optional(),
+  /** Time spent proving that a content-identical recorded deployment can be reused. */
+  deployReuseProofDurationMs: z.number().nonnegative().finite().nullable().optional(),
   /** Public Worker script and immutable Wrangler version proven by this entry. */
   deployedWorkerName: z.string().trim().min(1).nullable().optional(),
   deployedWorkerVersion: z.uuid().nullable().optional(),
@@ -4128,6 +4195,7 @@ async function deployPreviewApp(input: {
   runUrl: string | null;
   signal?: AbortSignal;
 }) {
+  const configStartedAt = Date.now();
   const appConfig = await readPreviewAppConfig({
     app: input.app,
     commandEnvironment: input.commandEnvironment,
@@ -4135,9 +4203,11 @@ async function deployPreviewApp(input: {
     repositoryRoot: input.repositoryRoot,
     signal: input.signal,
   });
+  const deployConfigDurationMs = Date.now() - configStartedAt;
   const baseEntry = {
     appDisplayName: input.app.displayName,
     appSlug: input.app.slug,
+    deployConfigDurationMs,
     headSha: input.pullRequestHeadSha,
     publicUrl: appConfig.baseUrl,
     runUrl: input.runUrl,
@@ -4146,44 +4216,52 @@ async function deployPreviewApp(input: {
   } as const;
 
   const fingerprint = previewAppContentFingerprint(input.app, input.repositoryRoot);
+  const existingEntry = input.existingEntry;
+  let deployReuseProofDurationMs: number | undefined;
   if (
     fingerprint !== null &&
-    input.existingEntry?.status === "deployed" &&
-    input.existingEntry.publicUrl === appConfig.baseUrl &&
-    input.existingEntry.deployedFingerprint === fingerprint &&
-    input.existingEntry.deployedWorkerName === appConfig.workerName &&
-    input.existingEntry.deployedWorkerVersion &&
+    existingEntry?.status === "deployed" &&
+    existingEntry.publicUrl === appConfig.baseUrl &&
+    existingEntry.deployedFingerprint === fingerprint &&
+    existingEntry.deployedWorkerName === appConfig.workerName &&
+    existingEntry.deployedWorkerVersion
+  ) {
     // The record alone is not proof the worker still answers — this app may
     // be selected precisely because the not-serving sweep found it dead
     // (selectRecordedGreenAppsNotServing), e.g. after a slot erase. Skip only
     // when every readiness URL answers right now.
-    (
+    const reuseProofStartedAt = Date.now();
+    const reuseProofPassed = (
       await Promise.all(
         resolvePreviewReadinessUrls({
           publicUrl: appConfig.baseUrl,
           readyUrlPath: input.app.previewReadyUrlPath,
         }).map((url) => probePreviewAppServingOnce(url)),
       )
-    ).every((probe) => probe.ok)
-  ) {
-    // Same slot, same content, last run fully green, worker answering: what
-    // is serving is byte-identical to what this deploy would upload. Skip
-    // the wrangler/Cloudflare-API round trip; the e2e smoke still verifies it.
-    logPreview(
-      `deploy skipped: ${input.app.slug} unchanged since ${input.existingEntry.shortSha ?? "the recorded deploy"} on this slot and serving (fingerprint ${fingerprint.slice(0, 12)}…)`,
-    );
-    return CloudflarePreviewAppEntry.parse({
-      ...baseEntry,
-      deployedFingerprint: fingerprint,
-      deployedWorkerName: input.existingEntry.deployedWorkerName,
-      deployedWorkerVersion: input.existingEntry.deployedWorkerVersion,
-      workerSizeKib: input.existingEntry.workerSizeKib ?? null,
-      workerGzipKib: input.existingEntry.workerGzipKib ?? null,
-      mainWorkerGzipKib: input.existingEntry.mainWorkerGzipKib ?? null,
-      status: "awaiting-tests",
-    });
+    ).every((probe) => probe.ok);
+    deployReuseProofDurationMs = Date.now() - reuseProofStartedAt;
+    if (reuseProofPassed) {
+      // Same slot, same content, last run fully green, worker answering: what
+      // is serving is byte-identical to what this deploy would upload. Skip
+      // the wrangler/Cloudflare-API round trip; the e2e smoke still verifies it.
+      logPreview(
+        `deploy skipped: ${input.app.slug} unchanged since ${existingEntry.shortSha ?? "the recorded deploy"} on this slot and serving (fingerprint ${fingerprint.slice(0, 12)}…)`,
+      );
+      return CloudflarePreviewAppEntry.parse({
+        ...baseEntry,
+        deployedFingerprint: fingerprint,
+        deployedWorkerName: existingEntry.deployedWorkerName,
+        deployedWorkerVersion: existingEntry.deployedWorkerVersion,
+        deployReuseProofDurationMs,
+        workerSizeKib: existingEntry.workerSizeKib ?? null,
+        workerGzipKib: existingEntry.workerGzipKib ?? null,
+        mainWorkerGzipKib: existingEntry.mainWorkerGzipKib ?? null,
+        status: "awaiting-tests",
+      });
+    }
   }
 
+  const commandStartedAt = Date.now();
   const deployResult = await runPreviewDeployCommand({
     app: input.app,
     commandEnvironment: input.commandEnvironment,
@@ -4192,6 +4270,7 @@ async function deployPreviewApp(input: {
     repositoryRoot: input.repositoryRoot,
     signal: input.signal,
   });
+  const deployCommandDurationMs = Date.now() - commandStartedAt;
   // Wrangler prints "Total Upload: … KiB / gzip: … KiB" on every upload —
   // lift it out of the captured deploy output for the PR table's size column.
   const workerSize = parseWorkerSizeFromDeployOutput(
@@ -4206,6 +4285,8 @@ async function deployPreviewApp(input: {
     return CloudflarePreviewAppEntry.parse({
       ...baseEntry,
       ...sizeFields,
+      deployCommandDurationMs,
+      deployReuseProofDurationMs,
       message: commandFailureMessage(deployResult, "Preview deployment failed."),
       status: "deploy-failed",
     });
@@ -4218,12 +4299,15 @@ async function deployPreviewApp(input: {
     return CloudflarePreviewAppEntry.parse({
       ...baseEntry,
       ...sizeFields,
+      deployCommandDurationMs,
+      deployReuseProofDurationMs,
       message:
         "Preview deployment succeeded, but wrangler did not report the exact Worker version required by preview tests.",
       status: "deploy-failed",
     });
   }
 
+  const readinessStartedAt = Date.now();
   const readiness = await waitForPreviewAppReadiness({
     publicUrl: appConfig.baseUrl,
     readyUrlPath: input.app.previewReadyUrlPath,
@@ -4238,10 +4322,14 @@ async function deployPreviewApp(input: {
           }
         : undefined,
   });
+  const deployReadinessDurationMs = Date.now() - readinessStartedAt;
   if (!readiness.ok) {
     return CloudflarePreviewAppEntry.parse({
       ...baseEntry,
       ...sizeFields,
+      deployCommandDurationMs,
+      deployReadinessDurationMs,
+      deployReuseProofDurationMs,
       message: readiness.message,
       status: "deploy-failed",
     });
@@ -4250,6 +4338,9 @@ async function deployPreviewApp(input: {
   return CloudflarePreviewAppEntry.parse({
     ...baseEntry,
     ...sizeFields,
+    deployCommandDurationMs,
+    deployReadinessDurationMs,
+    deployReuseProofDurationMs,
     deployedWorkerName: appConfig.workerName,
     deployedWorkerVersion,
     deployedFingerprint: fingerprint,

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -617,11 +617,11 @@ async function deployPreviewApps({
   // resurrect a pre-claim "waiting for a slot" banner.
   const accumulatedEntries: Record<string, CloudflarePreviewAppEntry> = {};
   for (const batch of orderPreviewDeployBatches(appsToDeploy)) {
-    const entries = await mapWithConcurrency(
+    const completedDeploys = await mapWithConcurrency(
       batch,
       defaultPreviewDeployConcurrency,
       async (app) => {
-        return await deployPreviewAppWithStatus({
+        const entry = await deployPreviewAppWithStatus({
           app,
           existingEntry: current.state.apps[app.slug] ?? null,
           commandEnvironment: {
@@ -643,16 +643,22 @@ async function deployPreviewApps({
           runUrl: context.workflowRunUrl,
           signal: runtime.signal,
         });
+        // Capture this before waiting for slower siblings in the batch. The
+        // lane timestamp must describe this app's own completion, not the tail
+        // of the concurrent deploy fleet.
+        return { entry, finishedAt: new Date().toISOString() };
       },
     );
+    const entries = completedDeploys.map(({ entry }) => entry);
     if (entries.some((entry) => entry.status === "deploy-failed")) {
       ok = false;
     }
 
-    for (const entry of entries) {
+    for (const { entry, finishedAt } of completedDeploys) {
       accumulatedEntries[entry.appSlug] = entry;
       telemetry.deployAppFinished({
         app: entry.appSlug,
+        finishedAt,
         slot: environmentConfigLease.slug,
         status: entry.status === "awaiting-tests" ? "passed" : "failed",
         durationMs: entry.deployDurationMs ?? 0,


### PR DESCRIPTION
## Outcome

This adds artifact-first timing for the deployment half of the canonical Depot Cloudflare Preview check, alongside the existing test telemetry. A preview run now records:

- total preview deployment wall time and outcome;
- one independently timestamped lane per app, with exact Worker name/version;
- Doppler/config resolution, deploy command, exact-version readiness, and unchanged-deployment proof durations;
- bounded deployment errors while retaining raw artifacts for replay.

The emitted events are `ci deploy run started/finished`, `ci deploy lane finished`, and `ci deploy phase finished`. They use the same immutable workflow/run/attempt, PR, SHA, Depot job, and preview-slot dimensions as the test events.

## Deliberately narrow scope

This PR is observability only:

- no warm-deployment cache or expanded fingerprint policy from closed PR #2233;
- no new retry layer;
- no test quarantine or skip;
- no preview concurrency, slot-allocation, deploy-order, or readiness-policy change;
- no sandbox-builder or AI Search code.

The small unchanged-fixture reuse check already on `main` is behaviorally unchanged; this only measures its existing proof request when eligible. **This PR introduced zero quarantines and zero skipped tests.**

## Telemetry contract hardening

Live review and canary validation found three correctness issues, all fixed before merge:

1. Deploy events were initially included in `runner_event_count`; the finalizer now counts only `ci test *` runner events.
2. A deployment that failed after an app lane completed could omit its slot; the run now infers the slot when all recorded lanes agree.
3. Fast apps in a concurrent deploy batch were initially stamped when the slowest sibling finished. Each promise now captures its own completion timestamp before the batch drains, so PostHog accurately shows overlap and tail latency.

Each contract has regression coverage.

## Live canonical proof

Three normal Depot preview checks exercised the real deployment and e2e path; no synthetic or nested retry loop was used.

| Head | Check result | Deploy wall | OS deploy | Streams deploy | Test result |
| --- | --- | ---: | ---: | ---: | --- |
| `1547756ec` | green | 148.9s | 133.4s | 72.9s | **not clean:** matrix ITX `agent-send-message` timed out once at 90.0s, then passed in 8.0s |
| `743d5eafb` | green | 138.5s | 131.6s | 96.4s | **not clean:** `stream-lifecycle` timed out waiting for the project-worker feed cursor, then passed |
| `24ebcbd23` | green | 162.9s | 156.6s | 83.7s | **clean:** every runner reported zero retries |

The first two checks were CI-green because the one allowed retry was absorbed, but they do **not** count as zero-retry stability successes. Both are unrelated pre-existing flakes surfaced by this work; neither was hidden, skipped, or quarantined here. The matrix example remains intact.

The final exact-head canary was the normal [Depot preview job](https://depot.dev/orgs/0p91s0lz49/workflows/7lf378drxq?job=6kgg11jqm3):

- GitHub check wall time: **5m24s** (12:48:04–12:53:28 UTC).
- Deploy: **162.885s** total.
  - OS: **156.614s** = 0.360s config + 37.470s command + **118.783s readiness**.
  - Streams: **83.692s** = 0.301s config + 13.683s command + **69.707s readiness**.
  - Auth: 16.501s; Semaphore: 12.510s; Dummy Petshop reuse proof: 0.266s.
- The five app test lanes began in parallel and passed:
  - OS 138.758s; Streams 56.942s; Semaphore 23.225s; Auth 11.358s; Dummy Petshop 6.539s.
  - Inside OS, Vitest (95.595s), Playwright (130.651s), and onboarding smoke (31.322s) also overlapped.
- PostHog received 5 deploy lanes, 14 deploy phases, all exact Worker identities, all-zero test retry counts, and a passing finalizer with 6,842 runner events.
- Finalizer reconciliation: `telemetry_incomplete=false`, missing sources 0, foreign artifacts 0, incomplete artifacts 0.

This exact-head run is clean proof for this observability PR. It is not being presented as the final 25-run streak because the two earlier flakes remain to be fixed and that follow-up will change the code under proof.

## What the timings say

The current critical path is not action pickup or package installation. In the final canary, pnpm installed the workspace in about 4s and all app tests ran concurrently. The dominant pre-test tail was Cloudflare rollout convergence: OS readiness alone consumed 118.8s while probe waves observed mixed old/new Durable Object versions; Streams readiness consumed 69.7s. After deployment, OS Playwright was the longest runner at 130.7s.

The new live [Preview CI stage latency insight](https://eu.posthog.com/project/115112/insights/Bcwlg4Cm) is attached to the [CI reliability dashboard](https://eu.posthog.com/project/115112/dashboard/839069). It compares workflow pickup, Depot runner pickup, whole-job reference time, deployment total, per-app deploy phases, and per-app test lanes with p50/p95 series. Whole-job and deploy totals are explicitly reference totals, not additive bars.

## Source-health correction

While validating the dashboard, I found that the source-health query used plain `argMax(nullable_error, timestamp)`. ClickHouse skips null aggregate arguments, so a current healthy sync could inherit an older failure message.

The documented and live [source-health insight](https://eu.posthog.com/project/115112/insights/HjhXLlJB) now normalizes null to an empty string inside `argMax` and converts it back afterwards. Depot, GitHub Actions, and GitHub Reviews resolve to fresh `HEALTHY / passed` rows without stale errors.

## Verification

Validated on top of `origin/main` at `1985834a4`:

- full `pnpm test` passed on the implementation (including the complete OS/workspace suites);
- final head `pnpm typecheck` passed;
- final head `pnpm lint` passed with zero warnings;
- final head `pnpm format:check` passed;
- final head scripts suite: 17 files / 271 tests passed;
- focused telemetry regression: 2/2 passed;
- `git diff --check` passed;
- every required exact-head PR check passed and every review thread was addressed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only: schema extension, event normalization, timing instrumentation, and documentation; deploy policy and concurrency are unchanged.
> 
> **Overview**
> Adds **preview deployment observability** to the same artifact-first PostHog pipeline as test runners, without changing deploy behavior.
> 
> The shared telemetry artifact schema gains optional **`deployment`** evidence (run outcome, preview slot, per-app lanes, and phase timings: config, command, readiness, reuse proof, plus Worker name/version). The preview orchestrator records deploy start/finish and per-app completion; **`deploy`** and **`run`** wrap deploy work in **`measurePreviewDeployRun`**, and each app deploy path now **timestamps** config resolution, wrangler command, readiness wait, and unchanged-deployment reuse proof into PR state fields consumed by telemetry.
> 
> The finalizer emits **`ci deploy run started/finished`**, **`ci deploy lane finished`**, and **`ci deploy phase finished`** alongside existing test events; **`runner_event_count`** counts only `ci test *` events. Docs add the deploy event table and fix the **source-health HogQL** so `argMax` on nullable errors cannot stick an old failure on the latest healthy sync row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24ebcbd2302aaea3da596e3fead29250bba1aa2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +29 -0 | +26 -0 🟩⬜⬜⬜⬜ |
| Tests | +136 -4 | +132 -4 🟩🟩⬜⬜⬜ |
| CI & scripts | +297 -34 | +279 -31 🟩🟩🟩🟩🟩 |
| Docs | +21 -12 | +20 -12 🟩⬜⬜⬜⬜ |
| **Total** | **+483 -50** | **+457 -47** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 1985834 and 24ebcbd, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-22T12:58:33.097Z",
      "headSha": "24ebcbd2302aaea3da596e3fead29250bba1aa2d",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/413099510040732",
      "shortSha": "24ebcbd",
      "cleanupDurationMs": 15809,
      "deployDurationMs": 156614,
      "deployConfigDurationMs": 360,
      "deployCommandDurationMs": 37470,
      "deployReadinessDurationMs": 118783,
      "deployedWorkerName": "os-preview-7",
      "deployedWorkerVersion": "0da1e0f0-d2fa-4371-a859-cc554ade3975",
      "testDurationMs": 138758,
      "testRetries": null,
      "workerSizeKib": 17317.89,
      "workerGzipKib": 4656.76,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 4667.57
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-22T12:58:18.018Z",
      "headSha": "24ebcbd2302aaea3da596e3fead29250bba1aa2d",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/413099510040732",
      "shortSha": "24ebcbd",
      "cleanupDurationMs": 727,
      "deployDurationMs": 12510,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 12247,
      "deployReadinessDurationMs": 257,
      "deployedWorkerName": "semaphore-preview-7",
      "deployedWorkerVersion": "52732ada-a9c5-455e-9c7a-6bfb12c78211",
      "testDurationMs": 23225,
      "testRetries": null,
      "workerSizeKib": 1915.22,
      "workerGzipKib": 440.99,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-22T12:58:20.974Z",
      "headSha": "24ebcbd2302aaea3da596e3fead29250bba1aa2d",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/413099510040732",
      "shortSha": "24ebcbd",
      "cleanupDurationMs": 3682,
      "deployDurationMs": 16501,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 16174,
      "deployReadinessDurationMs": 322,
      "deployedWorkerName": "auth-preview-7",
      "deployedWorkerVersion": "71f6f99a-3bbd-410a-a892-0e03165e6c88",
      "testDurationMs": 11358,
      "testRetries": null,
      "workerSizeKib": 3965.97,
      "workerGzipKib": 811.59,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-22T12:58:25.300Z",
      "headSha": "24ebcbd2302aaea3da596e3fead29250bba1aa2d",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/413099510040732",
      "shortSha": "24ebcbd",
      "cleanupDurationMs": 8006,
      "deployDurationMs": 83692,
      "deployConfigDurationMs": 301,
      "deployCommandDurationMs": 13683,
      "deployReadinessDurationMs": 69707,
      "deployedWorkerName": "streams-example-app-preview-7",
      "deployedWorkerVersion": "222c0970-daf4-4fdc-9ce4-de5326d4692b",
      "testDurationMs": 56942,
      "testRetries": null,
      "workerSizeKib": 5157.7,
      "workerGzipKib": 1472.7,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-22T12:58:18.349Z",
      "headSha": "24ebcbd2302aaea3da596e3fead29250bba1aa2d",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/413099510040732",
      "shortSha": "24ebcbd",
      "cleanupDurationMs": 1053,
      "deployDurationMs": 266,
      "deployConfigDurationMs": 4,
      "deployReuseProofDurationMs": 225,
      "deployedWorkerName": "dummy-petshop-preview-7",
      "deployedWorkerVersion": "f5bdeee0-2d51-4d8e-97b6-274c79a5f8f7",
      "testDurationMs": 6539,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `24ebcbd` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 811.6 KiB | 16.5s | 11.4s |  | 3.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/413099510040732) | 2026-07-22T12:58:20.974Z | Preview app released. |
| Dummy Petshop | released | `24ebcbd` | [https://dummy-petshop.iterate-preview-7.com](https://dummy-petshop.iterate-preview-7.com) | 198.3 KiB | 266ms | 6.5s |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/413099510040732) | 2026-07-22T12:58:18.349Z | Preview app released. |
| OS | released | `24ebcbd` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 4.55 MiB (-10.8 KiB vs main) | 156.6s | 138.8s |  | 15.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/413099510040732) | 2026-07-22T12:58:33.097Z | Preview app released. |
| Semaphore | released | `24ebcbd` | [https://semaphore.iterate-preview-7.com](https://semaphore.iterate-preview-7.com) | 441.0 KiB | 12.5s | 23.2s |  | 727ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/413099510040732) | 2026-07-22T12:58:18.018Z | Preview app released. |
| Streams Example App | released | `24ebcbd` | [https://streams.iterate-preview-7.com](https://streams.iterate-preview-7.com) | 1.44 MiB | 83.7s | 56.9s |  | 8.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/413099510040732) | 2026-07-22T12:58:25.300Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->
