### PR TITLE
fix(os): stabilize preview project creation

### DIFF
--- a/apps/os/e2e/vitest/onboarding-smoke.ts
+++ b/apps/os/e2e/vitest/onboarding-smoke.ts
@@ -28,6 +28,7 @@ import {
   type TestTelemetryAttempt,
 } from "@iterate-com/shared/test-support/ci-telemetry";
 import { cloudflareWorkerVersionOverrideHeaders } from "@iterate-com/shared/test-support/cloudflare-worker-version-overrides";
+import { waitForPreviewRolloutBeforeProjectCreation } from "@iterate-com/shared/test-support/preview-rollout-gate";
 import { connectItx } from "iterate/node";
 import {
   ensureOnboardingAgentReady,
@@ -48,6 +49,11 @@ type SmokePhase = { name: string; durationMs: number; category: string };
 async function attemptOnboardingSmoke(phases: SmokePhase[]): Promise<void> {
   const marker = Math.random().toString(36).slice(2, 8);
 
+  // Edge readiness does not mean a freshly deployed Durable Object namespace
+  // has finished propagating globally. Use the same absolute deployment
+  // boundary as Playwright so this early lane cannot create an object while
+  // Cloudflare is still replacing its assigned worker version.
+  await waitForPreviewRolloutBeforeProjectCreation();
   using session = connectItx({
     baseUrl,
     headers: cloudflareWorkerVersionOverrideHeaders(process.env),

--- a/apps/os/src/domains/devices/device-durable-object.ts
+++ b/apps/os/src/domains/devices/device-durable-object.ts
@@ -222,7 +222,8 @@ export class DeviceDurableObject extends DurableObject<Env> {
   }
 
   async #waitUntilProcessed(offset: number) {
-    await this.#registry.catchUp(DeviceProcessorContract.slug);
+    // The offset wait self-pulls and owns the complete read-your-writes
+    // timeout. Do not put an unbounded catch-up RPC in front of it.
     await this.#reads.waitUntilEvent({ offset, timeoutMs: INGEST_WAIT_TIMEOUT_MS });
   }
 

--- a/apps/os/src/domains/sandboxes/cloudflare/cloudflare-sandbox-durable-object.ts
+++ b/apps/os/src/domains/sandboxes/cloudflare/cloudflare-sandbox-durable-object.ts
@@ -1643,8 +1643,9 @@ export abstract class SandboxDurableObject extends Sandbox<Env> {
   }
 
   async #waitUntilProcessed(offset: number): Promise<void> {
-    const { reads, registry } = this.#processorResources();
-    await registry.catchUp(SandboxProcessorContract.slug);
+    const { reads } = this.#processorResources();
+    // The offset wait self-pulls and owns the complete read-your-writes
+    // timeout. Do not put an unbounded catch-up RPC in front of it.
     await reads.waitUntilEvent({ offset, timeoutMs: SANDBOX_PROCESSOR_WAIT_TIMEOUT_MS });
   }
 }

--- a/apps/os/src/domains/scheduler/scheduler-durable-object.ts
+++ b/apps/os/src/domains/scheduler/scheduler-durable-object.ts
@@ -199,11 +199,9 @@ export class SchedulerDurableObject extends DurableObject<Env> {
     });
   }
 
-  // catchUp swallows failures by design (it serves stale state to reads), so
-  // the write path adds a hard wait: the command only returns once the
-  // committed reduced state provably includes the event it just appended.
+  // The offset wait self-pulls and owns the complete read-your-writes
+  // timeout. Do not put an unbounded catch-up RPC in front of it.
   async #waitUntilProcessed(offset: number): Promise<void> {
-    await this.#registry.catchUp(PROCESSOR_SLUG);
     await this.#reads.waitUntilEvent({ offset, timeoutMs: INGEST_WAIT_TIMEOUT_MS });
   }
 }

--- a/apps/os/src/domains/secrets/secret-durable-object.ts
+++ b/apps/os/src/domains/secrets/secret-durable-object.ts
@@ -758,7 +758,10 @@ export class SecretDurableObject extends DurableObject<Env> {
   }
 
   async #waitUntilProcessed(offset: number): Promise<void> {
-    await this.#registry.catchUp(SecretProcessorContract.slug);
+    // The offset wait is the single bounded read-your-writes door: it
+    // self-pulls when the runner is behind. A separate catchUp here would put
+    // an unbounded Stream RPC in front of the timeout and can orphan the
+    // command even after the target Stream DO finished serving the read.
     await this.#reads.waitUntilEvent({ offset, timeoutMs: INGEST_WAIT_TIMEOUT_MS });
   }
 

