### PR TITLE
Close zero-budget dynamic worker build cache race

### DIFF
--- a/apps/os/src/domains/workers/worker-build-coordinator-durable-object.test.ts
+++ b/apps/os/src/domains/workers/worker-build-coordinator-durable-object.test.ts
@@ -58,6 +58,17 @@ beforeEach(() => {
 });
 
 describe("WorkerBuildCoordinatorDurableObject background handoff", () => {
+  it("serves a zero-budget follower from the settled coordinator artifact", async () => {
+    const { records, setAlarm, value } = coordinator();
+
+    await expect(value.build(request)).resolves.toBe(artifact);
+    await expect(value.build(request, 0)).resolves.toBe(artifact);
+
+    expect(h.execute).toHaveBeenCalledOnce();
+    expect(records.size).toBe(0);
+    expect(setAlarm).not.toHaveBeenCalled();
+  });
+
   it("persists an alarm handoff before a budgeted build call returns", async () => {
     const { records, setAlarm, value } = coordinator();
     const build = Promise.withResolvers<WorkerBuildArtifact>();

--- a/apps/os/src/domains/workers/worker-build-coordinator.test.ts
+++ b/apps/os/src/domains/workers/worker-build-coordinator.test.ts
@@ -24,6 +24,16 @@ const artifact: WorkerBuildArtifact = {
 };
 
 describe("WorkerBuildCoordinator", () => {
+  it("reuses its settled artifact without consulting the eventually-consistent store again", async () => {
+    const execute = vi.fn(async () => artifact);
+    const coordinator = new WorkerBuildCoordinator(execute);
+
+    await expect(coordinator.build(request)).resolves.toBe(artifact);
+    await expect(coordinator.build(request)).resolves.toBe(artifact);
+
+    expect(execute).toHaveBeenCalledOnce();
+  });
+
   it("gives concurrent followers their own answer from one build", async () => {
     const build = Promise.withResolvers<WorkerBuildArtifact>();
     const execute = vi.fn(async () => await build.promise);

--- a/apps/os/src/domains/workers/worker-build-coordinator.ts
+++ b/apps/os/src/domains/workers/worker-build-coordinator.ts
@@ -32,6 +32,7 @@ export class WorkerBuildCoordinator {
   readonly #now: () => number;
   readonly #observe: (event: WorkerBuildCoordinatorEvent) => void;
   #flight: Flight | undefined;
+  #settled: { artifact: WorkerBuildArtifact; buildKey: string } | undefined;
 
   constructor(
     execute: (request: WorkerBuildRequest) => Promise<WorkerBuildArtifact>,
@@ -46,13 +47,15 @@ export class WorkerBuildCoordinator {
   }
 
   async build(request: WorkerBuildRequest): Promise<WorkerBuildArtifact> {
+    const settled = this.#settled;
+    if (settled !== undefined) {
+      this.#assertBuildKey(settled.buildKey, request.buildKey);
+      return settled.artifact;
+    }
+
     const existing = this.#flight;
     if (existing !== undefined) {
-      if (existing.buildKey !== request.buildKey) {
-        throw new Error(
-          `Worker build coordinator for ${existing.buildKey} received ${request.buildKey}.`,
-        );
-      }
+      this.#assertBuildKey(existing.buildKey, request.buildKey);
       return await new Promise<WorkerBuildArtifact>((resolve, reject) => {
         existing.waiters.add({ reject, resolve });
         this.#emit(existing, "coalesced");
@@ -68,6 +71,12 @@ export class WorkerBuildCoordinator {
     this.#emit(flight, "started");
     try {
       const artifact = await this.#execute(request);
+      // One actor owns one immutable build key. Keep its successful result in
+      // memory so callers from other OS isolates do not fall back through the
+      // eventually-consistent KV cache immediately after the first build.
+      // Actor eviction remains the cache eviction policy; after that, the KV
+      // write is visible at the coordinator's stable location.
+      this.#settled = { artifact, buildKey: request.buildKey };
       this.#emit(flight, "settled", "built");
       for (const waiter of flight.waiters) waiter.resolve(artifact);
       return artifact;
@@ -81,6 +90,12 @@ export class WorkerBuildCoordinator {
       throw error;
     } finally {
       this.#flight = undefined;
+    }
+  }
+
+  #assertBuildKey(expected: string, received: string): void {
+    if (expected !== received) {
+      throw new Error(`Worker build coordinator for ${expected} received ${received}.`);
     }
   }
 


### PR DESCRIPTION
## Outcome

Fresh-project stream delivery now reuses the dynamic worker artifact that project readiness just built, even when the delivery caller has the intentional zero-millisecond cold-build budget.

This keeps #2251's safety property—stream alarms do not wait on genuinely cold builds—without making a ready worker look cold merely because another OS isolate cannot yet see the eventually-consistent KV write.

## Root cause

#2251 routes every immutable worker build through one build-key Durable Object and gives stream-delivery calls a `0ms` build budget. Project creation intentionally waits for the seeded worker to build and answer its readiness probe. The successful artifact is written to KV, but the coordinator discarded its in-memory result as soon as that foreground build settled.

A child stream can then run in another OS isolate immediately after `projects.create()` returns:

1. that isolate misses its local artifact memo;
2. KV has not propagated to that isolate yet;
3. it dials the same build-key coordinator;
4. the coordinator starts another asynchronous KV lookup;
5. the `0ms` budget wins before even that already-built artifact can be returned;
6. stream delivery receives `WorkerBuildInProgressError` and enters 1s/2s/4s/8s… durable backoff.

That backoff is why the lifecycle assertion could consume its full 30-second deadline even though project creation had already proven the worker ready. Raising the test timeout would only hide the coherence bug.

## Change

`WorkerBuildCoordinator` now retains its one successful immutable artifact for the lifetime of the build-key actor. Subsequent callers—including zero-budget stream deliveries from other OS isolates—receive it synchronously without another KV read or build.

The cache remains naturally bounded:

- one Durable Object owns exactly one SHA-256 build key;
- it retains at most one successful artifact;
- actor eviction is the memory eviction policy;
- KV remains the durable, 30-day artifact cache after eviction;
- failures are still not cached and retain the existing retry classification.

The durable handoff for genuinely cold or interrupted builds is unchanged.

## Regression coverage

The tests prove both layers of the failure:

- the coordinator core executes once and reuses its settled artifact;
- after an unbudgeted readiness-style build, a `build(request, 0)` follower succeeds without enqueueing an alarm or executing again.

The second test failed before the implementation change because the coordinator executed twice.

## Production-shaped evidence

PostHog's `ci test finished` history for:

> project streams are born with the project-worker push feed and replace it by key

shows no absorbed retries across roughly 90 preceding executions. After the zero-budget path landed, three of the latest seven executions exhausted the 30-second cursor deadline:

| UTC | duration | retries |
| --- | ---: | ---: |
| 11:54 | 53.121s | 1 |
| 12:41 | 58.568s | 1 |
| 12:56 | 55.689s | 1 |

Clean executions normally take about 8–14 seconds. The failure appeared only after the new zero-budget coordinator path and matches its exponential-backoff envelope.

## Exact-head preview validation

Commit `103fa9958ea588ef7c7d1bb025eafad19d7bc111` passed every required check. In the canonical preview deployment:

- the regression test passed on its first attempt in 15.814s (`retry_count = 0` in PostHog), versus 53–59s when the race absorbed a retry;
- all 47 OS Vitest files passed, as did Playwright, auth, and dummy-petshop;
- Cloudflare coordinator telemetry for deployed version `84074b12-8e06-4316-b8ea-a4ff8ba85d4e` recorded 1,253 coordinator events across 137 build keys, with coordinator errors = 0; source-invalid builds remained explicitly classified as `source-failed`;
- the deploy took 149.1s, of which 57.8s was bounded Durable Object version propagation/readiness; OS e2e took 179.7s.

The green run did absorb three unrelated retries and therefore does **not** count toward the 25-run zero-retry streak:

- `sandbox-timeout.e2e.test.ts`: runtime connection closed during the expected timeout/cleanup path; retry passed (3 retried runs in 117 PostHog observations);
- Playwright `provide-live-flattened` and `repo-edit-file`: both first attempts remained on the route spinner for 30s; both retries passed (each is the first retry in 78 PostHog observations).

No test is deleted or quarantined in this PR. These signals are being carried into the next fresh-main diagnosis rather than mixed into this narrowly scoped coordinator fix.

## Local validation

- focused coordinator suites: 9/9 passed
- worker-domain suite: 13 files, 89/89 passed
- OS unit suite: passed
- `pnpm typecheck`: passed
- `pnpm lint`: 0 warnings, 0 errors
- `pnpm format:check`: passed
- `pnpm test`: passed
- `git diff --check`: passed

The exact-head preview is green; the target regression passed without retry. Unrelated absorbed retries are documented above and exclude this run from the clean streak.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dynamic worker build coordination and stream delivery timing across isolates; scope is bounded (one artifact per actor, eviction on actor lifecycle) with no change to failure or cold-build paths.
> 
> **Overview**
> Fixes a race where **zero-budget** stream delivery (from another OS isolate right after project creation) could treat an already-built worker as still cold because the build-key coordinator dropped its in-memory result and KV was not yet visible locally.
> 
> **`WorkerBuildCoordinator`** now keeps the single successful artifact for the lifetime of the build-key actor. Later `build()` calls—including `build(request, 0)` followers—return that artifact immediately without another execute/KV round-trip. Failures are still not cached; cold-build alarm handoff behavior is unchanged. Build-key mismatch handling is centralized in `#assertBuildKey`.
> 
> Regression tests cover in-memory reuse after settle and DO-level zero-budget follower success without alarm or second execute.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 103fa9958ea588ef7c7d1bb025eafad19d7bc111. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +20 -5 | +13 -5 🟩🟩🟩🟩🟥 |
| Tests | +21 -0 | +15 -0 🟩🟩🟩🟩⬜ |
| **Total** | **+41 -5** | **+28 -5** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between ba8d708 and 103fa99, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->
