### PR TITLE
Run preview e2e on every triggered PR head

### DIFF
--- a/docs/dev-environments.md
+++ b/docs/dev-environments.md
@@ -424,6 +424,10 @@ e2e as one step, sharing one resolved PR head so a push cannot race into a
 gap between them. The PR body's managed "Environment Config Lease" section
 records the slot, per-app URLs and statuses; the workflow logs narrate every
 decision (which apps were selected and why, lease transitions, slot waits).
+Diff selection may reuse an unchanged app's exact recorded Worker deployment,
+but never its test result: every triggered PR head reruns every recorded app's
+e2e suite, and a run with no runnable deployment fails instead of reporting a
+green `deploy + e2e` check.
 Closing or merging the PR runs `pnpm preview cleanup`, which destroys the
 PR's apps (for os that means erasing the slot's data — auth D1 and
 project-directory KV) and releases the slot — after verifying the PR still

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -5,6 +5,7 @@ import { parse as parseYaml } from "yaml";
 import { z } from "zod";
 import {
   CloudflarePreviewAppEntry,
+  CloudflarePreviewAppSlug,
   CloudflarePreviewSlotDisplay,
   cloudflarePreviewApps,
   cloudflarePreviewAdditionalTriggerPaths,
@@ -62,6 +63,7 @@ const {
   selectExpiredLeasesForGc,
   selectPreviewAppsForPullRequest,
   selectPreviewAppsNeedingRetry,
+  selectPreviewAppsForTesting,
   selectPreviewSlotDataOwners,
   splitRepositoryFullName,
   syncPreviewInventory,
@@ -453,7 +455,7 @@ describe("preview workflow scope", () => {
             publicUrl: "https://dummy-petshop.iterate-preview-7.com",
           },
         },
-        headSha,
+        requiredDeploymentHeadSha: headSha,
       }),
     ).toEqual([
       "APP_CONFIG_BASE_URL=https://os.iterate-preview-7.com",
@@ -513,7 +515,7 @@ describe("preview workflow scope", () => {
         apps,
         appSlugs: ["os", "auth"],
         dopplerConfig: "preview_7",
-        headSha,
+        requiredDeploymentHeadSha: headSha,
       }),
     ).toBe(`auth-preview-7="${authVersion}",os-preview-7="${osVersion}"`);
 
@@ -522,7 +524,7 @@ describe("preview workflow scope", () => {
         apps: { ...apps, os: { ...apps.os, deployedWorkerVersion: null } },
         appSlugs: ["os", "auth"],
         dopplerConfig: "preview_7",
-        headSha,
+        requiredDeploymentHeadSha: headSha,
       }),
     ).toThrow(/exact os-preview-7 deployment identity is missing or stale/);
   });
@@ -541,9 +543,69 @@ describe("preview workflow scope", () => {
             publicUrl: "https://dummy-petshop.iterate-preview-7.com",
           },
         },
-        headSha: "current-head",
+        requiredDeploymentHeadSha: "current-head",
       }),
     ).toThrow(/PETSHOP_BASE_URL requires dummy-petshop deployed at head current/);