--- a/apps/os/src/domains/streams/stream-processor-runner.test.ts
+++ b/apps/os/src/domains/streams/stream-processor-runner.test.ts
@@ -149,6 +149,7 @@ function makeJournal(homePath = HOME) {
   const attempts: { path: string; event: StreamEventInput; deduped: boolean }[] = [];
   const failNext = new Map<string, Error>();
   let failNextRead: Error | undefined;
+  let hangNextRead = false;
   let createdAtClock = 0;
 
   const rowsFor = (path: string): StreamEvent[] => {
@@ -202,6 +203,10 @@ function makeJournal(homePath = HOME) {
         const limit = args?.limit ?? 500;
         return {
           next: () => {
+            if (hangNextRead) {
+              hangNextRead = false;
+              return new Promise<StreamEvent[]>(() => {});
+            }
             if (failNextRead !== undefined) {
               const error = failNextRead;
               failNextRead = undefined;
@@ -245,6 +250,9 @@ function makeJournal(homePath = HOME) {
     },
     failNextReadWith(error: Error) {
       failNextRead = error;
+    },
+    hangNextRead() {
+      hangNextRead = true;
     },
   };
 }
@@ -1367,6 +1375,18 @@ describe("StreamProcessorRunner.waitUntilEvent", () => {
       controller.abort();
       consoleError.mockRestore();
     }
+  });
+
+  it("offset form's timeout bounds a silently orphaned self-pull", async () => {
+    const harness = makeHarness();
+    harness.journal.hangNextRead();
+
+    await expect(
+      harness.runner.waitUntilEvent({
+        offset: 8,
+        timeoutMs: 20,
+      }),
+    ).rejects.toThrow("waitUntilEvent timed out after 20ms");
   });
 });
 

--- a/apps/os/src/project-directory.test.ts
+++ b/apps/os/src/project-directory.test.ts
@@ -15,60 +15,52 @@ const record: ProjectDirectoryRecord = {
   name: "Alpha",
 };
 
-function directoryWithPut(
-  put: ReturnType<typeof vi.fn>,
-  deleteKey = vi.fn().mockResolvedValue(undefined),
-): KVNamespace {
-  return { delete: deleteKey, put } as unknown as KVNamespace;
+function directoryWithPut(put: ReturnType<typeof vi.fn>): KVNamespace {
+  return { put } as unknown as KVNamespace;
 }
 
 describe("primeProjectDirectory", () => {
   beforeEach(() => auth.getProjectBySlug.mockReset());
 
-  it("writes both durable lookup keys and clears a stale shared miss", async () => {
+  it("writes both durable lookup keys", async () => {
     const put = vi.fn().mockResolvedValue(undefined);
-    const deleteKey = vi.fn().mockResolvedValue(undefined);
 
-    await primeProjectDirectory(directoryWithPut(put, deleteKey), record);
+    await primeProjectDirectory(directoryWithPut(put), record);
 
     const body = JSON.stringify(record);
     expect(put.mock.calls).toEqual([
       ["slug:alpha", body],
       ["project:prj_alpha", body],
     ]);
-    expect(deleteKey).toHaveBeenCalledExactlyOnceWith("missing-slug:alpha");
   });
 
-  it("recovers from one timed-out attempt and observes its late rejection", async () => {
+  it("retries only the timed-out key and observes its late rejection", async () => {
     vi.useFakeTimers();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
       const rejectLate: Array<(error: Error) => void> = [];
-      const put = vi
-        .fn()
-        .mockImplementationOnce(
-          () =>
-            new Promise<void>((_resolve, reject) => {
-              rejectLate.push(reject);
-            }),
-        )
-        .mockImplementationOnce(
-          () =>
-            new Promise<void>((_resolve, reject) => {
-              rejectLate.push(reject);
-            }),
-        )
-        .mockResolvedValueOnce(undefined)
-        .mockResolvedValueOnce(undefined);
+      let slugAttempts = 0;
+      const put = vi.fn((key: string) => {
+        if (key === "slug:alpha" && slugAttempts++ === 0) {
+          return new Promise<void>((_resolve, reject) => {
+            rejectLate.push(reject);
+          });
+        }
+        return Promise.resolve();
+      });
       const primed = primeProjectDirectory(directoryWithPut(put), record);
 
       await vi.advanceTimersByTimeAsync(10_000);
       await expect(primed).resolves.toBeUndefined();
 
-      expect(put).toHaveBeenCalledTimes(4);
+      expect(put.mock.calls.map(([key]) => key)).toEqual([
+        "slug:alpha",
+        "project:prj_alpha",
+        "slug:alpha",
+      ]);
       expect(warn).toHaveBeenCalledWith(
         "[project-directory] write failed; retrying",
-        expect.objectContaining({ attempt: 1, maxAttempts: 2 }),
+        expect.objectContaining({ attempt: 1, keyKind: "slug", maxAttempts: 2 }),
       );
       for (const reject of rejectLate) reject(new Error("late platform cancellation"));
       await Promise.resolve();
@@ -78,34 +70,71 @@ describe("primeProjectDirectory", () => {
     }
   });
 
-  it("rejects after two failed attempts instead of swallowing the dependency error", async () => {
+  it("does not retry a successful sibling when the other key rejects", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
-      const put = vi.fn().mockRejectedValue(new Error("KV unavailable"));
+      const put = vi.fn((key: string) =>
+        key === "slug:alpha" ? Promise.reject(new Error("KV unavailable")) : Promise.resolve(),
+      );
 
       await expect(primeProjectDirectory(directoryWithPut(put), record)).rejects.toThrow(
-        "Project directory write failed after 2 attempts: KV unavailable",
+        "Project directory slug write failed after 2 attempts: KV unavailable",
       );
-      expect(put).toHaveBeenCalledTimes(4);
+      expect(put.mock.calls.map(([key]) => key)).toEqual([
+        "slug:alpha",
+        "project:prj_alpha",
+        "slug:alpha",
+      ]);
     } finally {
       warn.mockRestore();
     }
   });
 
-  it("rejects after two bounded attempts when KV never settles", async () => {
+  it("recovers when both keys independently time out once", async () => {
     vi.useFakeTimers();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
-      const put = vi.fn(() => new Promise<void>(() => {}));
+      const attempts = new Map<string, number>();
+      const put = vi.fn((key: string) => {
+        const attempt = (attempts.get(key) ?? 0) + 1;
+        attempts.set(key, attempt);
+        return attempt === 1 ? new Promise<void>(() => {}) : Promise.resolve();
+      });
+      const primed = primeProjectDirectory(directoryWithPut(put), record);
+
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      await expect(primed).resolves.toBeUndefined();
+      expect(put).toHaveBeenCalledTimes(4);
+      expect(warn).toHaveBeenCalledTimes(2);
+    } finally {
+      warn.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("observes every late rejection after independent timeouts", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const rejectLate: Array<(error: Error) => void> = [];
+      const put = vi.fn(
+        () =>
+          new Promise<void>((_resolve, reject) => {
+            rejectLate.push(reject);
+          }),
+      );
       const primed = primeProjectDirectory(directoryWithPut(put), record);
       const rejected = expect(primed).rejects.toThrow(
-        "Project directory write failed after 2 attempts: Project directory KV write timed out after 10000ms",
+        "Project directory slug write failed after 2 attempts: Project directory KV write timed out after 10000ms",
       );
 
       await vi.advanceTimersByTimeAsync(20_000);
 
       await rejected;
       expect(put).toHaveBeenCalledTimes(4);
+      for (const reject of rejectLate) reject(new Error("late platform cancellation"));
+      await Promise.resolve();
     } finally {
       warn.mockRestore();
       vi.useRealTimers();

--- a/apps/os/src/project-directory.test.ts
+++ b/apps/os/src/project-directory.test.ts
@@ -15,23 +15,60 @@ const record: ProjectDirectoryRecord = {
   name: "Alpha",
 };
 
-function directoryWithPut(put: ReturnType<typeof vi.fn>): KVNamespace {
-  return { put } as unknown as KVNamespace;
+function directoryWithPut(
+  put: ReturnType<typeof vi.fn>,
+  deleteKey = vi.fn().mockResolvedValue(undefined),
+): KVNamespace {
+  return { delete: deleteKey, put } as unknown as KVNamespace;
 }
 
 describe("primeProjectDirectory", () => {
   beforeEach(() => auth.getProjectBySlug.mockReset());
 
-  it("writes both durable lookup keys", async () => {
+  it("writes both durable lookup keys and clears a stale shared miss", async () => {
     const put = vi.fn().mockResolvedValue(undefined);
+    const deleteKey = vi.fn().mockResolvedValue(undefined);
 
-    await primeProjectDirectory(directoryWithPut(put), record);
+    await primeProjectDirectory(directoryWithPut(put, deleteKey), record);
 
     const body = JSON.stringify(record);
     expect(put.mock.calls).toEqual([
       ["slug:alpha", body],
       ["project:prj_alpha", body],
     ]);
+    expect(deleteKey).toHaveBeenCalledExactlyOnceWith("missing-slug:alpha");
+  });
+
+  it("bounds stale-miss cleanup without failing the required writes", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      let rejectLate!: (error: Error) => void;
+      const deleteKey = vi.fn(
+        () =>
+          new Promise<void>((_resolve, reject) => {
+            rejectLate = reject;
+          }),
+      );
+      const put = vi.fn().mockResolvedValue(undefined);
+      const primed = primeProjectDirectory(directoryWithPut(put, deleteKey), record);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      await expect(primed).resolves.toBeUndefined();
+      expect(put.mock.calls.map(([key]) => key)).toEqual(["slug:alpha", "project:prj_alpha"]);
+      expect(deleteKey).toHaveBeenCalledExactlyOnceWith("missing-slug:alpha");
+      expect(warn).toHaveBeenCalledWith(
+        "[project-directory] stale negative marker cleanup failed; positive write remains authoritative",
+        expect.objectContaining({ reason: expect.stringContaining("timed out after 1000ms") }),
+      );
+
+      rejectLate(new Error("late platform cancellation"));
+      await Promise.resolve();
+    } finally {
+      warn.mockRestore();
+      vi.useRealTimers();
+    }
   });
 
   it("retries only the timed-out key and observes its late rejection", async () => {

--- a/apps/os/src/project-directory.ts
+++ b/apps/os/src/project-directory.ts
@@ -8,9 +8,9 @@
  * Layering per lookup: KV first (global, no expiry — slugs are immutable,
  * create overwrites its keys, and admin-lane projects have no auth-side row
  * so the cache is their only directory), then the auth worker behind a
- * short in-isolate negative memo plus a bounded shared negative marker. The
- * positive KV key is ALWAYS checked first, and every authoritative positive
- * write also deletes an older miss marker. That shared marker matters for
+ * short in-isolate negative memo plus a bounded shared negative marker. A
+ * visible positive KV key is ALWAYS checked first, so it outranks an older
+ * miss marker (which expires by itself). That shared marker matters for
  * canonical `<app>--<project>` hosts: the whole label is a legitimate
  * project-slug candidate, but its expected miss must not make each fresh
  * ingress isolate round-trip through the auth worker. Hits are written back,
@@ -40,12 +40,13 @@ export type ProjectIdentity = {
 
 const MEMO_TTL_MS = 15_000;
 // Cloudflare KV requires expirationTtl >= 60s. Reads check the separate
-// positive `slug:` key first, and every positive cache write invalidates this
-// marker; it exists only to suppress repeated authoritative misses.
+// positive `slug:` key first, so this marker cannot mask a visible positive;
+// it exists only to suppress repeated authoritative misses.
 const SHARED_NEGATIVE_TTL_SECONDS = 60;
 const SHARED_NEGATIVE_MARKER = "missing";
-// These writes are exact and idempotent. One retry absorbs a transient KV
-// stall while two short windows keep this required create step bounded.
+// These writes are exact and idempotent. Each key retries independently: a
+// transient stall on one key must not duplicate a successful sibling write
+// and turn that duplicate into a second, batch-wide stall.
 const REQUIRED_WRITE_ATTEMPT_TIMEOUT_MS = 10_000;
 const REQUIRED_WRITE_MAX_ATTEMPTS = 2;
 const CACHE_FILL_TIMEOUT_MS = 1_000;
@@ -185,8 +186,7 @@ export async function listProjectDirectory(
   return records;
 }
 
-/** Eagerly cache a project the caller just created or resolved, invalidating
- * any shared miss that predates the authoritative positive record. */
+/** Eagerly cache a project the caller just created or resolved. */
 export async function primeProjectDirectory(
   directory: KVNamespace,
   record: ProjectDirectoryRecord,
@@ -210,20 +210,34 @@ async function writeThrough(
   // No expiration: slugs are immutable and `projects.get(slug).create` overwrites the
   // keys it primes, so entries never go stale — and admin-lane projects
   // (auth mints only an id, no directory row) have NO auth fallback, so an
-  // expiring cache would break their slug ingress after the TTL. Clearing the
-  // negative marker is part of the same required write attempt: a positive
-  // prime must not leave a stale shared miss behind.
+  // expiring cache would break their slug ingress after the TTL. A stale
+  // negative marker needs no explicit delete: reads always check this positive
+  // slug key first, and the marker expires after 60 seconds in any case.
   const body = JSON.stringify(record);
+  await Promise.all([
+    writeDirectoryKey(directory, slugKey(record.slug), "slug", body, policy),
+    writeDirectoryKey(directory, projectKey(record.id), "project", body, policy),
+  ]);
+}
+
+async function writeDirectoryKey(
+  directory: KVNamespace,
+  key: string,
+  keyKind: "project" | "slug",
+  body: string,
+  policy: { attemptTimeoutMs: number; maxAttempts: number },
+): Promise<void> {
   let lastError: unknown;
   for (let attempt = 1; attempt <= policy.maxAttempts; attempt += 1) {
     try {
-      await writeDirectoryRecord(directory, record, body, policy.attemptTimeoutMs);
+      await writeDirectoryKeyAttempt(directory, key, body, policy.attemptTimeoutMs);
       return;
     } catch (error) {
       lastError = error;
       if (attempt < policy.maxAttempts) {
         console.warn("[project-directory] write failed; retrying", {
           attempt,
+          keyKind,
           maxAttempts: policy.maxAttempts,
           reason: errorMessage(error),
         });
@@ -232,22 +246,18 @@ async function writeThrough(
   }
 
   throw new Error(
-    `Project directory write failed after ${policy.maxAttempts} attempts: ${errorMessage(lastError)}`,
+    `Project directory ${keyKind} write failed after ${policy.maxAttempts} attempts: ${errorMessage(lastError)}`,
     { cause: lastError },
   );
 }
 
-async function writeDirectoryRecord(
+async function writeDirectoryKeyAttempt(
   directory: KVNamespace,
-  record: ProjectDirectoryRecord,
+  key: string,
   body: string,
   timeoutMs: number,
 ): Promise<void> {
-  const write = Promise.all([
-    directory.put(slugKey(record.slug), body),
-    directory.put(projectKey(record.id), body),
-    directory.delete(missingSlugKey(record.slug)),
-  ]);
+  const write = directory.put(key, body);
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     await Promise.race([

--- a/apps/os/src/project-directory.ts
+++ b/apps/os/src/project-directory.ts
@@ -9,8 +9,9 @@
  * create overwrites its keys, and admin-lane projects have no auth-side row
  * so the cache is their only directory), then the auth worker behind a
  * short in-isolate negative memo plus a bounded shared negative marker. A
- * visible positive KV key is ALWAYS checked first, so it outranks an older
- * miss marker (which expires by itself). That shared marker matters for
+ * visible positive KV key is ALWAYS checked first, and every authoritative
+ * prime separately makes a bounded best-effort deletion of an older marker.
+ * That shared marker matters for
  * canonical `<app>--<project>` hosts: the whole label is a legitimate
  * project-slug candidate, but its expected miss must not make each fresh
  * ingress isolate round-trip through the auth worker. Hits are written back,
@@ -40,8 +41,8 @@ export type ProjectIdentity = {
 
 const MEMO_TTL_MS = 15_000;
 // Cloudflare KV requires expirationTtl >= 60s. Reads check the separate
-// positive `slug:` key first, so this marker cannot mask a visible positive;
-// it exists only to suppress repeated authoritative misses.
+// positive `slug:` key first, and positive primes best-effort delete this
+// marker; it exists only to suppress repeated authoritative misses.
 const SHARED_NEGATIVE_TTL_SECONDS = 60;
 const SHARED_NEGATIVE_MARKER = "missing";
 // These writes are exact and idempotent. Each key retries independently: a
@@ -191,10 +192,13 @@ export async function primeProjectDirectory(
   directory: KVNamespace,
   record: ProjectDirectoryRecord,
 ): Promise<void> {
-  await writeThrough(directory, record, {
-    attemptTimeoutMs: REQUIRED_WRITE_ATTEMPT_TIMEOUT_MS,
-    maxAttempts: REQUIRED_WRITE_MAX_ATTEMPTS,
-  });
+  await Promise.all([
+    writeThrough(directory, record, {
+      attemptTimeoutMs: REQUIRED_WRITE_ATTEMPT_TIMEOUT_MS,
+      maxAttempts: REQUIRED_WRITE_MAX_ATTEMPTS,
+    }),
+    clearStaleNegativeMarker(directory, record.slug),
+  ]);
   memoize(record.slug, record);
 }
 
@@ -210,9 +214,7 @@ async function writeThrough(
   // No expiration: slugs are immutable and `projects.get(slug).create` overwrites the
   // keys it primes, so entries never go stale — and admin-lane projects
   // (auth mints only an id, no directory row) have NO auth fallback, so an
-  // expiring cache would break their slug ingress after the TTL. A stale
-  // negative marker needs no explicit delete: reads always check this positive
-  // slug key first, and the marker expires after 60 seconds in any case.
+  // expiring cache would break their slug ingress after the TTL.
   const body = JSON.stringify(record);
   await Promise.all([
     writeDirectoryKey(directory, slugKey(record.slug), "slug", body, policy),
@@ -257,20 +259,49 @@ async function writeDirectoryKeyAttempt(
   body: string,
   timeoutMs: number,
 ): Promise<void> {
-  const write = directory.put(key, body);
+  await waitForDirectoryOperation(
+    directory.put(key, body),
+    timeoutMs,
+    "Project directory KV write",
+  );
+}
+
+async function clearStaleNegativeMarker(directory: KVNamespace, slug: string): Promise<void> {
+  try {
+    // This remains independent of the two required positive writes. A stuck
+    // optional delete may add at most the ordinary cache-fill bound, but can
+    // neither fail project creation nor cause either positive key to replay.
+    await waitForDirectoryOperation(
+      directory.delete(missingSlugKey(slug)),
+      CACHE_FILL_TIMEOUT_MS,
+      "Project directory KV delete",
+    );
+  } catch (error) {
+    console.warn(
+      "[project-directory] stale negative marker cleanup failed; positive write remains authoritative",
+      { reason: errorMessage(error) },
+    );
+  }
+}
+
+async function waitForDirectoryOperation(
+  operation: Promise<void>,
+  timeoutMs: number,
+  description: string,
+): Promise<void> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     await Promise.race([
-      write,
+      operation,
       new Promise<never>((_resolve, reject) => {
         timer = setTimeout(
-          () => reject(new Error(`Project directory KV write timed out after ${timeoutMs}ms`)),
+          () => reject(new Error(`${description} timed out after ${timeoutMs}ms`)),
           timeoutMs,
         );
       }),
     ]);
   } finally {
-    // Promise.race keeps rejection handlers attached to the write after a
+    // Promise.race keeps rejection handlers attached to the operation after a
     // timeout, so a late platform rejection remains observed.
     clearTimeout(timer);
   }

--- a/scripts/preview/e2e-policy.test.ts
+++ b/scripts/preview/e2e-policy.test.ts
@@ -147,12 +147,15 @@ describe("retries live in exactly one layer", () => {
     expect(script.split("pnpm exec tsx e2e/vitest/onboarding-smoke.ts")).toHaveLength(2);
   });
 
-  it("the onboarding smoke gets one retry, like every other test", () => {
+  it("the onboarding smoke gets one retry and waits at its project-creation boundary", () => {
     const source = readFileSync(
       resolve(repoRoot, "apps/os/e2e/vitest/onboarding-smoke.ts"),
       "utf8",
     );
     expect(source).toContain("const ATTEMPTS = 2;");
+    const rolloutGate = "await waitForPreviewRolloutBeforeProjectCreation();";
+    expect(source).toContain(rolloutGate);
+    expect(source.indexOf(rolloutGate)).toBeLessThan(source.indexOf("root.projects.get("));
   });
 
   it("bounds the onboarding smoke as a joined background lane", () => {

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -910,8 +910,9 @@ describe("preview test commands", () => {
     expect(script).toContain('[ "$TUI_OK" -eq 0 ]');
     expect(script).toContain('[ "$E2E_OK" -eq 0 ]');
     // Independent setup starts immediately. Playwright begins as soon as
-    // Chromium is ready. Its project fixture consumes the absolute deadline
-    // from the environment, while the smoke and age clock gate Vitest here.
+    // Chromium is ready. Its project fixture and the smoke consume the
+    // absolute deadline from the environment, while the age clock gates
+    // Vitest here.
     for (const lane of ["run_visible_lane rollout-settle sleep", smokeLane, tuiLane]) {
       expect(script.indexOf(lane)).toBeLessThan(script.indexOf('wait "$PW_INSTALL_PID"'));
     }

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -2244,11 +2244,11 @@ export const cloudflarePreviewApps: Record<CloudflarePreviewAppSlug, CloudflareP
         // time we reach the specs instead of adding ~4s in front of them.
         "pnpm --dir ../.. exec playwright install chromium > /tmp/os-preview-pw-install.log 2>&1 & PW_INSTALL_PID=$!",
         // Smoke and TUI own isolated state, so start them with the Chromium
-        // install. Playwright starts as soon as Chromium is ready; its
-        // project-creation helpers use the absolute rollout boundary passed
-        // above, so browser/auth setup continues while fresh project-backed
-        // DO work waits. The high-fanout Vitest lane waits for both the
-        // production-shaped onboarding smoke and the same bounded age.
+        // install. Playwright starts as soon as Chromium is ready; both its
+        // project-creation helpers and the smoke consume the absolute rollout
+        // boundary passed above, so unrelated setup continues while fresh
+        // project-backed DO work waits. The high-fanout Vitest lane waits for
+        // both the production-shaped onboarding smoke and the same bounded age.
         // Edge readiness cannot prove global Durable Object code propagation:
         // Cloudflare may reset an object when its assigned version changes.
         // The age clock starts when deploy completes and overlaps every lane


### PR DESCRIPTION
## Problem

The first canonical full-fleet flake-athon run was green only after two absorbed Vitest retries, so it was rejected and the formal streak remains **0/25**.

- Depot attempt: `p0rm2qqmc5` (workflow `pmlh3g2sv6`)
- Runner-observed duration: **356s**
- OS E2E duration: **200.2s**
- PostHog: **310 final outcomes, 2 retries, 2 passed-after-retry, 0 final failures, 0 incomplete telemetry**
- Retried tests:
  - `catalogue example "repo-edit-file" runs identically across runtimes`
  - `a forwarded project-app-session token acts as its user on exactly its project`
- Both first attempts failed with `Project directory write failed after 2 attempts: Project directory KV write timed out after 10000ms`.

No test is deleted, skipped, quarantined, serialized, or given a larger timeout in this PR. No matrix ITX example coverage changes.

## Cause 1: one slow KV operation replayed successful writes

Project creation primed three independent KV operations in one `Promise.all`: the slug record, project record, and deletion of an optional negative-cache marker. One 10s batch timeout retried all three operations together.

Cloudflare native spans showed the required positive state was successfully written, but an unrelated sibling operation remained slow:

- Trace `3c159267b161cc9ce1f002d3bb422871`: attempt 1 project put 245ms and marker delete 944ms while slug put remained pending; attempt 2 slug put 179ms and project put 222ms while the duplicated marker delete consumed the second 10s deadline.
- Trace `b3cbaade5710ab15edb45c417f398145`: attempt 1 slug put 218ms and marker delete 160ms while project put took 15.6s; attempt 2 project put 232ms and marker delete 172ms while the duplicated slug put consumed the second deadline.

The caller therefore reported failure after the durable positive records already existed. Retrying the whole batch also amplified KV tail latency with duplicate writes. Depot peaked at only 56.9% CPU and 18.4% memory, ruling out runner saturation.

### Fix

- Retry the required slug and project keys independently.
- Never replay a key that has already succeeded.
- Observe every late rejection after a timeout so no detached promise becomes unhandled.
- Include the failed key kind in warnings and terminal errors.
- Keep stale negative-marker cleanup, as required for immediate Auth fallback, but make it one separate bounded best-effort operation with a 1s cache-fill deadline. It can neither fail project creation nor replay either required positive write.

The last point addresses [review feedback](https://github.com/iterate/iterate/pull/2269#discussion_r3635307678): simply leaving a stale `missing-slug` marker until its TTL could suppress Auth fallback in a colo where the new positive slug key was not yet visible.

Regression coverage proves both positive writes, independent recovery when either or both keys time out once, no replay of a successful sibling, observation of late failures after exhaustion, and bounded cleanup when the stale-marker delete hangs.

## Cause 2: onboarding smoke bypassed the rollout-safe project boundary

The first deployed fix-head run was not accepted:

- OS deployment completed at `03:13:00.287Z`.
- Onboarding smoke started at `03:13:03.566Z` and created projects immediately.
- Its two fresh projects failed at their first root Stream Durable Object call with `durableObjectReset: true`.
- The existing deployment-global rollout boundary was `03:14:28.754Z`.
- Playwright project fixtures consumed that gate, waited about 79s, and then all **63/63** tests passed in 2.8m with **zero test retries**.

The two smoke failures were distinct projects and Stream objects, and were the only keyed-stream Durable Object reset retries in the run:

- [`048aaae4f558575b8fe56253891f807f`](https://dash.cloudflare.com/376ef7ed81b0573f93524de763666c15/observability/traces/048aaae4f558575b8fe56253891f807f), ITX call `log_5970b90b9bcb43989df13728dedb0629`
- [`c868fe38c65470184f2b9c801d510fd4`](https://dash.cloudflare.com/376ef7ed81b0573f93524de763666c15/observability/traces/c868fe38c65470184f2b9c801d510fd4), ITX call `log_82228731ec6546d39fb4d59b6246a531`

This was a missing caller at an already-defined deployment boundary, not a shared non-horizontal service or runner-load problem.

### Fix

Onboarding smoke now calls the existing `waitForPreviewRolloutBeforeProjectCreation` immediately before `root.projects.get`. Unrelated setup remains parallel, every project-creating E2E lane observes the same absolute safe time, and this adds no new sleep duration, retry layer, timeout, or cross-test lock. A policy test enforces the ordering.

## Cause 3: a redundant catch-up escaped the write-fence timeout

The first final-head preview run was technically green but is also rejected because one OS Vitest attempt retried:

- Depot attempt `w5vwjj853m` (workflow `3rv9wfkgwr`, job `1rwpxj8n8m`)
- OS phase: **189.7s**
- Playwright: **63/63 passed**, zero retries
- Vitest: **48 files passed**, with one absorbed retry in `an external client authenticates with the project-secret credential and gets exactly its project`
- The first attempt failed while creating `/secrets/write-only-probe` with `Durable Object storage operation exceeded timeout which caused object to be reset.`

[Trace `c3c5865f613bf121981bccd1fa54858b`](https://dash.cloudflare.com/376ef7ed81b0573f93524de763666c15/observability/traces/c3c5865f613bf121981bccd1fa54858b) pins the failure to `Secret.create` (ITX call `log_2fbf11b0be324c59a218495141369b0`). The Secret Durable Object consumed **8ms CPU** but ended with native `exceededWallTime` after about **32.2s**. Its event append and all Durable Object SQL/KV operations completed in the first few seconds. The final child Stream Durable Object RPC also completed in **41ms**, but the Secret caller never resumed and Cloudflare eventually reset it.

The write path first awaited `registry.catchUp(...)` and only afterwards called `reads.waitUntilEvent({ offset, timeoutMs: 15_000 })`. The offset waiter is already the single read-your-writes primitive: it registers its deadline and self-pulls when behind. The extra catch-up was therefore redundant, and because it sat before the waiter, an orphaned native RPC could bypass the intended 15-second bound completely.

### Fix

- Remove that redundant pre-fence catch-up from Secret, Device, Scheduler, and Cloudflare Sandbox writers, which had copied the same pattern.
- Keep each domain wait on the offset-aware `waitUntilEvent`; it self-pulls and owns the complete write-fence deadline.
- Add a regression that silently orphans the self-pull and proves the offset waiter still rejects at its explicit deadline.
- Do not increase the test timeout, add a retry layer, serialize the test, or quarantine coverage.

The successful retry trace (`4c338e18850b0665f231937c5152a7cd`) followed the same operation and completed in about 2.1s, confirming that the credential assertion itself was valid and the first attempt exposed the unbounded write-fence composition.

## Validation

Local validation on commit `11de10101`:

- focused project-directory suite: **11/11 passed**
- focused preview policy/deployment suites: **149/149 passed**
- `pnpm typecheck`
- `pnpm lint` — zero warnings/errors
- `pnpm format`
- `pnpm test` — all workspaces green; OS: **2,280 passed**, 6 expected failures, 1 skipped

Exact-head deployed validation on `11de10101` is accepted:

- GitHub check: **3m51s**, successful ([Depot run `b2jwhtx6q4`](https://depot.dev/orgs/0p91s0lz49/workflows/jg6k1zsrb5?job=x4f0gpl0zs), attempt `nvg49cr0jp`)
- Real preview deploy: OS **39.5s**, Auth **14.0s**, Streams Example App **34.1s**; immutable Dummy Petshop reuse was proven in 46ms
- OS: **171.7s** total; Playwright **63/63** in 157s and Vitest **48 files** in 64s
- Other lanes: Auth **5/5**, Dummy Petshop **6/6**, Semaphore **12/12**, Streams Example App **31 passed + 1 documented skip** and **21/21 Vitest**
- Every app reports `testRetries: null`; all five app lanes passed
- PostHog preview evidence: **310 logical outcomes, 0 failures, 0 retries, 0 passed-after-retry**; the preview finalizer was healthy and matched **9/9** expected runner sources with no missing, incomplete, or foreign artifacts
- PostHog unit evidence: **3,046 logical outcomes, 0 failures, 0 retries**; the unit finalizer observed **10/10** workspaces
- Cloudflare audit for the deployed test window found no `exceededWallTime`, Durable Object reset, or resource-exhaustion outcome. The exception spans were the suite deliberately invoking `kill`/`reset` and terminating their subscribers; the two response-stream disconnects came from the explicit half-open WebSocket resilience test. Ordinary RPC/capability teardown was info-level `canceled`, with no error metadata.
- All required checks and Bugbot completed successfully; there are **zero unresolved review threads**

## Scope and flake-athon status

This PR contains the first high-confidence stability fixes found by the canonical run. The formal 25-run streak remains **0/25** and restarts from fresh `main` after merge.

PR #2233 was audited separately. Its broad warm-deployment reuse state machine is intentionally not carried forward: stale-state and false-green risks conflict with stability-first proof. The useful pieces—baked Depot workspace, offline pnpm, phase telemetry, and narrow immutable Dummy Petshop reuse—are already on `main`.

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +79 -35 | +52 -20 🟩🟩🟥⬜⬜ |
| Tests | +124 -28 | +108 -26 🟩🟩🟩🟩🟥 |
| CI & scripts | +5 -5 | +0 -0 ⬜⬜⬜⬜⬜ |
| **Total** | **+208 -68** | **+160 -46** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 8245f98 and 11de101, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-23T03:56:23.447Z",
      "deployedAt": "2026-07-23T03:47:38.627Z",
      "headSha": "11de10101adc8f27515da2eccfe31ec6988cdcb1",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/198512188512064",
      "shortSha": "11de101",
      "cleanupDurationMs": 13502,
      "deployDurationMs": 39471,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 39273,
      "deployReadinessDurationMs": 195,
      "deployedWorkerName": "os-preview-4",
      "deployedWorkerVersion": "3227e831-f9fb-49b5-8ea4-a5fc59473751",
      "testDurationMs": 171696,
      "testRetries": null,
      "workerSizeKib": 19778.9,
      "workerGzipKib": 5003.94,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5013.62
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-23T03:56:10.878Z",
      "deployedAt": "2026-07-23T03:26:02.366Z",
      "headSha": "204aab0c8f3c5d5d8bbee4e972a553126108ee1a",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/198512188512064",
      "shortSha": "204aab0",
      "cleanupDurationMs": 930,
      "deployDurationMs": 15549,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 15373,
      "deployReadinessDurationMs": 171,
      "deployedWorkerName": "semaphore-preview-4",
      "deployedWorkerVersion": "ec9894cf-bc4c-4a57-917c-7cc290465dbe",
      "testDurationMs": 20551,
      "testRetries": null,
      "workerSizeKib": 1915.22,
      "workerGzipKib": 440.99,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-23T03:56:14.137Z",
      "deployedAt": "2026-07-23T03:47:13.320Z",
      "headSha": "11de10101adc8f27515da2eccfe31ec6988cdcb1",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/198512188512064",
      "shortSha": "11de101",
      "cleanupDurationMs": 4188,
      "deployDurationMs": 14031,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 13964,
      "deployReadinessDurationMs": 62,
      "deployedWorkerName": "auth-preview-4",
      "deployedWorkerVersion": "adacd4c0-cf58-4f9c-9ac7-35c88d015aac",
      "testDurationMs": 3300,
      "testRetries": null,
      "workerSizeKib": 3965.97,
      "workerGzipKib": 811.24,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-23T03:56:21.735Z",
      "deployedAt": "2026-07-23T03:47:11.561Z",
      "headSha": "11de10101adc8f27515da2eccfe31ec6988cdcb1",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/198512188512064",
      "shortSha": "11de101",
      "cleanupDurationMs": 11783,
      "deployDurationMs": 34146,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 12204,
      "deployReadinessDurationMs": 21937,
      "deployedWorkerName": "streams-example-app-preview-4",
      "deployedWorkerVersion": "4b8869c0-756d-4012-b22c-58669b5ad5dc",
      "testDurationMs": 115318,
      "testRetries": null,
      "workerSizeKib": 5157.88,
      "workerGzipKib": 1472.67,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-23T03:56:11.003Z",
      "deployedAt": "2026-07-23T03:11:50.151Z",
      "headSha": "11de10101adc8f27515da2eccfe31ec6988cdcb1",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/198512188512064",
      "shortSha": "11de101",
      "cleanupDurationMs": 1046,
      "deployDurationMs": 46,
      "deployConfigDurationMs": 33,
      "deployReuseProofDurationMs": 10,
      "deployedWorkerName": "dummy-petshop-preview-4",
      "deployedWorkerVersion": "88ebd13f-f3d6-4c42-8676-2a4145d130a5",
      "testDurationMs": 5481,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `11de101` | [https://auth.iterate-preview-4.com](https://auth.iterate-preview-4.com) | 811.2 KiB | 14.0s | 3.3s |  | 4.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/198512188512064) | 2026-07-23T03:56:14.137Z | Preview app released. |
| Dummy Petshop | released | `11de101` | [https://dummy-petshop.iterate-preview-4.com](https://dummy-petshop.iterate-preview-4.com) | 198.3 KiB | 46ms | 5.5s |  | 1.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/198512188512064) | 2026-07-23T03:56:11.003Z | Preview app released. |
| OS | released | `11de101` | [https://os.iterate-preview-4.com](https://os.iterate-preview-4.com) | 4.89 MiB (-9.7 KiB vs main) | 39.5s | 171.7s |  | 13.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/198512188512064) | 2026-07-23T03:56:23.447Z | Preview app released. |
| Semaphore | released | `204aab0` | [https://semaphore.iterate-preview-4.com](https://semaphore.iterate-preview-4.com) | 441.0 KiB | 15.5s | 20.6s |  | 930ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/198512188512064) | 2026-07-23T03:56:10.878Z | Preview app released. |
| Streams Example App | released | `11de101` | [https://streams.iterate-preview-4.com](https://streams.iterate-preview-4.com) | 1.44 MiB | 34.1s | 115.3s |  | 11.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/198512188512064) | 2026-07-23T03:56:21.735Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes project-create KV behavior and core Durable Object write completion paths used across devices, secrets, sandboxes, and schedulers; fixes are targeted but affect high-traffic infrastructure.
> 
> **Overview**
> **Stabilizes preview E2E** by fixing two flake sources: project-directory KV priming during create, and onboarding smoke creating projects before the post-deploy rollout window.
> 
> **Project directory cache writes** no longer retry slug, project, and negative-marker delete in one batch. Required `slug:` and `project:` keys are written in parallel but each gets its own bounded retry (no replay after success). Stale `missing-slug:` cleanup is a separate 1s best-effort delete that cannot fail creation. Errors name which key failed.
> 
> **Read-your-writes on stream-backed Durable Objects** drops the extra `catchUp` immediately before `waitUntilEvent` on the device, sandbox, scheduler, and secret command paths. Offset waits self-pull with a fixed timeout; an unbounded catch-up RPC ahead of that could exceed the budget and leave commands hanging after the stream had already caught up.
> 
> **Onboarding smoke** calls `waitForPreviewRolloutBeforeProjectCreation` before `root.projects.get(...).create`, matching Playwright’s deployment boundary so fresh DOs are not hit while worker versions are still propagating.
> 
> Tests cover independent KV retries, bounded marker cleanup, rollout gate ordering in smoke, and a runner case where a hung self-pull still hits `waitUntilEvent` timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11de10101adc8f27515da2eccfe31ec6988cdcb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

