### PR TITLE
Scope workspace mount reads: a big repo's HEAD tree must never cross the 32MiB RPC

### DIFF
--- a/apps/os/e2e/vitest/workspace.itx.e2e.test.ts
+++ b/apps/os/e2e/vitest/workspace.itx.e2e.test.ts
@@ -84,6 +84,28 @@ test("workspaces are event-sourced and mount-routed: overlays shadow, commits ro
   expect(await workspace.listAllFiles()).not.toContain("/worker.ts");
   expect(await project.repo.readFile({ path: "worker.ts" })).not.toBeNull();
 
+  // -- batched reads agree with every single-file arm ------------------------
+  // One readFiles call mixing an overlay write, a copied-up edit, a whiteout,
+  // a pure mount fall-through, and a miss — the board-seed lane. The mount
+  // arm reaches the repo through a snapshot SCOPED to the asked paths (an
+  // unscoped one ships the whole HEAD tree across a 32MiB-capped RPC, which
+  // is exactly how big-repo boards died in production).
+  expect(
+    await workspace.readFiles([
+      "/notes/e2e.md",
+      "/docs/freshness.md",
+      "/worker.ts",
+      "/package.json",
+      "/nope/missing.md",
+    ]),
+  ).toEqual({
+    "/notes/e2e.md": "workspace hello world",
+    "/docs/freshness.md": "fresh off main + overlay addendum",
+    "/worker.ts": null,
+    "/package.json": seededPackageJson,
+    "/nope/missing.md": null,
+  });
+
   // revert un-pins one path: a shadowed file follows main again, a deleted
   // one comes back — the surgical sibling of reset().
   await workspace.revert("/docs/freshness.md");

--- a/apps/os/src/domains/repos/repo-durable-object.ts
+++ b/apps/os/src/domains/repos/repo-durable-object.ts
@@ -251,7 +251,9 @@ export class RepoDurableObject extends DurableObject<Env> {
    * A masked file snapshot at a branch head or pinned commit — the repo file
    * source for the worker build pipeline, and the one clone-and-read pathway
    * every read on this object goes through. Include/exclude globs bound what
-   * becomes build input.
+   * becomes build input; `paths` selects exact repo-relative files, which is
+   * how bulk consumers on big repos stay under the 32MiB RPC value cap (a
+   * monorepo's full HEAD tree does not fit — 43.7MB on iterate/iterate).
    *
    * With `commitOid`, `branch` names where that commit lives (git clones are
    * single-branch): worker builds pin a late-bound branch ref to the head it
@@ -263,6 +265,7 @@ export class RepoDurableObject extends DurableObject<Env> {
       commitOid?: string;
       exclude?: string[];
       include?: string[];
+      paths?: string[];
     } = {},
   ): Promise<{ commitOid: string; files: Record<string, string> }> {
     const branch = input.branch ?? REPO_DEFAULT_BRANCH;
@@ -272,8 +275,12 @@ export class RepoDurableObject extends DurableObject<Env> {
       input.exclude === undefined &&
       input.include === undefined;
     if (cacheable) {
-      return this.#headFilesSnapshot.get(
-        () => this.#loadFilesSnapshot({ ...input, branch }),
+      // A `paths` selection rides (and primes) the whole-head cache: the pick
+      // below keeps the RETURN small — the RPC cap binds the serialized
+      // value, not this object's memory — while repeat readers share one
+      // clone instead of re-cloning per scoped call.
+      const snapshot = await this.#headFilesSnapshot.get(
+        () => this.#loadFilesSnapshot({ branch }),
         (snapshot) => {
           // #checkout deliberately returns its last clone after the bounded
           // eventual-consistency retries. Let current callers use that result,
@@ -281,6 +288,13 @@ export class RepoDurableObject extends DurableObject<Env> {
           return decideHeadResolution(this.#branchAuthority(branch), snapshot.commitOid).cache;
         },
       );
+      if (input.paths === undefined) return snapshot;
+      const files: Record<string, string> = {};
+      for (const path of input.paths) {
+        const content = snapshot.files[path];
+        if (content !== undefined) files[path] = content;
+      }
+      return { commitOid: snapshot.commitOid, files };
     }
     return this.#loadFilesSnapshot(input);
   }
@@ -291,19 +305,23 @@ export class RepoDurableObject extends DurableObject<Env> {
       commitOid?: string;
       exclude?: string[];
       include?: string[];
+      paths?: string[];
     } = {},
   ): Promise<{ commitOid: string; files: Record<string, string> }> {
     const { filesystem, head } = await this.#checkout(input);
 
     // Mask paths BEFORE reading contents: an excluded tree (a committed
-    // node_modules/, build output) should cost a directory walk, not reads.
-    const paths = await walkCheckoutPaths(filesystem, REPO_DIR);
-    const selected = filterWorkerSnapshotPaths(paths.sort(), {
+    // node_modules/, build output) should cost a directory walk, not reads —
+    // and a `paths` selection reads only the requested files.
+    const walked = await walkCheckoutPaths(filesystem, REPO_DIR);
+    const selected = filterWorkerSnapshotPaths(walked.sort(), {
       exclude: input.exclude,
       include: input.include,
     });
+    const wanted = input.paths === undefined ? null : new Set(input.paths);
     const files: Record<string, string> = {};
     for (const path of selected) {
+      if (wanted !== null && !wanted.has(path)) continue;
       files[path] = await readCheckoutTextFile(filesystem, `${REPO_DIR}/${path}`);
     }
     return { commitOid: head.oid, files };

--- a/apps/os/src/domains/workspaces/workspace-core.test.ts
+++ b/apps/os/src/domains/workspaces/workspace-core.test.ts
@@ -59,6 +59,7 @@ function fakeKv() {
  * post-commit fall-through assertions test the real read-your-write shape. */
 function fakeRepo(tree: Record<string, string>) {
   const commits: { changes: unknown[]; message: string }[] = [];
+  const snapshotCalls: string[][] = [];
   const repo: MountRepoAccess = {
     readFile: async ({ encoding, path }) => {
       const content = tree[path];
@@ -70,7 +71,22 @@ function fakeRepo(tree: Record<string, string>) {
       };
     },
     listFiles: async () => ({ commitOid: "head-oid", paths: Object.keys(tree).sort() }),
-    getFilesSnapshot: async () => ({ commitOid: "head-oid", files: { ...tree } }),
+    getFilesSnapshot: async (input) => {
+      // The real repo object serializes this record across a workerd RPC with
+      // a 32MiB cap — an unscoped call on a big repo IS the outage (43.7MB
+      // crossed for 560KB of task files on iterate/iterate). Refusing it here
+      // means no fall-through pathway can regress to full-tree pulls.
+      if (input?.paths === undefined) {
+        throw new Error("unscoped getFilesSnapshot: the full HEAD tree must never cross the RPC");
+      }
+      snapshotCalls.push([...input.paths]);
+      const files: Record<string, string> = {};
+      for (const path of input.paths) {
+        const content = tree[path];
+        if (content !== undefined) files[path] = content;
+      }
+      return { commitOid: "head-oid", files };
+    },
     commitFiles: async (input) => {
       commits.push({ changes: input.changes, message: input.message });
       for (const change of input.changes) {
@@ -96,7 +112,7 @@ function fakeRepo(tree: Record<string, string>) {
       ].slice(0, limit ?? 1),
     }),
   };
-  return { commits, repo };
+  return { commits, repo, snapshotCalls };
 }
 
 const MOUNTS: Record<string, WorkspaceMount> = {
@@ -164,6 +180,65 @@ describe("mount-routed reads", () => {
     const { core } = subject();
     const bytes = await core.readFileBytes("/iterate/README.md");
     expect(new TextDecoder().decode(bytes!)).toBe("# iterate");
+  });
+});
+
+describe("batched mount reads", () => {
+  test("readMountFiles pays ONE scoped snapshot per mount, asking for exactly the routed paths", async () => {
+    const { config, core, iterate } = subject();
+    await expect(
+      core.readMountFiles([
+        "/config/worker.ts",
+        "/config/tasks/one.md",
+        "/iterate/tasks/two.md",
+        "/iterate/missing.md",
+        "/unmounted/scratch.txt",
+      ]),
+    ).resolves.toEqual({
+      "/config/worker.ts": "export default {}",
+      "/config/tasks/one.md": "# one",
+      "/iterate/tasks/two.md": "# two",
+      "/iterate/missing.md": null,
+      "/unmounted/scratch.txt": null,
+    });
+    expect(config.snapshotCalls).toEqual([["worker.ts", "tasks/one.md"]]);
+    expect(iterate.snapshotCalls).toEqual([["tasks/two.md", "missing.md"]]);
+  });
+
+  test("a big repo's unrequested files never ride the snapshot", async () => {
+    // The prod shape: iterate/iterate's 73 task files are 560KB, its full
+    // HEAD tree 43.7MB — past the RPC cap. The fixture throws on unscoped
+    // calls, so this resolving proves the board-seed read is bounded by what
+    // was asked, not by repo size.
+    const big = fakeRepo({
+      "tasks/board.md": "# board",
+      "vendored/blob.txt": "x".repeat(4096),
+    });
+    const { workspace } = fakeLocalLayer();
+    const core = new WorkspaceCore({
+      kv: fakeKv(),
+      mounts: async () => ({ "/": { policy: "commit-to-main", repoPath: "/repos/big" } }),
+      repo: () => big.repo,
+      workspace,
+    });
+    await expect(core.readMountFiles(["/tasks/board.md"])).resolves.toEqual({
+      "/tasks/board.md": "# board",
+    });
+    expect(big.snapshotCalls).toEqual([["tasks/board.md"]]);
+  });
+
+  test("whiteouts and virtual directories mask batched reads exactly like readFile", async () => {
+    const { config, core } = subject();
+    await core.deleteFile("/config/worker.ts");
+    await expect(
+      core.readMountFiles(["/config/worker.ts", "/config", "/config/tasks/one.md"]),
+    ).resolves.toEqual({
+      "/config/worker.ts": null,
+      "/config": null,
+      "/config/tasks/one.md": "# one",
+    });
+    // The masked paths never reached the repo — only the surviving one did.
+    expect(config.snapshotCalls).toEqual([["tasks/one.md"]]);
   });
 });
 

--- a/apps/os/src/domains/workspaces/workspace-core.ts
+++ b/apps/os/src/domains/workspaces/workspace-core.ts
@@ -41,10 +41,12 @@ export interface MountRepoAccess {
     encoding?: "utf8" | "base64";
   }): Promise<{ commitOid: string; content: string; path: string } | null>;
   listFiles(): Promise<{ commitOid: string; paths: string[] }>;
-  /** The whole HEAD tree's text contents in ONE call (head-cache-backed) —
-   * bulk consumers must use this instead of fanning readFile() per path,
-   * which overloads the repo object. */
-  getFilesSnapshot(input?: { branch?: string }): Promise<{
+  /** HEAD tree text contents in ONE call (head-cache-backed) — bulk consumers
+   * must use this instead of fanning readFile() per path, which overloads the
+   * repo object. `paths` scopes the returned record to exactly those
+   * repo-relative files; mount reads MUST pass it, because a big repo's full
+   * tree does not fit a 32MiB RPC (iterate/iterate: 43.7MB at HEAD). */
+  getFilesSnapshot(input?: { branch?: string; paths?: string[] }): Promise<{
     commitOid: string;
     files: Record<string, string>;
   }>;
@@ -229,10 +231,55 @@ export class WorkspaceCore {
     return resolved === null || resolved.repoRelativePath === "" ? null : resolved;
   }
 
-  /** The OVERLAY copy only — no mount fall-through (bulk readers group the
-   * fall-through per mount themselves; see the DO's readFiles). */
+  /** The OVERLAY copy only — no mount fall-through (bulk readers take the
+   * batched fall-through arm instead; see readMountFiles). */
   async readOverlayFile(path: string): Promise<string | null> {
     return this.#workspace.readFile(path);
+  }
+
+  /**
+   * The batched mount fall-through — readFile's routing at bulk-read scale.
+   * Each mount pays ONE snapshot RPC scoped to exactly the repo-relative
+   * paths routed to it: fanning readFile() per path overloads the repo
+   * object, and an UNSCOPED snapshot ships the whole HEAD tree across a
+   * 32MiB-capped RPC (43.7MB on iterate/iterate — the board-seed outage).
+   * Paths that resolve to no mount (whiteouts, virtual directories, scratch)
+   * read as null.
+   */
+  async readMountFiles(paths: string[]): Promise<Record<string, string | null>> {
+    const result: Record<string, string | null> = {};
+    // ONE mount-table read, then synchronous grouping — an awaited read per
+    // path could interleave with a configure, mint two groups for one mount,
+    // and route them by different tables.
+    const mounts = await this.#mounts();
+    const byMount = new Map<
+      string,
+      { entries: { path: string; repoRelativePath: string }[]; repoPath: string }
+    >();
+    for (const path of paths) {
+      const resolved = this.resolveMountFallThrough(mounts, path);
+      if (resolved === null) {
+        result[path] = null;
+        continue;
+      }
+      const group = byMount.get(resolved.mountPath) ?? {
+        entries: [],
+        repoPath: resolved.mount.repoPath,
+      };
+      group.entries.push({ path, repoRelativePath: resolved.repoRelativePath });
+      byMount.set(resolved.mountPath, group);
+    }
+    await Promise.all(
+      [...byMount.values()].map(async (group) => {
+        const snapshot = await this.#repo(group.repoPath).getFilesSnapshot({
+          paths: group.entries.map((entry) => entry.repoRelativePath),
+        });
+        for (const entry of group.entries) {
+          result[entry.path] = snapshot.files[entry.repoRelativePath] ?? null;
+        }
+      }),
+    );
+    return result;
   }
 
   /** The BASE of a path — its mount's content at HEAD, ignoring the overlay

--- a/apps/os/src/domains/workspaces/workspace-durable-object.ts
+++ b/apps/os/src/domains/workspaces/workspace-durable-object.ts
@@ -362,39 +362,11 @@ export class WorkspaceV2DurableObject extends DurableObject<Env> {
         leftover.push(path);
       }),
     );
-    // Grouping is SYNCHRONOUS — an awaited get/set per path could interleave,
-    // mint two groups for one mount, and drop the first group's members. The
-    // fall-through mirrors readFile exactly: whiteouts mask, virtual
-    // directories are directories, and the ROUTED repo-relative key (not a
-    // string slice of the raw path) addresses the snapshot. The mount table
-    // is read HERE — after the awaits — so a configure landing during the
-    // local reads routes exactly as a fresh per-file readFile would.
-    const mounts = this.#currentConfig().mounts;
-    const byMount = new Map<
-      string,
-      { entries: { path: string; repoRelativePath: string }[]; repoPath: string }
-    >();
-    for (const path of leftover) {
-      const resolved = this.#core.resolveMountFallThrough(mounts, path);
-      if (resolved === null) {
-        result[path] = null;
-        continue;
-      }
-      const group = byMount.get(resolved.mountPath) ?? {
-        entries: [],
-        repoPath: resolved.mount.repoPath,
-      };
-      group.entries.push({ path, repoRelativePath: resolved.repoRelativePath });
-      byMount.set(resolved.mountPath, group);
-    }
-    await Promise.all(
-      [...byMount.values()].map(async (group) => {
-        const snapshot = await this.#repoStub(group.repoPath).getFilesSnapshot();
-        for (const entry of group.entries) {
-          result[entry.path] = snapshot.files[entry.repoRelativePath] ?? null;
-        }
-      }),
-    );
+    // The core groups the fall-through per mount and asks each repo for
+    // exactly the routed paths — the mount table is read THERE, after the
+    // local awaits, so a configure landing during them routes exactly as a
+    // fresh per-file readFile would.
+    Object.assign(result, await this.#core.readMountFiles(leftover));
     return result;
   }
 


### PR DESCRIPTION
## The outage

Opening the tasks board on a **big repo** in production died:

```
Serialized RPC arguments or return values are limited to 32MiB, but the size of this value was: 43729639 bytes.
```

Reproduced read-only against prod (`workspace.readFiles` via the tasks vessel, mount `/repos/iterate`): fails after ~15s with exactly that byte count. The absurdity: the board asked for **73 task files totaling 560KB**, and the platform tried to move **43.7MB** — the full iterate/iterate HEAD tree — across one Durable Object RPC to answer.

## Where the bytes crossed

```
vessel files()                    workspace DO                      repo DO
  glob("**/tasks/**/*.md")   →   readFiles(73 paths)          →   getFilesSnapshot()   ← UNSCOPED
                                   live/overlay: local              returns FULL HEAD tree
                                   fall-through: grouped            {files: <43.7MB>}  ✗ 32MiB workerd RPC cap
                                   per mount… then asked
                                   for EVERYTHING anyway
```

The workspace's batched `readFiles` (from #2224) groups its mount fall-through correctly — one snapshot call per mount, routed repo-relative keys — but called `getFilesSnapshot()` with no arguments and filtered **after** the full tree had already crossed the DO-to-DO boundary. Small repos never noticed. The 32MiB cap binds the **serialized return value**, so no amount of client-side filtering helps: the scoping has to happen repo-side.

## The fix — ask for exactly what you need, everywhere

### 1. `RepoDurableObject.getFilesSnapshot` gains `paths` (exact repo-relative selection)

```ts
async getFilesSnapshot(
  input: { branch?: string; commitOid?: string; exclude?: string[]; include?: string[]; paths?: string[] } = {},
): Promise<{ commitOid: string; files: Record<string, string> }> {
```

Two lanes, both scoped:

- **Head-cache lane** (default branch): a `paths` call still rides — and primes — the shared whole-head snapshot cache, then picks the requested entries. The RPC cap binds the serialized *return*, not this object's memory, and repeat readers share one clone instead of re-cloning per scoped call. Deliberate subtlety: the cache loader is `#loadFilesSnapshot({ branch })`, **not** `{ ...input, branch }` — spreading the input would poison the shared head cache with a paths-scoped record.
- **Load lane** (pinned commit / globs): the existing "mask paths BEFORE reading contents" walk now also skips unrequested files, so a scoped read of a pinned commit reads 73 files off the checkout, not 30k.

`include`/`exclude` (the worker-build lane, `worker-build-capability.ts:80`) are untouched.

### 2. The mount grouping moves into `WorkspaceCore.readMountFiles`

```ts
// workspace-core.ts — the batched fall-through, readFile's routing at bulk scale
const snapshot = await this.#repo(group.repoPath).getFilesSnapshot({
  paths: group.entries.map((entry) => entry.repoRelativePath),
});
```

Same semantics as before, now in the host-agnostic core: ONE mount-table read then synchronous grouping (an awaited read per path could interleave with a `configure` and route one mount by two tables), whiteout/virtual-directory masks via the shared `resolveMountFallThrough` predicate, unrouted paths read as `null`. Moving it into core is what makes the regression **enforceable** — the core test fixtures now sit on the repo boundary (see Testing).

### 3. The workspace DO delegates

```ts
// workspace-durable-object.ts readFiles — live sessions and overlay copies first, then:
Object.assign(result, await this.#core.readMountFiles(leftover));
```

## Callsites

- **iterate/tasks vessel** (`src/rpc-api.ts` `files()`): `ws.glob("**/tasks/**/*.md")` → `ws.readFiles(paths)` — **no change needed**; the vessel's contract was already path-scoped. The fix is entirely below it.
- **`itx.workspaces.get(…).readFiles(paths)`** (public itx surface): unchanged signature, now safe on any repo size.
- **Worker builds** (`worker-build-capability.ts`): still use `include`/`exclude` globs; behavior identical.
- **Repo DO internal callers** (`repo-durable-object.ts:227/788/808`): bare or `{branch}`/`{commitOid}` calls; behavior identical.

## Testing

- **The fixture refuses the bug** (`workspace-core.test.ts`): the shared `fakeRepo.getFilesSnapshot` now **throws on any unscoped call** — "the full HEAD tree must never cross the RPC" — and records the asked paths. Any future pathway that regresses to a full-tree pull fails the suite structurally, not statistically.
- **New unit tests** (3): per-mount grouping asks for exactly the routed repo-relative paths (one scoped call per mount); a big-repo tree with an unrequested decoy blob resolves without it ever riding the snapshot; whiteouts + virtual directories mask batched reads exactly like `readFile` (masked paths never reach the repo).
- **e2e** (`workspace.itx.e2e.test.ts`): one `readFiles` call mixing an overlay write, a copied-up edit, a whiteout, a pure mount fall-through, and a miss — the board-seed lane against the real repo DO.
- **Suite**: 284 passed | 2 expected-fail across workspaces + repos domains.
- **Prod verification (after this deploys)**: `probe-bigrepo` (read-only: authenticate → workspace on `/repos/iterate` → `files()`), currently failing with the 43,729,639-byte error, must return ~73 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path bulk reads and repo snapshot RPC shaping; behavior for existing unscoped callers (worker builds, internal head resolution) is intended unchanged, but incorrect `paths` handling could still break reads or cache correctness on large repos.
> 
> **Overview**
> Fixes production failures when opening task boards on large repos: batched `readFiles` grouped mount fall-through correctly but called **unscoped** `getFilesSnapshot()`, serializing the entire HEAD tree (~43.7MB) across a 32MiB-capped repo DO RPC even when only ~560KB of task files were needed.
> 
> **Repo DO:** `getFilesSnapshot` accepts optional **`paths`** (exact repo-relative files). On the default-branch head-cache path, scoped calls still load/prime the full-head cache internally but **return only the requested entries** so the RPC payload stays small; the cache loader is not poisoned with a paths-scoped record. Non-cache loads skip reading unrequested files after the path walk.
> 
> **Workspace core:** New **`readMountFiles`** centralizes batched mount fall-through—one mount-table snapshot, group by mount, one scoped snapshot per repo with exactly the routed repo-relative paths. Whiteouts and virtual directories behave like `readFile`.
> 
> **Workspace DO:** `readFiles` delegates leftover paths to `readMountFiles` instead of duplicating grouping with unscoped snapshots.
> 
> Tests enforce the contract: `fakeRepo` throws on unscoped `getFilesSnapshot`, unit cases cover per-mount path lists and big-repo bounds, and e2e asserts a mixed `readFiles` batch matches single-file semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7a85813ee33b840997d94156170d8a41eb4a49b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-22T12:59:14.648Z",
      "headSha": "c7a85813ee33b840997d94156170d8a41eb4a49b",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-19.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/533951754356500",
      "shortSha": "c7a8581",
      "cleanupDurationMs": 15652,
      "deployDurationMs": 140689,
      "deployedWorkerName": "os-preview-19",
      "deployedWorkerVersion": "d5781090-e081-4596-8c29-3ffb9d66637b",
      "testDurationMs": 144510,
      "testRetries": "2 retried: project streams are born with the project-worker push feed and replace it by key (vitest x1) — Timed out waiting for project-worker feed ackedOffset to advance past the appended event · repl-examples.spec.ts › itx REPL catalogue examples › runs \"describe-project\" through the project REPL › web (playwright x1) — TimeoutError: locator.waitFor: Timeout 750ms exceeded. Call log: \u001b[2m - waiting for getByRole('button', { name: 'Run', exact: true }) to be visible\u001b[22m \u001b[33m Spinner was still visible after 30000ms, the UI is likely stuck.\u001b[0m",
      "workerSizeKib": 17319.11,
      "workerGzipKib": 4657.14,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 4667.57
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-22T12:59:01.646Z",
      "headSha": "c7a85813ee33b840997d94156170d8a41eb4a49b",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-19.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/533951754356500",
      "shortSha": "c7a8581",
      "cleanupDurationMs": 2647,
      "deployDurationMs": 20885,
      "deployedWorkerName": "auth-preview-19",
      "deployedWorkerVersion": "57c2f5e1-c06d-46de-bdad-4f32e914aec2",
      "testDurationMs": 13499,
      "testRetries": null,
      "workerSizeKib": 3965.97,
      "workerGzipKib": 811.45,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-22T12:58:59.562Z",
      "headSha": "c7a85813ee33b840997d94156170d8a41eb4a49b",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-19.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/533951754356500",
      "shortSha": "c7a8581",
      "cleanupDurationMs": 562,
      "deployDurationMs": 6077,
      "deployedWorkerName": "dummy-petshop-preview-19",
      "deployedWorkerVersion": "909cef2e-4e38-4700-a296-c7324242afec",
      "testDurationMs": 5760,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `c7a8581` | [https://auth.iterate-preview-19.com](https://auth.iterate-preview-19.com) | 811.5 KiB | 20.9s | 13.5s |  | 2.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/533951754356500) | 2026-07-22T12:59:01.646Z | Preview app released. |
| Dummy Petshop | released | `c7a8581` | [https://dummy-petshop.iterate-preview-19.com](https://dummy-petshop.iterate-preview-19.com) | 198.3 KiB | 6.1s | 5.8s |  | 562ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/533951754356500) | 2026-07-22T12:58:59.562Z | Preview app released. |
| OS | released | `c7a8581` | [https://os.iterate-preview-19.com](https://os.iterate-preview-19.com) | 4.55 MiB (-10.4 KiB vs main) | 140.7s | 144.5s | 2 retried: project streams are born with the project-worker push feed and replace it by key (vitest x1) — Timed out waiting for project-worker feed ackedOffset to advance past the appended event · repl-examples.spec.ts › itx REPL catalogue examples › runs "describe-project" through the project REPL › web (playwright x1) — TimeoutError: locator.waitFor: Timeout 750ms exceeded. Call log: [2m - waiting for getByRole('button', { name: 'Run', exact: true }) to be visible[22m [33m Spinner was still visible after 30000ms, the UI is likely stuck.[0m | 15.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/533951754356500) | 2026-07-22T12:59:14.648Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +82 -45 | +49 -31 🟩🟩🟩🟥🟥 |
| Tests | +99 -2 | +80 -2 🟩🟩🟩🟩🟩 |
| **Total** | **+181 -47** | **+129 -33** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 1985834 and c7a8581, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->