### PR TITLE
Start preview CI from the baked workspace

### DIFF
--- a/.depot/workflows/build-preview-ci-image.yml
+++ b/.depot/workflows/build-preview-ci-image.yml
@@ -1,12 +1,20 @@
 name: Build Preview CI Image
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - "**/package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "scripts/depot-ci/bake-preview-ci-image.sh"
+      - ".depot/workflows/build-preview-ci-image.yml"
   schedule:
-    # Weekly (Mondays 04:17 UTC). Mainline checks and production deploys use
-    # this snapshot; preview deploy/e2e uses Depot's standard runners. The
-    # reconcile step in each consumer validates the baked workspace against
-    # the checked-out lockfile, so weekly baking keeps startup fast without a
-    # daily image build. See docs/depot-ci.md.
+    # Weekly (Mondays 04:17 UTC) repairs drift even when dependency inputs have
+    # not changed. Relevant mainline changes rebuild immediately so consumers
+    # rarely spend startup time reconciling a stale snapshot. The reconcile
+    # step remains the correctness authority. See docs/depot-ci.md.
     - cron: "17 4 * * 1"
   workflow_dispatch: {}
 

--- a/.depot/workflows/cloudflare-previews.yml
+++ b/.depot/workflows/cloudflare-previews.yml
@@ -91,9 +91,12 @@ jobs:
       (github.event.action != 'labeled' || github.event.label.name == 'preview') &&
         (github.event.action != 'unlabeled' || github.event.label.name == 'preview')
     name: Preview / deploy + e2e
-    # The overlapping test pools peaked below ten cores on the 32-core runner;
-    # use the supported 16-core shape and keep allocation out of the long tail.
-    runs-on: depot-ubuntu-24.04-16
+    # The overlapping test pools peaked below ten cores. Keep the 16-core
+    # shape, but start from the same baked workspace used by mainline checks
+    # and production deploys so setup does not redownload the toolchain.
+    runs-on:
+      size: 16x64
+      image: 0p91s0lz49.registry.depot.dev/iterate-preview-ci:node24-pnpm10-worktree
     # Hard backstop on one attempt. Each parallel sub-lane retains its own
     # tighter watchdog; this outer bound catches setup, deploy, and reporting
     # runaways while leaving enough time to preserve failure artifacts.
@@ -105,6 +108,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          clean: false
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       # Permanent breaking-change floor: an old branch would deploy Auth first,
       # then fail or deploy an OS revision that cannot call the default RPC
@@ -119,19 +123,8 @@ jobs:
             echo "This branch predates preview deployment epoch $expected. Rebase onto main before deploying." >&2
             exit 1
           fi
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: pnpm
-      - name: Install dependencies
-        run: pnpm install
-      - name: Install Doppler CLI
-        run: |-
-          for i in 1 2 3; do curl -sfLS https://cli.doppler.com/install.sh | sh -s -- --no-package-manager && break; echo "Attempt $i failed, retrying in 5s..."; sleep 5; done
-          doppler --version || { echo 'Failed to install Doppler CLI after 3 attempts'; exit 1; }
+      - name: Reconcile dependencies (baked)
+        run: pnpm install --frozen-lockfile --prefer-offline
       # ONE step for deploy + e2e: `preview run` shares a single resolved PR
       # head between the two phases, so a push can no longer race into a gap
       # between separate deploy and test steps (that gap used to need a whole

--- a/docs/depot-ci.md
+++ b/docs/depot-ci.md
@@ -307,9 +307,14 @@ The baked image is built by `.depot/workflows/build-preview-ci-image.yml` using
 `scripts/depot-ci/bake-preview-ci-image.sh`.
 
 It contains Node, pnpm, workspace dependencies, Doppler CLI, and the preview
