### PR TITLE
Keep sandbox RPC calls alive until settlement

### DIFF
--- a/patches/@cloudflare__sandbox@0.12.3.patch
+++ b/patches/@cloudflare__sandbox@0.12.3.patch
@@ -1,0 +1,184 @@
+diff --git a/dist/sandbox-DI6suZAc.js b/dist/sandbox-DI6suZAc.js
+index 9d0eddb90a0c5757acf71dc9d275620894c10c93..739598c9967f11ce93c97884989fa040bc30e284 100644
+--- a/dist/sandbox-DI6suZAc.js
++++ b/dist/sandbox-DI6suZAc.js
+@@ -3424,17 +3424,18 @@ function buildInterruptedOperationResponse(transportResponse, context) {
+ * from the JSON wire format into typed SandboxError instances and signals
+ * activity at call start.
+ *
+-* `onCallStarted` fires synchronously when an RPC method is invoked. The
+-* ContainerControlClient uses this to renew the DO's activity timeout
+-* immediately, so even a call that completes entirely between two
+-* busy-poll ticks still pushes the sleepAfter deadline forward.
++* `onCallStarted` fires synchronously when an RPC method is invoked, and
++* `onCallSettled` fires when the returned promise settles. The
++* ContainerControlClient uses these hooks to keep the session marked busy
++* even if capnweb stats briefly report the bootstrap baseline while a call is
++* still pending.
+ *
+-* Note: there is no `onCallSettled` hook. A method whose returned promise
+-* resolves with a `ReadableStream` is *not* finished when the promise
+-* settles — capnweb keeps the export alive until the stream ends. The
+-* busy/idle poll on `getStats()` is the source of truth for that.
++* A method whose returned promise resolves with a `ReadableStream` is *not*
++* finished when the promise settles — capnweb keeps the export alive until
++* the stream ends. The busy/idle poll on `getStats()` remains the source of
++* truth for stream lifetimes after the initial RPC promise settles.
+ */
+-function wrapStub(stub, domain, onCallStarted) {
++function wrapStub(stub, domain, onCallStarted, onCallSettled) {
+ 	return new Proxy(stub, { get(target, prop, receiver) {
+ 		const value = Reflect.get(target, prop, receiver);
+ 		if (typeof value !== "function") return value;
+@@ -3443,9 +3444,11 @@ function wrapStub(stub, domain, onCallStarted) {
+ 			const operation = typeof prop === "string" ? `${domain}.${prop}` : domain;
+ 			try {
+ 				const result = Reflect.apply(value, target, args);
+-				if (result != null && typeof result.then === "function") return result.catch((err) => translateRPCError(err, { operation }));
++				if (result != null && typeof result.then === "function") return result.catch((err) => translateRPCError(err, { operation })).finally(onCallSettled);
++				onCallSettled();
+ 				return result;
+ 			} catch (err) {
++				onCallSettled();
+ 				translateRPCError(err, { operation });
+ 			}
+ 		};
+@@ -3475,6 +3478,8 @@ var ContainerControlClient = class {
+ 	conn = null;
+ 	idleTimer = null;
+ 	busyPollTimer = null;
++	/** Number of RPC method promises that have started but not settled. */
++	activeCalls = 0;
+ 	/** Tracks whether we currently believe the session is busy. */
+ 	busy = false;
+ 	constructor(options) {
+@@ -3507,13 +3512,46 @@ var ContainerControlClient = class {
+ 		return this.conn;
+ 	}
+ 	/**
++	* Mark the connection busy and cancel any pending idle disconnect.
++	*/
++	markBusy() {
++		if (!this.busy) {
++			this.busy = true;
++			this.onSessionBusy?.();
++		}
++		this.clearIdleTimer();
++	}
++	isSessionBusy(conn) {
++		const { imports, exports } = conn.getStats();
++		return this.activeCalls > 0 || imports > IDLE_IMPORT_THRESHOLD || exports > IDLE_EXPORT_THRESHOLD;
++	}
++	maybeTransitionIdle() {
++		const conn = this.conn;
++		if (!conn || !conn.isConnected()) return;
++		if (this.isSessionBusy(conn)) {
++			this.markBusy();
++			return;
++		}
++		if (this.busy) {
++			this.busy = false;
++			this.onSessionIdle?.();
++			this.scheduleIdleDisconnect();
++		} else if (!this.idleTimer) this.scheduleIdleDisconnect();
++	}
++	/**
+ 	* Called synchronously at the start of each RPC method invocation.
+-	* Renews the DO activity timeout so the sleepAfter alarm is pushed
+-	* forward before the container processes the call.
++	* Renews the DO activity timeout and pins the connection until the method
++	* promise settles.
+ 	*/
+-	renewActivity = () => {
++	recordCallStarted = () => {
++		this.activeCalls++;
++		this.markBusy();
+ 		this.onActivity?.();
+ 	};
++	recordCallSettled = () => {
++		this.activeCalls = Math.max(0, this.activeCalls - 1);
++		this.maybeTransitionIdle();
++	};
+ 	/**
+ 	* Sample `getStats()` and update busy/idle state. While busy, renews the
+ 	* activity timeout each tick so an in-flight stream keeps pushing the
+@@ -3529,14 +3567,9 @@ var ContainerControlClient = class {
+ 		const conn = this.conn;
+ 		if (!conn) return;
+ 		if (!conn.isConnected()) return;
+-		const { imports, exports } = conn.getStats();
+-		if (imports > IDLE_IMPORT_THRESHOLD || exports > IDLE_EXPORT_THRESHOLD) {
+-			if (!this.busy) {
+-				this.busy = true;
+-				this.onSessionBusy?.();
+-			}
++		if (this.isSessionBusy(conn)) {
++			this.markBusy();
+ 			this.onActivity?.();
+-			this.clearIdleTimer();
+ 		} else if (this.busy) {
+ 			this.busy = false;
+ 			this.onSessionIdle?.();
+@@ -3559,8 +3592,7 @@ var ContainerControlClient = class {
+ 			this.idleTimer = null;
+ 			const conn = this.conn;
+ 			if (!conn || !conn.isConnected()) return;
+-			const { imports, exports } = conn.getStats();
+-			if (imports <= IDLE_IMPORT_THRESHOLD && exports <= IDLE_EXPORT_THRESHOLD) {
++			if (!this.isSessionBusy(conn)) {
+ 				this.logger.debug("Disconnecting idle RPC connection");
+ 				this.destroyConnection();
+ 			}
+@@ -3575,6 +3607,7 @@ var ContainerControlClient = class {
+ 	destroyConnection() {
+ 		this.stopBusyPoll();
+ 		this.clearIdleTimer();
++		this.activeCalls = 0;
+ 		if (this.busy) {
+ 			this.busy = false;
+ 			this.onSessionIdle?.();
+@@ -3585,34 +3618,34 @@ var ContainerControlClient = class {
+ 		}
+ 	}
+ 	get commands() {
+-		return wrapStub(this.getConnection().rpc().commands, "commands", this.renewActivity);
++		return wrapStub(this.getConnection().rpc().commands, "commands", this.recordCallStarted, this.recordCallSettled);
+ 	}
+ 	get files() {
+-		return wrapStub(this.getConnection().rpc().files, "files", this.renewActivity);
++		return wrapStub(this.getConnection().rpc().files, "files", this.recordCallStarted, this.recordCallSettled);
+ 	}
+ 	get processes() {
+-		return wrapStub(this.getConnection().rpc().processes, "processes", this.renewActivity);
++		return wrapStub(this.getConnection().rpc().processes, "processes", this.recordCallStarted, this.recordCallSettled);
+ 	}
+ 	get ports() {
+-		return wrapStub(this.getConnection().rpc().ports, "ports", this.renewActivity);
++		return wrapStub(this.getConnection().rpc().ports, "ports", this.recordCallStarted, this.recordCallSettled);
+ 	}
+ 	get git() {
+-		return wrapStub(this.getConnection().rpc().git, "git", this.renewActivity);
++		return wrapStub(this.getConnection().rpc().git, "git", this.recordCallStarted, this.recordCallSettled);
+ 	}
+ 	get utils() {
+-		return wrapStub(this.getConnection().rpc().utils, "utils", this.renewActivity);
++		return wrapStub(this.getConnection().rpc().utils, "utils", this.recordCallStarted, this.recordCallSettled);
+ 	}
+ 	get backup() {
+-		return wrapStub(this.getConnection().rpc().backup, "backup", this.renewActivity);
++		return wrapStub(this.getConnection().rpc().backup, "backup", this.recordCallStarted, this.recordCallSettled);
+ 	}
+ 	get watch() {
+-		return wrapStub(this.getConnection().rpc().watch, "watch", this.renewActivity);
++		return wrapStub(this.getConnection().rpc().watch, "watch", this.recordCallStarted, this.recordCallSettled);
+ 	}
+ 	get tunnels() {
+-		return wrapStub(this.getConnection().rpc().tunnels, "tunnels", this.renewActivity);
++		return wrapStub(this.getConnection().rpc().tunnels, "tunnels", this.recordCallStarted, this.recordCallSettled);
+ 	}
+ 	get interpreter() {
+-		return wrapStub(this.getConnection().rpc().interpreter, "interpreter", this.renewActivity);
++		return wrapStub(this.getConnection().rpc().interpreter, "interpreter", this.recordCallStarted, this.recordCallSettled);
+ 	}
+ 	/**
+ 	* Update the upgrade retry budget. Applies to the current connection

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ patchedDependencies:
   '@better-auth/oauth-provider@1.6.9':
     hash: e05b6e0e968dd85c546197511b6b7bdeaf9f4449572e4a143d90d5d31008fb40
     path: patches/@better-auth__oauth-provider@1.6.9.patch
+  '@cloudflare/sandbox@0.12.3':
+    hash: ea669d99cbc7919697d6388129b469e444d53f36b4a76b77ed91e172e38ad724
+    path: patches/@cloudflare__sandbox@0.12.3.patch
   '@cloudflare/worker-bundler@0.2.1':
     hash: 73256eb6fd3dcae81991c5c1730c823d847cb51938ee0cdb524018a167f938c9
     path: patches/@cloudflare__worker-bundler@0.2.1.patch
@@ -536,7 +539,7 @@ importers:
         version: 0.3.7
       '@cloudflare/sandbox':
         specifier: 0.12.3
-        version: 0.12.3
+        version: 0.12.3(patch_hash=ea669d99cbc7919697d6388129b469e444d53f36b4a76b77ed91e172e38ad724)
       '@cloudflare/shell':
         specifier: ^0.3.4
         version: 0.3.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@tanstack/ai@0.10.2)(ai@6.0.159(zod@4.3.6))(zod@4.3.6)
@@ -14213,7 +14216,7 @@ snapshots:
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
-  '@cloudflare/sandbox@0.12.3':
+  '@cloudflare/sandbox@0.12.3(patch_hash=ea669d99cbc7919697d6388129b469e444d53f36b4a76b77ed91e172e38ad724)':
     dependencies:
       '@cloudflare/containers': 0.3.7
       aws4fetch: 1.0.20

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -96,6 +96,8 @@ packageExtensions:
 
 patchedDependencies:
   '@better-auth/oauth-provider@1.6.9': patches/@better-auth__oauth-provider@1.6.9.patch
+  # Remove once Cloudflare releases upstream fix 5fc1224cd73012d087b9438ff0ad931174e4bd86.
+  '@cloudflare/sandbox@0.12.3': patches/@cloudflare__sandbox@0.12.3.patch
   '@cloudflare/worker-bundler@0.2.1': patches/@cloudflare__worker-bundler@0.2.1.patch
   '@cloudflare/workers-types@4.20260621.1': patches/@cloudflare__workers-types@4.20260621.1.patch
   '@journeyapps/wa-sqlite@1.7.0': patches/@journeyapps__wa-sqlite@1.7.0.patch


### PR DESCRIPTION
## Summary

- Patch `@cloudflare/sandbox@0.12.3` with Cloudflare upstream commit [5fc1224](https://github.com/cloudflare/sandbox-sdk/commit/5fc1224cd73012d087b9438ff0ad931174e4bd86).
- Count RPC method promises synchronously from invocation through settlement, and cancel the idle-disconnect timer while any call is active.
- Preserve capnweb import/export polling as the source of truth for stream lifetimes after the initial method promise settles.
- Remove the patch when Cloudflare publishes that upstream fix.

## Why

During the canonical preview run for #2256, `sandbox-timeout.e2e.test.ts` failed its first attempt after the SDK disposed its own RPC connection during the internal process-group cleanup command:

```
Sandbox operation commands.execute was interrupted while the runtime connection was closing
```

The exact Cloudflare trace was `tr_f3950a6094ae4643` at 2026-07-22 13:16:09 UTC. The cleanup call was admitted, then the SDK idle timer closed the main stub 781 ms later. The released SDK only infers activity from capnweb import/export counters sampled once per second; a pending call can briefly look idle between samples. Cloudflare independently fixed this exact race upstream by tracking active method promises.

Retrying `commands.execute` would be unsafe because admission is unknown. This change prevents the self-disposal instead of adding another retry layer.

A PostHog history audit found three retries across 117 observations of this test. They have different signatures; this PR deliberately addresses the exact transport-disposed failure from #2256 without conflating the separate ITX WebSocket-close signature.

## Scope

- No test is deleted, skipped, or quarantined.
- No timeout or retry budget changes.
- No product-level command retry.
- No matrix/ITX example changes.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm test` — 2,206 OS unit tests passed; repository suite green
- `node --check apps/os/node_modules/@cloudflare/sandbox/dist/sandbox-DI6suZAc.js`

### Deployment-shaped preview proof

- Canonical preview run [802b24wrkw](https://depot.dev/orgs/0p91s0lz49/workflows/rhjdgksr9h?job=x40rl181s9) passed every required check against commit `a3d2fd2`.
- Both tests that exercise the reported lifecycle passed on their first attempt: process-group termination in 18.362s, and the absolute-deadline/in-script-timeout case in 40.380s.
- The entire OS Vitest lane passed with zero retries in 77s.
- The Playwright lane separately absorbed three first-attempt REPL-loading retries (`describe-project`, `run-script`, and `repo-edit-file`). All three created distinct projects and failed before executing their matrix example because the browser TypeScript VFS left a request for the nonexistent `lib.core.es6.d.ts` unsettled. That unrelated defect is isolated for the next PR; no matrix test was skipped or removed, and it does not exercise this sandbox RPC patch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sandbox container RPC connection lifecycle in a vendored dependency patch; behavior change is narrow but affects when connections disconnect during long or in-flight commands.
> 
> **Overview**
> Adds a **pnpm patch** on `@cloudflare/sandbox@0.12.3` (upstream commit `5fc1224`) and wires it through `pnpm-workspace.yaml` / the lockfile, with a note to drop the patch once that release ships.
> 
> The patch changes **`ContainerControlClient`** so the session stays busy while any RPC method promise is outstanding: `wrapStub` gains an **`onCallSettled`** hook, **`activeCalls`** is incremented on start and decremented on settle, and busy/idle plus idle disconnect use **`isSessionBusy()`** (`activeCalls > 0` or capnweb import/export thresholds). That stops the SDK from closing the main RPC stub while a call such as `commands.execute` is still pending—a race that showed up as “operation interrupted while the runtime connection was closing” in sandbox e2e. **Capnweb polling** is unchanged for lifetimes after a call resolves with a **`ReadableStream`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3d2fd2bc588d74e9c46d1a23a0754c112927093. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "deployed",
      "updatedAt": "2026-07-22T13:51:58.627Z",
      "headSha": "a3d2fd2bc588d74e9c46d1a23a0754c112927093",
      "message": null,
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/157515082590237",
      "shortSha": "a3d2fd2",
      "deployDurationMs": 170152,
      "deployConfigDurationMs": 205,
      "deployCommandDurationMs": 82333,
      "deployReadinessDurationMs": 87613,
      "deployedWorkerName": "os-preview-1",
      "deployedWorkerVersion": "d08770ac-7603-4c48-ba2b-e3209d4da5a3",
      "testDurationMs": 173878,
      "testRetries": "3 retried: repl-examples.spec.ts › itx REPL catalogue examples › runs \"describe-project\" through the project REPL › web (playwright x1) — TimeoutError: locator.waitFor: Timeout 750ms exceeded. Call log: \^[[2m - waiting for getByRole('button', { name: 'Run', exact: true }) to be visible\^[[22m \^[[33m Spinner was still visible after 30000ms, the UI is likely stuck.\^[[0m · repl-examples.spec.ts › itx REPL catalogue examples › runs \"run-script\" through the project REPL › web (playwright x1) — TimeoutError: locator.waitFor: Timeout 750ms exceeded. Call log: \^[[2m - waiting for getByRole('button', { name: 'Run', exact: true }) to be visible\^[[22m \^[[33m Spinner was still visible after 30000ms, the UI is likely stuck.\^[[0m · repl-examples.spec.ts › itx REPL catalogue examples › runs \"repo-edit-file\" through the project REPL › web (playwright x1) — TimeoutError: locator.waitFor: Timeout 750ms exceeded. Call log: \^[[2m - waiting for getByRole('button', { name: 'Run', exact: true }) to be visible\^[[22m \^[[33m Spinner was still visible after 30000ms, the UI is likely stuck.\^[[0m",
      "workerSizeKib": 17320.7,
      "workerGzipKib": 4657.58,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 4668.05
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "deployed",
      "updatedAt": "2026-07-22T13:49:21.568Z",
      "headSha": "a3d2fd2bc588d74e9c46d1a23a0754c112927093",
      "message": null,
      "publicUrl": "https://semaphore.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/157515082590237",
      "shortSha": "a3d2fd2",
      "deployDurationMs": 13586,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 13351,
      "deployReadinessDurationMs": 232,
      "deployedWorkerName": "semaphore-preview-1",
      "deployedWorkerVersion": "24783e29-7678-422f-b195-78eecfca3d80",
      "testDurationMs": 16819,
      "testRetries": null,
      "workerSizeKib": 1915.22,
      "workerGzipKib": 440.99,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "deployed",
      "updatedAt": "2026-07-22T13:49:09.596Z",
      "headSha": "a3d2fd2bc588d74e9c46d1a23a0754c112927093",
      "message": null,
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/157515082590237",
      "shortSha": "a3d2fd2",
      "deployDurationMs": 19537,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 19485,
      "deployReadinessDurationMs": 48,
      "deployedWorkerName": "auth-preview-1",
      "deployedWorkerVersion": "4f126125-1f97-40ea-9bf5-8cd6c7158a42",
      "testDurationMs": 4844,
      "testRetries": null,
      "workerSizeKib": 3965.97,
      "workerGzipKib": 811.48,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "deployed",
      "updatedAt": "2026-07-22T13:50:05.983Z",
      "headSha": "a3d2fd2bc588d74e9c46d1a23a0754c112927093",
      "message": null,
      "publicUrl": "https://streams.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/157515082590237",
      "shortSha": "a3d2fd2",
      "deployDurationMs": 106566,
      "deployConfigDurationMs": 176,
      "deployCommandDurationMs": 13282,
      "deployReadinessDurationMs": 93108,
      "deployedWorkerName": "streams-example-app-preview-1",
      "deployedWorkerVersion": "68e07c8a-245f-41ea-a627-dff214d2b922",
      "testDurationMs": 61231,
      "testRetries": null,
      "workerSizeKib": 5157.7,
      "workerGzipKib": 1472.7,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "deployed",
      "updatedAt": "2026-07-22T13:49:10.557Z",
      "headSha": "a3d2fd2bc588d74e9c46d1a23a0754c112927093",
      "message": null,
      "publicUrl": "https://dummy-petshop.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/157515082590237",
      "shortSha": "a3d2fd2",
      "deployDurationMs": 6519,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 6159,
      "deployReadinessDurationMs": 307,
      "deployedWorkerName": "dummy-petshop-preview-1",
      "deployedWorkerVersion": "c3820a09-3f16-49fe-a76e-122f3ac0a255",
      "testDurationMs": 5804,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": {
    "dopplerConfig": "preview_1",
    "slug": "preview-1"
  },
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>Slot: preview-1 | Doppler config: preview_1</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | deployed | `a3d2fd2` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 811.5 KiB | 19.5s | 4.8s |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/157515082590237) | 2026-07-22T13:49:09.596Z |  |
| Dummy Petshop | deployed | `a3d2fd2` | [https://dummy-petshop.iterate-preview-1.com](https://dummy-petshop.iterate-preview-1.com) | 198.3 KiB | 6.5s | 5.8s |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/157515082590237) | 2026-07-22T13:49:10.557Z |  |
| OS | deployed | `a3d2fd2` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 4.55 MiB (-10.5 KiB vs main) | 170.2s | 173.9s | 3 retried: repl-examples.spec.ts › itx REPL catalogue examples › runs "describe-project" through the project REPL › web (playwright x1) — TimeoutError: locator.waitFor: Timeout 750ms exceeded. Call log: ^[[2m - waiting for getByRole('button', { name: 'Run', exact: true }) to be visible^[[22m ^[[33m Spinner was still visible after 30000ms, the UI is likely stuck.^[[0m · repl-examples.spec.ts › itx REPL catalogue examples › runs "run-script" through the project REPL › web (playwright x1) — TimeoutError: locator.waitFor: Timeout 750ms exceeded. Call log: ^[[2m - waiting for getByRole('button', { name: 'Run', exact: true }) to be visible^[[22m ^[[33m Spinner was still visible after 30000ms, the UI is likely stuck.^[[0m · repl-examples.spec.ts › itx REPL catalogue examples › runs "repo-edit-file" through the project REPL › web (playwright x1) — TimeoutError: locator.waitFor: Timeout 750ms exceeded. Call log: ^[[2m - waiting for getByRole('button', { name: 'Run', exact: true }) to be visible^[[22m ^[[33m Spinner was still visible after 30000ms, the UI is likely stuck.^[[0m |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/157515082590237) | 2026-07-22T13:51:58.627Z |  |
| Semaphore | deployed | `a3d2fd2` | [https://semaphore.iterate-preview-1.com](https://semaphore.iterate-preview-1.com) | 441.0 KiB | 13.6s | 16.8s |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/157515082590237) | 2026-07-22T13:49:21.568Z |  |
| Streams Example App | deployed | `a3d2fd2` | [https://streams.iterate-preview-1.com](https://streams.iterate-preview-1.com) | 1.44 MiB | 106.6s | 61.2s |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/157515082590237) | 2026-07-22T13:50:05.983Z |  |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Config | +2 -0 | +2 -0 🟩⬜⬜⬜⬜ |
| Other | +184 -0 | +184 -0 🟩🟩🟩🟩🟩 |
| Generated | +5 -2 | +5 -2 🟩⬜⬜⬜⬜ |
| **Total** | **+191 -2** | **+191 -2** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 66364aa and a3d2fd2, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->