### PR TITLE
Stabilize preview e2e across Durable Object rollouts

### DIFF
--- a/apps/os/e2e/vitest/agent-handle-pipelining.itx.e2e.test.ts
+++ b/apps/os/e2e/vitest/agent-handle-pipelining.itx.e2e.test.ts
@@ -29,10 +29,7 @@
  * build where a method-returned surface is a Proxy.
  */
 import { test } from "vitest";
-import {
-  annotateE2ePhase,
-  measureE2ePhase,
-} from "@iterate-com/shared/test-support/measure-e2e-phase";
+import { measureE2ePhase } from "@iterate-com/shared/test-support/measure-e2e-phase";
 import type { Agent, CapabilityHost, StreamEvent } from "../../src/itx-api.generated.ts";
 import { createTestProject } from "../test-support/create-test-project.ts";
 import { itxScript } from "../test-support/itx-script-builder.ts";
@@ -85,73 +82,72 @@ test(
     // if agents.get() returns anything workerd cannot pipeline on, these
     // throw "The RPC receiver does not implement the method ...".
     using projectHost = itx.capabilityHosts.get("/");
-    const scriptStartedAt = new Date();
-    const scriptStartedAtPerformance = performance.now();
-    const run = (
-      await itxScript(projectHost)
-        .context<{
-          agents: {
-            get(path: string): Agent & {
-              proofAppend: ProofAppend;
-              capabilityHost: CapabilityHost & { proofAppend: ProofAppend };
-            };
-          };
-          capabilityHosts: { get(path: string): CapabilityHost & { proofAppend: ProofAppend } };
-        }>()
-        .vars({ agentPath, marker, proofType: PROOF_TYPE })
-        .execute(async (itx, vars) => {
-          // 1. message() on the pipelined result of get(). The agent was born
-          //    explicitly above; message is an ordinary post-birth command.
-          const sent = await itx.agents.get(vars.agentPath).message("pipelined hello");
+    const run = await measurePhase(
+      "execute pipelined worker script",
+      "operation",
+      async () =>
+        (
+          await itxScript(projectHost)
+            .context<{
+              agents: {
+                get(path: string): Agent & {
+                  proofAppend: ProofAppend;
+                  capabilityHost: CapabilityHost & { proofAppend: ProofAppend };
+                };
+              };
+              capabilityHosts: { get(path: string): CapabilityHost & { proofAppend: ProofAppend } };
+            }>()
+            .vars({ agentPath, marker, proofType: PROOF_TYPE })
+            .execute(async (itx, vars) => {
+              // 1. message() on the pipelined result of get(). The agent was born
+              //    explicitly above; message is an ordinary post-birth command.
+              const sent = await itx.agents.get(vars.agentPath).message("pipelined hello");
 
-          // 2. A dynamic capability DIRECTLY on the fetched handle: proofAppend
-          //    is an unknown member, resolved by the prototype-chain fallback
-          //    and dispatched through the agent scope's capability host —
-          //    all one un-awaited chain.
-          const [appended] = await itx.agents.get(vars.agentPath).proofAppend({
-            type: vars.proofType,
-            payload: { marker: vars.marker },
-          });
+              // 2. A dynamic capability DIRECTLY on the fetched handle: proofAppend
+              //    is an unknown member, resolved by the prototype-chain fallback
+              //    and dispatched through the agent scope's capability host —
+              //    all one un-awaited chain.
+              const [appended] = await itx.agents.get(vars.agentPath).proofAppend({
+                type: vars.proofType,
+                payload: { marker: vars.marker },
+              });
 
-          // 3. The same capability through the explicit capabilityHost door —
-          //    equivalent spelling, also pipelined (capabilityHost is a
-          //    property hop, proofAppend the dynamic name).
-          const [appendedViaHost] = await itx.agents
-            .get(vars.agentPath)
-            .capabilityHost.proofAppend({
-              type: vars.proofType,
-              payload: { marker: vars.marker + "-via-host" },
-            });
+              // 3. The same capability through the explicit capabilityHost door —
+              //    equivalent spelling, also pipelined (capabilityHost is a
+              //    property hop, proofAppend the dynamic name).
+              const [appendedViaHost] = await itx.agents
+                .get(vars.agentPath)
+                .capabilityHost.proofAppend({
+                  type: vars.proofType,
+                  payload: { marker: vars.marker + "-via-host" },
+                });
 
-          // 4. Another method-returned surface entirely: capabilityHosts.get()
-          //    used to hand back a Proxy too — a declared CLASS method must
-          //    pipeline (__describe), and so must a DYNAMIC capability name
-          //    resolved by the same hop (proofAppend, mounted above).
-          const hostDescription = await itx.capabilityHosts.get(vars.agentPath).__describe();
-          const [appendedViaHostsGet] = await itx.capabilityHosts.get(vars.agentPath).proofAppend({
-            type: vars.proofType,
-            payload: { marker: vars.marker + "-via-hosts-get" },
-          });
+              // 4. Another method-returned surface entirely: capabilityHosts.get()
+              //    used to hand back a Proxy too — a declared CLASS method must
+              //    pipeline (__describe), and so must a DYNAMIC capability name
+              //    resolved by the same hop (proofAppend, mounted above).
+              const hostDescription = await itx.capabilityHosts.get(vars.agentPath).__describe();
+              const [appendedViaHostsGet] = await itx.capabilityHosts
+                .get(vars.agentPath)
+                .proofAppend({
+                  type: vars.proofType,
+                  payload: { marker: vars.marker + "-via-hosts-get" },
+                });
 
-          return {
-            messageActor: sent.payload?.actor,
-            messageOffset: sent.offset,
-            messageRole: sent.payload?.role,
-            messageType: sent.type,
-            proofOffset: appended.offset,
-            proofType: appended.type,
-            proofViaHostOffset: appendedViaHost.offset,
-            proofViaHostsGetOffset: appendedViaHostsGet.offset,
-            hostPath: hostDescription.path,
-          };
-        })
-    ).execution;
-    await annotateE2ePhase(annotate, {
-      name: "execute pipelined worker script",
-      category: "operation",
-      startedAt: scriptStartedAt,
-      durationMs: performance.now() - scriptStartedAtPerformance,
-    });
+              return {
+                messageActor: sent.payload?.actor,
+                messageOffset: sent.offset,
+                messageRole: sent.payload?.role,
+                messageType: sent.type,
+                proofOffset: appended.offset,
+                proofType: appended.type,
+                proofViaHostOffset: appendedViaHost.offset,
+                proofViaHostsGetOffset: appendedViaHostsGet.offset,
+                hostPath: hostDescription.path,
+              };
+            })
+        ).execution,
+    );
 
     expect(run.result).toMatchObject({
       messageActor: { type: "user", origin: "web" },

--- a/apps/os/e2e/vitest/agent-handle-pipelining.itx.e2e.test.ts
+++ b/apps/os/e2e/vitest/agent-handle-pipelining.itx.e2e.test.ts
@@ -29,6 +29,10 @@
  * build where a method-returned surface is a Proxy.
  */
 import { test } from "vitest";
+import {
+  annotateE2ePhase,
+  measureE2ePhase,
+} from "@iterate-com/shared/test-support/measure-e2e-phase";
 import type { Agent, CapabilityHost, StreamEvent } from "../../src/itx-api.generated.ts";
 import { createTestProject } from "../test-support/create-test-project.ts";
 import { itxScript } from "../test-support/itx-script-builder.ts";
@@ -46,8 +50,13 @@ type ProofAppend = (event: { type: string; payload: { marker: string } }) => Pro
 test(
   "itx.agents.get(...) pipelines: .message(), .<dynamic capability>(), and .capabilityHost.<dynamic capability>()",
   { timeout: 120_000 },
-  async ({ expect }) => {
-    await using handle = await createTestProject({ slugPrefix: "handle-pipeline" });
+  async ({ annotate, expect }) => {
+    const measurePhase = <Value>(name: string, category: string, operation: () => Promise<Value>) =>
+      measureE2ePhase(annotate, name, category, operation);
+
+    await using handle = await measurePhase("create test project", "fixture", () =>
+      createTestProject({ slugPrefix: "handle-pipeline" }),
+    );
     using itx = handle.itx();
     const agentPath = "/agents/pipeline-target";
     const marker = crypto.randomUUID().slice(0, 8);
@@ -55,25 +64,29 @@ test(
     // Creation is explicit. This call itself is pipelined through get(); the
     // rest of the test proves the other methods still pipeline on the
     // already-created handle.
-    await itx.agents.get(agentPath).create();
+    await measurePhase("create target agent", "fixture", () => itx.agents.get(agentPath).create());
 
     // A DURABLE dynamic capability on the agent's scope (an itx-expression
     // method alias: calling it appends to the proof stream). Durable rather
     // than live because the script below runs server-side, long after this
     // capnweb session's live table would have been the wrong place anyway.
     using host = itx.capabilityHosts.get(agentPath);
-    using _provision = await host.provideCapability({
-      expression: ["streams", ["get", PROOF_STREAM], "append"],
-      instructions: "e2e proof: appends its argument to the proof stream.",
-      path: ["proofAppend"],
-      type: "itx-expression",
-    });
+    using _provision = await measurePhase("provide proof capability", "fixture", () =>
+      host.provideCapability({
+        expression: ["streams", ["get", PROOF_STREAM], "append"],
+        instructions: "e2e proof: appends its argument to the proof stream.",
+        path: ["proofAppend"],
+        type: "itx-expression",
+      }),
+    );
 
     // Run the assertions IN the script lane — a dynamic worker whose itx is a
     // workerd stub. Everything inside is a single un-awaited chain per call:
     // if agents.get() returns anything workerd cannot pipeline on, these
     // throw "The RPC receiver does not implement the method ...".
     using projectHost = itx.capabilityHosts.get("/");
+    const scriptStartedAt = new Date();
+    const scriptStartedAtPerformance = performance.now();
     const run = (
       await itxScript(projectHost)
         .context<{
@@ -133,6 +146,12 @@ test(
           };
         })
     ).execution;
+    await annotateE2ePhase(annotate, {
+      name: "execute pipelined worker script",
+      category: "operation",
+      startedAt: scriptStartedAt,
+      durationMs: performance.now() - scriptStartedAtPerformance,
+    });
 
     expect(run.result).toMatchObject({
       messageActor: { type: "user", origin: "web" },
@@ -155,7 +174,9 @@ test(
 
     // The side effects are real, not just unthrown: the message folded into
     // the agent stream and the dynamic capability appended the proof event.
-    const agentEvents = await itx.streams.get(agentPath).getEvents({});
+    const agentEvents = await measurePhase("read target agent events", "assertion", () =>
+      itx.streams.get(agentPath).getEvents({}),
+    );
     expect(
       agentEvents.some(
         (event) =>
@@ -168,7 +189,9 @@ test(
           event.payload.content === "pipelined hello",
       ),
     ).toBe(true);
-    const proofEvents = await itx.streams.get(PROOF_STREAM).getEvents({});
+    const proofEvents = await measurePhase("read proof events", "assertion", () =>
+      itx.streams.get(PROOF_STREAM).getEvents({}),
+    );
     expect(
       proofEvents.some((event) => event.type === PROOF_TYPE && event.payload?.marker === marker),
     ).toBe(true);

--- a/apps/os/src/domains/repos/repo-processor-implementation.ts
+++ b/apps/os/src/domains/repos/repo-processor-implementation.ts
@@ -11,7 +11,7 @@ import {
   repoArtifactPushFromEventPayload,
   repoGithubPushFromWebhookPayload,
 } from "./repo-push-events.ts";
-import { isRepoNotSeededError } from "./utils.ts";
+import { isRepoNotSeededError, isRetryableArtifactsInfrastructureError } from "./utils.ts";
 
 /**
  * The repo processor: one stream per repo, projecting its lifecycle and Git
@@ -32,9 +32,10 @@ import { isRepoNotSeededError } from "./utils.ts";
  * redelivery or revival cannot rotate them and double-birth. A vendor/domain
  * error settles the saga as `repos/create-failed` — FAIL-CLOSED: a failed
  * repo's stream never reacts to anything again. A still-materializing
- * Artifact (RepoNotSeededError) or Durable Object lifecycle interruption is
- * not a domain failure: no terminal fact is journaled and the durable
- * obligation remains open for redelivery/revival.
+ * Artifact (RepoNotSeededError), an Artifacts service-availability failure,
+ * or a Durable Object lifecycle interruption is not a domain failure: no
+ * terminal fact is journaled and the durable obligation remains open for
+ * redelivery/revival.
  *
  * Commit facts come from ONE source: the Cloudflare Artifacts event queue.
  * Each `repo/cloudflare-artifact-event-received` push on the default branch
@@ -238,9 +239,10 @@ export class RepoProcessor extends StreamProcessor<RepoProcessorContract, RepoPr
    * private GitHub repo starts from an empty Artifact, links, and pulls the
    * default branch through the Worker at depth one. Any vendor error settles
    * the saga as `repos/create-failed` — EXCEPT a still-materializing Artifact
-   * (RepoNotSeededError) or a Durable Object lifecycle interruption. Those
-   * keep the obligation open for redelivery/revival instead of permanently
-   * failing a repo because infrastructure restarted underneath it.
+   * (RepoNotSeededError), a retryable Artifacts service failure, or a Durable
+   * Object lifecycle interruption. Those keep the obligation open for
+   * redelivery/revival instead of permanently failing a repo because
+   * infrastructure restarted underneath it.
    */
   async #createRepoTerminal(
     request: RepoCreateRequest,
@@ -253,7 +255,11 @@ export class RepoProcessor extends StreamProcessor<RepoProcessorContract, RepoPr
         payload: { ...artifact, request },
       };
     } catch (error) {
-      if (isRepoNotSeededError(error) || isRetryableDurableObjectAvailabilityError(error)) {
+      if (
+        isRepoNotSeededError(error) ||
+        isRetryableArtifactsInfrastructureError(error) ||
+        isRetryableDurableObjectAvailabilityError(error)
+      ) {
         throw error;
       }
       return {

--- a/apps/os/src/domains/repos/repo-processor.test.ts
+++ b/apps/os/src/domains/repos/repo-processor.test.ts
@@ -270,10 +270,13 @@ describe("RepoProcessor creation saga", () => {
     expect(h.events("events.iterate.com/repos/created")).toHaveLength(1);
   });
 
-  it("settles a vendor failure as create-failed instead of claiming the repo was created", async () => {
+  it("settles a non-retryable Artifacts input failure as create-failed", async () => {
     const h = makeRepoHarness();
     h.importPublic.impl = async () => {
-      throw new Error("Cloudflare Artifacts 10400: An internal error occurred");
+      throw Object.assign(new Error("The repository name is invalid."), {
+        code: "INVALID_REPO_NAME",
+        name: "ArtifactsError",
+      });
     };
     const request = {
       type: "github-public" as const,
@@ -290,7 +293,7 @@ describe("RepoProcessor creation saga", () => {
     expect(h.events("events.iterate.com/repos/create-failed")).toMatchObject([
       {
         idempotencyKey: "repo/create-failed",
-        payload: { error: "Cloudflare Artifacts 10400: An internal error occurred", request },
+        payload: { error: "The repository name is invalid.", request },
       },
     ]);
     expect(h.state()).toMatchObject({ createFailure: { request }, birthCertificate: null });

--- a/apps/os/src/domains/repos/repo-recovery.test.ts
+++ b/apps/os/src/domains/repos/repo-recovery.test.ts
@@ -95,6 +95,31 @@ describe("RepoProcessor eviction recovery", () => {
     expect(h.events("events.iterate.com/repos/created")).toHaveLength(1);
   });
 
+  it("redelivers an Artifacts infrastructure failure without poisoning the repo", async () => {
+    const h = makeHarness();
+    let calls = 0;
+    h.createEmpty.impl = async () => {
+      calls += 1;
+      if (calls === 1) {
+        throw Object.assign(new Error("An internal error occurred."), {
+          code: "INTERNAL_ERROR",
+          name: "ArtifactsError",
+        });
+      }
+      return CREATED_ARTIFACT;
+    };
+    await h.stream.append(EMPTY_REQUEST);
+
+    await expect(h.settle()).rejects.toThrow("An internal error occurred.");
+    expect(calls).toBe(1);
+    expect(h.events("events.iterate.com/repos/create-failed")).toHaveLength(0);
+
+    await h.settle();
+
+    expect(calls).toBe(2);
+    expect(h.events("events.iterate.com/repos/created")).toHaveLength(1);
+  });
+
   it("re-drives an interrupted creation obligation after the keepalive alarm", async () => {
     const h = makeHarness();
     h.createEmpty.impl = () => new Promise<never>(() => {});

--- a/apps/os/src/domains/repos/utils.test.ts
+++ b/apps/os/src/domains/repos/utils.test.ts
@@ -10,6 +10,7 @@ import {
   classifyRepoAccessError,
   gitBranchContainsCommit,
   isRepoNotSeededError,
+  isRetryableArtifactsInfrastructureError,
 } from "./utils.ts";
 
 describe("RepoArtifactNameCodec", () => {
@@ -141,6 +142,50 @@ describe("classifyRepoAccessError", () => {
       name: "ArtifactsError",
     });
     expect(isRepoNotSeededError(internal)).toBe(false);
+  });
+});
+
+describe("isRetryableArtifactsInfrastructureError", () => {
+  test.each(["INTERNAL_ERROR", "UPSTREAM_UNAVAILABLE"])(
+    "matches the retryable Artifacts service code %s",
+    (code) => {
+      expect(
+        isRetryableArtifactsInfrastructureError(
+          Object.assign(new Error("Artifacts service unavailable"), {
+            code,
+            name: "ArtifactsError",
+          }),
+        ),
+      ).toBe(true);
+    },
+  );
+
+  test("walks a wrapped error cause", () => {
+    const artifactError = Object.assign(new Error("An internal error occurred."), {
+      code: "INTERNAL_ERROR",
+      name: "ArtifactsError",
+    });
+    expect(
+      isRetryableArtifactsInfrastructureError(
+        new Error("Could not create config repo", { cause: artifactError }),
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects domain errors and lookalike codes", () => {
+    expect(
+      isRetryableArtifactsInfrastructureError(
+        Object.assign(new Error("invalid repo"), {
+          code: "INVALID_REPO_NAME",
+          name: "ArtifactsError",
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isRetryableArtifactsInfrastructureError(
+        Object.assign(new Error("different service"), { code: "INTERNAL_ERROR" }),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/apps/os/src/domains/repos/utils.ts
+++ b/apps/os/src/domains/repos/utils.ts
@@ -68,6 +68,11 @@ const ARTIFACTS_REPO_NOT_READY_NUMERIC_CODES = new Set([10200, 10302, 10303]);
 const ARTIFACTS_REPO_NOT_READY_MESSAGE =
   /^Repository "[^"]+" is currently being (?:created|imported|forked)\. The repository is not yet available\. Retry after \d+ seconds\.$/;
 
+const RETRYABLE_ARTIFACTS_INFRASTRUCTURE_CODES = new Set([
+  "INTERNAL_ERROR",
+  "UPSTREAM_UNAVAILABLE",
+]);
+
 function isArtifactsRepoNotReadyError(error: unknown) {
   if (typeof error !== "object" || error === null) return false;
   const code = "code" in error ? error.code : undefined;
@@ -88,6 +93,31 @@ export function isRepoNotSeededError(error: unknown): boolean {
     (error as { name?: string } | null)?.name === RepoNotSeededError.NAME ||
     isArtifactsRepoNotReadyError(error)
   );
+}
+
+/**
+ * Whether Cloudflare Artifacts rejected an idempotent repo operation because
+ * its service was temporarily unavailable, rather than because the requested
+ * repo was invalid. Inspect causes because domain helpers may wrap the binding
+ * error with operation context before it reaches the repo processor.
+ */
+export function isRetryableArtifactsInfrastructureError(error: unknown): boolean {
+  const seen = new Set<object>();
+  let candidate = error;
+  while (typeof candidate === "object" && candidate !== null) {
+    if (seen.has(candidate)) return false;
+    seen.add(candidate);
+    const artifactError = candidate as { cause?: unknown; code?: unknown; name?: unknown };
+    if (
+      artifactError.name === "ArtifactsError" &&
+      typeof artifactError.code === "string" &&
+      RETRYABLE_ARTIFACTS_INFRASTRUCTURE_CODES.has(artifactError.code)
+    ) {
+      return true;
+    }
+    candidate = artifactError.cause;
+  }
+  return false;
 }
 
 /**

--- a/docs/ci-preview-performance.md
+++ b/docs/ci-preview-performance.md
@@ -16,9 +16,11 @@ The preview lifecycle has two barriers:
 2. Start every selected app test lane together; wait until every lane finishes.
 
 OS starts its onboarding smoke, explicit TUI quarantine marker, Chromium setup,
-Playwright, and a bounded deployment-age clock together. High-fanout Vitest
-joins after the smoke and age clock; both gates normally finish under
-Playwright's longer critical path. Therefore, healthy wall time should approach:
+Playwright, and a bounded deployment-age clock together. Browser and auth setup
+continue immediately, while project-backed Playwright fixture creation and
+high-fanout Vitest respect the rollout boundary. The gate normally finishes
+under Playwright's longer critical path. Therefore, healthy wall time should
+approach:
 
 ```text
 pickup + setup + slowest deploy + slowest test lane + reporting
@@ -36,9 +38,12 @@ raise the budget automatically.
   tests start only after the whole selected fleet is ready.
 - Different app suites run concurrently.
 - OS smoke, the explicit TUI quarantine marker, Chromium setup, Playwright, and
-  the rollout-age clock run concurrently. High-fanout Vitest waits only for the
-  smoke and clock; every background process is joined even if another one
-  fails, so a failure cannot orphan work or discard another lane's result.
+  the rollout-age clock run concurrently. Playwright workers may perform
+  browser/auth setup immediately, but their shared project-creation helpers
+  wait on the clock's absolute deadline before addressing fresh project-backed
+  Durable Objects. High-fanout Vitest waits only for the smoke and clock; every
+  background process is joined even if another one fails, so a failure cannot
+  orphan work or discard another lane's result.
 - Chromium installation begins before the four OS lanes and overlaps their
   startup.
 - OS Vitest gives every current file a worker immediately and permits at most
@@ -76,11 +81,13 @@ serially because they intentionally share one warm container.
   documents that Worker/DO updates are globally eventually consistent even
   after the new edge Worker answers, and changing an object's assigned version
   resets that object. For a newly deployed OS version, the dense Vitest fan-out
-  therefore waits until 90 seconds after the successful deploy command. The
-  clock overlaps exact-version readiness, onboarding smoke, Chromium setup,
-  Playwright, TUI, and every other app suite. Reused old deployments wait zero
-  seconds. This is one visible lifecycle boundary, not a retry or a synthetic
-  placement sample.
+  therefore waits until 90 seconds after the successful deploy command. Root
+  Playwright receives that absolute deadline too: its process and non-project
+  work begin immediately, while forged-session and real-signup helpers wait at
+  the project-create operation. The clock overlaps exact-version readiness,
+  onboarding smoke, Chromium setup, Playwright setup, TUI, and every other app
+  suite. Reused old deployments wait zero seconds. This is one visible
+  lifecycle boundary, not a retry or a synthetic placement sample.
 - **Warm OS deploys skip only proven-unchanged container work.** Wrangler
   otherwise builds and reconciles the six stock sandbox image applications
   serially even when all six report `no changes`. The orchestrator requests

--- a/docs/ci-preview-performance.md
+++ b/docs/ci-preview-performance.md
@@ -15,9 +15,10 @@ The preview lifecycle has two barriers:
    and readiness check finishes.
 2. Start every selected app test lane together; wait until every lane finishes.
 
-OS starts its onboarding smoke, explicit TUI quarantine marker, Vitest, and
-Playwright as four independent sub-lanes. Therefore, healthy wall time should
-approach:
+OS starts its onboarding smoke, explicit TUI quarantine marker, Chromium setup,
+Playwright, and a bounded deployment-age clock together. High-fanout Vitest
+joins after the smoke and age clock; both gates normally finish under
+Playwright's longer critical path. Therefore, healthy wall time should approach:
 
 ```text
 pickup + setup + slowest deploy + slowest test lane + reporting
@@ -34,9 +35,10 @@ raise the budget automatically.
   it is not a deployment-order edge. Each deploy owns its readiness check, and
   tests start only after the whole selected fleet is ready.
 - Different app suites run concurrently.
-- OS smoke, the explicit TUI quarantine marker, Vitest, and Playwright run
-  concurrently. Every background process is joined even if another one fails,
-  so a failure cannot orphan work or discard another lane's result.
+- OS smoke, the explicit TUI quarantine marker, Chromium setup, Playwright, and
+  the rollout-age clock run concurrently. High-fanout Vitest waits only for the
+  smoke and clock; every background process is joined even if another one
+  fails, so a failure cannot orphan work or discard another lane's result.
 - Chromium installation begins before the four OS lanes and overlaps their
   startup.
 - OS Vitest gives every current file a worker immediately and permits at most
@@ -70,6 +72,15 @@ serially because they intentionally share one warm container.
   final version on the health probe (no multi-second dwell after first match).
   The probe is a cheap public health request and never wakes synthetic Durable
   Objects.
+- **Global Durable Object rollout gets a bounded age gate.** Cloudflare
+  documents that Worker/DO updates are globally eventually consistent even
+  after the new edge Worker answers, and changing an object's assigned version
+  resets that object. For a newly deployed OS version, the dense Vitest fan-out
+  therefore waits until 90 seconds after the successful deploy command. The
+  clock overlaps exact-version readiness, onboarding smoke, Chromium setup,
+  Playwright, TUI, and every other app suite. Reused old deployments wait zero
+  seconds. This is one visible lifecycle boundary, not a retry or a synthetic
+  placement sample.
 - **Warm OS deploys skip only proven-unchanged container work.** Wrangler
   otherwise builds and reconciles the six stock sandbox image applications
   serially even when all six report `no changes`. The orchestrator requests
@@ -78,11 +89,11 @@ serially because they intentionally share one warm container.
   cap, package, or Wrangler-config input. New slots, bootstraps, force-pushes,
   truncated/unavailable comparisons, and relevant changes use the full
   rollout.
-- **Durable Object resets are handled by product operations.** Cloudflare may
-  still move an individual Durable Object to new code after edge readiness.
-  Idempotent operations must redeliver after that explicit lifecycle outcome
-  without committing terminal failure state. A finite placement sample cannot
-  prove the whole fleet, so readiness does not pretend otherwise.
+- **Product operations still handle lifecycle resets.** The CI age gate avoids
+  deliberately launching the densest test burst during the documented rollout
+  window; it cannot make arbitrary in-flight product operations replay-safe.
+  Idempotent operations must still redeliver after an explicit lifecycle
+  outcome without committing terminal failure state.
 - **Readiness retries are bounded and diagnostic.** Each request has a short
   watchdog, the overall deploy check has a hard deadline, and the final HTTP
   response body or transport error is retained in the failure message.
@@ -112,7 +123,8 @@ serially because they intentionally share one warm container.
 - `depot ci metrics --run <run-id> --org 0p91s0lz49` shows host CPU and memory.
 - `[preview] deploy passed: <app> (Ns)` and `[preview] test passed: <app> (Ns)`
   in the run log show phase wall times.
-- `[preview:os] lane start/finish` lines show the four overlapping OS lanes.
+- `[preview:os] lane start/finish` lines show the overlapping OS work, including
+  the visible `rollout-settle` clock and when Vitest was released.
 - The managed preview block in the PR body records per-app deploy duration,
   test duration, and consumed retries.
 - The reporting tail remains part of the end-to-end budget. Test events are

--- a/docs/ci-preview-performance.md
+++ b/docs/ci-preview-performance.md
@@ -15,12 +15,13 @@ The preview lifecycle has two barriers:
    and readiness check finishes.
 2. Start every selected app test lane together; wait until every lane finishes.
 
-OS starts its onboarding smoke, explicit TUI quarantine marker, Chromium setup,
-Playwright, and a bounded deployment-age clock together. Browser and auth setup
-continue immediately, while project-backed Playwright fixture creation and
-high-fanout Vitest respect the rollout boundary. The gate normally finishes
-under Playwright's longer critical path. Therefore, healthy wall time should
-approach:
+Every freshly deployed live suite that addresses Durable Objects respects one
+bounded deployment-age clock. Short Semaphore, Streams, and Petshop suites wait
+at their own command boundary. OS starts its onboarding smoke, explicit TUI
+quarantine marker, Chromium setup, and Playwright immediately; browser and auth
+setup continue while project-backed Playwright fixture creation and high-fanout
+Vitest wait for the same absolute boundary. The clock normally finishes under
+Playwright's longer critical path. Therefore, healthy wall time should approach:
 
 ```text
 pickup + setup + slowest deploy + slowest test lane + reporting
@@ -37,6 +38,9 @@ raise the budget automatically.
   it is not a deployment-order edge. Each deploy owns its readiness check, and
   tests start only after the whole selected fleet is ready.
 - Different app suites run concurrently.
+- The short Semaphore, Streams, and Petshop commands wait independently at
+  their own rollout boundary; this does not serialize them with OS or with one
+  another. Auth has no live Durable Object suite and starts immediately.
 - OS smoke, the explicit TUI quarantine marker, Chromium setup, Playwright, and
   the rollout-age clock run concurrently. Playwright workers may perform
   browser/auth setup immediately, but their shared project-creation helpers
@@ -80,14 +84,15 @@ serially because they intentionally share one warm container.
 - **Global Durable Object rollout gets a bounded age gate.** Cloudflare
   documents that Worker/DO updates are globally eventually consistent even
   after the new edge Worker answers, and changing an object's assigned version
-  resets that object. For a newly deployed OS version, the dense Vitest fan-out
-  therefore waits until 90 seconds after the successful deploy command. Root
-  Playwright receives that absolute deadline too: its process and non-project
-  work begin immediately, while forged-session and real-signup helpers wait at
-  the project-create operation. The clock overlaps exact-version readiness,
-  onboarding smoke, Chromium setup, Playwright setup, TUI, and every other app
-  suite. Reused old deployments wait zero seconds. This is one visible
-  lifecycle boundary, not a retry or a synthetic placement sample.
+  resets that object. Every freshly deployed app whose live suite calls Durable
+  Objects therefore waits until 90 seconds after its successful deploy command.
+  Short suites wait immediately before their command. Root Playwright receives
+  OS's absolute deadline instead: its process and non-project work begin
+  immediately, while forged-session and real-signup helpers wait at the
+  project-create operation; OS Vitest waits at its fan-out boundary. All app
+  lanes remain concurrent, and reused old deployments wait zero seconds. This
+  is one visible lifecycle boundary per deployment, not a retry or a synthetic
+  placement sample.
 - **Warm OS deploys skip only proven-unchanged container work.** Wrangler
   otherwise builds and reconciles the six stock sandbox image applications
   serially even when all six report `no changes`. The orchestrator requests
@@ -132,6 +137,8 @@ serially because they intentionally share one warm container.
   in the run log show phase wall times.
 - `[preview:os] lane start/finish` lines show the overlapping OS work, including
   the visible `rollout-settle` clock and when Vitest was released.
+- `[preview] rollout settle start/finish` lines expose the independent boundary
+  for each short Durable Object-backed app suite.
 - The managed preview block in the PR body records per-app deploy duration,
   test duration, and consumed retries.
 - The reporting tail remains part of the end-to-end budget. Test events are

--- a/docs/preview-e2e-flake-hunt.md
+++ b/docs/preview-e2e-flake-hunt.md
@@ -55,7 +55,8 @@ starting a new proof—accepted streaks are never inferred across ledgers.
 ## Round 10 (2026-07-23, post-#2263)
 
 This round starts from `origin/main` at
-`707903ca74da1d9eece8b519933902f36780d486`. PR #2263 fixed the false-green
+`7b41300708f49146603fea09766fca64a07f1eb8`, including the lazy repository lane
+from PR #2262. PR #2263 fixed the false-green
 boundary exposed by PR #2262: a head that selected no deployment work reused an
 older head's test result and returned success in six seconds. Deployment reuse
 is still allowed, but every triggered PR head now executes every runnable app

--- a/docs/preview-e2e-flake-hunt.md
+++ b/docs/preview-e2e-flake-hunt.md
@@ -127,6 +127,38 @@ page setup, authentication, browser-only specs, smoke, TUI, and other app suites
 continue to overlap the rollout. The rejected 4/25 streak remains diagnostic
 evidence only; the accepted counter restarts at 0/25 on the new head.
 
+PR #2265's first formal head, `e5e9990986834b9c3c340e746b626ba0974e96bb`,
+then passed one complete run in 285 seconds with zero retries. The next run was
+rejected at 372 seconds after three permitted test retries exposed two distinct
+defects:
+
+- Semaphore and Streams addressed old Durable Object versions after their new
+  edge Workers were ready. Semaphore traces contained both the prior and new
+  code versions; Streams reported an explicit code-update reset. The 90-second
+  gate had covered only OS, so the fix applies the same
+  per-deployment boundary to every live suite that calls Durable Objects. The
+  short app commands wait at their own boundaries while all app lanes remain
+  concurrent; OS still overlaps browser/auth setup internally.
+- Playwright's empty-agent-feed case timed out while creating project
+  `prj_ddc2a50bba2941878bed307b207417ea`. Trace
+  `eb26b8dc5ae96c5da9373abef6e8606d` shows `Project.create` alive until the
+  90-second caller watchdog canceled it. The durable event history is
+  conclusive: config-repo creation began, Cloudflare Artifacts returned
+  `INTERNAL_ERROR` after 32.7 seconds, and the repo processor journaled
+  `repos/create-failed`. No `repos/created` or `project/ready` fact followed,
+  even after later wakes. The Playwright retry created a different project and
+  passed, masking the permanently poisoned first project.
+
+`INTERNAL_ERROR` and `UPSTREAM_UNAVAILABLE` are Artifacts service-availability
+outcomes, not invalid repo requests. Repo creation now leaves its existing
+idempotent durable obligation open for redelivery on those two codes, exactly
+as it already does for a Durable Object lifecycle reset or an Artifact that is
+still materializing. Input/domain errors still append terminal
+`repos/create-failed` and remain fail-closed. Focused processor tests prove both
+classifications and the failed-attempt → redelivery → one `repos/created`
+recovery path. These fixes change the immutable head, so neither formal run is
+counted and the accepted streak restarts at 0/25.
+
 ## Round 9 (2026-07-22, post-#2260)
 
 This proof starts from `origin/main` at

--- a/docs/preview-e2e-flake-hunt.md
+++ b/docs/preview-e2e-flake-hunt.md
@@ -111,6 +111,22 @@ is a visible bounded lifecycle gate, not a retry, test quarantine, synthetic
 Durable Object sampler, or serial deployment barrier. The accepted counter
 remains 0/25 until the new immutable PR head completes the canonical marathon.
 
+The first formal head then passed four consecutive full runs in 231–241
+seconds with zero retries. Run 5 took 361 seconds and was rejected because two
+Playwright cases needed their permitted retry. Both failed before their named
+stimulus: one fresh onboarding feed never painted its greeting, and one REPL
+case timed out inside project creation. Cloudflare telemetry for the first
+project records successful birth/readiness followed by `durableObjectReset`
+warnings on its stream sink at `00:05:00Z` and `00:05:04Z`. Its creation began
+before the 90-second clock expired, because only Vitest consumed that boundary.
+
+The follow-up keeps the Playwright process parallel but passes the absolute
+rollout deadline into its project helpers. Forged-session creation and the real
+email-signup form wait only immediately before creating a project; Chromium,
+page setup, authentication, browser-only specs, smoke, TUI, and other app suites
+continue to overlap the rollout. The rejected 4/25 streak remains diagnostic
+evidence only; the accepted counter restarts at 0/25 on the new head.
+
 ## Round 9 (2026-07-22, post-#2260)
 
 This proof starts from `origin/main` at

--- a/docs/preview-e2e-flake-hunt.md
+++ b/docs/preview-e2e-flake-hunt.md
@@ -52,6 +52,64 @@ normal telemetry; if the workstation sleeps or exits, no running test is
 misclassified and no later run is silently counted. Resume by explicitly
 starting a new proof—accepted streaks are never inferred across ledgers.
 
+## Round 10 (2026-07-23, post-#2263)
+
+This round starts from `origin/main` at
+`707903ca74da1d9eece8b519933902f36780d486`. PR #2263 fixed the false-green
+boundary exposed by PR #2262: a head that selected no deployment work reused an
+older head's test result and returned success in six seconds. Deployment reuse
+is still allowed, but every triggered PR head now executes every runnable app
+suite against the exact recorded Worker versions. An empty runnable set fails
+loudly with `E2e was NOT run` instead of becoming a skipped success.
+
+The repaired #2262 check at head `1ef0f722…` performed all five app suites and
+passed in 3m37s with zero retries. Its later head `6f1d610f…` then provided an
+important real failure rather than another false green: Playwright and all
+non-OS suites passed, while six OS Vitest cases retried and one still failed.
+The failures spanned unrelated project, agent, MCP, egress, worker-readiness,
+and sandbox cases. One error explicitly said `Durable Object reset because its
+code was updated`; another script execution was orphaned because its
+incarnation disappeared. All affected tests owned distinct projects.
+
+PostHog places the OS deploy-phase finish at `23:05:30.758Z` and the Vitest
+start at `23:05:51.367Z`: only 20.6 seconds separated edge readiness from the
+full fan-out. Exact-version readiness itself took 58ms. The explicit reset
+arrived about 51 seconds after Wrangler uploaded the version. Cloudflare's
+[known-issues documentation](https://developers.cloudflare.com/durable-objects/platform/known-issues/)
+says Worker/DO code propagation is globally eventually consistent for seconds
+to minutes, while the
+[Durable Object lifecycle](https://developers.cloudflare.com/durable-objects/concepts/durable-object-lifecycle/)
+documents that a code update shuts an object down and can terminate in-flight
+RPC. Exact edge-version health is therefore necessary but cannot certify every
+future Durable Object placement.
+
+A control on the next #2262 head, `410c1774…`, was genuinely green in 3m48s:
+all five suites ran, OS Playwright passed 63/63, OS Vitest passed all 170
+reported cases, and raw telemetry recorded zero retries. On that run OS
+readiness naturally consumed 31.1 seconds before the smoke's 22.6-second path
+to Vitest, giving the deployment about 53.7 seconds of age before fan-out. That
+does not prove 54 seconds is a safe boundary, but the contrast localizes the
+failure cluster to the fresh global-rollout window rather than shared project
+state or one victim test.
+
+Round-10 preflight ledger:
+
+| Proof                     | Revision                                   | Accepted runs | Retries | Outcome                                      |
+| ------------------------- | ------------------------------------------ | ------------: | ------: | -------------------------------------------- |
+| Repaired #2262 full check | `1ef0f722…`                                |          0/25 |       0 | Real five-suite pass in 3m37s                |
+| Fresh-rollout failure     | `6f1d610fdea1521ca93a6e5c4a3bcdee203e5dc0` |          0/25 |       6 | OS Vitest failed after rollout-reset cluster |
+| Natural-readiness control | `410c1774d8b0a614096d89dcfe39c1e44359a9b6` |          0/25 |       0 | Real five-suite pass in 3m48s                |
+
+The smallest deterministic CI boundary is a 90-second minimum age from the
+successful OS deploy command to high-fanout Vitest. The clock starts before
+exact-version readiness and runs concurrently with readiness, onboarding
+smoke, Chromium installation, Playwright, TUI, and every other app suite;
+reused older deployments wait zero seconds. Playwright remains on the critical
+path in the observed runs, so the clock should add little or no wall time. This
+is a visible bounded lifecycle gate, not a retry, test quarantine, synthetic
+Durable Object sampler, or serial deployment barrier. The accepted counter
+remains 0/25 until the new immutable PR head completes the canonical marathon.
+
 ## Round 9 (2026-07-22, post-#2260)
 
 This proof starts from `origin/main` at

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -18,6 +18,7 @@
     "./test-support/ci-telemetry": "./src/test-support/ci-telemetry.ts",
     "./test-support/measure-e2e-phase": "./src/test-support/measure-e2e-phase.ts",
     "./test-support/cloudflare-worker-version-overrides": "./src/test-support/cloudflare-worker-version-overrides.ts",
+    "./test-support/preview-rollout-gate": "./src/test-support/preview-rollout-gate.ts",
     "./test-support/fetch-safe-port": "./src/test-support/fetch-safe-port.ts",
     "./test-support/fixture-slug": "./src/test-support/fixture-slug.ts",
     "./request-logging": "./src/request-logging.ts",

--- a/packages/shared/src/test-support/preview-rollout-gate.test.ts
+++ b/packages/shared/src/test-support/preview-rollout-gate.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  PREVIEW_APP_ROLLOUT_READY_AT_MS_ENV,
+  resolvePreviewRolloutWaitMs,
+  waitForPreviewRolloutBeforeProjectCreation,
+} from "./preview-rollout-gate.ts";
+
+describe("preview rollout project-creation gate", () => {
+  test("waits only for the remaining absolute rollout interval", async () => {
+    const sleep = vi.fn(async () => {});
+    const log = vi.fn();
+    const readyAtMs = Date.parse("2026-07-23T00:05:06.000Z");
+    const environment = {
+      [PREVIEW_APP_ROLLOUT_READY_AT_MS_ENV]: String(readyAtMs),
+    };
+
+    expect(
+      resolvePreviewRolloutWaitMs({
+        environment,
+        nowMs: Date.parse("2026-07-23T00:04:48.000Z"),
+      }),
+    ).toBe(18_000);
+
+    await waitForPreviewRolloutBeforeProjectCreation({
+      environment,
+      log,
+      nowMs: Date.parse("2026-07-23T00:04:48.000Z"),
+      sleep,
+    });
+
+    expect(sleep).toHaveBeenCalledExactlyOnceWith(18_000);
+    expect(log).toHaveBeenCalledWith(
+      "[preview-rollout] project creation waits 18000ms until 2026-07-23T00:05:06.000Z",
+    );
+  });
+
+  test("does not wait locally or after the absolute boundary", async () => {
+    const sleep = vi.fn(async () => {});
+    await waitForPreviewRolloutBeforeProjectCreation({ environment: {}, sleep });
+    await waitForPreviewRolloutBeforeProjectCreation({
+      environment: { [PREVIEW_APP_ROLLOUT_READY_AT_MS_ENV]: "1000" },
+      nowMs: 1000,
+      sleep,
+    });
+
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  test.each(["tomorrow", "1.5", String(Number.MAX_SAFE_INTEGER + 1)])(
+    "rejects malformed harness value %s",
+    async (value) => {
+      await expect(
+        waitForPreviewRolloutBeforeProjectCreation({
+          environment: { [PREVIEW_APP_ROLLOUT_READY_AT_MS_ENV]: value },
+        }),
+      ).rejects.toThrow(PREVIEW_APP_ROLLOUT_READY_AT_MS_ENV);
+    },
+  );
+});

--- a/packages/shared/src/test-support/preview-rollout-gate.test.ts
+++ b/packages/shared/src/test-support/preview-rollout-gate.test.ts
@@ -7,6 +7,7 @@ import {
 
 describe("preview rollout project-creation gate", () => {
   test("waits only for the remaining absolute rollout interval", async () => {
+    const beforeWait = vi.fn(async () => {});
     const sleep = vi.fn(async () => {});
     const log = vi.fn();
     const readyAtMs = Date.parse("2026-07-23T00:05:06.000Z");
@@ -22,12 +23,14 @@ describe("preview rollout project-creation gate", () => {
     ).toBe(18_000);
 
     await waitForPreviewRolloutBeforeProjectCreation({
+      beforeWait,
       environment,
       log,
       nowMs: Date.parse("2026-07-23T00:04:48.000Z"),
       sleep,
     });
 
+    expect(beforeWait).toHaveBeenCalledExactlyOnceWith(18_000);
     expect(sleep).toHaveBeenCalledExactlyOnceWith(18_000);
     expect(log).toHaveBeenCalledWith(
       "[preview-rollout] project creation waits 18000ms until 2026-07-23T00:05:06.000Z",
@@ -35,14 +38,17 @@ describe("preview rollout project-creation gate", () => {
   });
 
   test("does not wait locally or after the absolute boundary", async () => {
+    const beforeWait = vi.fn(async () => {});
     const sleep = vi.fn(async () => {});
-    await waitForPreviewRolloutBeforeProjectCreation({ environment: {}, sleep });
+    await waitForPreviewRolloutBeforeProjectCreation({ beforeWait, environment: {}, sleep });
     await waitForPreviewRolloutBeforeProjectCreation({
+      beforeWait,
       environment: { [PREVIEW_APP_ROLLOUT_READY_AT_MS_ENV]: "1000" },
       nowMs: 1000,
       sleep,
     });
 
+    expect(beforeWait).not.toHaveBeenCalled();
     expect(sleep).not.toHaveBeenCalled();
   });
 

--- a/packages/shared/src/test-support/preview-rollout-gate.ts
+++ b/packages/shared/src/test-support/preview-rollout-gate.ts
@@ -1,0 +1,53 @@
+/**
+ * Absolute wall-clock boundary after which preview tests may create new
+ * project-backed Durable Objects. Preview CI sets this from the successful OS
+ * deploy timestamp; local development leaves it unset and waits zero time.
+ */
+export const PREVIEW_APP_ROLLOUT_READY_AT_MS_ENV = "PREVIEW_APP_ROLLOUT_READY_AT_MS";
+
+type PreviewRolloutGateEnvironment = Readonly<Record<string, string | undefined>>;
+
+export function resolvePreviewRolloutWaitMs(input: {
+  environment: PreviewRolloutGateEnvironment;
+  nowMs?: number;
+}): number {
+  const rawReadyAtMs = input.environment[PREVIEW_APP_ROLLOUT_READY_AT_MS_ENV]?.trim();
+  if (!rawReadyAtMs) return 0;
+
+  if (!/^\d+$/.test(rawReadyAtMs)) {
+    throw new Error(`${PREVIEW_APP_ROLLOUT_READY_AT_MS_ENV} must be an epoch-millisecond integer.`);
+  }
+
+  const readyAtMs = Number(rawReadyAtMs);
+  if (!Number.isSafeInteger(readyAtMs)) {
+    throw new Error(
+      `${PREVIEW_APP_ROLLOUT_READY_AT_MS_ENV} must be a safe epoch-millisecond integer.`,
+    );
+  }
+
+  return Math.max(0, readyAtMs - (input.nowMs ?? Date.now()));
+}
+
+/**
+ * Wait only at the operation that first creates project-backed Durable
+ * Objects. Browser startup, authentication, and unrelated tests remain free to
+ * overlap Cloudflare's global code propagation window.
+ */
+export async function waitForPreviewRolloutBeforeProjectCreation(input?: {
+  environment?: PreviewRolloutGateEnvironment;
+  log?: (message: string) => void;
+  nowMs?: number;
+  sleep?: (waitMs: number) => Promise<void>;
+}): Promise<void> {
+  const environment = input?.environment ?? process.env;
+  const waitMs = resolvePreviewRolloutWaitMs({ environment, nowMs: input?.nowMs });
+  if (waitMs === 0) return;
+
+  const readyAtMs = Number(environment[PREVIEW_APP_ROLLOUT_READY_AT_MS_ENV]);
+  (input?.log ?? console.log)(
+    `[preview-rollout] project creation waits ${waitMs}ms until ${new Date(readyAtMs).toISOString()}`,
+  );
+  await (
+    input?.sleep ?? ((durationMs) => new Promise((resolve) => setTimeout(resolve, durationMs)))
+  )(waitMs);
+}

--- a/packages/shared/src/test-support/preview-rollout-gate.ts
+++ b/packages/shared/src/test-support/preview-rollout-gate.ts
@@ -34,6 +34,7 @@ export function resolvePreviewRolloutWaitMs(input: {
  * overlap Cloudflare's global code propagation window.
  */
 export async function waitForPreviewRolloutBeforeProjectCreation(input?: {
+  beforeWait?: (waitMs: number) => void | Promise<void>;
   environment?: PreviewRolloutGateEnvironment;
   log?: (message: string) => void;
   nowMs?: number;
@@ -44,6 +45,7 @@ export async function waitForPreviewRolloutBeforeProjectCreation(input?: {
   if (waitMs === 0) return;
 
   const readyAtMs = Number(environment[PREVIEW_APP_ROLLOUT_READY_AT_MS_ENV]);
+  await input?.beforeWait?.(waitMs);
   (input?.log ?? console.log)(
     `[preview-rollout] project creation waits ${waitMs}ms until ${new Date(readyAtMs).toISOString()}`,
   );

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -926,7 +926,7 @@ describe("preview test commands", () => {
     );
   });
 
-  test("waits at most 90 seconds from a fresh OS deployment and only gates OS", () => {
+  test("waits at most 90 seconds for fresh deployments whose live suites call Durable Objects", () => {
     const deployedAt = "2026-07-22T23:05:30.000Z";
     const now = Date.parse(deployedAt);
 
@@ -947,13 +947,13 @@ describe("preview test commands", () => {
         nowMs: now + 90_000,
       }),
     ).toBe(0);
-    expect(
-      resolvePreviewRolloutRemainingSeconds({
-        appSlug: "auth",
-        deployedAt,
-        nowMs: now,
-      }),
-    ).toBe(0);
+    for (const appSlug of ["semaphore", "streams-example-app", "dummy-petshop"] as const) {
+      expect(resolvePreviewRolloutRemainingSeconds({ appSlug, deployedAt, nowMs: now })).toBe(90);
+      expect(resolvePreviewRolloutReadyAtMs({ appSlug, deployedAt })).toBe(now + 90_000);
+    }
+    expect(resolvePreviewRolloutRemainingSeconds({ appSlug: "auth", deployedAt, nowMs: now })).toBe(
+      0,
+    );
     expect(resolvePreviewRolloutRemainingSeconds({ appSlug: "os", nowMs: now })).toBe(0);
     expect(resolvePreviewRolloutReadyAtMs({ appSlug: "os", deployedAt })).toBe(now + 90_000);
     expect(resolvePreviewRolloutReadyAtMs({ appSlug: "auth", deployedAt })).toBe(0);
@@ -970,11 +970,16 @@ describe("preview test commands", () => {
     expect(cloudflarePreviewApps.os).toMatchObject({
       previewDeployBudgetMs: 90_000,
       previewReadyWorkerVersion: true,
+      previewTestRolloutGate: "inside-suite",
       previewTestBudgetMs: 100_000,
     });
     expect(cloudflarePreviewApps["streams-example-app"]).toMatchObject({
       previewReadyWorkerVersion: true,
+      previewTestRolloutGate: "before-suite",
     });
+    expect(cloudflarePreviewApps.semaphore.previewTestRolloutGate).toBe("before-suite");
+    expect(cloudflarePreviewApps["dummy-petshop"].previewTestRolloutGate).toBe("before-suite");
+    expect(cloudflarePreviewApps.auth.previewTestRolloutGate).toBeUndefined();
 
     const workflow = parseYaml(
       readFileSync(resolve(repoRoot, ".depot/workflows/cloudflare-previews.yml"), "utf8"),

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -56,6 +56,7 @@ const {
   resolvePreviewCompareBaseSha,
   resolvePreviewOsContainerRollout,
   resolvePreviewReadinessUrls,
+  resolvePreviewRolloutRemainingSeconds,
   resolvePreviewTestBaseUrlEnvironment,
   resolvePreviewTestTargetPlan,
   resolvePreviewTestTelemetryEnvironment,
@@ -878,7 +879,7 @@ describe("preview test commands", () => {
     expect(collector).not.toContain("runner-telemetry");
   });
 
-  test("gates high-fanout OS Vitest on the production-shaped rollout smoke", () => {
+  test("gates high-fanout OS Vitest on rollout age and the production-shaped smoke", () => {
     const script = cloudflarePreviewApps.os.previewTestCommandArgs[2];
     const playwrightInstall = "pnpm --dir ../.. exec playwright install chromium";
     const smokeLane = "pnpm exec tsx e2e/vitest/onboarding-smoke.ts";
@@ -896,26 +897,70 @@ describe("preview test commands", () => {
     );
     expect(script).toContain('wait "$PW_INSTALL_PID"');
     expect(script).toContain("SMOKE_PID");
+    expect(script).toContain("ROLLOUT_PID");
     expect(script).toContain("TUI_PID");
     expect(script).toContain("E2E_PID");
     expect(script).toContain("SPEC_PID");
     expect(script).toContain('wait "$SMOKE_PID"');
+    expect(script).toContain('wait "$ROLLOUT_PID"');
     expect(script).toContain('wait "$TUI_PID"');
     expect(script).toContain('wait "$E2E_PID"');
     expect(script).toContain('[ "$SMOKE_OK" -eq 0 ]');
     expect(script).toContain('[ "$TUI_OK" -eq 0 ]');
     expect(script).toContain('[ "$E2E_OK" -eq 0 ]');
     // Independent setup starts immediately. Playwright begins as soon as
-    // Chromium is ready, while the production-shaped smoke becomes the only
-    // rollout gate in front of high-fanout Vitest.
-    for (const lane of [smokeLane, tuiLane]) {
+    // Chromium is ready, while the production-shaped smoke and bounded
+    // deployment-age clock gate only high-fanout Vitest.
+    for (const lane of ["run_visible_lane rollout-settle sleep", smokeLane, tuiLane]) {
       expect(script.indexOf(lane)).toBeLessThan(script.indexOf('wait "$PW_INSTALL_PID"'));
     }
     expect(script.indexOf('wait "$PW_INSTALL_PID"')).toBeLessThan(script.indexOf(playwrightSpec));
     expect(script.indexOf(playwrightSpec)).toBeLessThan(script.indexOf('wait "$SMOKE_PID"'));
+    expect(script.indexOf('wait "$SMOKE_PID"')).toBeLessThan(script.indexOf('wait "$ROLLOUT_PID"'));
+    expect(script.indexOf('wait "$ROLLOUT_PID"')).toBeLessThan(script.indexOf(e2eLane));
     expect(script.indexOf('wait "$SMOKE_PID"')).toBeLessThan(script.indexOf(e2eLane));
     expect(script.indexOf(playwrightSpec)).toBeLessThan(script.indexOf('wait "$E2E_PID"'));
-    expect(script).not.toContain("sleep ");
+    expect(script).toContain(
+      'run_visible_lane rollout-settle sleep "$PREVIEW_APP_ROLLOUT_REMAINING_SECONDS"',
+    );
+  });
+
+  test("waits at most 90 seconds from a fresh OS deployment and only gates OS", () => {
+    const deployedAt = "2026-07-22T23:05:30.000Z";
+    const now = Date.parse(deployedAt);
+
+    expect(resolvePreviewRolloutRemainingSeconds({ appSlug: "os", deployedAt, nowMs: now })).toBe(
+      90,
+    );
+    expect(
+      resolvePreviewRolloutRemainingSeconds({
+        appSlug: "os",
+        deployedAt,
+        nowMs: now + 20_001,
+      }),
+    ).toBe(70);
+    expect(
+      resolvePreviewRolloutRemainingSeconds({
+        appSlug: "os",
+        deployedAt,
+        nowMs: now + 90_000,
+      }),
+    ).toBe(0);
+    expect(
+      resolvePreviewRolloutRemainingSeconds({
+        appSlug: "auth",
+        deployedAt,
+        nowMs: now,
+      }),
+    ).toBe(0);
+    expect(resolvePreviewRolloutRemainingSeconds({ appSlug: "os", nowMs: now })).toBe(0);
+    expect(() =>
+      resolvePreviewRolloutRemainingSeconds({
+        appSlug: "os",
+        deployedAt: "not-a-timestamp",
+        nowMs: now,
+      }),
+    ).toThrow(/Invalid preview deployment timestamp/);
   });
 
   test("guards the parallel OS preview lane with target budgets", () => {

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -56,6 +56,7 @@ const {
   resolvePreviewCompareBaseSha,
   resolvePreviewOsContainerRollout,
   resolvePreviewReadinessUrls,
+  resolvePreviewRolloutReadyAtMs,
   resolvePreviewRolloutRemainingSeconds,
   resolvePreviewTestBaseUrlEnvironment,
   resolvePreviewTestTargetPlan,
@@ -879,7 +880,7 @@ describe("preview test commands", () => {
     expect(collector).not.toContain("runner-telemetry");
   });
 
-  test("gates high-fanout OS Vitest on rollout age and the production-shaped smoke", () => {
+  test("starts Playwright early while gating project-backed work and Vitest", () => {
     const script = cloudflarePreviewApps.os.previewTestCommandArgs[2];
     const playwrightInstall = "pnpm --dir ../.. exec playwright install chromium";
     const smokeLane = "pnpm exec tsx e2e/vitest/onboarding-smoke.ts";
@@ -909,8 +910,8 @@ describe("preview test commands", () => {
     expect(script).toContain('[ "$TUI_OK" -eq 0 ]');
     expect(script).toContain('[ "$E2E_OK" -eq 0 ]');
     // Independent setup starts immediately. Playwright begins as soon as
-    // Chromium is ready, while the production-shaped smoke and bounded
-    // deployment-age clock gate only high-fanout Vitest.
+    // Chromium is ready. Its project fixture consumes the absolute deadline
+    // from the environment, while the smoke and age clock gate Vitest here.
     for (const lane of ["run_visible_lane rollout-settle sleep", smokeLane, tuiLane]) {
       expect(script.indexOf(lane)).toBeLessThan(script.indexOf('wait "$PW_INSTALL_PID"'));
     }
@@ -954,6 +955,8 @@ describe("preview test commands", () => {
       }),
     ).toBe(0);
     expect(resolvePreviewRolloutRemainingSeconds({ appSlug: "os", nowMs: now })).toBe(0);
+    expect(resolvePreviewRolloutReadyAtMs({ appSlug: "os", deployedAt })).toBe(now + 90_000);
+    expect(resolvePreviewRolloutReadyAtMs({ appSlug: "auth", deployedAt })).toBe(0);
     expect(() =>
       resolvePreviewRolloutRemainingSeconds({
         appSlug: "os",

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -67,11 +67,11 @@ const draftPreviewNotice = [
 // consistent after the new edge Worker version is serving. A newly addressed
 // Durable Object can therefore still be assigned the prior code for seconds
 // to minutes, and an in-flight RPC is reset when that assignment changes.
-// Keep project-backed DO creation and the dense OS fan-out behind a bounded
-// deployment-age gate. Browser/auth setup, smoke, installation, and every
-// other app keep running while this clock elapses, so it normally stays off
-// the critical path.
-const osPreviewMinimumDeploymentAgeMs = 90_000;
+// Keep live e2e work that creates or calls Durable Objects behind a bounded
+// deployment-age gate. Apps still start concurrently; long suites can overlap
+// independent setup with this clock while short DO suites wait at their own
+// boundary, so the gate does not serialize the fleet.
+const previewMinimumDeploymentAgeMs = 90_000;
 const previewRolloutRemainingSecondsEnvironment = "PREVIEW_APP_ROLLOUT_REMAINING_SECONDS";
 
 /**
@@ -851,14 +851,14 @@ function resolvePreviewRolloutReadyAtMs(input: {
   appSlug: CloudflarePreviewAppSlugType;
   deployedAt?: string | null;
 }) {
-  if (input.appSlug !== "os" || !input.deployedAt) return 0;
+  if (!cloudflarePreviewApps[input.appSlug].previewTestRolloutGate || !input.deployedAt) return 0;
 
   const deployedAtMs = Date.parse(input.deployedAt);
   if (!Number.isFinite(deployedAtMs)) {
     throw new Error(`Invalid preview deployment timestamp: ${input.deployedAt}`);
   }
 
-  return deployedAtMs + osPreviewMinimumDeploymentAgeMs;
+  return deployedAtMs + previewMinimumDeploymentAgeMs;
 }
 
 async function testPreviewApps({
@@ -1021,10 +1021,17 @@ async function testPreviewApps({
     const telemetryArtifactDirectory = runtime.commandEnvironment.TEST_TELEMETRY_ARTIFACT_DIR
       ? resolve(runtime.repositoryRoot, runtime.commandEnvironment.TEST_TELEMETRY_ARTIFACT_DIR)
       : undefined;
+    telemetry.appStarted(app.previewTestArtifactSources);
+    if (app.previewTestRolloutGate === "before-suite" && rolloutRemainingSeconds > 0) {
+      logPreview(
+        `rollout settle start: ${app.slug} (${rolloutRemainingSeconds}s remaining from deployment)`,
+      );
+      await sleep(rolloutRemainingSeconds * 1_000, runtime.signal);
+      logPreview(`rollout settle finish: ${app.slug}`);
+    }
     logPreview(
       `test start: ${app.slug} against ${existingEntry.publicUrl} (doppler config ${environmentConfigLease.dopplerConfig})`,
     );
-    telemetry.appStarted(app.previewTestArtifactSources);
     // One attempt, deliberately: retries live in the individual test
     // (docs/testing.md#retries-and-timeouts) — everything above only
     // watches and fails.
@@ -1038,7 +1045,7 @@ async function testPreviewApps({
         "--",
         "env",
         `${E2E_CLOUDFLARE_WORKERS_VERSION_OVERRIDES_ENV}=${workerVersionOverrides}`,
-        ...(app.slug === "os"
+        ...(app.previewTestRolloutGate === "inside-suite"
           ? [
               `${previewRolloutRemainingSecondsEnvironment}=${rolloutRemainingSeconds}`,
               `${PREVIEW_APP_ROLLOUT_READY_AT_MS_ENV}=${rolloutReadyAtMs}`,
@@ -1826,6 +1833,13 @@ export type CloudflarePreviewApp = {
    * finite sample of Durable Objects cannot prove the whole fleet.
    */
   previewReadyWorkerVersion?: true;
+  /**
+   * Cloudflare Worker and Durable Object code propagation is eventually
+   * consistent after deploy. Live suites that call a DO either wait before
+   * their short command starts, or consume the absolute boundary inside a
+   * longer command so independent setup can overlap it.
+   */
+  previewTestRolloutGate?: "before-suite" | "inside-suite";
   previewTestBaseUrlEnvVar: string;
   /** Every canonical artifact the app-level test command must produce once. */
   previewTestArtifactSources: readonly TestTelemetryArtifactSource[];
@@ -2174,6 +2188,7 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
     // preview deploy waits the full 10min readiness timeout on a 404 and fails.
     previewReadyUrlPath: "/api/health",
     previewReadyWorkerVersion: true,
+    previewTestRolloutGate: "inside-suite",
     paths: [
       "apps/os/**",
       // The root Playwright suite is part of OS preview e2e. A test or
@@ -2306,6 +2321,7 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
     paths: ["apps/semaphore/**"],
     // Co-select auth for an environment-coherent test run. Deploys are independent.
     previewDependencies: ["auth"],
+    previewTestRolloutGate: "before-suite",
     previewTestBaseUrlEnvVar: "SEMAPHORE_BASE_URL",
     previewTestArtifactSources: [previewVitestArtifactSource("@iterate-com/semaphore")],
     // `env -u SEMAPHORE_API_TOKEN`: the CI lane runs under an outer
@@ -2388,6 +2404,7 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
     previewDependencies: ["auth"],
     previewReadyUrlPath: "/api/__internal/health",
     previewReadyWorkerVersion: true,
+    previewTestRolloutGate: "before-suite",
     previewTestBaseUrlEnvVar: "WORKER_URL",
     previewTestArtifactSources: [
       previewVitestArtifactSource("@iterate-com/streams-example-app"),
@@ -2463,6 +2480,7 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
     // it decides the generated wrangler routes.
     contentFingerprintPaths: ["apps/dummy-petshop", "envs.ts"],
     previewReadyUrlPath: "/",
+    previewTestRolloutGate: "before-suite",
     previewTestBaseUrlEnvVar: "PETSHOP_BASE_URL",
     previewTestArtifactSources: [previewVitestArtifactSource("@iterate-com/dummy-petshop")],
     previewTestCommandArgs: [

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -36,6 +36,7 @@ import {
   E2E_CLOUDFLARE_WORKERS_VERSION_OVERRIDES_ENV,
   renderCloudflareWorkerVersionOverrides,
 } from "../../packages/shared/src/test-support/cloudflare-worker-version-overrides.ts";
+import { PREVIEW_APP_ROLLOUT_READY_AT_MS_ENV } from "../../packages/shared/src/test-support/preview-rollout-gate.ts";
 import {
   parseWorkerSizeFromDeployOutput,
   parseWorkerSizeStatusDescription,
@@ -66,9 +67,10 @@ const draftPreviewNotice = [
 // consistent after the new edge Worker version is serving. A newly addressed
 // Durable Object can therefore still be assigned the prior code for seconds
 // to minutes, and an in-flight RPC is reset when that assignment changes.
-// Keep the one dense OS fan-out behind a bounded deployment-age gate; smoke,
-// browser tests, browser installation, and every other app keep running while
-// this clock elapses, so it normally stays off the critical path.
+// Keep project-backed DO creation and the dense OS fan-out behind a bounded
+// deployment-age gate. Browser/auth setup, smoke, installation, and every
+// other app keep running while this clock elapses, so it normally stays off
+// the critical path.
 const osPreviewMinimumDeploymentAgeMs = 90_000;
 const previewRolloutRemainingSecondsEnvironment = "PREVIEW_APP_ROLLOUT_REMAINING_SECONDS";
 
@@ -839,17 +841,24 @@ function resolvePreviewRolloutRemainingSeconds(input: {
   deployedAt?: string | null;
   nowMs?: number;
 }) {
-  if (input.appSlug !== "os" || !input.deployedAt) {
-    return 0;
-  }
+  const readyAtMs = resolvePreviewRolloutReadyAtMs(input);
+  if (readyAtMs === 0) return 0;
+
+  return Math.ceil(Math.max(0, readyAtMs - (input.nowMs ?? Date.now())) / 1_000);
+}
+
+function resolvePreviewRolloutReadyAtMs(input: {
+  appSlug: CloudflarePreviewAppSlugType;
+  deployedAt?: string | null;
+}) {
+  if (input.appSlug !== "os" || !input.deployedAt) return 0;
 
   const deployedAtMs = Date.parse(input.deployedAt);
   if (!Number.isFinite(deployedAtMs)) {
     throw new Error(`Invalid preview deployment timestamp: ${input.deployedAt}`);
   }
 
-  const elapsedMs = Math.max(0, (input.nowMs ?? Date.now()) - deployedAtMs);
-  return Math.ceil(Math.max(0, osPreviewMinimumDeploymentAgeMs - elapsedMs) / 1_000);
+  return deployedAtMs + osPreviewMinimumDeploymentAgeMs;
 }
 
 async function testPreviewApps({
@@ -995,12 +1004,17 @@ async function testPreviewApps({
       app,
       apps: recorded.apps,
     });
+    const rolloutDeploymentTimestamp = existingEntry.deployedAt ?? existingEntry.updatedAt;
     const rolloutRemainingSeconds = resolvePreviewRolloutRemainingSeconds({
       appSlug: app.slug,
       // Entries written before deployedAt existed fall back to their last
       // recorded transition. That may wait conservatively on one legacy
       // rerun, but it cannot release a genuinely fresh deployment early.
-      deployedAt: existingEntry.deployedAt ?? existingEntry.updatedAt,
+      deployedAt: rolloutDeploymentTimestamp,
+    });
+    const rolloutReadyAtMs = resolvePreviewRolloutReadyAtMs({
+      appSlug: app.slug,
+      deployedAt: rolloutDeploymentTimestamp,
     });
 
     const startedAt = Date.now();
@@ -1025,7 +1039,10 @@ async function testPreviewApps({
         "env",
         `${E2E_CLOUDFLARE_WORKERS_VERSION_OVERRIDES_ENV}=${workerVersionOverrides}`,
         ...(app.slug === "os"
-          ? [`${previewRolloutRemainingSecondsEnvironment}=${rolloutRemainingSeconds}`]
+          ? [
+              `${previewRolloutRemainingSecondsEnvironment}=${rolloutRemainingSeconds}`,
+              `${PREVIEW_APP_ROLLOUT_READY_AT_MS_ENV}=${rolloutReadyAtMs}`,
+            ]
           : []),
         ...baseUrlEnvironment,
         ...app.previewTestCommandArgs,
@@ -2212,9 +2229,11 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
         // time we reach the specs instead of adding ~4s in front of them.
         "pnpm --dir ../.. exec playwright install chromium > /tmp/os-preview-pw-install.log 2>&1 & PW_INSTALL_PID=$!",
         // Smoke and TUI own isolated state, so start them with the Chromium
-        // install. Playwright starts as soon as Chromium is ready. The
-        // high-fanout Vitest lane waits for both the production-shaped
-        // onboarding smoke and a bounded age on a newly deployed OS version.
+        // install. Playwright starts as soon as Chromium is ready; its
+        // project-creation helpers use the absolute rollout boundary passed
+        // above, so browser/auth setup continues while fresh project-backed
+        // DO work waits. The high-fanout Vitest lane waits for both the
+        // production-shaped onboarding smoke and the same bounded age.
         // Edge readiness cannot prove global Durable Object code propagation:
         // Cloudflare may reset an object when its assigned version changes.
         // The age clock starts when deploy completes and overlaps every lane
@@ -6150,6 +6169,7 @@ export const previewInternals = {
   resolvePreviewOsContainerRollout,
   resolvePreviewReadinessUrls,
   resolvePreviewTestBaseUrlEnvironment,
+  resolvePreviewRolloutReadyAtMs,
   resolvePreviewRolloutRemainingSeconds,
   resolvePreviewTestTargetPlan,
   resolvePreviewTestTelemetryEnvironment,

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -62,6 +62,16 @@ const draftPreviewNotice = [
   `To get previews: add the \`${previewOptInLabel}\` label, mark the PR ready for review, or dispatch the Cloudflare Previews workflow for a one-off run.`,
 ].join(" ");
 
+// Cloudflare documents that a Worker/DO code update is globally eventually
+// consistent after the new edge Worker version is serving. A newly addressed
+// Durable Object can therefore still be assigned the prior code for seconds
+// to minutes, and an in-flight RPC is reset when that assignment changes.
+// Keep the one dense OS fan-out behind a bounded deployment-age gate; smoke,
+// browser tests, browser installation, and every other app keep running while
+// this clock elapses, so it normally stays off the critical path.
+const osPreviewMinimumDeploymentAgeMs = 90_000;
+const previewRolloutRemainingSecondsEnvironment = "PREVIEW_APP_ROLLOUT_REMAINING_SECONDS";
+
 /**
  * Draft PRs don't hold preview slots unless they ask: there are only nine
  * slots and drafts are the default for agent-opened PRs, so a busy night of
@@ -824,6 +834,24 @@ function resolvePreviewTestWorkerVersionOverrides(input: {
   );
 }
 
+function resolvePreviewRolloutRemainingSeconds(input: {
+  appSlug: CloudflarePreviewAppSlugType;
+  deployedAt?: string | null;
+  nowMs?: number;
+}) {
+  if (input.appSlug !== "os" || !input.deployedAt) {
+    return 0;
+  }
+
+  const deployedAtMs = Date.parse(input.deployedAt);
+  if (!Number.isFinite(deployedAtMs)) {
+    throw new Error(`Invalid preview deployment timestamp: ${input.deployedAt}`);
+  }
+
+  const elapsedMs = Math.max(0, (input.nowMs ?? Date.now()) - deployedAtMs);
+  return Math.ceil(Math.max(0, osPreviewMinimumDeploymentAgeMs - elapsedMs) / 1_000);
+}
+
 async function testPreviewApps({
   context,
   runtime,
@@ -967,6 +995,13 @@ async function testPreviewApps({
       app,
       apps: recorded.apps,
     });
+    const rolloutRemainingSeconds = resolvePreviewRolloutRemainingSeconds({
+      appSlug: app.slug,
+      // Entries written before deployedAt existed fall back to their last
+      // recorded transition. That may wait conservatively on one legacy
+      // rerun, but it cannot release a genuinely fresh deployment early.
+      deployedAt: existingEntry.deployedAt ?? existingEntry.updatedAt,
+    });
 
     const startedAt = Date.now();
     const telemetryArtifactDirectory = runtime.commandEnvironment.TEST_TELEMETRY_ARTIFACT_DIR
@@ -989,6 +1024,9 @@ async function testPreviewApps({
         "--",
         "env",
         `${E2E_CLOUDFLARE_WORKERS_VERSION_OVERRIDES_ENV}=${workerVersionOverrides}`,
+        ...(app.slug === "os"
+          ? [`${previewRolloutRemainingSecondsEnvironment}=${rolloutRemainingSeconds}`]
+          : []),
         ...baseUrlEnvironment,
         ...app.previewTestCommandArgs,
       ],
@@ -2175,11 +2213,12 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
         "pnpm --dir ../.. exec playwright install chromium > /tmp/os-preview-pw-install.log 2>&1 & PW_INSTALL_PID=$!",
         // Smoke and TUI own isolated state, so start them with the Chromium
         // install. Playwright starts as soon as Chromium is ready. The
-        // high-fanout Vitest lane waits for the production-shaped onboarding
-        // smoke to prove that the freshly deployed Durable Objects can serve a
-        // complete project/agent/stream flow. This absorbs rollout propagation
-        // under Playwright's longer critical path instead of probing synthetic
-        // Durable Object names or sleeping for an arbitrary interval.
+        // high-fanout Vitest lane waits for both the production-shaped
+        // onboarding smoke and a bounded age on a newly deployed OS version.
+        // Edge readiness cannot prove global Durable Object code propagation:
+        // Cloudflare may reset an object when its assigned version changes.
+        // The age clock starts when deploy completes and overlaps every lane
+        // above, so this does not serialize the suite or probe synthetic DOs.
         //
         // The `timeout` on the vitest lane is a WATCHDOG, not a retry
         // (docs/testing.md#retries-and-timeouts): it sits just above a
@@ -2196,19 +2235,21 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
         // preview.ts to fold into the PR body alongside Playwright's report.
         'run_logged_lane() { local lane="$1"; local log="$2"; shift 2; local started="$SECONDS"; local rc=0; echo "[preview:os] lane start: $lane"; "$@" > "$log" 2>&1 || rc=$?; echo "[preview:os] lane finish: $lane ($((SECONDS - started))s, exit $rc)"; return "$rc"; }',
         'run_visible_lane() { local lane="$1"; shift; local started="$SECONDS"; local rc=0; echo "[preview:os] lane start: $lane"; "$@" || rc=$?; echo "[preview:os] lane finish: $lane ($((SECONDS - started))s, exit $rc)"; return "$rc"; }',
+        `run_visible_lane rollout-settle sleep "$${previewRolloutRemainingSecondsEnvironment}" & ROLLOUT_PID=$!`,
         `run_logged_lane smoke /tmp/os-preview-smoke.log env TEST_TELEMETRY_LANE=onboarding-smoke TEST_TELEMETRY_WORKSPACE=iterate-root TEST_TELEMETRY_ARTIFACT_FILE=${osOnboardingSmokeTelemetryFile} timeout ${OS_ONBOARDING_SMOKE_TIMEOUT_SECS} pnpm exec tsx e2e/vitest/onboarding-smoke.ts & SMOKE_PID=$!`,
         `run_logged_lane tui /tmp/os-preview-tui.log env TEST_TELEMETRY_LANE=tui TEST_TELEMETRY_WORKSPACE=iterate-root TEST_TELEMETRY_ARTIFACT_FILE=${osTuiRetryTelemetryFile} timeout ${OS_TUI_LANE_TIMEOUT_SECS} pnpm exec tsx e2e/tui-test/run.ts & TUI_PID=$!`,
         'PW_INSTALL_OK=0; wait "$PW_INSTALL_PID" || PW_INSTALL_OK=$?',
         `SPEC_OK=0; SPEC_PID=""; if [ "$PW_INSTALL_OK" -eq 0 ]; then run_visible_lane playwright env TEST_TELEMETRY_LANE=playwright TEST_TELEMETRY_WORKSPACE=iterate-root PLAYWRIGHT_PREVIEW_SLOW_FIRST=1 timeout ${OS_PREVIEW_LANE_TIMEOUT_SECS} pnpm --dir ../.. spec & SPEC_PID=$!; else cat /tmp/os-preview-pw-install.log; SPEC_OK=$PW_INSTALL_OK; fi`,
         'SMOKE_OK=0; wait "$SMOKE_PID" || SMOKE_OK=$?',
-        `E2E_OK=0; E2E_PID=""; if [ "$SMOKE_OK" -eq 0 ]; then run_logged_lane vitest /tmp/os-preview-vitest.log env TEST_TELEMETRY_LANE=vitest TEST_TELEMETRY_WORKSPACE=@iterate-com/os TEST_TELEMETRY_ARTIFACT_FILE=${osVitestRetryTelemetryFile} timeout ${OS_PREVIEW_LANE_TIMEOUT_SECS} pnpm e2e --project node & E2E_PID=$!; else E2E_OK=$SMOKE_OK; fi`,
+        'ROLLOUT_OK=0; wait "$ROLLOUT_PID" || ROLLOUT_OK=$?',
+        `E2E_OK="$SMOKE_OK"; if [ "$E2E_OK" -eq 0 ]; then E2E_OK="$ROLLOUT_OK"; fi; E2E_PID=""; if [ "$E2E_OK" -eq 0 ]; then run_logged_lane vitest /tmp/os-preview-vitest.log env TEST_TELEMETRY_LANE=vitest TEST_TELEMETRY_WORKSPACE=@iterate-com/os TEST_TELEMETRY_ARTIFACT_FILE=${osVitestRetryTelemetryFile} timeout ${OS_PREVIEW_LANE_TIMEOUT_SECS} pnpm e2e --project node & E2E_PID=$!; fi`,
         'if [ -n "$E2E_PID" ]; then wait "$E2E_PID" || E2E_OK=$?; fi',
         'if [ -n "$SPEC_PID" ]; then wait "$SPEC_PID" || SPEC_OK=$?; fi',
         'TUI_OK=0; wait "$TUI_PID" || TUI_OK=$?',
         "cat /tmp/os-preview-smoke.log",
         "if [ -f /tmp/os-preview-vitest.log ]; then cat /tmp/os-preview-vitest.log; fi",
         "cat /tmp/os-preview-tui.log",
-        '[ "$SMOKE_OK" -eq 0 ] && [ "$E2E_OK" -eq 0 ] && [ "$TUI_OK" -eq 0 ] && [ "$SPEC_OK" -eq 0 ]',
+        '[ "$ROLLOUT_OK" -eq 0 ] && [ "$SMOKE_OK" -eq 0 ] && [ "$E2E_OK" -eq 0 ] && [ "$TUI_OK" -eq 0 ] && [ "$SPEC_OK" -eq 0 ]',
       ].join("; "),
     ],
     collectTestTelemetry: async ({ repositoryRoot }) => {
@@ -2499,6 +2540,8 @@ export const CloudflarePreviewAppEntry = z.object({
   appSlug: z.string().trim().min(1),
   status: CloudflarePreviewStatus,
   updatedAt: z.string().trim().min(1),
+  /** When the successful app deploy command completed for this exact version. */
+  deployedAt: z.iso.datetime({ offset: true }).nullable().optional(),
   headSha: z.string().trim().min(1).nullable().optional(),
   message: z.string().trim().min(1).nullable().optional(),
   publicUrl: z.string().trim().url().nullable().optional(),
@@ -4215,6 +4258,7 @@ async function deployPreviewApp(input: {
       );
       return CloudflarePreviewAppEntry.parse({
         ...baseEntry,
+        deployedAt: existingEntry.deployedAt,
         deployedFingerprint: fingerprint,
         deployedWorkerName: existingEntry.deployedWorkerName,
         deployedWorkerVersion: existingEntry.deployedWorkerVersion,
@@ -4257,6 +4301,7 @@ async function deployPreviewApp(input: {
       status: "deploy-failed",
     });
   }
+  const deployedAt = new Date().toISOString();
 
   const deployedWorkerVersion = parseLastDeployedWorkerVersionId(
     `${deployResult.stdout}\n${deployResult.stderr}`,
@@ -4265,6 +4310,7 @@ async function deployPreviewApp(input: {
     return CloudflarePreviewAppEntry.parse({
       ...baseEntry,
       ...sizeFields,
+      deployedAt,
       deployCommandDurationMs,
       deployReuseProofDurationMs,
       message:
@@ -4289,6 +4335,7 @@ async function deployPreviewApp(input: {
     return CloudflarePreviewAppEntry.parse({
       ...baseEntry,
       ...sizeFields,
+      deployedAt,
       deployCommandDurationMs,
       deployReadinessDurationMs,
       deployReuseProofDurationMs,
@@ -4300,6 +4347,7 @@ async function deployPreviewApp(input: {
   return CloudflarePreviewAppEntry.parse({
     ...baseEntry,
     ...sizeFields,
+    deployedAt,
     deployCommandDurationMs,
     deployReadinessDurationMs,
     deployReuseProofDurationMs,
@@ -6102,6 +6150,7 @@ export const previewInternals = {
   resolvePreviewOsContainerRollout,
   resolvePreviewReadinessUrls,
   resolvePreviewTestBaseUrlEnvironment,
+  resolvePreviewRolloutRemainingSeconds,
   resolvePreviewTestTargetPlan,
   resolvePreviewTestTelemetryEnvironment,
   resolvePreviewTestWorkerVersionOverrides,

--- a/specs/create-project.spec.ts
+++ b/specs/create-project.spec.ts
@@ -12,7 +12,7 @@ import { test } from "./test-support/test.ts";
 // freshly signed-up user, not a forged session. Creating a project mints new
 // auth claims, and only a real session can refresh its access token to pick
 // up the new project claim the post-create navigation authorizes with.
-test("a new user can create a project through the UI form", async ({ page }) => {
+test("a new user can create a project through the UI form", async ({ page }, testInfo) => {
   test.skip(
     !(await startEmailOtpSignIn(page)),
     "Email OTP sign-in is disabled for this deployment (APP_CONFIG_EMAIL_OTP_ENABLED on auth / APP_CONFIG_ITERATE_AUTH__EMAIL_OTP_ENABLED on OS).",
@@ -21,6 +21,7 @@ test("a new user can create a project through the UI form", async ({ page }) => 
   await signUpWithEmailOtp(page, {
     email: uniqueSignupEmail("create-project"),
     projectSlug: firstSlug,
+    testInfo,
   });
 
   const slug = uniqueFixtureSlug("create-project");

--- a/specs/seeded-apps.spec.ts
+++ b/specs/seeded-apps.spec.ts
@@ -42,7 +42,10 @@ test("the seeded guestbook app works after creating a project", async ({
 // and organization: project-member auth deliberately checks the live Auth
 // directory on every request, not merely the OS access-token claims used by
 // the suite's usual forged-session fixture.
-test("the seeded todo app authenticates a real project member", async ({ baseURL, page }) => {
+test("the seeded todo app authenticates a real project member", async ({
+  baseURL,
+  page,
+}, testInfo) => {
   test.setTimeout(E2E_HEAVY_TEST_TIMEOUT_MS);
   test.skip(
     !(await startEmailOtpSignIn(page)),
@@ -53,6 +56,7 @@ test("the seeded todo app authenticates a real project member", async ({ baseURL
   await signUpWithEmailOtp(page, {
     email: uniqueSignupEmail("todo-app-auth"),
     projectSlug: slug,
+    testInfo,
   });
 
   // First-run onboarding creates the Auth directory membership and the

--- a/specs/signup.spec.ts
+++ b/specs/signup.spec.ts
@@ -11,7 +11,7 @@ import { test } from "./test-support/test.ts";
 // Deviation from the suite's forged-session fixture pattern: this spec's whole
 // point is the REAL signup flow (goal 1 of the itx-v4 migration), so it drives
 // the apps/auth email-OTP lane instead of minting a session.
-test("can sign up with an email one-time passcode", async ({ page }) => {
+test("can sign up with an email one-time passcode", async ({ page }, testInfo) => {
   test.skip(
     !(await startEmailOtpSignIn(page)),
     "Email OTP sign-in is disabled for this deployment (APP_CONFIG_EMAIL_OTP_ENABLED on auth / APP_CONFIG_ITERATE_AUTH__EMAIL_OTP_ENABLED on OS).",
@@ -22,7 +22,11 @@ test("can sign up with an email one-time passcode", async ({ page }) => {
   // on auth, and the root `/` starts the engine bootstrap. The creation panel
   // is deliberately transient (and can be hidden in a responsive side panel),
   // so it is not a completion signal. Assert the durable destination below.
-  await signUpWithEmailOtp(page, { email: uniqueSignupEmail("signup"), projectSlug: slug });
+  await signUpWithEmailOtp(page, {
+    email: uniqueSignupEmail("signup"),
+    projectSlug: slug,
+    testInfo,
+  });
 
   await spinnerWaiter.settings.run({ disabled: true }, async () => {
     // The composer is the destination route's structural chrome — it renders

--- a/specs/test-support/email-otp-signup.ts
+++ b/specs/test-support/email-otp-signup.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 import { spinnerWaiter } from "middlewright";
+import { waitForPreviewRolloutBeforeProjectCreation } from "@iterate-com/shared/test-support/preview-rollout-gate";
 
 /**
  * Real signup through the apps/auth email-OTP lane. Non-production auth
@@ -58,6 +59,7 @@ export async function signUpWithEmailOtp(
       .getByLabel("Organization name")
       .fill(`Playwright ${input.email.split("@")[0]}`, { timeout: 30_000 });
     await page.getByLabel("Project slug").fill(input.projectSlug, { timeout: 15_000 });
+    await waitForPreviewRolloutBeforeProjectCreation();
     await page.getByRole("button", { name: "Get started" }).click({ timeout: 15_000 });
   });
 }

--- a/specs/test-support/email-otp-signup.ts
+++ b/specs/test-support/email-otp-signup.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test";
+import type { Page, TestInfo } from "@playwright/test";
 import { spinnerWaiter } from "middlewright";
 import { waitForPreviewRolloutBeforeProjectCreation } from "@iterate-com/shared/test-support/preview-rollout-gate";
 
@@ -43,7 +43,7 @@ export async function startEmailOtpSignIn(page: Page) {
  */
 export async function signUpWithEmailOtp(
   page: Page,
-  input: { email: string; projectSlug: string },
+  input: { email: string; projectSlug: string; testInfo: TestInfo },
 ) {
   await page.getByTestId("email-input").fill(input.email);
   await page.getByTestId("email-submit-button").click();
@@ -59,7 +59,9 @@ export async function signUpWithEmailOtp(
       .getByLabel("Organization name")
       .fill(`Playwright ${input.email.split("@")[0]}`, { timeout: 30_000 });
     await page.getByLabel("Project slug").fill(input.projectSlug, { timeout: 15_000 });
-    await waitForPreviewRolloutBeforeProjectCreation();
+    await waitForPreviewRolloutBeforeProjectCreation({
+      beforeWait: (waitMs) => input.testInfo.setTimeout(input.testInfo.timeout + waitMs),
+    });
     await page.getByRole("button", { name: "Get started" }).click({ timeout: 15_000 });
   });
 }

--- a/specs/test-support/forged-session.ts
+++ b/specs/test-support/forged-session.ts
@@ -6,6 +6,7 @@ import type {
 } from "@iterate-com/shared/auth-claims";
 import { cloudflareWorkerVersionOverrideHeaders } from "@iterate-com/shared/test-support/cloudflare-worker-version-overrides";
 import { uniqueFixtureSlug } from "@iterate-com/shared/test-support/fixture-slug";
+import { waitForPreviewRolloutBeforeProjectCreation } from "@iterate-com/shared/test-support/preview-rollout-gate";
 import { connectItx } from "iterate/node";
 import { doppler } from "../../apps/os/scripts/dev.ts";
 import { mintForgedAccessToken, mintForgedIdToken } from "../../scripts/auth/forge-token.ts";
@@ -132,6 +133,7 @@ export async function connectAdminItx(baseUrl: string) {
 
 export async function createAdminProject(input: { baseUrl: string; slug: string }) {
   const config = await resolveOsPlaywrightAuthConfig();
+  await waitForPreviewRolloutBeforeProjectCreation();
   // itx-v4 cutover: this used to dial the legacy client (`withItx({baseUrl,
   // token})`) and then poll `project.processor.onStateChange` until the
   // project reached phase "ready". The itx create resolves only after the

--- a/specs/test-support/forged-session.ts
+++ b/specs/test-support/forged-session.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test";
+import type { Page, TestInfo } from "@playwright/test";
 import { z } from "zod/v4";
 import type {
   IterateAuthAccessTokenOrganizationClaim,
@@ -52,16 +52,28 @@ let configPromise: Promise<OsPlaywrightAuthConfig> | undefined;
 
 export async function createProjectFixture(
   slugPrefix: string,
-  input: { baseURL: string | undefined; page: Page; projectCount?: number },
+  input: {
+    baseURL: string | undefined;
+    page: Page;
+    projectCount?: number;
+    testInfo: TestInfo;
+  },
 ) {
   const baseUrl = input.baseURL;
   if (!baseUrl) throw new Error("Playwright baseURL fixture is required.");
 
+  const [config] = await Promise.all([
+    resolveOsPlaywrightAuthConfig(),
+    waitForPreviewRolloutBeforeProjectCreation({
+      beforeWait: (waitMs) => input.testInfo.setTimeout(input.testInfo.timeout + waitMs),
+    }),
+  ]);
   const projectSlug = uniqueFixtureSlug(slugPrefix);
   const projectFixtures = await Promise.all(
     Array.from({ length: input.projectCount ?? 1 }, (_, index) =>
-      createAdminProject({
+      createAdminProjectAfterPreviewRollout({
         baseUrl,
+        config,
         slug: index === 0 ? projectSlug : uniqueFixtureSlug(`${slugPrefix}-${index + 1}`),
       }),
     ),
@@ -131,9 +143,11 @@ export async function connectAdminItx(baseUrl: string) {
   });
 }
 
-export async function createAdminProject(input: { baseUrl: string; slug: string }) {
-  const config = await resolveOsPlaywrightAuthConfig();
-  await waitForPreviewRolloutBeforeProjectCreation();
+async function createAdminProjectAfterPreviewRollout(input: {
+  baseUrl: string;
+  config: OsPlaywrightAuthConfig;
+  slug: string;
+}) {
   // itx-v4 cutover: this used to dial the legacy client (`withItx({baseUrl,
   // token})`) and then poll `project.processor.onStateChange` until the
   // project reached phase "ready". The itx create resolves only after the
@@ -141,7 +155,7 @@ export async function createAdminProject(input: { baseUrl: string; slug: string 
   // seeded, project worker probed), so the readiness wait is gone and auth is
   // an explicit admin-secret credential on connect.
   using session = connectItx({
-    auth: { type: "admin-secret", secret: config.adminApiSecret },
+    auth: { type: "admin-secret", secret: input.config.adminApiSecret },
     baseUrl: input.baseUrl,
     headers: cloudflareWorkerVersionOverrideHeaders(process.env),
   });

--- a/specs/test-support/test.ts
+++ b/specs/test-support/test.ts
@@ -114,7 +114,7 @@ export const test = base.extend<{
     }
   },
   previewRolloutTimeoutBudget: [
-    async (_fixtures, use, testInfo) => {
+    async ({ browserName: _browserName }, use, testInfo) => {
       // The project-create gate is intentional harness time, not product test
       // time. Preserve every test's configured execution budget while still
       // making the wait visible inside its trace and wall-clock telemetry.

--- a/specs/test-support/test.ts
+++ b/specs/test-support/test.ts
@@ -10,6 +10,7 @@ import {
   uiErrorReporter,
   videoMode,
 } from "middlewright";
+import { resolvePreviewRolloutWaitMs } from "@iterate-com/shared/test-support/preview-rollout-gate";
 import { createProjectFixture as createForgedProjectFixture } from "./forged-session.ts";
 import { screenshot } from "./screenshot.ts";
 
@@ -41,6 +42,7 @@ export const test = base.extend<{
     ) => Promise<Awaited<ReturnType<typeof createForgedProjectFixture>>>;
   };
   page: Awaited<ReturnType<typeof addPagePlugins>>;
+  previewRolloutTimeoutBudget: void;
 }>({
   context: async ({ context }, use) => {
     if (Object.keys(cloudflareWorkerVersionOverrideHeaders(process.env)).length > 0) {
@@ -111,4 +113,15 @@ export const test = base.extend<{
       for (const dispose of extraPageDisposers) await dispose().catch(() => {});
     }
   },
+  previewRolloutTimeoutBudget: [
+    async (_fixtures, use, testInfo) => {
+      // The project-create gate is intentional harness time, not product test
+      // time. Preserve every test's configured execution budget while still
+      // making the wait visible inside its trace and wall-clock telemetry.
+      const rolloutWaitMs = resolvePreviewRolloutWaitMs({ environment: process.env });
+      if (rolloutWaitMs > 0) testInfo.setTimeout(testInfo.timeout + rolloutWaitMs);
+      await use();
+    },
+    { auto: true },
+  ],
 });

--- a/specs/test-support/test.ts
+++ b/specs/test-support/test.ts
@@ -10,7 +10,6 @@ import {
   uiErrorReporter,
   videoMode,
 } from "middlewright";
-import { resolvePreviewRolloutWaitMs } from "@iterate-com/shared/test-support/preview-rollout-gate";
 import { createProjectFixture as createForgedProjectFixture } from "./forged-session.ts";
 import { screenshot } from "./screenshot.ts";
 
@@ -42,7 +41,6 @@ export const test = base.extend<{
     ) => Promise<Awaited<ReturnType<typeof createForgedProjectFixture>>>;
   };
   page: Awaited<ReturnType<typeof addPagePlugins>>;
-  previewRolloutTimeoutBudget: void;
 }>({
   context: async ({ context }, use) => {
     if (Object.keys(cloudflareWorkerVersionOverrideHeaders(process.env)).length > 0) {
@@ -73,12 +71,12 @@ export const test = base.extend<{
     }
     await use(context);
   },
-  helpers: async ({ baseURL, page }, use) => {
+  helpers: async ({ baseURL, page }, use, testInfo) => {
     if (!baseURL) throw new Error("Playwright baseURL fixture is required.");
     await use({
       createFixture: (slugPrefix, options) =>
         base.step("create project fixture", () =>
-          createForgedProjectFixture(slugPrefix, { baseURL, page, ...options }),
+          createForgedProjectFixture(slugPrefix, { baseURL, page, testInfo, ...options }),
         ),
     });
   },
@@ -113,15 +111,4 @@ export const test = base.extend<{
       for (const dispose of extraPageDisposers) await dispose().catch(() => {});
     }
   },
-  previewRolloutTimeoutBudget: [
-    async ({ browserName: _browserName }, use, testInfo) => {
-      // The project-create gate is intentional harness time, not product test
-      // time. Preserve every test's configured execution budget while still
-      // making the wait visible inside its trace and wall-clock telemetry.
-      const rolloutWaitMs = resolvePreviewRolloutWaitMs({ environment: process.env });
-      if (rolloutWaitMs > 0) testInfo.setTimeout(testInfo.timeout + rolloutWaitMs);
-      await use();
-    },
-    { auto: true },
-  ],
 });

--- a/tasks/playwright-project-fixture-create-stall.md
+++ b/tasks/playwright-project-fixture-create-stall.md
@@ -60,19 +60,41 @@ The relevant client path is:
 `packages/iterate/src/itx/itx-node-client.ts` already configures a 15-second
 WebSocket handshake timeout. A local socket that accepted TCP but never
 answered the upgrade rejected an in-flight RPC after `15,011ms` with
-`WebSocket connection failed.`, so the basic client handshake bound works;
-the preview failure needs stage-level evidence before changing that client.
+`WebSocket connection failed.`, so the basic client handshake bound works.
+The recurrence below identifies a server-side terminal failure instead of a
+client-handshake defect.
 
-## Work
+## 2026-07-23 recurrence: server-side terminal failure identified
 
-- Attach named, timed fixture stages (config, admin itx connect/create,
-  description/readiness, token mint, cookie install) to Playwright results so
-  an outer timeout identifies the pending operation and fixture slug.
-- Capture a failed first-attempt trace (or equivalent client frame/transport
-  evidence) without relying on the retry trace.
-- Reproduce against a preview with normal CI concurrency; correlate the slug,
-  WebSocket session, `ProjectCollection.create` RPC, and `create-timing` steps.
-- Fix the demonstrated pending operation. Keep recovery bounded and observable;
-  do not turn the fixture into an unreported inner retry loop.
+PR #2265's second formal preview run reproduced the outer 90-second fixture
+timeout in `empty agent feeds distinguish waiting from filtered zero matches`.
+This time the named timing and trace evidence identify the exact project and
+terminal state:
+
+- Failed project: `prj_ddc2a50bba2941878bed307b207417ea` (slug
+  `agent-initializing-mrwsg32j-f065698a`).
+- Root trace: `eb26b8dc5ae96c5da9373abef6e8606d` on `os-preview-11`.
+- `Project.create` remained pending for 88.3 seconds until Playwright canceled
+  the request. Project birth took 37.7 seconds; config-repo birth took 36.3
+  seconds.
+- Inside config-repo birth, `artifact-get-or-create` failed after 32.7 seconds.
+  The config stream then recorded `repos/create-failed` with `An internal error
+  occurred.` and cross-posted it to the root stream. It never recorded
+  `repos/created` or `project/ready`, including after later processor wakes.
+- The test retry created `prj_20587…`, completed birth in 3.8 seconds, and
+  passed. The test retry therefore hid a defective first project; this was not
+  merely a slow browser or a lost readiness notification.
+
+Cloudflare's binding contract classifies this as Artifacts `INTERNAL_ERROR`.
+Repo creation previously treated every Artifacts error except a
+still-materializing repo as a permanent domain failure. PR #2265 changes the
+processor to redeliver the already-idempotent creation obligation for
+`INTERNAL_ERROR` and `UPSTREAM_UNAVAILABLE`, while preserving terminal
+fail-closed behavior for invalid input and other domain errors. The focused
+recovery test proves that the first service error appends no `create-failed`,
+the next delivery succeeds, and exactly one `repos/created` fact is recorded.
+
+## Remaining proof
+
 - Prove the fix with repeated retry-disabled preview runs and zero unexplained
   error/retry telemetry.


### PR DESCRIPTION
## Outcome

The six-second “success” on #2262 was a false green, not a fast test run. A docs-only head selected no deployment work, and preview orchestration reused an older commit's successful e2e result. PR #2263 is already merged and closes that hole: deployment artifacts may be reused, test results may not. Every triggered head must run every runnable recorded app suite, and an empty runnable set fails with `E2e was NOT run`.

This PR is the follow-on reliability and proof change. It makes those mandatory real suites safe across fresh Cloudflare Durable Object rollouts and corrects the project-creation defect exposed by the first formal runs. It contains no AI Search work, sandbox-builder work, test quarantine, timeout increase, workflow retry, or project reuse.

## Resulting preview lifecycle

1. Resolve the preview lease and recorded deployments.
2. Deploy every selected app concurrently. A deployment may be reused only when its recorded URL/version is still serving; test success is never reused.
3. Start every runnable app test lane concurrently, including suites whose deployment was reused.
4. Each freshly deployed app whose live suite calls Durable Objects uses one visible 90-second deployment-age boundary. Short Semaphore, Streams, and Petshop lanes wait independently at their own command boundary. Auth has no live DO suite and starts immediately.
5. OS overlaps the boundary with onboarding smoke, TUI, Chromium installation, Playwright, and browser/auth setup. Only project creation and high-fanout Vitest wait for the absolute deadline.
6. Missing suites, incomplete telemetry, failed lanes, or failed retry policy fail the check loudly.

The fleet remains parallel in both phases. There is no deployment ordering edge, global mutex, synthetic Durable Object sampler, app-lane serialization, or second test implementation.

## Why the rollout boundary exists

Once #2263 made every head run real coverage, unrelated fresh projects failed together while Cloudflare propagated new Durable Object code. Exact edge-Worker readiness had already passed, but traces contained both old and new DO versions, explicit `durableObjectReset` flags, and `Durable Object reset because its code was updated`. The same victim tests passed against a settled deployment.

The first implementation gated only OS. Formal PR #2265 run 1 passed all five suites in 285 seconds with zero retries. Formal run 2 was rejected at 372 seconds with three test retries: Semaphore failed while crossing old/new versions, Streams reported an explicit code-update reset, and one OS Playwright fixture timed out during project creation. This head therefore extends the same boundary to every DO-backed live suite while keeping their commands concurrent.

Reused deployments older than the deadline wait zero. `[preview] rollout settle start/finish` and OS's existing rollout-lane telemetry make every intentional wait visible.

## Project-creation defect found in formal run 2

The Playwright timeout was not a slow browser and not a missing client timeout. It was project `prj_ddc2a50bba2941878bed307b207417ea`, root trace `eb26b8dc5ae96c5da9373abef6e8606d` on `os-preview-11`:

- project birth spent 37.7s; config-repo birth spent 36.3s;
- `artifact-get-or-create` failed after 32.7s with Cloudflare Artifacts `INTERNAL_ERROR`;
- the repo processor incorrectly journaled terminal `repos/create-failed`;
- no `repos/created` or `project/ready` fact appeared, including after later durable wakes;
- Playwright's permitted retry created a different project and passed, masking the poisoned first project.

`INTERNAL_ERROR` and `UPSTREAM_UNAVAILABLE` are Artifacts service-availability outcomes, not invalid repo requests. Repo creation now leaves the existing idempotent durable obligation open for redelivery on exactly those two codes, as it already does for a DO lifecycle reset or an Artifact still materializing. Input/domain errors such as `INVALID_REPO_NAME` still append terminal `repos/create-failed` and remain fail-closed. This is product recovery, not a test retry.

The regression harness proves: first infrastructure failure rejects visibly and appends no terminal failure; the next durable delivery succeeds; exactly one `repos/created` fact lands. Separate tests prove non-retryable Artifacts errors remain terminal.

## Performance and tail model

Healthy wall time remains:

```text
pickup + setup + slowest parallel deploy + slowest parallel test lane + reporting
```

It does not become the sum of deployments, app suites, or OS sub-lanes. The short-app gates run simultaneously and usually consume time already spent in the global deploy barrier and OS Playwright. The 3m30 target and five-minute hard acceptance ceiling are unchanged.

The exact final head completed the canonical check in 4m40s (291s from Depot pickup through finish), below the five-minute ceiling. All five app suites ran: Petshop 6/6, Auth 5/5, Semaphore 12/12, Streams 21 Vitest plus 32 Playwright, and OS 63/63 Playwright plus 170 Vitest cases (164 passed, 1 expected failure, 5 skipped). Playwright had zero retries. One OS Vitest case used its single allowed retry after Cloudflare returned “Durable Object is overloaded. Requests queued for too long”; it then passed and is recorded explicitly in the PR preview table and telemetry. Per the repository policy and maintainer direction, an absorbed retry remains green, but it is not counted toward the separate 25-consecutive-clean-run proof.

## Verification on final head `92dcdb40ddbe321bd242622a9dbb29c2322955ff`

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test` — all workspaces green; OS: 2,274 passed, 6 expected failures, 1 existing skip
- focused repo processor/recovery/utils tests: 54/54
- preview orchestration tests: 135/135
- Playwright discovery: 63 tests in 22 files
- `git diff --check`
- rollout-timeout regression: 5/5 focused tests; the exact pending wait is reserved at the project-creation boundary and no budget is added when the boundary has passed
- canonical Depot preview check: all five suites passed in 4m40s; telemetry normalized 10 artifacts into 6,828 events

## Acceptance protocol

Satisfied for merge: the exact final head ran all five real suites, finished below five minutes, uploaded the complete 10-artifact test bundle, normalized 6,828 telemetry events, and left every required check green. The one explicitly reported OS Vitest retry is permitted to pass this PR but resets the stricter 25-consecutive-clean-run counter; that flake investigation continues on the next flake-athon branch rather than withholding this reliability fix from main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes preview orchestration timing and repo bootstrap failure handling on a critical path, but behavior is bounded, heavily tested, and leaves domain errors terminal.
> 
> **Overview**
> Adds a **90-second post-deploy rollout boundary** for preview suites that hit Durable Objects, so tests do not fan out while Cloudflare is still assigning new object code. Fresh deploys record **`deployedAt`**; Semaphore, Streams, and Petshop wait at their own command start, while **OS** runs smoke, TUI, Chromium, and Playwright in parallel and only blocks **high-fanout Vitest** (and **project creation** in Playwright helpers) until the absolute deadline via **`PREVIEW_APP_ROLLOUT_READY_AT_MS`**. Reused deployments skip the wait.
> 
> **Repo creation** no longer journals terminal **`repos/create-failed`** on Cloudflare Artifacts **`INTERNAL_ERROR`** / **`UPSTREAM_UNAVAILABLE`**; those errors keep the idempotent obligation open for redelivery, matching DO resets and still-materializing repos. Invalid input errors (e.g. **`INVALID_REPO_NAME`**) stay fail-closed.
> 
> Docs and flake-hunt notes capture Round 10 rationale; an OS Vitest pipelining e2e test gains phased timing annotations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92dcdb40ddbe321bd242622a9dbb29c2322955ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +99 -8 | +66 -2 🟩⬜⬜⬜⬜ |
| Tests | +297 -78 | +265 -63 🟩🟩🟩🟩🟥 |
| CI & scripts | +96 -9 | +63 -3 🟩⬜⬜⬜⬜ |
| Config | +1 -0 | +1 -0 🟩⬜⬜⬜⬜ |
| Docs | +181 -26 | +162 -24 🟩🟩🟩⬜⬜ |
| Other | +30 -10 | +30 -10 🟩⬜⬜⬜⬜ |
| **Total** | **+704 -131** | **+587 -102** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 8a2f197 and 92dcdb4, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-23T01:29:56.536Z",
      "deployedAt": "2026-07-23T01:22:59.443Z",
      "headSha": "92dcdb40ddbe321bd242622a9dbb29c2322955ff",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/144043950921865",
      "shortSha": "92dcdb4",
      "cleanupDurationMs": 21846,
      "deployDurationMs": 54301,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 40383,
      "deployReadinessDurationMs": 13914,
      "deployedWorkerName": "os-preview-11",
      "deployedWorkerVersion": "2e666633-afaf-4296-a857-6fc246c6344e",
      "testDurationMs": 198521,
      "testRetries": "1 retried: itx expression replacement records the recipe without evaluating it (vitest x1) — stream-unavailable: Durable Object is overloaded. Requests queued for too long.",
      "workerSizeKib": 19777.63,
      "workerGzipKib": 5003.84,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5013.18
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-23T01:29:35.598Z",
      "deployedAt": "2026-07-23T01:22:31.846Z",
      "headSha": "92dcdb40ddbe321bd242622a9dbb29c2322955ff",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/144043950921865",
      "shortSha": "92dcdb4",
      "cleanupDurationMs": 905,
      "deployDurationMs": 12970,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 12783,
      "deployReadinessDurationMs": 182,
      "deployedWorkerName": "semaphore-preview-11",
      "deployedWorkerVersion": "d6ba2327-31da-454c-8d14-726ebc9da071",
      "testDurationMs": 69688,
      "testRetries": null,
      "workerSizeKib": 1915.22,
      "workerGzipKib": 440.99,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-23T01:29:38.577Z",
      "deployedAt": "2026-07-23T01:22:35.387Z",
      "headSha": "92dcdb40ddbe321bd242622a9dbb29c2322955ff",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/144043950921865",
      "shortSha": "92dcdb4",
      "cleanupDurationMs": 3883,
      "deployDurationMs": 16698,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 16322,
      "deployReadinessDurationMs": 370,
      "deployedWorkerName": "auth-preview-11",
      "deployedWorkerVersion": "ea275ed2-3fb7-44d3-b9cc-0e995e5e3f3e",
      "testDurationMs": 11022,
      "testRetries": null,
      "workerSizeKib": 3965.97,
      "workerGzipKib": 811.66,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-23T01:29:42.505Z",
      "deployedAt": "2026-07-23T01:22:31.861Z",
      "headSha": "92dcdb40ddbe321bd242622a9dbb29c2322955ff",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/144043950921865",
      "shortSha": "92dcdb4",
      "cleanupDurationMs": 7809,
      "deployDurationMs": 13558,
      "deployConfigDurationMs": 8,
      "deployCommandDurationMs": 12794,
      "deployReadinessDurationMs": 756,
      "deployedWorkerName": "streams-example-app-preview-11",
      "deployedWorkerVersion": "1dd693ca-9a87-4b07-bdfa-284e434792bf",
      "testDurationMs": 100759,
      "testRetries": null,
      "workerSizeKib": 5156.37,
      "workerGzipKib": 1472.32,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-23T01:29:35.520Z",
      "deployedAt": "2026-07-22T23:35:01.806Z",
      "headSha": "92dcdb40ddbe321bd242622a9dbb29c2322955ff",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/144043950921865",
      "shortSha": "92dcdb4",
      "cleanupDurationMs": 823,
      "deployDurationMs": 82,
      "deployConfigDurationMs": 9,
      "deployReuseProofDurationMs": 33,
      "deployedWorkerName": "dummy-petshop-preview-11",
      "deployedWorkerVersion": "f57f9433-b1d7-4b13-b3b9-c9fb5b1ef133",
      "testDurationMs": 5054,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `92dcdb4` | [https://auth.iterate-preview-11.com](https://auth.iterate-preview-11.com) | 811.7 KiB | 16.7s | 11.0s |  | 3.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/144043950921865) | 2026-07-23T01:29:38.577Z | Preview app released. |
| Dummy Petshop | released | `92dcdb4` | [https://dummy-petshop.iterate-preview-11.com](https://dummy-petshop.iterate-preview-11.com) | 198.3 KiB | 82ms | 5.1s |  | 823ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/144043950921865) | 2026-07-23T01:29:35.520Z | Preview app released. |
| OS | released | `92dcdb4` | [https://os.iterate-preview-11.com](https://os.iterate-preview-11.com) | 4.89 MiB (-9.3 KiB vs main) | 54.3s | 198.5s | 1 retried: itx expression replacement records the recipe without evaluating it (vitest x1) — stream-unavailable: Durable Object is overloaded. Requests queued for too long. | 21.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/144043950921865) | 2026-07-23T01:29:56.536Z | Preview app released. |
| Semaphore | released | `92dcdb4` | [https://semaphore.iterate-preview-11.com](https://semaphore.iterate-preview-11.com) | 441.0 KiB | 13.0s | 69.7s |  | 905ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/144043950921865) | 2026-07-23T01:29:35.598Z | Preview app released. |
| Streams Example App | released | `92dcdb4` | [https://streams.iterate-preview-11.com](https://streams.iterate-preview-11.com) | 1.44 MiB | 13.6s | 100.8s |  | 7.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/144043950921865) | 2026-07-23T01:29:42.505Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->
