### PR TITLE
docs(lazy-repo-lane): production pressure-test numbers and findings

### DIFF
--- a/docs/lazy-repo-lane.md
+++ b/docs/lazy-repo-lane.md
@@ -65,6 +65,22 @@ The repo Durable Object used to equate every read with _possessing the whole rep
 
 Prod (deployed pair, before this branch merged — clone lane): the same iterate/iterate cold read was **36.9 s**, re-paid after every push; warm 438 ms.
 
+### Production, after the merge (2026-07-23, tasks.iterate.workers.dev → os.iterate.com)
+
+| Scenario                                                       | Result                             |
+| -------------------------------------------------------------- | ---------------------------------- |
+| iterate/iterate board, cold (fresh workspace + repo store)     | 8.7 s once, durable                |
+| iterate/iterate board, warm                                    | 466 ms                             |
+| write → commit → board reload (the flow that used to re-clone) | 55 ms / ~280 ms / **233 ms**       |
+| **10,018-file prd repo**: 10 × 1,000-file batched commits      | committed clean; `listFiles` 69 ms |
+| 10k board seed through the tasks vessel (2 × 5k chunked reads) | **~1.1 s** end to end              |
+| write + commit at 10k scale                                    | 51 ms / 963 ms                     |
+
+Two findings from the prod pressure run:
+
+- **The 10,001st task broke the board** — the vessel's single `readFiles` call hit the platform's 10,000-path cap and threw. Fixed in iterate/tasks (`9c8366b`): the board seed reads in 5,000-path chunks, two lanes at a time. The cap itself stays (it bounds one RPC's work honestly).
+- **Back-to-back commits on a GitHub-linked repo wait ~12 s** — every commit schedules a full GitHub mirror push ON the repo DO's serialized write chain, so the next commit queues behind a clone+push to GitHub. Pre-existing main behavior (the lazy lane made it _visible_ by making commits fast); prod `/repos/iterate` has additionally diverged from its GitHub source, so those mirror pushes cannot fast-forward. Follow-up candidates: move the mirror push off the write chain, or mirror from the lazy store without a clone.
+
 ## Known limitations (ranked; documented, not hidden)
 
 1. **Kernel-scale repos fail at the SERVICE, not the client.** Artifacts' upload-pack returns HTTP 500 after ~73 s for the 281 MB-pack kernel snapshot — real `git clone --depth 1` fails identically, so the clone lane is equally dead. The practical ceiling sits somewhere between a ~20 MB pack (works, fast) and a ~281 MB pack (server 500). Pushing the same repo INTO Artifacts worked (6 min), so ingest and serving limits differ. Follow-up if kernel-scale becomes real: manifest-first cold sync (batched tree-only wants — the arbitrary-oid want primitive already supports it) + blob-on-demand, which also sidesteps the isolate-memory point below.


### PR DESCRIPTION
Appends the post-merge production measurements to the running lazy-lane document: the 10k-task prd project (board seed ~1.1s end to end, 10×1,000-file batched commits, commit 963ms at scale), the iterate/iterate cold/warm/commit-cycle numbers, and the two findings — the vessel-side 10,000-path cap break (fixed in iterate/tasks 9c8366b with chunked board seeds) and the pre-existing GitHub mirror-push write-chain serialization that fast commits made visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to measured numbers and known limitations; no runtime or API behavior changes in this PR.
> 
> **Overview**
> Extends **`docs/lazy-repo-lane.md`** with post-merge production benchmarks (2026-07-23) and documents two pressure-test outcomes.
> 
> Adds a **“Production, after the merge”** table: iterate/iterate cold/warm board loads, write→commit→reload timings, 10k-file prd batched commits, chunked vessel board seed (~1.1 s), and 10k-scale write/commit latency.
> 
> Records two findings: the **10,001st task** tripping a **10,000-path `readFiles` cap** (fixed in iterate/tasks `9c8366b` via 5k chunked reads) and **~12 s gaps between back-to-back commits** on GitHub-linked repos due to mirror pushes on the serialized write chain, with noted follow-ups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac80d1c551b3a46169fe1a695a9b7ead17e2990a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Docs | +16 -0 | +12 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+16 -0** | **+12 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 7b41300 and ac80d1c, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->