### PR TITLE
Recover processor waits across transient Durable Object overload

### DIFF
--- a/apps/os/src/domains/streams/stream-processor-rpc-target.test.ts
+++ b/apps/os/src/domains/streams/stream-processor-rpc-target.test.ts
@@ -718,6 +718,135 @@ describe("ProcessorRelayRpcTarget", () => {
     }
   });
 
+  it("re-acquires within the public deadline after repeated availability failures", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const lifecycleReset = new Error(
+      "stream-unavailable: Durable Object is overloaded. Requests queued for too long.",
+    );
+    const waits: { offset: number; timeoutMs?: number }[] = [];
+    const disposals: number[] = [];
+    let acquisitions = 0;
+    const relay = new ProcessorRelayRpcTarget({
+      auth: { principal: "trusted-internal" } as never,
+      host: () => ({
+        processor: Promise.resolve({}),
+        wakeStreamSubscriber: async () => {
+          throw new Error("not used");
+        },
+      }),
+      processorFacade: () => {
+        acquisitions += 1;
+        const acquisition = acquisitions;
+        return Promise.resolve({
+          [Symbol.dispose]: () => disposals.push(acquisition),
+          getRuntimeState: async () => ({ snapshot: { offset: 0, state: {} } }),
+          snapshot: async () => ({ offset: 0, state: {} }),
+          waitUntilProcessed: async (input: { offset: number; timeoutMs?: number }) => {
+            waits.push(input);
+            if (acquisition <= 6) throw lifecycleReset;
+          },
+        });
+      },
+    });
+
+    const waiting = relay.waitUntilProcessed({ offset: 3, timeoutMs: 5_000 });
+    const completed = expect(waiting).resolves.toBeUndefined();
+    try {
+      await vi.advanceTimersByTimeAsync(700);
+      await completed;
+      expect(waits).toEqual([
+        { offset: 3, timeoutMs: 5_000 },
+        { offset: 3, timeoutMs: 5_000 },
+        { offset: 3, timeoutMs: 4_900 },
+        { offset: 3, timeoutMs: 4_900 },
+        { offset: 3, timeoutMs: 4_700 },
+        { offset: 3, timeoutMs: 4_700 },
+        { offset: 3, timeoutMs: 4_300 },
+      ]);
+      expect(disposals).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    } finally {
+      await waiting.catch(() => undefined);
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not re-acquire a wait after a processor application error", async () => {
+    const applicationError = new Error("project birth was rejected");
+    const dispose = vi.fn();
+    let acquisitions = 0;
+    const relay = new ProcessorRelayRpcTarget({
+      auth: { principal: "trusted-internal" } as never,
+      host: () => ({
+        processor: Promise.resolve({}),
+        wakeStreamSubscriber: async () => {
+          throw new Error("not used");
+        },
+      }),
+      processorFacade: () => {
+        acquisitions += 1;
+        return Promise.resolve({
+          [Symbol.dispose]: dispose,
+          getRuntimeState: async () => ({ snapshot: { offset: 0, state: {} } }),
+          snapshot: async () => ({ offset: 0, state: {} }),
+          waitUntilProcessed: async () => {
+            throw applicationError;
+          },
+        });
+      },
+    });
+
+    await expect(relay.waitUntilProcessed({ offset: 3, timeoutMs: 30_000 })).rejects.toBe(
+      applicationError,
+    );
+    expect(acquisitions).toBe(1);
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+
+  it("bounds repeated availability re-acquisition by the public timeout", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const lifecycleReset = new Error(
+      "stream-unavailable: Durable Object is overloaded. Requests queued for too long.",
+    );
+    const dispose = vi.fn();
+    let acquisitions = 0;
+    const relay = new ProcessorRelayRpcTarget({
+      auth: { principal: "trusted-internal" } as never,
+      host: () => ({
+        processor: Promise.resolve({}),
+        wakeStreamSubscriber: async () => {
+          throw new Error("not used");
+        },
+      }),
+      processorFacade: () => {
+        acquisitions += 1;
+        return Promise.resolve({
+          [Symbol.dispose]: dispose,
+          getRuntimeState: async () => ({ snapshot: { offset: 0, state: {} } }),
+          snapshot: async () => ({ offset: 0, state: {} }),
+          waitUntilProcessed: async () => {
+            throw lifecycleReset;
+          },
+        });
+      },
+    });
+
+    const waiting = relay.waitUntilProcessed({ offset: 3, timeoutMs: 500 });
+    const rejected = expect(waiting).rejects.toThrow(
+      "waitUntilProcessed timed out after 500ms waiting for offset 3",
+    );
+    try {
+      await vi.advanceTimersByTimeAsync(500);
+      await rejected;
+      expect(acquisitions).toBe(6);
+      expect(dispose).toHaveBeenCalledTimes(6);
+    } finally {
+      await waiting.catch(() => undefined);
+      vi.useRealTimers();
+    }
+  });
+
   it("re-acquires when a remote processor waiter is orphaned", async () => {
     vi.useFakeTimers();
     const firstWait = Promise.withResolvers<void>();

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -6683,6 +6683,8 @@ type ProjectRouterProcessorHostStub = ProcessorHostStub & {
 };
 
 const PROCESSOR_WAIT_REACQUIRE_MS = 10_000;
+const PROCESSOR_WAIT_AVAILABILITY_BACKOFF_INITIAL_MS = 100;
+const PROCESSOR_WAIT_AVAILABILITY_BACKOFF_MAX_MS = 1_000;
 
 /**
  * Isolate-side relay for a Durable-Object-hosted processor facade.
@@ -6840,6 +6842,7 @@ export class ProcessorRelayRpcTarget<State, Host extends ProcessorHostStub = Pro
       new Error(
         `waitUntilProcessed timed out after ${input.timeoutMs}ms waiting for offset ${input.offset}`,
       );
+    let consecutiveAvailabilityFailures = 0;
     while (Date.now() < deadline) {
       // A remote RpcTarget call can be orphaned when its hosting DO is
       // replaced without workerd rejecting the caller. Bound the LOCAL
@@ -6855,7 +6858,34 @@ export class ProcessorRelayRpcTarget<State, Host extends ProcessorHostStub = Pro
           : processor.waitUntilProcessed({ ...input, timeoutMs });
       }, attemptDeadline);
       if (outcome.status === "fulfilled") return outcome.value;
-      if (outcome.status === "rejected") throw outcome.error;
+      if (outcome.status === "rejected") {
+        if (!isRetryableDurableObjectAvailabilityError(outcome.error)) throw outcome.error;
+
+        // Waiting for durable progress is idempotent. A short run of overload
+        // or lifecycle resets must therefore reacquire the processor facade
+        // under the SAME caller deadline, just like an orphaned remote waiter.
+        // Exponential backoff caps the retry rate; the public deadline caps
+        // both total attempts and elapsed recovery time.
+        consecutiveAvailabilityFailures += 1;
+        const remainingMs = deadline - Date.now();
+        if (remainingMs <= 0) break;
+        const backoffMs = Math.min(
+          PROCESSOR_WAIT_AVAILABILITY_BACKOFF_INITIAL_MS *
+            2 ** Math.min(consecutiveAvailabilityFailures - 1, 4),
+          PROCESSOR_WAIT_AVAILABILITY_BACKOFF_MAX_MS,
+          remainingMs,
+        );
+        console.info("processor relay re-acquiring after transient availability failure", {
+          offset: input.offset,
+          consecutiveAvailabilityFailures,
+          backoffMs,
+          remainingMs,
+          error: outcome.error,
+        });
+        await new Promise<void>((resolve) => setTimeout(resolve, backoffMs));
+        continue;
+      }
+      consecutiveAvailabilityFailures = 0;
       if (attemptDeadline >= deadline) break;
       console.info("processor relay re-acquiring after bounded wait slice", {
         offset: input.offset,

--- a/docs/preview-e2e-flake-hunt.md
+++ b/docs/preview-e2e-flake-hunt.md
@@ -52,6 +52,47 @@ normal telemetry; if the workstation sleeps or exits, no running test is
 misclassified and no later run is silently counted. Resume by explicitly
 starting a new proof—accepted streaks are never inferred across ledgers.
 
+## Round 11 (2026-07-23, post-#2265)
+
+This round starts from `origin/main` at
+`56fdbd4e447ab53f3011a60417349f76223db30d`. PR #2265's final exact-head
+canonical check ran all five suites successfully in 291 seconds from pickup to
+finish (the GitHub check itself reported 4m40s): Depot run
+[`79jc4l57lt`](https://depot.dev/orgs/0p91s0lz49/workflows/37tr66gdxx?job=nk8k8jvb81),
+attempt `c2mnb0ph28`. Playwright had zero retries, but OS Vitest absorbed one,
+so this is a useful ordinary green and a rejected formal proof; the accepted
+counter remains 0/25.
+
+The retry was `itx expression replacement records the recipe without
+evaluating it`. Its first attempt failed during fresh-project creation with
+`stream-unavailable: Durable Object is overloaded. Requests queued for too
+long.`; the full-test retry created a second project and passed. PostHog records
+153 executions of this exact case over the preceding 30 days and only this one
+retry (0.65%). Duration was normally 9.0s at p50 and 14.9s at p95; the retried
+run took 19.3s. That history does not justify quarantine, serialization, or
+project reuse.
+
+Cloudflare traces locate the first failure in project
+`prj_d2cb39d19139488fba1c5236b17d61da`, not in deployment-global state. Its
+root Project Durable Object repeatedly rejected delivery while
+`ProjectProcessor.#createSiblingProcessors` waited for the root capability-host
+birth. The stream sink durably backed off and re-poked the subscription, and
+the same project subsequently reached ready about nine seconds after
+registration. The caller nevertheless failed earlier: the processor relay
+performed its one immediate lifecycle retry, received another availability
+rejection, and threw even though `waitUntilProcessed` still had most of its
+75-second public deadline available.
+
+The round-11 fix makes only that idempotent wait operation reacquire a fresh
+processor facade after repeated availability failures. It retains one caller
+deadline, applies exponential backoff capped at one second, disposes every
+transient facade, and fails when the deadline expires. Application errors still
+propagate immediately, and non-wait processor calls keep their existing single
+retry. Focused tests cover recovery after more than two availability failures,
+decreasing timeout propagation, application-error fail-fast behavior, and
+bounded exhaustion. This pays off the product-layer wait contract instead of
+adding a test retry, longer timeout, quarantine, or global Vitest throttle.
+
 ## Round 10 (2026-07-23, post-#2263)
 
 This round starts from `origin/main` at


### PR DESCRIPTION
## Summary

This fixes the single absorbed retry from PR #2265's final canonical preview run at the product boundary that failed.

`ProcessorRelayRpcTarget.waitUntilProcessed` already owns one caller deadline and can reacquire a facade when a remote waiter is orphaned. However, after two immediate Durable Object availability failures it threw immediately—even when most of that deadline remained. Fresh project creation could therefore fail while durable stream delivery was correctly backing off and the same project became ready seconds later.

The wait now:

- reacquires only after an explicitly classified Durable Object lifecycle/availability failure;
- retains the original public deadline and passes decreasing time to every remote waiter;
- uses exponential backoff from 100ms, capped at 1s, so recovery is bounded in both time and request rate;
- disposes every transient remote facade;
- still propagates application errors immediately;
- leaves non-wait processor methods on their existing single lifecycle retry.

There is no test-level retry, timeout increase, quarantine, project reuse, or Vitest serialization.

## Evidence

PR #2265's final exact-head run passed all five suites in 291 seconds from pickup to finish: [Depot run `79jc4l57lt`, attempt `c2mnb0ph28`](https://depot.dev/orgs/0p91s0lz49/workflows/37tr66gdxx?job=nk8k8jvb81). Playwright had zero retries. OS Vitest absorbed one retry in `itx expression replacement records the recipe without evaluating it`, so the run was an ordinary green but rejected from the formal zero-retry streak.

The first attempt failed during fresh-project creation with:

```text
stream-unavailable: Durable Object is overloaded. Requests queued for too long.
```

Cloudflare traces locate the failure in one fresh project's root Project Durable Object while `ProjectProcessor.#createSiblingProcessors` waited for the root capability-host birth. Its stream sink durably backed off and re-poked delivery, and that same project reached ready about nine seconds after registration. The caller had already exhausted the relay's two immediate attempts; the full Vitest retry created a second project and passed.

PostHog records 153 executions of this exact test over the preceding 30 days and only this retry (0.65%). Duration is 9.0s at p50 and 14.9s at p95; the retried run took 19.3s. That evidence points to the processor-wait contract, not a flaky victim test or shared deployment-global bottleneck.

The full investigation and round-11 acceptance state are recorded in `docs/preview-e2e-flake-hunt.md`. The formal counter remains 0/25 until this exact head completes clean canonical runs.

## Validation

- `pnpm --dir apps/os typecheck`
- `pnpm --dir apps/os test:unit` — 233 files, 2,277 passed, 6 expected failures, 1 skipped
- focused processor-relay regression — 26/26 passed
- targeted Oxlint and Oxfmt checks

Focused regressions prove recovery after more than two availability failures, decreasing timeout propagation, immediate application-error failure, facade disposal, and bounded timeout exhaustion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core stream/processor wait behavior on the isolate→DO relay path; mistakes could mask real errors or extend load under overload, though scope is limited to classified availability failures and the existing public deadline.
> 
> **Overview**
> **`ProcessorRelayRpcTarget.waitUntilProcessed`** no longer fails after a couple of transient Durable Object availability errors while most of the caller’s timeout is still left. For timed waits it now treats **`isRetryableDurableObjectAvailabilityError`** like orphaned waiters: keep the original deadline, pass shrinking **`timeoutMs`** to each remote attempt, dispose superseded facades, and **re-acquire** with exponential backoff (100ms → 1s cap) until success or timeout. **Application errors** still fail on the first rejection; other processor RPC paths are unchanged.
> 
> Adds focused relay tests for multi-failure recovery, fail-fast on application errors, and bounded exhaustion, plus **Round 11** notes in **`docs/preview-e2e-flake-hunt.md`** tying the change to preview Vitest **`stream-unavailable`** during fresh project creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70606a3c8649af790e64216cf296fcfd2c790c96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +31 -1 | +25 -1 🟩⬜⬜⬜⬜ |
| Tests | +129 -0 | +123 -0 🟩🟩🟩🟩🟩 |
| Docs | +41 -0 | +36 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+201 -1** | **+184 -1** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 56fdbd4 and 70606a3, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-23T01:52:42.202Z",
      "deployedAt": "2026-07-23T01:47:28.931Z",
      "headSha": "70606a3c8649af790e64216cf296fcfd2c790c96",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/34653876127695",
      "shortSha": "70606a3",
      "cleanupDurationMs": 11779,
      "deployDurationMs": 75970,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 75908,
      "deployReadinessDurationMs": 59,
      "deployedWorkerName": "os-preview-13",
      "deployedWorkerVersion": "f3e79af2-a50d-4ca8-8a4c-7ae2791e8eeb",
      "testDurationMs": 212765,
      "testRetries": null,
      "workerSizeKib": 19778.5,
      "workerGzipKib": 5004.06,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5013.48
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-23T01:52:33.941Z",
      "deployedAt": "2026-07-23T01:46:31.884Z",
      "headSha": "70606a3c8649af790e64216cf296fcfd2c790c96",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/34653876127695",
      "shortSha": "70606a3",
      "cleanupDurationMs": 3516,
      "deployDurationMs": 19268,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 18857,
      "deployReadinessDurationMs": 406,
      "deployedWorkerName": "auth-preview-13",
      "deployedWorkerVersion": "3af59ae7-b4c5-403b-8b62-965498f875fa",
      "testDurationMs": 10676,
      "testRetries": null,
      "workerSizeKib": 3965.97,
      "workerGzipKib": 811.61,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-23T01:52:39.229Z",
      "deployedAt": "2026-07-23T01:46:53.163Z",
      "headSha": "70606a3c8649af790e64216cf296fcfd2c790c96",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/34653876127695",
      "shortSha": "70606a3",
      "cleanupDurationMs": 8800,
      "deployDurationMs": 40892,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 40135,
      "deployReadinessDurationMs": 751,
      "deployedWorkerName": "streams-example-app-preview-13",
      "deployedWorkerVersion": "9d919deb-6a67-4ce0-8ecd-d16fe5dc6d8d",
      "testDurationMs": 104966,
      "testRetries": null,
      "workerSizeKib": 5157.24,
      "workerGzipKib": 1472.52,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-23T01:52:31.324Z",
      "deployedAt": "2026-07-23T01:46:18.696Z",
      "headSha": "70606a3c8649af790e64216cf296fcfd2c790c96",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/34653876127695",
      "shortSha": "70606a3",
      "cleanupDurationMs": 893,
      "deployDurationMs": 5987,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 5627,
      "deployReadinessDurationMs": 314,
      "deployedWorkerName": "dummy-petshop-preview-13",
      "deployedWorkerVersion": "235b1f79-8717-4f9a-a6b0-f5350d4d067b",
      "testDurationMs": 23358,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `70606a3` | [https://auth.iterate-preview-13.com](https://auth.iterate-preview-13.com) | 811.6 KiB | 19.3s | 10.7s |  | 3.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/34653876127695) | 2026-07-23T01:52:33.941Z | Preview app released. |
| Dummy Petshop | released | `70606a3` | [https://dummy-petshop.iterate-preview-13.com](https://dummy-petshop.iterate-preview-13.com) | 198.3 KiB | 6.0s | 23.4s |  | 893ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/34653876127695) | 2026-07-23T01:52:31.324Z | Preview app released. |
| OS | released | `70606a3` | [https://os.iterate-preview-13.com](https://os.iterate-preview-13.com) | 4.89 MiB (-9.4 KiB vs main) | 76.0s | 212.8s |  | 11.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/34653876127695) | 2026-07-23T01:52:42.202Z | Preview app released. |
| Streams Example App | released | `70606a3` | [https://streams.iterate-preview-13.com](https://streams.iterate-preview-13.com) | 1.44 MiB | 40.9s | 105.0s |  | 8.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/34653876127695) | 2026-07-23T01:52:39.229Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->