+  });
+
+  test("reruns every app suite when unchanged deployments come from an older head", () => {
+    const oldHead = "older-deployment-head";
+    const osVersion = "11111111-1111-4111-8111-111111111111";
+    const authVersion = "22222222-2222-4222-8222-222222222222";
+    const apps = {
+      auth: CloudflarePreviewAppEntry.parse({
+        appDisplayName: "Auth",
+        appSlug: "auth",
+        deployedWorkerName: "auth-preview-7",
+        deployedWorkerVersion: authVersion,
+        headSha: oldHead,
+        publicUrl: "https://auth.iterate-preview-7.com",
+        status: "deployed",
+        updatedAt: "2026-07-22T00:00:00.000Z",
+      }),
+      "dummy-petshop": CloudflarePreviewAppEntry.parse({
+        appDisplayName: "Dummy Petshop",
+        appSlug: "dummy-petshop",
+        deployedWorkerName: "dummy-petshop-preview-7",
+        deployedWorkerVersion: "33333333-3333-4333-8333-333333333333",
+        headSha: oldHead,
+        publicUrl: "https://dummy-petshop.iterate-preview-7.com",
+        status: "deployed",
+        updatedAt: "2026-07-22T00:00:00.000Z",
+      }),
+      os: CloudflarePreviewAppEntry.parse({
+        appDisplayName: "OS",
+        appSlug: "os",
+        deployedWorkerName: "os-preview-7",
+        deployedWorkerVersion: osVersion,
+        headSha: oldHead,
+        publicUrl: "https://os.iterate-preview-7.com",
+        status: "deployed",
+        updatedAt: "2026-07-22T00:00:00.000Z",
+      }),
+    };
+
+    expect(selectPreviewAppsForTesting(apps).map((app) => app.slug)).toEqual([
+      "auth",
+      "dummy-petshop",
+      "os",
+    ]);
+    expect(
+      resolvePreviewTestWorkerVersionOverrides({
+        apps,
+        appSlugs: ["auth", "os"],
+        dopplerConfig: "preview_7",
+      }),
+    ).toBe(`auth-preview-7="${authVersion}",os-preview-7="${osVersion}"`);
+    expect(
+      resolvePreviewTestBaseUrlEnvironment({
+        app: cloudflarePreviewApps.os,
+        apps,
+      }),
+    ).toEqual([
+      "APP_CONFIG_BASE_URL=https://os.iterate-preview-7.com",
+      "PETSHOP_BASE_URL=https://dummy-petshop.iterate-preview-7.com",
+    ]);
   });
 
   test("rejects pre-RPC branches before the preview orchestrator can deploy Auth", () => {
@@ -1099,17 +1161,27 @@ describe("preview retry selection", () => {
     },
     {
       // An awaiting-tests entry at any head is a deploy whose tests never ran
-      // (a cancelled run). Redeploying it at the current head is idempotent
-      // and is what keeps `test`'s "no app recorded at this head" skip honest
-      // (observed 2026-07-10: a cancelled run's deploy landed, the next
-      // push's non-app diff selected nothing, and the check went green over
-      // deployments that never passed tests).
+      // (a cancelled run). Redeploying it at the current head is the only
+      // valid route back to a tested state (observed 2026-07-10: a cancelled
+      // run's deploy landed, the next push's non-app diff selected nothing,
+      // and the check went green over deployments that never passed tests).
       name: "re-runs awaiting-tests apps whatever head deployed them — their e2e never ran",
       recorded: {
         appDisplayName: "OS",
         appSlug: "os",
         headSha: "old-head",
         status: "awaiting-tests" as const,
+      },
+      expected: ["os", "auth", "dummy-petshop"],
+    },
+    {
+      name: "redeploys legacy green rows that cannot pin an immutable Worker version",
+      recorded: {
+        appDisplayName: "OS",
+        appSlug: "os",
+        headSha: "old-head",
+        publicUrl: "https://os.iterate-preview-7.com",
+        status: "deployed" as const,
       },
       expected: ["os", "auth", "dummy-petshop"],
     },
@@ -1120,7 +1192,7 @@ describe("preview retry selection", () => {
           apps: {
             [recorded.appSlug]: { ...recorded, updatedAt: "2026-05-01T00:00:00.000Z" },
           },
-          environmentConfigLease: null,
+          environmentConfigLease: { dopplerConfig: "preview_7", slug: "preview-7" },
           notice: null,
         },
       }).map((app) => app.slug),
@@ -1143,9 +1215,13 @@ describe("preview deploy selection", () => {
     displayName: string,
     overrides: Partial<CloudflarePreviewAppEntry> = {},
   ) {
+    const appSlug = CloudflarePreviewAppSlug.parse(slug);
     return CloudflarePreviewAppEntry.parse({
       appDisplayName: displayName,
-      appSlug: slug,
+      appSlug,
+      deployedWorkerName:
+        cloudflarePreviewApps[appSlug].resolvePreviewAppConfig("preview_7").workerName,
+      deployedWorkerVersion: "11111111-1111-4111-8111-111111111111",
       headSha: currentHead,
       publicUrl: `https://${slug}.iterate-preview-7.com`,
       shortSha: "current",
@@ -1165,7 +1241,7 @@ describe("preview deploy selection", () => {
       ...selectionInput,
       previousState: {
         apps: { os: recordedApp("os", "OS"), auth: recordedApp("auth", "Auth") },
-        environmentConfigLease: null,
+        environmentConfigLease: { dopplerConfig: "preview_7", slug: "preview-7" },
         notice: null,
       },
       fetchCompare: compareMustNotRun,
@@ -1240,7 +1316,7 @@ describe("preview deploy selection", () => {
             status: "tests-failed" as const,
           }),
         },
-        environmentConfigLease: null,
+        environmentConfigLease: { dopplerConfig: "preview_7", slug: "preview-7" },
         notice: null,
       },
       fetchCompare: compareMustNotRun,

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -87,13 +87,10 @@ function decideDraftPreviewPolicy(input: {
 type DeployCommandOptions = PullRequestCommandOptions & {
   /**
    * Deploy every preview app regardless of the diff. Diff selection only
-   * redeploys apps affected since their LAST DEPLOYED head, so unaffected
-   * apps keep an older recorded head and the test lane leaves them out of
-   * its testable set (stale — deploy has not run for the current head). A
-   * caller that needs the whole fleet testable at the current head — the
-   * flake-hunt marathon preflight — uses this to reunify the fleet
-   * explicitly instead of relying on the commit happening to touch a
-   * fleet-shared path.
+   * redeploys apps affected since their LAST DEPLOYED head. A caller that
+   * needs a fresh deployment of the whole fleet — the flake-hunt marathon
+   * preflight — uses this explicitly instead of relying on the commit
+   * happening to touch a fleet-shared path.
    */
   allApps?: boolean;
   /**
@@ -197,7 +194,7 @@ export async function testTarget(options: TestTargetOptions) {
   const baseUrlEnvironment = resolvePreviewTestBaseUrlEnvironment({
     app,
     apps: recorded.apps,
-    headSha: context.pullRequestHeadSha,
+    requiredDeploymentHeadSha: context.pullRequestHeadSha,
   });
   // Match the full preview lane: RPC-only dependencies such as auth need an
   // exact version pin even though they do not contribute a public base URL.
@@ -206,7 +203,7 @@ export async function testTarget(options: TestTargetOptions) {
     apps: recorded.apps,
     appSlugs: versionedAppSlugs,
     dopplerConfig: environmentConfigLease.dopplerConfig,
-    headSha: context.pullRequestHeadSha,
+    requiredDeploymentHeadSha: context.pullRequestHeadSha,
   });
   const plan = resolvePreviewTestTargetPlan({
     ...selection,
@@ -305,8 +302,9 @@ export async function run(options: DeployCommandOptions = {}) {
       return deployResult;
     }
 
-    // A "nothing to deploy" skip still tests: the recorded deployments ARE the
-    // current head's code, and their green must be earned, not assumed.
+    // A "nothing to deploy" skip still tests. Unchanged apps may reuse their
+    // exact recorded Worker versions, but every PR head earns its own e2e
+    // result; a previous head's green is never promoted to this check.
     return await testPreviewApps({ context, runtime, state: deployResult.state, telemetry });
   });
 }
@@ -707,13 +705,14 @@ async function deployPreviewApps({
 function resolvePreviewTestBaseUrlEnvironment({
   app,
   apps,
-  headSha,
+  requiredDeploymentHeadSha,
 }: {
   app: CloudflarePreviewApp;
   apps: Partial<
     Record<CloudflarePreviewAppSlug, { headSha?: string | null; publicUrl?: string | null }>
   >;
-  headSha: string;
+  /** Targeted runs can require a fresh current-head deployment; full CI may reuse proven unchanged versions. */
+  requiredDeploymentHeadSha?: string;
 }): string[] {
   const requiredUrls = new Map<CloudflarePreviewAppSlug, string>();
   requiredUrls.set(app.slug, app.previewTestBaseUrlEnvVar);
@@ -727,9 +726,14 @@ function resolvePreviewTestBaseUrlEnvironment({
 
   const environment = [...requiredUrls].map(([appSlug, environmentVariable]) => {
     const entry = apps[appSlug];
-    if (!entry?.publicUrl || entry.headSha !== headSha) {
+    if (
+      !entry?.publicUrl ||
+      (requiredDeploymentHeadSha != null && entry.headSha !== requiredDeploymentHeadSha)
+    ) {
       throw new Error(
-        `Cannot test ${app.slug}: ${environmentVariable} requires ${appSlug} deployed at head ${headSha.slice(0, 7)}. Re-run preview deploy.`,
+        requiredDeploymentHeadSha == null
+          ? `Cannot test ${app.slug}: ${environmentVariable} requires a recorded ${appSlug} deployment. Re-run preview deploy.`
+          : `Cannot test ${app.slug}: ${environmentVariable} requires ${appSlug} deployed at head ${requiredDeploymentHeadSha.slice(0, 7)}. Re-run preview deploy.`,
       );
     }
     return `${environmentVariable}=${entry.publicUrl}`;
@@ -790,7 +794,8 @@ function resolvePreviewTestWorkerVersionOverrides(input: {
   apps: Partial<Record<CloudflarePreviewAppSlug, CloudflarePreviewAppEntry>>;
   appSlugs: readonly CloudflarePreviewAppSlugType[];
   dopplerConfig: string;
-  headSha: string;
+  /** Targeted runs can require a fresh current-head deployment; full CI pins the recorded unchanged version. */
+  requiredDeploymentHeadSha?: string;
 }): string {
   return renderCloudflareWorkerVersionOverrides(
     input.appSlugs.map((appSlug) => {
@@ -799,12 +804,16 @@ function resolvePreviewTestWorkerVersionOverrides(input: {
         input.dopplerConfig,
       ).workerName;
       if (
-        entry?.headSha !== input.headSha ||
+        entry == null ||
+        (input.requiredDeploymentHeadSha != null &&
+          entry.headSha !== input.requiredDeploymentHeadSha) ||
         entry.deployedWorkerName !== expectedWorkerName ||
         !entry.deployedWorkerVersion
       ) {
         throw new Error(
-          `Cannot test ${appSlug}: its exact ${expectedWorkerName} deployment identity is missing or stale for head ${input.headSha.slice(0, 7)}. Re-run preview deploy.`,
+          input.requiredDeploymentHeadSha == null
+            ? `Cannot test ${appSlug}: its exact ${expectedWorkerName} deployment identity is missing. Re-run preview deploy.`
+            : `Cannot test ${appSlug}: its exact ${expectedWorkerName} deployment identity is missing or stale for head ${input.requiredDeploymentHeadSha.slice(0, 7)}. Re-run preview deploy.`,
         );
       }
       return {
@@ -864,14 +873,10 @@ async function testPreviewApps({
       canRunPreviewTests(entry),
     );
     if (!displaySlot && !hasTestableRecordedApps) {
-      logPreview(
-        `the semaphore leases no slot to ${holder} and nothing is deployed — skipping tests`,
-      );
-      return {
-        ok: true,
-        skipped: true,
-        state: recorded,
-      };
+      const message = `Refusing to report preview e2e success: the semaphore leases no slot to ${holder} and no runnable deployment is recorded. E2e was NOT run. Run preview deploy first.`;
+      logPreview(message);
+      await updatePreviewState(context, (state) => ({ ...state, notice: message }));
+      throw new Error(message);
     }
 
     // This PR has deployments on record but no slot: the slot was stolen (or
@@ -924,42 +929,29 @@ async function testPreviewApps({
     }));
   }
 
-  const testableApps = Object.values(recorded.apps)
-    .filter((entry) => canRunPreviewTests(entry) && entry.headSha === context.pullRequestHeadSha)
-    .map((entry) => cloudflarePreviewApps[entry.appSlug as CloudflarePreviewAppSlugType])
-    .filter((app): app is PreviewAppRuntime => app != null);
+  const testableApps = selectPreviewAppsForTesting(recorded.apps);
 
   if (testableApps.length === 0) {
-    // Deploy leaves nothing recorded at this head only when nothing
-    // app-affecting changed since the last fully tested deploy: its retry
-    // selection redeploys every non-green recorded app at the current head
-    // regardless of which head produced it (see
-    // selectPreviewAppsNeedingRetry), so any app still at an older head is a
-    // green whose results stand. `preview run` shares one resolved head
-    // between the deploy and test phases, so the old two-step hazard — a
-    // push racing into the gap and a green check describing a commit that
-    // never ran — cannot reach this branch there. A standalone `test` just
-    // reports the skip; the flake-hunt loop already treats any skip as "not
-    // a green run".
-    const notice = `Preview e2e skipped for head ${context.pullRequestHeadSha.slice(0, 7)}: no app is recorded at this head — nothing app-affecting changed since the last fully tested deploy, so the recorded results below still stand. If this PR has never deployed for this head, run preview deploy first.`;
+    const notice = `Refusing to report preview e2e success for head ${context.pullRequestHeadSha.slice(0, 7)}: no runnable app deployment is recorded. E2e was NOT run. Run preview deploy first.`;
     logPreview(notice);
     await updatePreviewState(context, (state) => ({
       ...state,
       notice,
     }));
-    return {
-      ok: true,
-      skipped: true,
-      skippedReason: "no-apps-at-current-head",
-      state: recorded,
-    };
+    throw new Error(notice);
   }
-  logPreview(`testable apps: ${testableApps.map((app) => app.slug).join(", ")}`);
+  logPreview(
+    `testable apps for head ${context.pullRequestHeadSha.slice(0, 7)}: ${testableApps
+      .map((app) => {
+        const deployedHead = recorded.apps[app.slug]?.headSha;
+        return `${app.slug}@${deployedHead?.slice(0, 7) ?? "unknown"}`;
+      })
+      .join(", ")}`,
+  );
   const workerVersionOverrides = resolvePreviewTestWorkerVersionOverrides({
     apps: recorded.apps,
     appSlugs: testableApps.map((app) => app.slug),
     dopplerConfig: environmentConfigLease.dopplerConfig,
-    headSha: context.pullRequestHeadSha,
   });
 
   // Preview e2e commands are full app-level suites. They run concurrently:
@@ -974,7 +966,6 @@ async function testPreviewApps({
     const baseUrlEnvironment = resolvePreviewTestBaseUrlEnvironment({
       app,
       apps: recorded.apps,
-      headSha: context.pullRequestHeadSha,
     });
 
     const startedAt = Date.now();
@@ -5659,18 +5650,52 @@ function selectPreviewAppsNeedingRetry(params: { previousState: CloudflarePrevie
   // deploy", the test lane then skipped its stale recorded apps and the
   // whole check went GREEN on a slot with three deploy-failed apps). For
   // awaiting-tests: at any head it means a deploy landed and its e2e never
-  // ran (a cancelled run), so redeploying it at the current head — idempotent
-  // and cheap — is what makes the test lane's "no app recorded at this head"
-  // an honest green skip (observed 2026-07-10: run 7 deployed then got
-  // cancelled by run 8's push; run 8's one-line non-app diff then skipped
-  // green while every app sat at awaiting-tests).
+  // ran (a cancelled run), so redeploying it at the current head is the only
+  // valid route back to a tested state. A recorded green that lacks its exact
+  // immutable Worker identity is also untestable: select it once so legacy or
+  // stale PR-body state self-heals instead of failing every future run.
+  const recordedSlot = params.previousState.environmentConfigLease;
   const retrySlugs = Object.values(params.previousState.apps)
-    .filter((entry) =>
-      ["awaiting-tests", "claim-failed", "deploy-failed", "tests-failed"].includes(entry.status),
-    )
+    .filter((entry) => {
+      if (
+        ["awaiting-tests", "claim-failed", "deploy-failed", "tests-failed"].includes(entry.status)
+      ) {
+        return true;
+      }
+      if (entry.status !== "deployed") return false;
+
+      const app = cloudflarePreviewApps[entry.appSlug as CloudflarePreviewAppSlugType];
+      const expectedWorkerName = recordedSlot
+        ? app?.resolvePreviewAppConfig(recordedSlot.dopplerConfig).workerName
+        : null;
+      return (
+        !entry.publicUrl ||
+        !entry.deployedWorkerVersion ||
+        !expectedWorkerName ||
+        entry.deployedWorkerName !== expectedWorkerName
+      );
+    })
     .map((entry) => CloudflarePreviewAppSlug.parse(entry.appSlug));
 
   return expandPreviewDependencies(retrySlugs).map((slug) => cloudflarePreviewApps[slug]);
+}
+
+/**
+ * Every runnable deployment participates in every PR-head e2e check. The
+ * deployment may come from an older head when the deploy selector proved that
+ * none of that app's inputs changed; its immutable Worker version is pinned by
+ * {@link resolvePreviewTestWorkerVersionOverrides}. Only deployment work is
+ * reusable — test results never are.
+ */
+function selectPreviewAppsForTesting(
+  apps: Partial<Record<string, CloudflarePreviewAppEntry>>,
+): PreviewAppRuntime[] {
+  return Object.values(apps)
+    .filter(
+      (entry): entry is CloudflarePreviewAppEntry => entry != null && canRunPreviewTests(entry),
+    )
+    .map((entry) => cloudflarePreviewApps[entry.appSlug as CloudflarePreviewAppSlugType])
+    .filter((app): app is PreviewAppRuntime => app != null);
 }
 
 function expandPreviewDependencies(appSlugs: readonly CloudflarePreviewAppSlugType[]) {
@@ -6082,6 +6107,7 @@ export const previewInternals = {
   resolvePreviewTestWorkerVersionOverrides,
   selectPreviewAppsForPullRequest,
   selectPreviewAppsNeedingRetry,
+  selectPreviewAppsForTesting,
   selectPreviewSlotDataOwners,
   splitRepositoryFullName,
   syncPreviewInventory,


### PR DESCRIPTION
## Problem

PR #2262 produced a false-green Preview e2e check on its current head: https://github.com/iterate/iterate/pull/2262/checks?check_run_id=89069204591

The preview orchestrator correctly determined that the latest commit changed no deployable app, but then reused the previous head's test result too. The job printed `nothing to deploy`, returned `ok: true` with `skippedReason: no-apps-at-current-head`, and made the current commit green without executing any E2E lane.

## Fix

- Keep immutable deployment reuse: unchanged apps do not need another deploy.
- Never reuse an earlier head's test result: every triggered PR head runs every runnable recorded app suite.
- Pin reused deployments to their exact recorded Worker versions and URLs during the run.
- Preserve the stricter current-head deployment requirement for targeted/marathon runs.
- Fail closed when no runnable deployment or lease exists instead of reporting a green skip.
- Redeploy stale legacy PR-body records that do not contain enough immutable deployment identity to run safely.

This separates the two concepts that had been conflated: a deployment can be proven unchanged and reused, but a test result cannot stand in for testing a new commit.

## Validation

- `pnpm --dir scripts exec vitest run preview/preview.test.ts preview/e2e-policy.test.ts` — 148 passed
- `pnpm --dir scripts test` — 265 passed
- `pnpm typecheck`
- `pnpm lint` — 0 warnings/errors
- `pnpm format:check`
- `git diff --check`

The decisive acceptance proof is this PR's own Preview e2e check: it must execute real test lanes and must not take the former green skip path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes preview CI gating behavior for all PRs (more e2e runs, failures where skips were green); logic is well-tested but affects a critical check path.
> 
> **Overview**
> Fixes **false-green** Preview e2e when a push changes nothing deployable: unchanged Worker deployments may still be reused, but **every triggered PR head must run the full recorded app e2e suites**—prior greens are never promoted to the current check.
> 
> **Test selection** uses new `selectPreviewAppsForTesting` (all runnable `deployed` apps), not only apps whose `headSha` matches the PR head. Full CI pins reused deployments via recorded Worker versions/URLs; **targeted** `test-target` / marathon paths keep optional `requiredDeploymentHeadSha` so they still demand a fresh current-head deploy.
> 
> **Fail-closed:** no runnable deployment or no lease → **error** instead of `ok: true` with `skippedReason: no-apps-at-current-head`. **Retry** also redeploys legacy green rows missing immutable Worker identity (`deployedWorkerVersion`, worker name, etc.).
> 
> Docs updated for the deploy-vs-test reuse split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca84613a3beef2e2e7b94d5d9ff57e2ed96f7250. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +89 -13 | +83 -8 🟩🟩🟩🟩🟩 |
| CI & scripts | +85 -59 | +63 -34 🟩🟩🟩🟥🟥 |
| Docs | +4 -0 | +4 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+178 -72** | **+150 -42** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between d03f39e and ca84613, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-22T22:55:13.827Z",
      "headSha": "ca84613a3beef2e2e7b94d5d9ff57e2ed96f7250",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/462484633082148",
      "shortSha": "ca84613",
      "cleanupDurationMs": 13363,
      "deployDurationMs": 64948,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 63858,
      "deployReadinessDurationMs": 1086,
      "deployedWorkerName": "os-preview-5",
      "deployedWorkerVersion": "34a3d71e-6524-4d02-b92d-94d8bccc423f",
      "testDurationMs": 193814,
      "testRetries": "9 retried: catalogue example \"repo-edit-file\" runs identically across runtimes (vitest x1) — internal error; reference = mtq0cb1r70ls1v0cobf368kn · itx expression capabilities reject self-aliases at provide time (vitest x1) — internal error; reference = n0ahjrbest4ol9qcr1b3ms6d · an in-flight refresh cannot resurrect material after an egress event (vitest x1) — internal error; reference = 12hm79d3ikvfh6n88tn2qoot · Project repos, workers, runScript, and dynamic worker refs compose (vitest x1) — internal error; reference = ilpvgr1qt2n0v67m71h7n6vt · an external client authenticates with the project-secret credential and gets exactly its project (vitest x1) — internal error; reference = hp68u813dvmbabnhhgpk48fv · ephemeral subscriptions cannot reuse a configured subscription key (vitest x1) — internal error; reference = 8npgruq3rh7nv5udbdmkf6hi · stream-resume-after-suspend.spec.ts › feed resumes after the /api WebSocket dies (clean close) › preview-resilience (playwright x1) — Error: internal error; reference = kopsr35buvjg0u68fiv4ecid · stream-resume-after-suspend.spec.ts › feed resumes after the /api WebSocket goes half-open (no close frame) › preview-resilience (playwright x1) — Error: stream-wait-timeout: Timed out waiting for stream event after 120000ms (the public deadline expired while recovery re-armed one-shot waits). · dashboard.spec.ts › loads project navigation only when it opens › web (playwright x1) — Error: internal error; reference = 7jg9r2p07jhc3nf34oq10m9r",
      "workerSizeKib": 19640.43,
      "workerGzipKib": 4971.06,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 4978.52
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-22T22:55:01.308Z",
      "headSha": "ca84613a3beef2e2e7b94d5d9ff57e2ed96f7250",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/462484633082148",
      "shortSha": "ca84613",
      "cleanupDurationMs": 840,
      "deployDurationMs": 12939,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 12768,
      "deployReadinessDurationMs": 166,
      "deployedWorkerName": "semaphore-preview-5",
      "deployedWorkerVersion": "ae58af23-aa20-44f9-a380-970a24f11d77",
      "testDurationMs": 18812,
      "testRetries": null,
      "workerSizeKib": 1915.22,
      "workerGzipKib": 440.99,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-22T22:55:04.041Z",
      "headSha": "ca84613a3beef2e2e7b94d5d9ff57e2ed96f7250",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/462484633082148",
      "shortSha": "ca84613",
      "cleanupDurationMs": 3572,
      "deployDurationMs": 19126,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 18812,
      "deployReadinessDurationMs": 310,
      "deployedWorkerName": "auth-preview-5",
      "deployedWorkerVersion": "fd93b79a-a501-46ae-9317-71ec3df6b21a",
      "testDurationMs": 11563,
      "testRetries": null,
      "workerSizeKib": 3965.97,
      "workerGzipKib": 811.46,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-22T22:55:10.076Z",
      "headSha": "ca84613a3beef2e2e7b94d5d9ff57e2ed96f7250",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/462484633082148",
      "shortSha": "ca84613",
      "cleanupDurationMs": 9604,
      "deployDurationMs": 21260,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 14543,
      "deployReadinessDurationMs": 6711,
      "deployedWorkerName": "streams-example-app-preview-5",
      "deployedWorkerVersion": "8f623ac5-b641-4a2c-bc5c-125c7a3fb42c",
      "testDurationMs": 75755,
      "testRetries": "1 retried: stream capnweb protocol > at() resolves ..-relative parent, grandparent and mixed paths (vitest x1) — Test timed out in 30000ms. If this is a long-running test, pass a timeout value as the last argument or configure it globally with \"testTimeout\".",
      "workerSizeKib": 5156.37,
      "workerGzipKib": 1472.32,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-22T22:55:01.419Z",
      "headSha": "ca84613a3beef2e2e7b94d5d9ff57e2ed96f7250",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/462484633082148",
      "shortSha": "ca84613",
      "cleanupDurationMs": 946,
      "deployDurationMs": 5954,
      "deployConfigDurationMs": 7,
      "deployCommandDurationMs": 5700,
      "deployReadinessDurationMs": 220,
      "deployedWorkerName": "dummy-petshop-preview-5",
      "deployedWorkerVersion": "e9391837-fd3d-4025-9a33-94d5521714b2",
      "testDurationMs": 11696,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `ca84613` | [https://auth.iterate-preview-5.com](https://auth.iterate-preview-5.com) | 811.5 KiB | 19.1s | 11.6s |  | 3.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/462484633082148) | 2026-07-22T22:55:04.041Z | Preview app released. |
| Dummy Petshop | released | `ca84613` | [https://dummy-petshop.iterate-preview-5.com](https://dummy-petshop.iterate-preview-5.com) | 198.3 KiB | 6.0s | 11.7s |  | 946ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/462484633082148) | 2026-07-22T22:55:01.419Z | Preview app released. |
| OS | released | `ca84613` | [https://os.iterate-preview-5.com](https://os.iterate-preview-5.com) | 4.85 MiB (-7.5 KiB vs main) | 64.9s | 193.8s | 9 retried: catalogue example "repo-edit-file" runs identically across runtimes (vitest x1) — internal error; reference = mtq0cb1r70ls1v0cobf368kn · itx expression capabilities reject self-aliases at provide time (vitest x1) — internal error; reference = n0ahjrbest4ol9qcr1b3ms6d · an in-flight refresh cannot resurrect material after an egress event (vitest x1) — internal error; reference = 12hm79d3ikvfh6n88tn2qoot · Project repos, workers, runScript, and dynamic worker refs compose (vitest x1) — internal error; reference = ilpvgr1qt2n0v67m71h7n6vt · an external client authenticates with the project-secret credential and gets exactly its project (vitest x1) — internal error; reference = hp68u813dvmbabnhhgpk48fv · ephemeral subscriptions cannot reuse a configured subscription key (vitest x1) — internal error; reference = 8npgruq3rh7nv5udbdmkf6hi · stream-resume-after-suspend.spec.ts › feed resumes after the /api WebSocket dies (clean close) › preview-resilience (playwright x1) — Error: internal error; reference = kopsr35buvjg0u68fiv4ecid · stream-resume-after-suspend.spec.ts › feed resumes after the /api WebSocket goes half-open (no close frame) › preview-resilience (playwright x1) — Error: stream-wait-timeout: Timed out waiting for stream event after 120000ms (the public deadline expired while recovery re-armed one-shot waits). · dashboard.spec.ts › loads project navigation only when it opens › web (playwright x1) — Error: internal error; reference = 7jg9r2p07jhc3nf34oq10m9r | 13.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/462484633082148) | 2026-07-22T22:55:13.827Z | Preview app released. |
| Semaphore | released | `ca84613` | [https://semaphore.iterate-preview-5.com](https://semaphore.iterate-preview-5.com) | 441.0 KiB | 12.9s | 18.8s |  | 840ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/462484633082148) | 2026-07-22T22:55:01.308Z | Preview app released. |
| Streams Example App | released | `ca84613` | [https://streams.iterate-preview-5.com](https://streams.iterate-preview-5.com) | 1.44 MiB | 21.3s | 75.8s | 1 retried: stream capnweb protocol > at() resolves ..-relative parent, grandparent and mixed paths (vitest x1) — Test timed out in 30000ms. If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout". | 9.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/462484633082148) | 2026-07-22T22:55:10.076Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->