-browser. A snapshot is independent of sandbox size: choose `2x8`, `4x16`, or
-`8x32` from measured workload demand. Jobs that consume it must keep the image
-and checkout behavior:
+browser. A snapshot is independent of sandbox size: choose `2x8`, `4x16`,
+`8x32`, or `16x64` from measured workload demand. Preview deploy/e2e retains
+`16x64` for its overlapping browser and Vitest pools. The image rebuilds when
+dependency manifests or its bake inputs land on `main`, with a weekly scheduled
+rebuild as drift repair. Consumers still run
+`pnpm install --frozen-lockfile --prefer-offline`; that reconcile is the
+correctness check and safely handles a stale image. Jobs that consume it must
+keep the image and checkout behavior:
 
 ```yaml
 runs-on:

--- a/scripts/ci/depot-workflows.test.ts
+++ b/scripts/ci/depot-workflows.test.ts
@@ -30,6 +30,7 @@ type Workflow = {
   permissions?: Record<string, string>;
   on?: {
     push?: {
+      branches?: string[];
       paths?: string[];
     };
   };
@@ -213,6 +214,40 @@ describe("Depot credential boundaries", () => {
 });
 
 describe("Depot validation capacity", () => {
+  it("refreshes the baked workspace when dependency inputs land on main", () => {
+    const workflow = loadWorkflow(".depot/workflows/build-preview-ci-image.yml");
+
+    expect(workflow.on?.push?.branches).toEqual(["main"]);
+    expect(workflow.on?.push?.paths).toEqual(
+      expect.arrayContaining([
+        "**/package.json",
+        "pnpm-lock.yaml",
+        "pnpm-workspace.yaml",
+        "scripts/depot-ci/bake-preview-ci-image.sh",
+        ".depot/workflows/build-preview-ci-image.yml",
+      ]),
+    );
+  });
+
+  it("starts preview deploy/e2e from the baked workspace", () => {
+    const workflow = loadWorkflow(".depot/workflows/cloudflare-previews.yml");
+    const job = workflow.jobs.preview;
+
+    expect(job["runs-on"]).toEqual({
+      size: "16x64",
+      image: "0p91s0lz49.registry.depot.dev/iterate-preview-ci:node24-pnpm10-worktree",
+    });
+
+    const checkout = job.steps?.find((step) => step.uses === "actions/checkout@v4");
+    expect(checkout?.with).toMatchObject({ clean: false });
+
+    const reconcile = job.steps?.find((step) => step.name === "Reconcile dependencies (baked)");
+    expect(reconcile?.run).toBe("pnpm install --frozen-lockfile --prefer-offline");
+    expect(job.steps?.map((step) => step.name)).not.toEqual(
+      expect.arrayContaining(["Setup pnpm", "Setup Node", "Install Doppler CLI"]),
+    );
+  });
+
   it("runs every workspace test script, including the iterate CLI", () => {
     const packageJson = JSON.parse(readFileSync(resolve(repoRoot, "package.json"), "utf8")) as {
       scripts: { test: string };


### PR DESCRIPTION
## Summary

This moves only the Cloudflare preview job onto the existing baked Depot workspace already used by mainline tests, lint, and production deploys.

- retain the measured 16-core preview runner shape
- use the existing Node 24 / pnpm 10 baked image
- preserve baked dependencies with `actions/checkout clean: false`
- reconcile the checked-out lockfile with `pnpm install --frozen-lockfile --prefer-offline`
- rebuild the image when dependency inputs land on `main`, while retaining the weekly drift repair

It removes fresh Node, pnpm, workspace dependency, and Doppler installation from every preview pickup. It does not reuse deployments or test results, change app selection, reduce test scope, add retries, or serialize any test lane.

## Evidence

The live proof for #2266 showed the preview job still starting on a stock runner and downloading the entire 2,311-package workspace plus Node, pnpm, and Doppler before deploy could begin. The earlier isolated experiment in #2233 measured command start falling from 9.96s to 5.60s and Playwright launch delay from 6.86s to 0.68s. Remote Cloudflare variance limited that single end-to-end comparison, so this PR will be judged on its own canonical all-suite run and PostHog phase evidence.

Correctness remains with the checked-out lockfile: every run still executes frozen `pnpm install`, which fills anything absent from a stale image. The image path and checkout pattern are already exercised by repository tests, lint/typecheck, and production deployment workflows.

## Validation

- `pnpm --dir scripts exec vitest run ci/depot-workflows.test.ts` — 32 passed
- `pnpm --dir scripts typecheck`
- focused Oxlint and Oxfmt checks
- `git diff --check`

The PR preview must run the complete selected suites with zero retries before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow and startup-path changes only; deploy/e2e behavior and lockfile-gated install correctness stay the same pattern as other baked-image jobs.
> 
> **Overview**
> **Cloudflare preview deploy/e2e** now uses the same **baked Depot CI image** as mainline checks and production deploys, keeping the **16x64** runner shape but dropping per-run **Node/pnpm/Doppler install** and full workspace download.
> 
> Checkout uses **`clean: false`** so baked `node_modules` survive; a single **`pnpm install --frozen-lockfile --prefer-offline`** step reconciles the PR head against the lockfile.
> 
> The **preview CI image bake** workflow also **rebuilds on `main` pushes** when dependency manifests, lockfile, bake script, or its own workflow change, with the **weekly cron** retained as drift repair. **`docs/depot-ci.md`** documents the **`16x64`** preview sizing and rebuild policy; **`depot-workflows.test.ts`** locks in the new triggers and preview job shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06f196f238345736caa0756a954fb79fc2b119c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +35 -0 | +29 -0 🟩🟩🟩⬜⬜ |
| CI & scripts | +22 -21 | +22 -21 🟩🟩🟩🟥🟥 |
| Docs | +8 -3 | +8 -3 🟩⬜⬜⬜⬜ |
| **Total** | **+65 -24** | **+59 -24** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 1256921 and 06f196f, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-23T02:04:22.113Z",
      "deployedAt": "2026-07-23T01:57:33.339Z",
      "headSha": "06f196f238345736caa0756a954fb79fc2b119c8",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/178409440466270",
      "shortSha": "06f196f",
      "cleanupDurationMs": 13324,
      "deployDurationMs": 73387,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 72301,
      "deployReadinessDurationMs": 1084,
      "deployedWorkerName": "os-preview-7",
      "deployedWorkerVersion": "dbda2ed2-4bc0-42b2-ab5f-b7aade4862fa",
      "testDurationMs": 221230,
      "testRetries": null,
      "workerSizeKib": 19778.5,
      "workerGzipKib": 5004.06,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5013.62
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-23T02:04:09.757Z",
      "deployedAt": "2026-07-23T01:56:35.551Z",
      "headSha": "06f196f238345736caa0756a954fb79fc2b119c8",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/178409440466270",
      "shortSha": "06f196f",
      "cleanupDurationMs": 965,
      "deployDurationMs": 14719,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 14510,
      "deployReadinessDurationMs": 204,
      "deployedWorkerName": "semaphore-preview-7",
      "deployedWorkerVersion": "fdb19fa5-19e8-4b62-ae87-02146abf1e79",
      "testDurationMs": 50167,
      "testRetries": null,
      "workerSizeKib": 1915.22,
      "workerGzipKib": 440.99,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-23T02:04:12.566Z",
      "deployedAt": "2026-07-23T01:56:41.836Z",
      "headSha": "06f196f238345736caa0756a954fb79fc2b119c8",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/178409440466270",
      "shortSha": "06f196f",
      "cleanupDurationMs": 3772,
      "deployDurationMs": 21156,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 20794,
      "deployReadinessDurationMs": 356,
      "deployedWorkerName": "auth-preview-7",
      "deployedWorkerVersion": "8d2077e4-18b5-48ed-a68d-a30d2d183888",
      "testDurationMs": 11313,
      "testRetries": null,
      "workerSizeKib": 3965.97,
      "workerGzipKib": 811.34,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-23T02:04:17.102Z",
      "deployedAt": "2026-07-23T01:56:48.391Z",
      "headSha": "06f196f238345736caa0756a954fb79fc2b119c8",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/178409440466270",
      "shortSha": "06f196f",
      "cleanupDurationMs": 8306,
      "deployDurationMs": 45160,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 27348,
      "deployReadinessDurationMs": 17807,
      "deployedWorkerName": "streams-example-app-preview-7",
      "deployedWorkerVersion": "daa1313a-1d00-4774-828a-888ebc0b781b",
      "testDurationMs": 96200,
      "testRetries": null,
      "workerSizeKib": 5157.24,
      "workerGzipKib": 1472.52,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-23T02:04:09.888Z",
      "deployedAt": "2026-07-23T01:56:26.897Z",
      "headSha": "06f196f238345736caa0756a954fb79fc2b119c8",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/178409440466270",
      "shortSha": "06f196f",
      "cleanupDurationMs": 1089,
      "deployDurationMs": 6072,
      "deployConfigDurationMs": 7,
      "deployCommandDurationMs": 5810,
      "deployReadinessDurationMs": 213,
      "deployedWorkerName": "dummy-petshop-preview-7",
      "deployedWorkerVersion": "32ef9ccc-6919-4ab1-be53-49b0ffa54218",
      "testDurationMs": 28002,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `06f196f` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 811.3 KiB | 21.2s | 11.3s |  | 3.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/178409440466270) | 2026-07-23T02:04:12.566Z | Preview app released. |
| Dummy Petshop | released | `06f196f` | [https://dummy-petshop.iterate-preview-7.com](https://dummy-petshop.iterate-preview-7.com) | 198.3 KiB | 6.1s | 28.0s |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/178409440466270) | 2026-07-23T02:04:09.888Z | Preview app released. |
| OS | released | `06f196f` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 4.89 MiB (-9.6 KiB vs main) | 73.4s | 221.2s |  | 13.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/178409440466270) | 2026-07-23T02:04:22.113Z | Preview app released. |
| Semaphore | released | `06f196f` | [https://semaphore.iterate-preview-7.com](https://semaphore.iterate-preview-7.com) | 441.0 KiB | 14.7s | 50.2s |  | 965ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/178409440466270) | 2026-07-23T02:04:09.757Z | Preview app released. |
| Streams Example App | released | `06f196f` | [https://streams.iterate-preview-7.com](https://streams.iterate-preview-7.com) | 1.44 MiB | 45.2s | 96.2s |  | 8.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/178409440466270) | 2026-07-23T02:04:17.102Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->