### PR TITLE
Make REPL TypeScript startup independent of CDN

### DIFF
--- a/apps/os/src/components/itx-repl-typescript.worker.ts
+++ b/apps/os/src/components/itx-repl-typescript.worker.ts
@@ -1,8 +1,4 @@
-import {
-  createDefaultMapFromCDN,
-  createSystem,
-  createVirtualTypeScriptEnvironment,
-} from "@typescript/vfs";
+import { createSystem, createVirtualTypeScriptEnvironment } from "@typescript/vfs";
 import { createWorker } from "@valtown/codemirror-ts/worker";
 import * as Comlink from "comlink";
 import ts from "typescript";
@@ -11,6 +7,34 @@ import { ITX_TYPES_PATH, itxReplDeclaration, itxTypesDeclaration } from "./itx-r
 
 const REPL_SOURCE_PATH = "/repl.ts";
 const REPL_TYPES_PATH = "/iterate-repl-globals.d.ts";
+
+// Ship the configured libs with the worker so editor startup has no runtime
+// dependency on the TypeScript playground CDN. The ES prefixes include the
+// transitive references needed by es2022; DOM and decorators are explicit.
+const typeScriptLibSources = import.meta.glob<string>(
+  [
+    "/node_modules/typescript/lib/lib.decorators*.d.ts",
+    "/node_modules/typescript/lib/lib.dom.d.ts",
+    "/node_modules/typescript/lib/lib.es5.d.ts",
+    "/node_modules/typescript/lib/lib.es2015*.d.ts",
+    "/node_modules/typescript/lib/lib.es2016*.d.ts",
+    "/node_modules/typescript/lib/lib.es2017*.d.ts",
+    "/node_modules/typescript/lib/lib.es2018*.d.ts",
+    "/node_modules/typescript/lib/lib.es2019*.d.ts",
+    "/node_modules/typescript/lib/lib.es2020*.d.ts",
+    "/node_modules/typescript/lib/lib.es2021*.d.ts",
+    "/node_modules/typescript/lib/lib.es2022*.d.ts",
+  ],
+  { eager: true, import: "default", query: "?raw" },
+);
+
+const createTypeScriptLibMap = () =>
+  new Map(
+    Object.entries(typeScriptLibSources).map(([path, source]) => [
+      `/${path.slice(path.lastIndexOf("/") + 1)}`,
+      source,
+    ]),
+  );
 
 const compilerOptions: ts.CompilerOptions = {
   // The prelude imports the design-of-record module as "./itx-types.ts".
@@ -34,7 +58,7 @@ const compilerOptions: ts.CompilerOptions = {
 const IGNORED_DIAGNOSTIC_CODES = new Set([1108]);
 
 const worker = createWorker(async () => {
-  const fsMap = await createDefaultMapFromCDN(compilerOptions, ts.version, false, ts);
+  const fsMap = createTypeScriptLibMap();
   fsMap.set(ITX_TYPES_PATH, itxTypesDeclaration);
   fsMap.set(REPL_TYPES_PATH, itxReplDeclaration);
   fsMap.set(REPL_SOURCE_PATH, "\n");


### PR DESCRIPTION
## What changed

- Bundle the TypeScript ES2022, DOM, and decorator declaration files into the REPL TypeScript worker at build time.
- Initialize the virtual filesystem synchronously from those bundled sources.
- Remove the runtime dependency on `createDefaultMapFromCDN`.

## Why

The canonical preview for #2257 absorbed first-attempt failures in the `describe-project`, `run-script`, and `repo-edit-file` matrix specs. Their traces showed that project creation, navigation, and server data all completed, but the REPL Run button remained disabled at `Loading...` until the 30-second waiter failed.

Each failed trace had one request that never settled: `https://playgroundcdn.typescriptlang.org/cdn/5.9.3/typescript/lib/lib.core.es6.d.ts`. That filename does not exist. `@typescript/vfs` includes it in its hard-coded CDN list and awaits all library fetches in one `Promise.all`, so one hung network request leaves worker initialization unbounded. The matrix example itself never begins.

The worker now uses the declaration files from the installed, lockfile-pinned `typescript` package. This removes roughly 80 external startup requests and makes the editor independent of CDN availability and behavior. The built worker contains no runtime TypeScript playground CDN URL.

## Scope

This is a one-file reliability fix. It does not add retries, raise timeouts, quarantine tests, alter project creation, or change any matrix examples.

The declaration payload is about 2.35 MB of source and compresses efficiently. The resulting worker is 6.09 MB raw / 1.35 MB gzip in the local production build.

## Local proof

- `pnpm --dir apps/os build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test`
  - OS: 231 test files passed
  - OS: 2,216 tests passed, 6 expected failures, 1 existing skip

## Preview proof

Canonical Depot run [`fxrm72rsq6`](https://depot.dev/orgs/0p91s0lz49/workflows/h1xn180kdn?job=r89cfs1kcj&attempt=2r7pbmql3b) passed at commit `98c465180819894bb06807a5ec6a795c9db21b07`.

- All three deployed apps passed: OS, Auth, and Dummy Petshop.
- Playwright: 63/63 passed in 143.1s with **0 retries**, 0 flaky outcomes, and 0 collection errors.
- The three cases that exposed the CDN hang all passed on their first attempt: `describe-project` in 13.0s, `run-script` in 15.6s, and `repo-edit-file` in 20.4s.
- OS Vitest e2e: 163 passed, 1 expected failure, and 5 existing skips in 79.2s; its 169 reported tests had **0 retries** and 0 collection errors.
- Auth Vitest: 5/5 passed with **0 retries**. Dummy Petshop Vitest: 6/6 passed with **0 retries**. The onboarding smoke also passed with **0 retries**.
- The normalized telemetry manifest was complete: 7/7 artifacts, 5,694 events, no missing or incomplete sources. The uploaded PostHog lane events independently report `retry_count = 0` and `telemetry_incomplete = false` for this SHA.
- End-to-end OS testing took 152.0s. OS deployment took 142.2s, including 59.1s waiting for Cloudflare rollout readiness; those tails are visible but unrelated to this reliability fix.

No retry, timeout, quarantine, project-creation, or matrix-test behavior was changed. No tests were newly skipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-worker reliability change with no auth or data-path impact; main tradeoff is a larger worker bundle (~1.35 MB gzip).
> 
> **Overview**
> Fixes REPL editor startup hanging when the TypeScript playground CDN never returns a missing lib file, which left the Run button stuck on **Loading...** and broke matrix e2e flows.
> 
> The REPL TypeScript worker no longer calls **`createDefaultMapFromCDN`**. It **eagerly bundles** the `es2022`, **DOM**, and **decorator** declaration files from the lockfile-pinned **`typescript`** package via **`import.meta.glob`**, builds the virtual FS map synchronously, and initializes the language service without ~80 runtime CDN requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98c465180819894bb06807a5ec6a795c9db21b07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-22T20:58:09.624Z",
      "headSha": "98c465180819894bb06807a5ec6a795c9db21b07",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/274766833363266",
      "shortSha": "98c4651",
      "cleanupDurationMs": 10280,
      "deployDurationMs": 142172,
      "deployConfigDurationMs": 192,
      "deployCommandDurationMs": 82925,
      "deployReadinessDurationMs": 59053,
      "deployedWorkerName": "os-preview-17",
      "deployedWorkerVersion": "cf934df0-a1e0-4335-a069-389b4abc9949",
      "testDurationMs": 151993,
      "testRetries": null,
      "workerSizeKib": 19637.67,
      "workerGzipKib": 4970.47,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 4670.42
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-22T20:58:02.084Z",
      "headSha": "98c465180819894bb06807a5ec6a795c9db21b07",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/274766833363266",
      "shortSha": "98c4651",
      "cleanupDurationMs": 2738,
      "deployDurationMs": 20273,
      "deployConfigDurationMs": 1,
      "deployCommandDurationMs": 19946,
      "deployReadinessDurationMs": 325,
      "deployedWorkerName": "auth-preview-17",
      "deployedWorkerVersion": "b1e9d645-a709-4d94-b4a1-73d49bafbee4",
      "testDurationMs": 10754,
      "testRetries": null,
      "workerSizeKib": 3965.97,
      "workerGzipKib": 811.31,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-22T20:58:00.147Z",
      "headSha": "98c465180819894bb06807a5ec6a795c9db21b07",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/274766833363266",
      "shortSha": "98c4651",
      "cleanupDurationMs": 798,
      "deployDurationMs": 5995,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 5726,
      "deployReadinessDurationMs": 239,
      "deployedWorkerName": "dummy-petshop-preview-17",
      "deployedWorkerVersion": "f42b27b4-d825-4fb5-8547-02985b42c984",
      "testDurationMs": 5559,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `98c4651` | [https://auth.iterate-preview-17.com](https://auth.iterate-preview-17.com) | 811.3 KiB | 20.3s | 10.8s |  | 2.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/274766833363266) | 2026-07-22T20:58:02.084Z | Preview app released. |
| Dummy Petshop | released | `98c4651` | [https://dummy-petshop.iterate-preview-17.com](https://dummy-petshop.iterate-preview-17.com) | 198.3 KiB | 6.0s | 5.6s |  | 798ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/274766833363266) | 2026-07-22T20:58:00.147Z | Preview app released. |
| OS | released | `98c4651` | [https://os.iterate-preview-17.com](https://os.iterate-preview-17.com) | 4.85 MiB (+300.1 KiB vs main) | 142.2s | 152.0s |  | 10.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/274766833363266) | 2026-07-22T20:58:09.624Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| UI components | +30 -6 | +25 -6 🟩🟩🟩🟩🟥 |
| **Total** | **+30 -6** | **+25 -6** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 356f79c and 98c4651, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->