### PR TITLE
fix(streams): decouple wake delivery settlement

### DIFF
--- a/apps/os/docs/stream-subscribers-design.md
+++ b/apps/os/docs/stream-subscribers-design.md
@@ -22,11 +22,12 @@ are deleted and re-expressed on this one machine.
 
 - **R1 — Warm latency:** append→processed in single-digit milliseconds on a warmed-up stream.
   Voice rides this. A CI latency probe asserts the envelope.
-- **R2 — One-way traffic:** during warm delivery, frames flow stream→subscriber only. Ephemeral
-  subscribers generate **zero** return frames (batch results disposed unpulled,
-  `stream-connections.ts:402`); durable subscribers generate exactly **one non-gating resolve
-  frame per batch**, kept deliberately as the prompt dead-connection signal (`:391-400`). The
-  pump never awaits delivery. Wire tests enforce this (they existed —
+- **R2 — Non-gating traffic:** during warm delivery, the pump never awaits a subscriber.
+  Ephemeral subscribers generate **zero** return frames (batch results are disposed unpulled).
+  Durable wake subscribers also dispose the batch result unpulled, then send exactly **one
+  explicit one-way settlement message per batch** through an independent capability. Separating
+  that verdict from the batch result avoids a cyclic actor-drain tree when a processor appends
+  back to its delivering stream. Wire tests enforce the unpulled batch result (they existed —
   `packages/streams/example-app/e2e/vitest/stream-capnweb.test.ts` "delivers event batches
   without subscriber-originated return traffic" — died in the #1525 move; resurrect them).
   Note: capnweb `ReadableStream` is structurally two-way (per-chunk write acks feed a BBR-style
@@ -59,7 +60,7 @@ are deleted and re-expressed on this one machine.
 | Offset owner    | client, in-memory                              | **subscriber** — `{offset, state}` snapshot, atomic with the fold                            | **stream** — spine row, atomic with the log                              |
 | Stream-side row | none                                           | yes — _observational_ watermark (poke coalescing, retry, lag); lost row = one redundant poke | yes — _authoritative_ cursor; lost row = bounded redelivery              |
 | Warm transport  | retained one-way callback                      | retained one-way sink (from the poke)                                                        | per-batch awaited capability call                                        |
-| Return frames   | **zero**                                       | one non-gating resolve per batch (liveness)                                                  | one awaited return per batch (**the ack**)                               |
+| Result frames   | **zero**                                       | **zero**; one explicit non-gating settlement message                                         | one awaited return per batch (**the ack**)                               |
 | Cold start      | client re-subscribes wherever it likes         | spine pokes; subscriber hands back `{checkpointOffset, sink}`                                | spine drains from `acked_offset`                                         |
 | Retry/park      | none — client's problem                        | spine: backoff rows, durable alarm, parked fact                                              | same spine, same machine                                                 |
 | Filter          | `EventSelector` on subscribe args              | `EventSelector` derived from `contract.consumes` (+ optional condition)                      | `EventSelector` in config                                                |
@@ -175,10 +176,13 @@ async wakeStreamSubscriber(request: StreamSubscriberWakeRequest): Promise<{
 }>
 ```
 
-The stream retains the returned sink (ownership transfers with the return value — no dup dance),
-streams one-way batches from `checkpointOffset + 1`, pulls each batch's resolve as the liveness
-signal (R2), and on rejection: dispose sink → spine sees watermark lag → poke with backoff. Sink
-replacement is unambiguous — the stream initiated the poke and owns both incarnations —so
+The stream retains the returned sink (ownership transfers with the return value — no dup dance)
+and streams batches from `checkpointOffset + 1` without pulling their results. Each batch carries
+an independent one-shot settlement capability; the processor reports success or a serialized
+failure after its durable attempt. On failure: dispose sink → spine sees watermark lag → poke with
+backoff. A missing settlement remains pending, so bounded idle teardown treats the sink as wedged
+and re-pokes from the processor's unchanged durable checkpoint. Sink replacement is unambiguous —
+the stream initiated the poke and owns both incarnations — so
 `supersedeConnection`, generation fencing, and the trusted-internal `subscribe({configured: true})`
 RPC entry (`rpc-targets.ts:290-298`) are all deleted. Durable connections stop being externally
 openable; only the spine creates them. Idle teardown stays (retained stubs still pin DOs while
@@ -264,7 +268,7 @@ apps/os/src/domains/streams/
                             # { store, readEvents, dial, appendFact, coreState, clock, armAlarm }.
                             # Zero cloudflare:workers imports. (Absorbs stream-connections.ts.)
   subscriber-sinks.ts       # the quarantine: stub retention (dup/dispose/onRpcBroken/
-                            # pulled-vs-disposed results). The only file that knows RPC exists.
+                            # one-way result ownership). The only file that knows RPC exists.
   subscriber-math.ts        # pure, table-testable: computeBackoff, shouldPark, applySelector,
                             # bisectLimit, deliver-policy → initial cursor
   event-selector.ts         # EventSelector schema + compile (shared JSONata cache)

--- a/apps/os/src/domains/streams/README.md
+++ b/apps/os/src/domains/streams/README.md
@@ -112,7 +112,7 @@ webhook is the same cursor machinery pointed at plain HTTP:
 | stream-side row         | none                                                                        | observational watermark (poke coalescing, lag)                      | authoritative cursor                                                   | authoritative cursor                             |
 | sink arrives as         | `subscribe()` parameter                                                     | returned from the expression-named poke                             | named by a persisted itx expression                                    | the configured URL                               |
 | warm transport          | retained one-way callback                                                   | retained one-way sink                                               | fresh awaited call per batch                                           | one `fetch` POST per event                       |
-| return frames per batch | **zero** (result disposed unpulled)                                         | one, non-gating (pulled as the liveness signal)                     | one, awaited (**the ack** that advances the cursor)                    | the 2xx response (**the ack**), per event        |
+| result frames per batch | **zero** (result disposed unpulled)                                         | **zero**; one explicit, non-gating settlement message               | one, awaited (**the ack** that advances the cursor)                    | the 2xx response (**the ack**), per event        |
 | retry / failure         | client's problem                                                            | spine: backoff rows + alarm → parked fact                           | same spine, same machine (+ `onPoison: park \| skip`)                  | same spine, same machine, per-event granularity  |
 | replay                  | durable rows after `replayAfterOffset`; ephemeral rows only live after open | subscriber's checkpoint decides                                     | `deliver: "all" \| "new" \| {afterOffset}` + `cursor-set`              | same as push                                     |
 | filter                  | `selector` / `eventTypes` on subscribe                                      | processor `contract.consumes` (announced on the poke)               | `selector: {eventTypes?, condition?}` in config                        | same selector shape                              |
@@ -181,13 +181,17 @@ types delivers nothing, silently — there is nothing durable to deliver.
 
 The pump never awaits a delivery on the ephemeral and wake lanes — that is
 what keeps warm append→processed latency in single-digit milliseconds (voice
-rides this). Batch results on the ephemeral lane are disposed **unpulled**, so
-those subscriptions generate zero subscriber-originated return frames (a
-`ReadableStream` could never do this: its per-chunk acks ARE its flow
-control — see the `FlowController` in
-[capnweb](https://github.com/cloudflare/capnweb)); durable batch results are
-pulled — never awaited — purely as the prompt dead-connection signal
-([stub lifecycle rules](https://developers.cloudflare.com/workers/runtime-apis/rpc/lifecycle/)).
+rides this). Both batch-call results are disposed **unpulled**, so neither
+lane emits a result frame (a `ReadableStream` could never do this: its
+per-chunk acks ARE its flow control — see the `FlowController` in
+[capnweb](https://github.com/cloudflare/capnweb)). Wake batches instead carry
+a one-shot settlement capability. The subscriber sends one explicit,
+non-gating success/failure message after its durable processor attempt and
+disposes that call's result unpulled too. Keeping the settlement out of the
+batch call's result is load-bearing: processors routinely append back to the
+delivering stream, and a pulled result would make that nested append part of a
+cyclic actor-drain tree. `onRpcBroken` remains the prompt best-effort transport
+hint ([stub lifecycle rules](https://developers.cloudflare.com/workers/runtime-apis/rpc/lifecycle/)).
 
 ## The spine: durable delivery bookkeeping
 
@@ -379,7 +383,7 @@ by a compatibility vector over all members) are mirror-level.
 | `core-processor-contract.ts` | Core contract: reduced-state schema (v11) + the `events.iterate.com/stream/*` event catalog                                         |
 | `stream-storage.ts`          | Chunked SQLite event log (2 MB cell limit → JS chunking) + the spine's `subscriptions` cursor rows                                  |
 | `stream-subscribers.ts`      | Every subscriber, one module: sink table, connection pump, the durable spine (ports-only; no RPC, no clock)                         |
-| `subscriber-sinks.ts`        | The RPC quarantine: stub retention (dup/dispose/onRpcBroken, pulled-vs-disposed results)                                            |
+| `subscriber-sinks.ts`        | The RPC quarantine: stub retention (dup/dispose/onRpcBroken, one-way result ownership)                                              |
 | `subscriber-math.ts`         | Pure spine math: backoff, initial cursors, bisect, delivery ids (table-tested)                                                      |
 | `event-selector.ts`          | `EventSelector` — THE filter shape on every lane; shared JSONata compile cache                                                      |
 | `processor-contracts.ts`     | `defineProcessorContract` + event-type → payload-schema resolution machinery                                                        |

--- a/apps/os/src/domains/streams/stream-processor-registry.test.ts
+++ b/apps/os/src/domains/streams/stream-processor-registry.test.ts
@@ -14,7 +14,7 @@
 //  - recovery revival: a runner that died owing work is revived by the alarm,
 //    and on a two-processor DO only the runner that owes work revives.
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { defineProcessorContract } from "iterate/processors";
 import { StreamProcessor } from "iterate/processors";
@@ -25,6 +25,10 @@ import {
   type StreamProcessorRegistry,
 } from "iterate/processors/cloudflare";
 import { STREAM_PROCESSOR_REVIVED_EVENT_TYPE } from "iterate/processors";
+import type {
+  StreamSubscriberWakeResponse,
+  StreamWakeDeliverySettlement,
+} from "iterate/processors";
 
 const HOME = "/tests/registry";
 const REQUESTED = "events.iterate.com/registry-test/requested";
@@ -190,7 +194,7 @@ function makeHarness(opts: { betaRecovery?: boolean } = {}) {
       const woken = await harness.wake(slug);
       const events = stream.events.filter((event) => event.offset > woken.checkpointOffset);
       if (events.length > 0) {
-        await woken.sink({
+        const settlement = await deliverWakeBatch(woken, {
           projectId: null,
           path: HOME,
           events,
@@ -199,6 +203,9 @@ function makeHarness(opts: { betaRecovery?: boolean } = {}) {
           streamMaxOffset: head(),
           state: null,
         });
+        if (settlement.outcome === "error") {
+          throw new Error(settlement.error.message);
+        }
       }
       await settle();
       return woken;
@@ -220,6 +227,21 @@ function makeHarness(opts: { betaRecovery?: boolean } = {}) {
 }
 
 const hang = () => new Promise<never>(() => {});
+
+async function deliverWakeBatch(
+  woken: StreamSubscriberWakeResponse,
+  batch: Omit<Parameters<StreamSubscriberWakeResponse["sink"]>[0], "settleDelivery">,
+): Promise<StreamWakeDeliverySettlement> {
+  let settle!: (value: StreamWakeDeliverySettlement) => void;
+  const settled = new Promise<StreamWakeDeliverySettlement>((resolve) => {
+    settle = resolve;
+  });
+  woken.sink({
+    ...batch,
+    settleDelivery: (value) => settle(value),
+  });
+  return await settled;
+}
 
 /** The processorSlugs of every journaled revival fact, sorted — revivals share
  * the ONE core type, so the payload's slug is what identifies the runner. */
@@ -427,16 +449,19 @@ describe("wakeStreamSubscriber", () => {
     };
     expect(subscriber.processor.announcement.slug).toBe("alpha-proc");
 
-    // The returned sink IS the runner's: driving it advances durable progress.
-    await woken.sink({
-      projectId: null,
-      path: HOME,
-      events: h.stream.events.slice(),
-      scannedAfterOffset: woken.checkpointOffset,
-      scannedThroughOffset: h.head(),
-      streamMaxOffset: h.head(),
-      state: null,
-    });
+    // The returned sink is one-way. Its independent settlement reports when
+    // the runner has durably advanced progress.
+    await expect(
+      deliverWakeBatch(woken, {
+        projectId: null,
+        path: HOME,
+        events: h.stream.events.slice(),
+        scannedAfterOffset: woken.checkpointOffset,
+        scannedThroughOffset: h.head(),
+        streamMaxOffset: h.head(),
+        state: null,
+      }),
+    ).resolves.toEqual({ outcome: "ok" });
     const runtime = await woken.getRuntimeState!();
     expect(runtime.snapshot).toEqual({ offset: 1, state: { ids: ["a"] } });
     // The frame commit notified the registry's observer, which reassembled
@@ -446,6 +471,84 @@ describe("wakeStreamSubscriber", () => {
     // A fresh wake resumes from the durably committed cursor.
     const rewoken = await h.wake("alpha-proc");
     expect(rewoken.checkpointOffset).toBe(1);
+  });
+
+  it("returns the sink call before blocking processor work and settles independently", async () => {
+    const h = makeHarness();
+    let releaseBlocker!: () => void;
+    const blocker = new Promise<void>((resolve) => {
+      releaseBlocker = resolve;
+    });
+    h.hooks.alpha.onProcess = (args) => {
+      if (args.event?.type === REQUESTED) {
+        args.blockProcessorWhile(() => blocker);
+      }
+    };
+    await h.stream.append({ type: REQUESTED, payload: { id: "slow" } });
+    const woken = await h.wake("alpha-proc");
+    let settlement: StreamWakeDeliverySettlement | undefined;
+
+    const returned = woken.sink({
+      projectId: null,
+      path: HOME,
+      events: h.stream.events.slice(),
+      scannedAfterOffset: 0,
+      scannedThroughOffset: h.head(),
+      streamMaxOffset: h.head(),
+      state: null,
+      settleDelivery: (value) => {
+        settlement = value;
+      },
+    });
+
+    expect(returned).toBeUndefined();
+    await h.settle();
+    expect(settlement).toBeUndefined();
+
+    releaseBlocker();
+    await expect.poll(() => settlement).toEqual({ outcome: "ok" });
+    await expect(woken.getRuntimeState!()).resolves.toMatchObject({
+      snapshot: { offset: 1 },
+    });
+  });
+
+  it("reports processor failures with lifecycle classification intact", async () => {
+    const h = makeHarness();
+    const lifecycleReset = Object.assign(new Error("subscriber incarnation reset"), {
+      durableObjectReset: true,
+      retryable: true,
+    });
+    h.hooks.alpha.onProcess = (args) => {
+      if (args.event?.type === REQUESTED) {
+        args.blockProcessorWhile(() => Promise.reject(lifecycleReset));
+      }
+    };
+    await h.stream.append({ type: REQUESTED, payload: { id: "reset" } });
+    const woken = await h.wake("alpha-proc");
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    try {
+      await expect(
+        deliverWakeBatch(woken, {
+          projectId: null,
+          path: HOME,
+          events: h.stream.events.slice(),
+          scannedAfterOffset: 0,
+          scannedThroughOffset: h.head(),
+          streamMaxOffset: h.head(),
+          state: null,
+        }),
+      ).resolves.toEqual({
+        outcome: "error",
+        error: {
+          name: "Error",
+          message: "subscriber incarnation reset",
+          durableObjectReset: true,
+          retryable: true,
+        },
+      });
+    } finally {
+      errorLog.mockRestore();
+    }
   });
 
   it("rejects a wake whose stream coordinate does not match the registry's own (isolation fence)", async () => {

--- a/apps/os/src/domains/streams/stream-subscribers.teardown.test.ts
+++ b/apps/os/src/domains/streams/stream-subscribers.teardown.test.ts
@@ -9,7 +9,7 @@
 // the log, every fact-append triggers wake(), parked facts fold.
 
 import { describe, expect, it } from "vitest";
-import type { StreamEvent, StreamEventInput } from "iterate/processors";
+import type { StreamEvent, StreamEventInput, StreamWakeEventBatch } from "iterate/processors";
 import {
   CoreProcessorContract,
   type SubscriptionConfiguredPayload,
@@ -20,7 +20,7 @@ import type { SubscriptionCursorRow, SubscriptionCursorStore } from "./stream-st
 
 type PokeImpl = (request: { subscriptionKey: string }) => Promise<{
   checkpointOffset: number;
-  sink: RetainedProcessEventBatch;
+  sink: RetainedProcessEventBatch<StreamWakeEventBatch>;
 }>;
 
 function makeFaithfulHarness(pokeImpl?: PokeImpl) {
@@ -133,11 +133,16 @@ function makeFaithfulHarness(pokeImpl?: PokeImpl) {
         poke: async (_expression, request) => {
           pokes.push(request.subscriptionKey);
           if (pokeImpl !== undefined) return pokeImpl(request);
-          const sink = Object.assign(() => undefined, {
-            [Symbol.dispose]() {
-              sinkAlive = false;
+          const sink = Object.assign(
+            (batch: StreamWakeEventBatch) => {
+              batch.settleDelivery({ outcome: "ok" });
             },
-          }) as RetainedProcessEventBatch;
+            {
+              [Symbol.dispose]() {
+                sinkAlive = false;
+              },
+            },
+          ) as RetainedProcessEventBatch<StreamWakeEventBatch>;
           sinkAlive = true;
           return { checkpointOffset: log.length, sink };
         },
@@ -233,10 +238,10 @@ describe("StreamSubscribers with a DO-faithful (log-appending) harness", () => {
     let pokes = 0;
     const h = makeFaithfulHarness(async () => {
       pokes += 1;
-      const sink = Object.assign(() => undefined, {
-        pendingDeliveries: () => 1, // permanently unsettled delivery
+      const sink = Object.assign((_batch: StreamWakeEventBatch) => undefined, {
+        // Deliberately never invokes `settleDelivery`.
         [Symbol.dispose]() {},
-      }) as RetainedProcessEventBatch;
+      }) as RetainedProcessEventBatch<StreamWakeEventBatch>;
       return { checkpointOffset: 0, sink };
     });
     h.configured["k"] = {

--- a/apps/os/src/domains/streams/stream-subscribers.test.ts
+++ b/apps/os/src/domains/streams/stream-subscribers.test.ts
@@ -1300,6 +1300,56 @@ describe("StreamSubscribers", () => {
     }
   });
 
+  it("backs off an RPC-broken wake sink before reconciling instead of hot re-poking", async () => {
+    const h = makeHarness();
+    h.configure(wakePayload(), 1);
+    h.append(evt(1, "a"));
+
+    let reportBroken: ((error: unknown) => void) | undefined;
+    const dispose = vi.fn();
+    const sink = Object.assign((_batch: StreamWakeEventBatch) => undefined, {
+      [Symbol.dispose]: dispose,
+      onRpcBroken: (handler: (error: unknown) => void) => {
+        reportBroken = handler;
+      },
+    }) as RetainedProcessEventBatch<StreamWakeEventBatch>;
+    h.dialImpl.poke = async () => ({ checkpointOffset: 0, sink });
+    h.subscribers.wake();
+    await h.settle();
+    expect(h.pokes).toHaveLength(1);
+    expect(reportBroken).toBeDefined();
+
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const warningLog = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      const broken = new Error("remote capability disconnected");
+      reportBroken!(broken);
+      await h.settle();
+
+      expect(errorLog).not.toHaveBeenCalled();
+      expect(warningLog).toHaveBeenCalledWith(
+        "stream durable sink unavailable; backing off before re-poke",
+        expect.objectContaining({
+          subscriptionKey: "k",
+          reason: "rpc-broken",
+          error: broken,
+        }),
+      );
+      expect(dispose).toHaveBeenCalledOnce();
+      expect(h.subscribers.hasConnection("k")).toBe(false);
+      expect(h.row("k")?.attempt).toBe(1);
+      expect(h.row("k")?.nextAttemptAt).not.toBeNull();
+      expect(h.pokes).toHaveLength(1);
+      expect(h.factsOfType(DISCONNECTED).at(-1)?.payload).toMatchObject({
+        subscriptionKey: "k",
+        reason: "rpc-broken",
+      });
+    } finally {
+      errorLog.mockRestore();
+      warningLog.mockRestore();
+    }
+  });
+
   it("t. an in-flight push delivery cannot clobber a cursor seek (epoch fence)", async () => {
     const h = makeHarness();
     h.configure(pushPayload(), 0);

--- a/apps/os/src/domains/streams/stream-subscribers.test.ts
+++ b/apps/os/src/domains/streams/stream-subscribers.test.ts
@@ -10,6 +10,7 @@ import type {
   StreamEventBatch,
   StreamPushEventBatch,
   StreamSubscriberWakeRequest,
+  StreamWakeEventBatch,
   StreamWebhookDelivery,
 } from "iterate/processors";
 import {
@@ -368,9 +369,12 @@ function makeSink() {
   const sink = Object.assign(
     (batch: StreamEventBatch) => {
       batches.push(batch);
+      if ("settleDelivery" in batch) {
+        (batch as StreamWakeEventBatch).settleDelivery({ outcome: "ok" });
+      }
     },
     { [Symbol.dispose]: () => {} },
-  ) as RetainedProcessEventBatch;
+  ) as RetainedProcessEventBatch<StreamEventBatch>;
   return { sink, batches };
 }
 
@@ -952,6 +956,42 @@ describe("StreamSubscribers", () => {
     });
   });
 
+  it("a late wake settlement from a replaced connection cannot close its successor", async () => {
+    const h = makeHarness();
+    h.configure(wakePayload(), 0);
+    h.append(evt(1, "a"));
+    const batches: StreamWakeEventBatch[] = [];
+    h.dialImpl.poke = async () => ({
+      checkpointOffset: 0,
+      sink: Object.assign(
+        (batch: StreamWakeEventBatch) => {
+          batches.push(batch);
+        },
+        { [Symbol.dispose]: () => {} },
+      ),
+    });
+
+    h.subscribers.wake();
+    await h.settle();
+    expect(batches).toHaveLength(1);
+
+    h.configure(wakePayload(), 2);
+    h.subscribers.onSubscriptionConfigured(wakePayload(), 2);
+    await h.settle();
+    expect(batches).toHaveLength(2);
+    expect(h.subscribers.hasConnection("k")).toBe(true);
+
+    batches[0]!.settleDelivery({
+      outcome: "error",
+      error: { name: "Error", message: "obsolete connection failed late" },
+    });
+    await h.settle();
+
+    expect(h.subscribers.hasConnection("k")).toBe(true);
+    expect(h.row("k")?.attempt).toBe(0);
+    batches[1]!.settleDelivery({ outcome: "ok" });
+  });
+
   it("m. removal deletes the cursor row and closes the connection", async () => {
     const h = makeHarness();
     h.configure(wakePayload(), 0);
@@ -1168,16 +1208,29 @@ describe("StreamSubscribers", () => {
     h.append(evt(1, "a"));
 
     let checkpoint = 0;
-    h.dialImpl.poke = async () => ({ checkpointOffset: checkpoint, sink: makeSink().sink });
+    let latestBatch: StreamWakeEventBatch | undefined;
+    h.dialImpl.poke = async () => ({
+      checkpointOffset: checkpoint,
+      sink: Object.assign(
+        (batch: StreamWakeEventBatch) => {
+          latestBatch = batch;
+        },
+        { [Symbol.dispose]: () => {} },
+      ),
+    });
     h.subscribers.wake();
     await h.settle();
     expect(h.pokes).toHaveLength(1);
+    expect(latestBatch).toBeDefined();
 
-    // A post-poke sink delivery failure must run the failure machine: nack'd
-    // row, closed connection, and NO immediate re-poke — the bug this pins is
-    // the close→wake→re-poke hot loop that never backed off and never parked
-    // (each poke's ack used to reset the attempt counter too).
-    h.subscribers.onDurableDeliveryError("k", new Error("ingest rejects deterministically"));
+    // A processor's independent error settlement must run the failure
+    // machine: nack'd row, closed connection, and NO immediate re-poke — the
+    // bug this pins is the close→wake→re-poke hot loop that never backed off
+    // and never parked (each poke's ack used to reset the attempt counter).
+    latestBatch!.settleDelivery({
+      outcome: "error",
+      error: { name: "Error", message: "ingest rejects deterministically" },
+    });
     await h.settle();
     expect(h.subscribers.hasConnection("k")).toBe(false);
     expect(h.row("k")?.attempt).toBe(1);
@@ -1194,7 +1247,10 @@ describe("StreamSubscribers", () => {
 
     // Sustained deterministic failure parks at the shared threshold.
     for (let round = 0; round < 400 && h.factsOfType(PARKED).length === 0; round += 1) {
-      h.subscribers.onDurableDeliveryError("k", new Error("still failing"));
+      latestBatch!.settleDelivery({
+        outcome: "error",
+        error: { name: "Error", message: "still failing" },
+      });
       await h.settle();
       const next = h.store.minNextAttemptAt();
       if (next === null) break;
@@ -1212,6 +1268,7 @@ describe("StreamSubscribers", () => {
     await h.settle();
     expect(h.subscribers.hasConnection("k")).toBe(true);
     expect(h.row("k")?.attempt).toBe(0);
+    latestBatch!.settleDelivery({ outcome: "ok" });
   });
 
   it("classifies a Durable Object lifecycle reset as availability, not a delivery error", async () => {
@@ -1779,7 +1836,7 @@ describe("StreamSubscribers runtime metrics", () => {
     expect(h.egress).toEqual([{ count: 3, bytes: subscription.bytesSent }]);
   });
 
-  it("wake-lane settle latency: the pulled batch result settling records commit→consumed", async () => {
+  it("wake-lane settle latency: the independent settlement records commit→consumed", async () => {
     const h = makeHarness();
     h.append(evt(1, "a"), evt(2, "b")); // createdAt = epoch 1..2ms
     h.advanceTo(500);
@@ -1788,15 +1845,11 @@ describe("StreamSubscribers runtime metrics", () => {
     let settleBatch: (() => void) | undefined;
     h.dialImpl.poke = async () => ({
       checkpointOffset: 0,
-      // Retained exactly like the real dial does (durable lane pulls results),
-      // so the spine's onSettled option is exercised for real.
-      sink: retainProcessEventBatch(
-        () =>
-          new Promise<void>((resolve) => {
-            settleBatch = resolve;
-          }),
-        { onDeliveryError: () => {} },
-      ),
+      // Retained exactly like the real dial does: the sink result stays
+      // unpulled and the processor reports completion out of band.
+      sink: retainProcessEventBatch((batch: StreamWakeEventBatch) => {
+        settleBatch = () => batch.settleDelivery({ outcome: "ok" });
+      }),
     });
 
     h.subscribers.wake();

--- a/apps/os/src/domains/streams/stream-subscribers.ts
+++ b/apps/os/src/domains/streams/stream-subscribers.ts
@@ -1247,7 +1247,20 @@ export class StreamSubscribers {
         ...(args.presence === undefined ? {} : { subscriber: args.presence }),
       },
     });
-    sink.onRpcBroken?.(() => connection.close("rpc-broken"));
+    sink.onRpcBroken?.((error) => {
+      if (subscriptionType === "configured") {
+        // A disposed predecessor can report its transport break late. Fence
+        // the hint to this exact connection so it cannot nack and close the
+        // replacement currently stored under the same subscription key.
+        if (this.#connections.get(subscriptionKey) === connection) {
+          this.#onDurableSinkFailure(subscriptionKey, error, "rpc-broken");
+        }
+      } else {
+        // Session-scoped ephemerals have no durable cursor to nack or retry;
+        // disconnecting forgets them exactly as their ownership contract says.
+        connection.close("rpc-broken");
+      }
+    });
     connection.wake();
     return connection;
   }
@@ -1262,20 +1275,31 @@ export class StreamSubscribers {
    * see #poke) and parks at the same threshold as every other lane.
    */
   onDurableDeliveryError(subscriptionKey: string, error: unknown): void {
+    this.#onDurableSinkFailure(subscriptionKey, error, "delivery-failed");
+  }
+
+  #onDurableSinkFailure(
+    subscriptionKey: string,
+    error: unknown,
+    reason: Extract<StreamSubscriberDisconnectReason, "rpc-broken" | "delivery-failed">,
+  ): void {
     const connection = this.#connections.get(subscriptionKey);
     if (connection === undefined) return;
-    const details = { subscriptionKey, error };
-    if (isDurableObjectLifecycleError(error)) {
+    const details = { subscriptionKey, reason, error };
+    if (reason === "rpc-broken" || isDurableObjectLifecycleError(error)) {
       // A killed, evicted, deployed, or overloaded subscriber is a modelled
-      // availability transition: the durable cursor stays put and the
-      // bounded backoff below reconnects it. Keep that expected transition
-      // out of the error signal while retaining an observable warning.
+      // availability transition. `onRpcBroken` is itself the transport's
+      // authoritative availability signal even when its Error lost workerd's
+      // lifecycle flags crossing an RPC boundary. The durable cursor stays
+      // put and the bounded backoff below reconnects it; keep that expected
+      // transition out of the error signal while retaining an observable
+      // warning.
       console.warn("stream durable sink unavailable; backing off before re-poke", details);
     } else {
       console.error("stream durable sink delivery failed; backing off before re-poke", details);
     }
     this.#onDeliveryFailure(subscriptionKey, error);
-    connection.close("delivery-failed");
+    connection.close(reason);
   }
 
   // ===========================================================================

--- a/apps/os/src/domains/streams/stream-subscribers.ts
+++ b/apps/os/src/domains/streams/stream-subscribers.ts
@@ -9,7 +9,7 @@
 // | lane       | sink arrives as                       | call result            |
 // |------------|---------------------------------------|------------------------|
 // | ephemeral  | `subscribe()` parameter               | disposed unpulled — zero return frames |
-// | wake       | returned from the expression-named poke| pulled, never awaited — prompt corpse detection |
+// | wake       | returned from the expression-named poke| disposed unpulled; independent per-batch settlement |
 // | push       | named by a persisted itx expression   | awaited — the ack that advances the cursor |
 // | webhook    | the configured URL (per-event POST)   | awaited 2xx — the ack that advances the cursor |
 //
@@ -24,7 +24,7 @@
 //
 // Runtime metrics: every connection carries real counters (events/bytes
 // delivered, lag from cursor), the durable lanes record commit→settled
-// latency on the stream's own clock (wake: the pulled result settling; push/
+// latency on the stream's own clock (wake: the settlement callback; push/
 // webhook: the awaited ack), and subscribers that hand over a ping capability
 // get NTP-style RTT sampled when runtime observation begins, throttled, and
 // purely observational (a failed ping drops the sample, nothing else).
@@ -48,6 +48,9 @@ import type {
   StreamPushEventBatch,
   StreamSubscriberPing,
   StreamSubscriberWakeRequest,
+  StreamWakeDeliveryError,
+  StreamWakeDeliverySettlement,
+  StreamWakeEventBatch,
   StreamWebhookDelivery,
 } from "iterate/processors";
 import {
@@ -101,10 +104,10 @@ export type ConnectionRuntimeState = {
   lastDeliveredAt?: string;
   /**
    * Commit-to-settled latency, stream clock only: `createdAt` of the newest
-   * event in a batch → the pulled batch result settling (the subscriber's
-   * ingest resolved). Durable (wake) lane only — ephemeral results are
-   * disposed unpulled, so ephemeral consumption is self-reported by the host
-   * through `getRuntimeState` instead. Absent until a sample exists.
+   * event in a batch → the subscriber's explicit settlement callback.
+   * Durable (wake) lane only — ephemeral results are disposed unpulled, so
+   * ephemeral consumption is self-reported by the host through
+   * `getRuntimeState` instead. Absent until a sample exists.
    */
   settleLatencyMs?: LatencyStats;
   /** Mutual-ping transport RTT to this subscriber (observer-driven sampling). Absent until pinged. */
@@ -117,7 +120,7 @@ export type ConnectionRuntimeState = {
    */
   subscriber?: StreamSubscriberDescriptor;
   /**
-   * True while the last batch handed to this connection's sink is unsettled —
+   * True while any batch handed to this connection's sink is unsettled —
    * exactly the signal idle teardown consults to classify a sink as wedged.
    */
   hasPendingDelivery: boolean;
@@ -178,11 +181,8 @@ type Connection = {
 };
 
 /** Everything `open()` needs to start one delivery connection. */
-type OpenConnectionArgs = {
+type OpenConnectionBase = {
   subscriptionKey: string;
-  subscriptionType: StreamSubscriptionType;
-  /** Already-retained sink (subscriber-sinks.ts owns retention semantics). */
-  sink: RetainedProcessEventBatch;
   replayAfterOffset?: number;
   /** Stable stream creation identity observed by the caller; null binds to an unborn stream. */
   expectedIncarnation?: string | null;
@@ -199,6 +199,18 @@ type OpenConnectionArgs = {
   ping?: StreamSubscriberPing;
 };
 
+type OpenConnectionArgs =
+  | (OpenConnectionBase & {
+      subscriptionType: "ephemeral";
+      /** Already-retained sink (subscriber-sinks.ts owns retention semantics). */
+      sink: RetainedProcessEventBatch<StreamEventBatch>;
+    })
+  | (OpenConnectionBase & {
+      subscriptionType: "configured";
+      /** One-way durable sink; completion arrives through each batch's settlement door. */
+      sink: RetainedProcessEventBatch<StreamWakeEventBatch>;
+    });
+
 /**
  * The transport quarantine's face: how the spine reaches subscribers. Wake and
  * push are BOTH itx-expression evaluations against the stream's authority root
@@ -213,7 +225,7 @@ export type SubscriberDial = {
     request: StreamSubscriberWakeRequest,
   ): Promise<{
     checkpointOffset: number;
-    sink: RetainedProcessEventBatch;
+    sink: RetainedProcessEventBatch<StreamWakeEventBatch>;
     subscriber?: unknown;
     getRuntimeState?: GetProcessorRuntimeState;
     ping?: StreamSubscriberPing;
@@ -1057,6 +1069,8 @@ export class StreamSubscribers {
     let initialBatchPending = true;
     let draining = false;
     let open = true;
+    const pendingDeliveries = new Set<symbol>();
+    let connection!: Connection;
 
     const pump = async () => {
       if (draining) return;
@@ -1118,45 +1132,59 @@ export class StreamSubscribers {
               "Cannot deliver stream batch before stream coordinates are initialized.",
             );
           }
-          // Wake-lane batches have their results pulled anyway (corpse
-          // detection), so the settle doubles as a free commit→consumed
-          // sample on the stream's own clock. Ephemeral results stay
-          // unpulled: no onSettled ever fires there (see subscriber-sinks.ts).
+          // A wake batch reports completion through an independent one-shot
+          // capability. Its sink result is disposed unpulled, exactly like an
+          // ephemeral batch, so a processor that appends back to this stream
+          // cannot close a cyclic actor-drain dependency through its return
+          // value.
           const newestCreatedAtMs =
             events.length === 0 ? undefined : Date.parse(events.at(-1)!.createdAt);
-          sink(
-            {
-              projectId: currentState.projectId,
-              path: currentState.path,
-              events,
-              scannedAfterOffset,
-              scannedThroughOffset: cursor,
-              streamMaxOffset: currentState.maxOffset,
-              // Read in the same synchronous block as streamMaxOffset, so the
-              // two always correspond (state-at-streamMaxOffset; see rpc-types.ts).
-              state: currentState,
-            } satisfies StreamEventBatch,
-            {
-              onSettled: (outcome) => {
-                if (
-                  outcome === "ok" &&
-                  newestCreatedAtMs !== undefined &&
-                  Number.isFinite(newestCreatedAtMs)
-                ) {
-                  const settledAtMs = this.#hooks.now();
-                  connection.settleLatency.record(settledAtMs - newestCreatedAtMs, settledAtMs);
+          const batch = {
+            projectId: currentState.projectId,
+            path: currentState.path,
+            events,
+            scannedAfterOffset,
+            scannedThroughOffset: cursor,
+            streamMaxOffset: currentState.maxOffset,
+            // Read in the same synchronous block as streamMaxOffset, so the
+            // two always correspond (state-at-streamMaxOffset; see rpc-types.ts).
+            state: currentState,
+          } satisfies StreamEventBatch;
+          if (args.subscriptionType === "configured") {
+            const delivery = Symbol("stream wake delivery");
+            pendingDeliveries.add(delivery);
+            // Publish the pending state BEFORE dispatch. A local sink can
+            // settle synchronously, and debug state must still observe the
+            // real pending → settled transition.
+            this.#hooks.runtimeChanged();
+            args.sink({
+              ...batch,
+              settleDelivery: (settlement) => {
+                // One callback capability belongs to one batch. Duplicates
+                // and late reports after close/replacement are harmless.
+                if (!pendingDeliveries.delete(delivery)) return;
+                if (open && this.#connections.get(subscriptionKey) === connection) {
+                  const parsed = parseWakeDeliverySettlement(settlement);
+                  if (parsed.outcome === "ok") {
+                    if (newestCreatedAtMs !== undefined && Number.isFinite(newestCreatedAtMs)) {
+                      const settledAtMs = this.#hooks.now();
+                      connection.settleLatency.record(settledAtMs - newestCreatedAtMs, settledAtMs);
+                    }
+                  } else {
+                    // Fence on the exact connection above: a late failure
+                    // from a replaced sink must never close its successor.
+                    this.onDurableDeliveryError(subscriptionKey, parsed.error);
+                  }
                 }
-                // `hasPendingDelivery` changed on every durable settle,
-                // including empty/state-only and rejected deliveries that
-                // record no latency sample.
+                // Includes empty/state-only, rejected, stale, and duplicate-
+                // fenced deliveries: pending state changed for the first
+                // terminal report even when no latency sample was recorded.
                 this.#hooks.runtimeChanged();
               },
-            },
-          );
-          // The durable wrapper increments its pending count synchronously;
-          // publish that transition before its eventual settle callback
-          // publishes the return to idle.
-          this.#hooks.runtimeChanged();
+            } satisfies StreamWakeEventBatch);
+          } else {
+            args.sink(batch);
+          }
           await Promise.resolve();
         }
       } finally {
@@ -1164,7 +1192,7 @@ export class StreamSubscribers {
       }
     };
 
-    const connection: Connection = {
+    connection = {
       subscriptionType,
       startedAt: new Date(this.#hooks.now()).toISOString(),
       ...(args.presence === undefined ? {} : { subscriber: args.presence }),
@@ -1180,10 +1208,11 @@ export class StreamSubscribers {
       pingRtt: new LatencyRing(),
       wake: () => void pump(),
       isLive: () => open,
-      hasPendingDelivery: () => (sink.pendingDeliveries?.() ?? 0) > 0,
+      hasPendingDelivery: () => pendingDeliveries.size > 0,
       close: (reason) => {
         if (!open) return;
         open = false;
+        pendingDeliveries.clear();
         if (this.#connections.get(subscriptionKey) === connection) {
           this.#connections.delete(subscriptionKey);
           this.#hooks.runtimeChanged();
@@ -1272,8 +1301,8 @@ export class StreamSubscribers {
    * runtime LiveState observer attaching triggers it. A stream with no debug
    * observer is never pinged. Purely
    * observational: a failed/garbage/slow ping drops the sample and NOTHING
-   * else (liveness stays owned by result-pulling and onRpcBroken); it never
-   * wakes pumps and never re-arms the idle timer.
+   * else (liveness stays owned by explicit delivery settlement and
+   * onRpcBroken); it never wakes pumps and never re-arms the idle timer.
    */
   samplePingsSoon(): void {
     const now = this.#hooks.now();
@@ -1510,4 +1539,34 @@ function selectorMatchesSafely(selector: CompiledEventSelector, event: StreamEve
 
 function errorMessage(error: unknown): string {
   return (error instanceof Error ? error.message : String(error)) || "unknown error";
+}
+
+function parseWakeDeliverySettlement(
+  value: StreamWakeDeliverySettlement,
+): { outcome: "ok" } | { outcome: "error"; error: Error } {
+  const candidate = value as Partial<StreamWakeDeliverySettlement> | null;
+  if (candidate?.outcome === "ok") return { outcome: "ok" };
+  if (candidate?.outcome !== "error" || !("error" in candidate)) {
+    return {
+      outcome: "error",
+      error: new Error("wake delivery reported an invalid settlement"),
+    };
+  }
+  const serialized = candidate.error as Partial<StreamWakeDeliveryError> | null;
+  if (typeof serialized?.name !== "string" || typeof serialized.message !== "string") {
+    return {
+      outcome: "error",
+      error: new Error("wake delivery reported an invalid failure"),
+    };
+  }
+  const error = new Error(serialized.message);
+  error.name = serialized.name;
+  return {
+    outcome: "error",
+    error: Object.assign(error, {
+      ...(serialized.durableObjectReset === true ? { durableObjectReset: true } : {}),
+      ...(serialized.overloaded === true ? { overloaded: true } : {}),
+      ...(serialized.retryable === true ? { retryable: true } : {}),
+    }),
+  };
 }

--- a/apps/os/src/domains/streams/subscriber-sinks.test.ts
+++ b/apps/os/src/domains/streams/subscriber-sinks.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import type {
   GetProcessorRuntimeState,
-  ProcessEventBatch,
+  ProcessStreamWakeEventBatch,
   StreamPushEventBatch,
   StreamSubscriberPing,
+  StreamWakeEventBatch,
 } from "iterate/processors";
 
 const dialMocks = vi.hoisted(() => ({
@@ -187,8 +188,46 @@ describe("push delivery RPC ownership", () => {
 });
 
 describe("wake-handshake RPC ownership", () => {
+  test("disposes durable batch results without pulling their resolution", () => {
+    const disposeCallResult = vi.fn();
+    let thenReads = 0;
+    const callResult = {
+      [Symbol.dispose]: disposeCallResult,
+      get then() {
+        thenReads += 1;
+        return () => {
+          throw new Error("durable sink result must stay unpulled");
+        };
+      },
+    };
+    const sink = remoteCallback<StreamWakeEventBatch, unknown>(() => callResult);
+    const retained = retainWakeHandshakeResponse({
+      onDeliveryError: vi.fn(),
+      value: {
+        checkpointOffset: 0,
+        sink: sink.raw as ProcessStreamWakeEventBatch,
+        [Symbol.dispose]: vi.fn(),
+      },
+    });
+
+    retained.sink({
+      events: [],
+      path: "/",
+      projectId: "prj_test",
+      scannedAfterOffset: 0,
+      scannedThroughOffset: 0,
+      state: {},
+      streamMaxOffset: 0,
+      settleDelivery: () => undefined,
+    });
+
+    expect(disposeCallResult).toHaveBeenCalledOnce();
+    expect(thenReads).toBe(0);
+    retained.sink[Symbol.dispose]();
+  });
+
   test("retains every returned capability and disposes the original RPC result", async () => {
-    const sink = remoteCallback<Parameters<ProcessEventBatch>[0], void>(() => {});
+    const sink = remoteCallback<Parameters<ProcessStreamWakeEventBatch>[0], void>(() => {});
     const getRuntimeState = remoteCallback<void, { snapshot: { offset: number; state: object } }>(
       () => ({ snapshot: { offset: 17, state: {} } }),
     );
@@ -208,7 +247,7 @@ describe("wake-handshake RPC ownership", () => {
       onDeliveryError: vi.fn(),
       value: {
         checkpointOffset: 17,
-        sink: sink.raw as ProcessEventBatch,
+        sink: sink.raw as ProcessStreamWakeEventBatch,
         getRuntimeState: getRuntimeState.raw as GetProcessorRuntimeState,
         ping: ping.raw as StreamSubscriberPing,
         [Symbol.dispose]: disposeResult,
@@ -231,6 +270,7 @@ describe("wake-handshake RPC ownership", () => {
       scannedThroughOffset: 17,
       state: {},
       streamMaxOffset: 17,
+      settleDelivery: () => undefined,
     });
     expect(await retained.getRuntimeState?.()).toEqual({
       snapshot: { offset: 17, state: {} },

--- a/apps/os/src/domains/streams/subscriber-sinks.ts
+++ b/apps/os/src/domains/streams/subscriber-sinks.ts
@@ -19,26 +19,26 @@
 // - Return values: ownership transfers to the caller (us). We retain what the
 //   poke returned and are responsible for disposing it.
 //
-// Delivery is fire-and-forget by design (the pump never awaits a batch); the
-// asymmetry between ephemeral and durable subscribers is WHO PULLS THE RESULT:
-// ephemeral batch results are disposed unpulled — zero subscriber-originated
-// return frames on the wire — while durable batch results are pulled (never
-// awaited) purely as the prompt dead-connection signal. See
-// `retainProcessEventBatch` below and the wire tests in
-// stream-wire.e2e.test.ts.
+// Delivery is fire-and-forget by design (the pump never awaits a batch).
+// Every live sink result is disposed unpulled. Durable wake subscribers report
+// success/failure through the batch's independent settlement capability; this
+// keeps the sink call genuinely one-way even when the processor appends back
+// to the delivering stream. See `retainProcessEventBatch` below and the wire
+// tests in stream-wire.e2e.test.ts.
 
 import { disposeIgnoredRpcResult, isThenable, retainCallback } from "iterate/sdk/capnweb";
 import { StreamReceiverUnavailableError } from "iterate/processors";
 import type {
   GetProcessorRuntimeState,
-  ProcessEventBatch,
   ProcessorRuntimeState,
+  StreamEventBatch,
   StreamPingInput,
   StreamPingReply,
   StreamPushEventBatch,
   StreamSubscriberPing,
   StreamSubscriberWakeRequest,
   StreamSubscriberWakeResponse,
+  StreamWakeEventBatch,
   StreamWebhookDelivery,
 } from "iterate/processors";
 import { evaluateItxExpression, type ItxExpression } from "../../itx/expression.ts";
@@ -77,48 +77,28 @@ function rethrowPushEvaluationError(error: unknown): never {
   throw error;
 }
 
-/**
- * Per-call delivery options, consumed LOCALLY by the retained wrapper — never
- * serialized, never on the wire. `onSettled` fires when the durable lane's
- * pulled result settles (the subscriber's ingest resolved/rejected); on the
- * ephemeral lane, where results are disposed unpulled by design, it never
- * fires.
- */
-export type DeliveryOptions = {
-  onSettled?: (outcome: "ok" | "error") => void;
-};
-
 /** The pump-facing delivery callback: fire-and-forget, disposable, broken-transport aware. */
-export type RetainedProcessEventBatch = ((
-  batch: Parameters<ProcessEventBatch>[0],
-  opts?: DeliveryOptions,
+export type RetainedProcessEventBatch<Batch extends StreamEventBatch = StreamEventBatch> = ((
+  batch: Batch,
 ) => void) &
   Disposable & {
     onRpcBroken?(callback: (error: unknown) => void): void;
-    /**
-     * Dispatched-but-unsettled deliveries (durable lane only, where results
-     * are pulled). Idle teardown consults this: a sink with an unsettled
-     * batch belongs to a wedged subscriber, and its watermark must not be
-     * advanced as if the batch were digested.
-     */
-    pendingDeliveries?(): number;
   };
 
 /**
  * Retains a delivery sink and wraps it in the pump's fire-and-forget calling
  * convention.
  *
- * Without `onDeliveryError` (ephemeral subscribers) the batch result is
- * disposed WITHOUT ever being pulled, so the remote never ships a resolution —
- * frames flow in one direction only. With it (durable subscribers) the result
- * is pulled — never awaited, never gating the pump — because a dead stub
- * rejects every call, and observing that rejection is the only reliable,
- * PROMPT "this connection is a corpse" signal (`onRpcBroken` is best-effort
- * and can be a pipelined fake). One resolve frame per batch is the price of
- * millisecond-grade dead-connection detection on the lane voice rides.
+ * The batch result is disposed WITHOUT ever being pulled, so the remote never
+ * ships a resolution and frames flow in one direction only. Durable wake
+ * subscribers carry a separate per-batch settlement capability; pulling the
+ * sink result itself would create an actor-drain cycle whenever processing
+ * appends back to this same stream. `onDeliveryError` therefore covers only a
+ * synchronous dead-stub throw; `onRpcBroken` remains the prompt best-effort
+ * transport hint.
  */
-export function retainProcessEventBatch(
-  processEventBatch: ProcessEventBatch,
+export function retainProcessEventBatch<Batch extends StreamEventBatch>(
+  processEventBatch: (batch: Batch) => unknown,
   opts: {
     onDeliveryError?: (error: unknown) => void;
     /**
@@ -128,59 +108,25 @@ export function retainProcessEventBatch(
      */
     onDisposed?: () => void;
   } = {},
-): RetainedProcessEventBatch {
+): RetainedProcessEventBatch<Batch> {
   // `retainCallback` owns the transport dance (dup, idempotent dispose, and
   // the defensive onRpcBroken wiring — see iterate/sdk/capnweb/retain.ts for why that
   // wiring is subtle); this layer adds only the pump's delivery semantics.
-  const retained = retainCallback<Parameters<ProcessEventBatch>[0]>(processEventBatch);
+  const retained = retainCallback<Batch>(processEventBatch);
   const onDeliveryError = opts.onDeliveryError;
-  let pendingDeliveries = 0;
-  const callback: RetainedProcessEventBatch = Object.assign(
-    (batch: Parameters<ProcessEventBatch>[0], opts?: DeliveryOptions) => {
+  const callback: RetainedProcessEventBatch<Batch> = Object.assign(
+    (batch: Batch) => {
       let result: unknown;
       try {
         result = retained(batch);
       } catch (error) {
         // A disposed/broken stub can throw synchronously at call time.
         onDeliveryError?.(error);
-        opts?.onSettled?.("error");
-        return;
-      }
-      if (onDeliveryError !== undefined && isThenable(result)) {
-        // Delivery stays fire-and-forget (the pump never awaits the remote
-        // result), but the rejection must be observed: a dead stub rejects
-        // every call, and swallowing that left broken connections in place
-        // forever. Dispose only after settle; disposing before the result is
-        // pulled opts out of observing the rejection signal this path needs.
-        pendingDeliveries += 1;
-        void Promise.resolve(result)
-          .then(
-            () => {
-              pendingDeliveries -= 1;
-              opts?.onSettled?.("ok");
-            },
-            (error: unknown) => {
-              pendingDeliveries -= 1;
-              try {
-                onDeliveryError(error);
-              } finally {
-                opts?.onSettled?.("error");
-              }
-            },
-          )
-          .finally(() => {
-            disposeIgnoredRpcResult(result);
-          });
         return;
       }
       disposeIgnoredRpcResult(result);
-      // Ephemeral lane (results disposed unpulled): "settled" is meaningless
-      // here — the subscriber's consumption is self-reported instead — but a
-      // LOCAL sink's synchronous return is a genuine settle.
-      if (onDeliveryError !== undefined) opts?.onSettled?.("ok");
     },
     {
-      pendingDeliveries: () => pendingDeliveries,
       [Symbol.dispose]() {
         try {
           retained[Symbol.dispose]();
@@ -255,7 +201,7 @@ export type RetainedSubscriberPing = ((
 
 type RetainedWakeHandshakeResponse = {
   checkpointOffset: number;
-  sink: RetainedProcessEventBatch;
+  sink: RetainedProcessEventBatch<StreamWakeEventBatch>;
   subscriber?: unknown;
   getRuntimeState?: GetProcessorRuntimeState & Disposable;
   ping?: RetainedSubscriberPing;
@@ -283,7 +229,7 @@ export function retainWakeHandshakeResponse(args: {
 
   let getRuntimeState: (GetProcessorRuntimeState & Disposable) | undefined;
   let ping: RetainedSubscriberPing | undefined;
-  let sink: RetainedProcessEventBatch | undefined;
+  let sink: RetainedProcessEventBatch<StreamWakeEventBatch> | undefined;
   let retainedReleased = false;
   const releaseRetained = () => {
     if (retainedReleased) return;
@@ -364,9 +310,10 @@ export function createSubscriberDial(deps: {
      * checkpoint plus a live sink whose ownership transfers to this stream
      * (returned-stub semantics:
      * https://developers.cloudflare.com/workers/runtime-apis/rpc/lifecycle/).
-     * The sink is retained with the durable lane's result-pulling liveness
-     * policy attached. The local root owns no remote lifetime; the returned
-     * handshake value still transfers its own RPC disposal group.
+     * The sink is retained with best-effort broken-transport detection; each
+     * delivered batch carries its own explicit settlement capability. The
+     * local root owns no remote lifetime; the returned handshake value still
+     * transfers its own RPC disposal group.
      */
     async poke(expression: ItxExpression, request: StreamSubscriberWakeRequest) {
       const { value } = await evaluateItxExpression(

--- a/apps/os/src/itx-api-graph.generated.ts
+++ b/apps/os/src/itx-api-graph.generated.ts
@@ -1185,10 +1185,14 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
     name: "StreamSubscriberWakeResponse",
     kind: "typeAlias",
     sourceText:
-      "/**\n * What the poked subscriber hands back — the entire handshake in one return\n * value. The stream retains `sink` (ownership of a returned stub transfers to\n * the caller) and streams one-way batches into it from `checkpointOffset + 1`;\n * there is no subscribe-back call and therefore no handshake race to fence.\n */\nexport type StreamSubscriberWakeResponse = {\n  /** The processor's durable checkpoint offset — replay resumes after it. */\n  checkpointOffset: number;\n  /** The live delivery callback the stream retains and invokes per batch. */\n  sink: ProcessEventBatch;\n  /**\n   * Serializable subscriber identity (validated against\n   * `StreamSubscriberDescriptor` by the stream) appended as the\n   * subscriber-connected presence fact; carries the processor's contract\n   * announcement for the stream's `processorsBySlug` registry.\n   */\n  subscriber?: unknown;\n  /** Live runtime-state capability, retained for the connection lifetime. */\n  getRuntimeState?: GetProcessorRuntimeState;\n  /** Optional ping capability, retained for the connection lifetime (see {@link StreamSubscriberPing}). */\n  ping?: StreamSubscriberPing;\n};",
+      "/**\n * What the poked subscriber hands back — the entire handshake in one return\n * value. The stream retains `sink` (ownership of a returned stub transfers to\n * the caller) and streams one-way batches into it from `checkpointOffset + 1`;\n * there is no subscribe-back call and therefore no handshake race to fence.\n */\nexport type StreamSubscriberWakeResponse = {\n  /** The processor's durable checkpoint offset — replay resumes after it. */\n  checkpointOffset: number;\n  /**\n   * The live delivery callback the stream retains and invokes per batch.\n   * Calls are one-way; each batch reports completion through its independent\n   * `settleDelivery` capability.\n   */\n  sink: ProcessStreamWakeEventBatch;\n  /**\n   * Serializable subscriber identity (validated against\n   * `StreamSubscriberDescriptor` by the stream) appended as the\n   * subscriber-connected presence fact; carries the processor's contract\n   * announcement for the stream's `processorsBySlug` registry.\n   */\n  subscriber?: unknown;\n  /** Live runtime-state capability, retained for the connection lifetime. */\n  getRuntimeState?: GetProcessorRuntimeState;\n  /** Optional ping capability, retained for the connection lifetime (see {@link StreamSubscriberPing}). */\n  ping?: StreamSubscriberPing;\n};",
     summary: "What the poked subscriber hands back — the entire handshake in one return value.",
     memberSummaries: {},
-    referencedTypeNames: ["ProcessEventBatch", "GetProcessorRuntimeState", "StreamSubscriberPing"],
+    referencedTypeNames: [
+      "ProcessStreamWakeEventBatch",
+      "GetProcessorRuntimeState",
+      "StreamSubscriberPing",
+    ],
   },
   {
     name: "LiveUpdate",
@@ -1906,6 +1910,15 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
     referencedTypeNames: [],
   },
   {
+    name: "ProcessStreamWakeEventBatch",
+    kind: "typeAlias",
+    sourceText:
+      "/** Durable wake-mode sink. Its call result is always disposed unpulled. */\nexport type ProcessStreamWakeEventBatch = (batch: StreamWakeEventBatch) => unknown;",
+    summary: "Durable wake-mode sink.",
+    memberSummaries: {},
+    referencedTypeNames: ["StreamWakeEventBatch"],
+  },
+  {
     name: "LiveStatePatch",
     kind: "typeAlias",
     sourceText:
@@ -2189,7 +2202,7 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
     name: "ConnectionRuntimeState",
     kind: "typeAlias",
     sourceText:
-      "/** Serializable debug view of one live connection, for `runtimeState()`. */\nexport type ConnectionRuntimeState = {\n  subscriptionType: StreamSubscriptionType;\n  startedAt: string;\n  cursor: number;\n  /** `maxOffset - cursor` — real offset lag for EVERY connection kind, ephemeral included. */\n  lag: number;\n  batchesSent: number;\n  eventsSent: number;\n  /** Serialized payload bytes delivered into this connection's sink (cumulative). */\n  bytesSent: number;\n  lastDeliveredAt?: string;\n  /**\n   * Commit-to-settled latency, stream clock only: `createdAt` of the newest\n   * event in a batch → the pulled batch result settling (the subscriber's\n   * ingest resolved). Durable (wake) lane only — ephemeral results are\n   * disposed unpulled, so ephemeral consumption is self-reported by the host\n   * through `getRuntimeState` instead. Absent until a sample exists.\n   */\n  settleLatencyMs?: LatencyStats;\n  /** Mutual-ping transport RTT to this subscriber (observer-driven sampling). Absent until pinged. */\n  pingRttMs?: LatencyStats;\n  /**\n   * The connect-time identity descriptor. The runtime table is the ONLY home\n   * for ephemeral identity — ephemeral connections don't fold into the\n   * reduced `connectionsByKey` roster (core state v14) — so debug surfaces\n   * read who's connected from here.\n   */\n  subscriber?: StreamSubscriberDescriptor;\n  /**\n   * True while the last batch handed to this connection's sink is unsettled —\n   * exactly the signal idle teardown consults to classify a sink as wedged.\n   */\n  hasPendingDelivery: boolean;\n};",
+      "/** Serializable debug view of one live connection, for `runtimeState()`. */\nexport type ConnectionRuntimeState = {\n  subscriptionType: StreamSubscriptionType;\n  startedAt: string;\n  cursor: number;\n  /** `maxOffset - cursor` — real offset lag for EVERY connection kind, ephemeral included. */\n  lag: number;\n  batchesSent: number;\n  eventsSent: number;\n  /** Serialized payload bytes delivered into this connection's sink (cumulative). */\n  bytesSent: number;\n  lastDeliveredAt?: string;\n  /**\n   * Commit-to-settled latency, stream clock only: `createdAt` of the newest\n   * event in a batch → the subscriber's explicit settlement callback.\n   * Durable (wake) lane only — ephemeral results are disposed unpulled, so\n   * ephemeral consumption is self-reported by the host through\n   * `getRuntimeState` instead. Absent until a sample exists.\n   */\n  settleLatencyMs?: LatencyStats;\n  /** Mutual-ping transport RTT to this subscriber (observer-driven sampling). Absent until pinged. */\n  pingRttMs?: LatencyStats;\n  /**\n   * The connect-time identity descriptor. The runtime table is the ONLY home\n   * for ephemeral identity — ephemeral connections don't fold into the\n   * reduced `connectionsByKey` roster (core state v14) — so debug surfaces\n   * read who's connected from here.\n   */\n  subscriber?: StreamSubscriberDescriptor;\n  /**\n   * True while any batch handed to this connection's sink is unsettled —\n   * exactly the signal idle teardown consults to classify a sink as wedged.\n   */\n  hasPendingDelivery: boolean;\n};",
     summary: "Serializable debug view of one live connection, for `runtimeState()`.",
     memberSummaries: {},
     referencedTypeNames: ["StreamSubscriptionType", "LatencyStats", "StreamSubscriberDescriptor"],
@@ -2241,6 +2254,15 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
       "The mutual ping's reply half: the responder echoes `t0` and reports when it received the request (`t1`) and sent the reply (`t2`) on ITS clock.",
     memberSummaries: {},
     referencedTypeNames: [],
+  },
+  {
+    name: "StreamWakeEventBatch",
+    kind: "typeAlias",
+    sourceText:
+      "/** Internal wake-mode frame: an ordinary batch plus its one-shot settlement door. */\nexport type StreamWakeEventBatch = StreamEventBatch & {\n  settleDelivery: SettleStreamWakeDelivery;\n};",
+    summary: "Internal wake-mode frame: an ordinary batch plus its one-shot settlement door.",
+    memberSummaries: {},
+    referencedTypeNames: ["StreamEventBatch", "SettleStreamWakeDelivery"],
   },
   {
     name: "TypedStreamEventInput",
@@ -2406,6 +2428,15 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
     referencedTypeNames: ["MinuteWindow", "ThroughputSeries"],
   },
   {
+    name: "SettleStreamWakeDelivery",
+    kind: "typeAlias",
+    sourceText:
+      "/**\n * One-shot acknowledgement capability owned by a single durable wake batch.\n *\n * It is deliberately independent of the sink call's return value. A\n * processor may append back to the stream that delivered the batch; making\n * the stream pull that sink result creates a cyclic actor-drain dependency.\n */\nexport type SettleStreamWakeDelivery = (settlement: StreamWakeDeliverySettlement) => unknown;",
+    summary: "One-shot acknowledgement capability owned by a single durable wake batch.",
+    memberSummaries: {},
+    referencedTypeNames: ["StreamWakeDeliverySettlement"],
+  },
+  {
     name: "CfImageTransformOptions",
     kind: "typeAlias",
     sourceText:
@@ -2502,6 +2533,15 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
     referencedTypeNames: [],
   },
   {
+    name: "StreamWakeDeliverySettlement",
+    kind: "typeAlias",
+    sourceText:
+      '/** The subscriber\'s terminal verdict for one durable wake delivery. */\nexport type StreamWakeDeliverySettlement =\n  | { outcome: "ok" }\n  | { outcome: "error"; error: StreamWakeDeliveryError };',
+    summary: "The subscriber's terminal verdict for one durable wake delivery.",
+    memberSummaries: {},
+    referencedTypeNames: ["StreamWakeDeliveryError"],
+  },
+  {
     name: "WorkerBundlerCreateAppOptions",
     kind: "typeAlias",
     sourceText:
@@ -2518,6 +2558,15 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
     summary: "Serializable `createWorker` input.",
     memberSummaries: {},
     referencedTypeNames: ["WorkerBundlerOptions", "WorkerFileSource"],
+  },
+  {
+    name: "StreamWakeDeliveryError",
+    kind: "typeAlias",
+    sourceText:
+      "/**\n * Serializable failure reported after a durable wake delivery finishes.\n *\n * The settlement crosses an independent one-way RPC hop, so preserve the\n * lifecycle flags the stream uses to distinguish a dead Durable Object from\n * an application failure. Error prototypes and arbitrary properties do not\n * survive that hop reliably.\n */\nexport type StreamWakeDeliveryError = {\n  name: string;\n  message: string;\n  durableObjectReset?: true;\n  overloaded?: true;\n  retryable?: true;\n};",
+    summary: "Serializable failure reported after a durable wake delivery finishes.",
+    memberSummaries: {},
+    referencedTypeNames: [],
   },
   {
     name: "WorkerBundlerOptions",

--- a/apps/os/src/itx-api.generated.ts
+++ b/apps/os/src/itx-api.generated.ts
@@ -2050,8 +2050,12 @@ export type StreamSubscriberWakeRequest = {
 export type StreamSubscriberWakeResponse = {
   /** The processor's durable checkpoint offset — replay resumes after it. */
   checkpointOffset: number;
-  /** The live delivery callback the stream retains and invokes per batch. */
-  sink: ProcessEventBatch;
+  /**
+   * The live delivery callback the stream retains and invokes per batch.
+   * Calls are one-way; each batch reports completion through its independent
+   * `settleDelivery` capability.
+   */
+  sink: ProcessStreamWakeEventBatch;
   /**
    * Serializable subscriber identity (validated against
    * `StreamSubscriberDescriptor` by the stream) appended as the
@@ -3252,6 +3256,9 @@ export type ProcessorSnapshot<State> = {
   state: State;
 };
 
+/** Durable wake-mode sink. Its call result is always disposed unpulled. */
+export type ProcessStreamWakeEventBatch = (batch: StreamWakeEventBatch) => unknown;
+
 /**
  * A structural patch turning a previous JSON value into the next one. Two
  * shapes, discriminated by whether the `set` key is present:
@@ -3625,10 +3632,10 @@ export type ConnectionRuntimeState = {
   lastDeliveredAt?: string;
   /**
    * Commit-to-settled latency, stream clock only: `createdAt` of the newest
-   * event in a batch → the pulled batch result settling (the subscriber's
-   * ingest resolved). Durable (wake) lane only — ephemeral results are
-   * disposed unpulled, so ephemeral consumption is self-reported by the host
-   * through `getRuntimeState` instead. Absent until a sample exists.
+   * event in a batch → the subscriber's explicit settlement callback.
+   * Durable (wake) lane only — ephemeral results are disposed unpulled, so
+   * ephemeral consumption is self-reported by the host through
+   * `getRuntimeState` instead. Absent until a sample exists.
    */
   settleLatencyMs?: LatencyStats;
   /** Mutual-ping transport RTT to this subscriber (observer-driven sampling). Absent until pinged. */
@@ -3641,7 +3648,7 @@ export type ConnectionRuntimeState = {
    */
   subscriber?: StreamSubscriberDescriptor;
   /**
-   * True while the last batch handed to this connection's sink is unsettled —
+   * True while any batch handed to this connection's sink is unsettled —
    * exactly the signal idle teardown consults to classify a sink as wedged.
    */
   hasPendingDelivery: boolean;
@@ -3714,6 +3721,11 @@ export type StreamPingInput = { t0: number };
  * ping failures drop the sample and never affect delivery or liveness.
  */
 export type StreamPingReply = { t0: number; t1: number; t2: number };
+
+/** Internal wake-mode frame: an ordinary batch plus its one-shot settlement door. */
+export type StreamWakeEventBatch = StreamEventBatch & {
+  settleDelivery: SettleStreamWakeDelivery;
+};
 
 /** `StreamEventInput` with `type`/`payload` narrowed to one event definition. */
 type TypedStreamEventInput<Type extends string = string, Payload = Record<string, unknown>> = Omit<
@@ -3925,6 +3937,15 @@ export type ThroughputReport = {
   series: ThroughputSeries;
 };
 
+/**
+ * One-shot acknowledgement capability owned by a single durable wake batch.
+ *
+ * It is deliberately independent of the sink call's return value. A
+ * processor may append back to the stream that delivered the batch; making
+ * the stream pull that sink result creates a cyclic actor-drain dependency.
+ */
+export type SettleStreamWakeDelivery = (settlement: StreamWakeDeliverySettlement) => unknown;
+
 /** One Cloudflare Images transform step (width, height, fit, rotate, …),
  * passed through to the Images binding verbatim. */
 export type CfImageTransformOptions = { [x: string]: unknown };
@@ -3992,6 +4013,11 @@ export type ThroughputSeries = {
   bytes: number[];
 };
 
+/** The subscriber's terminal verdict for one durable wake delivery. */
+export type StreamWakeDeliverySettlement =
+  | { outcome: "ok" }
+  | { outcome: "error"; error: StreamWakeDeliveryError };
+
 /** Serializable `createApp` input. The generated browser bundles and explicit
  * text assets are retained in the host and served by worker-bundler's own
  * asset handler. ArrayBuffer assets and the esbuild plugin callback are the
@@ -4012,6 +4038,22 @@ export type WorkerBundlerCreateWorkerOptions = WorkerBundlerOptions & {
   files: WorkerFileSource;
   entryPoint?: string;
   virtualModules?: Record<string, string>;
+};
+
+/**
+ * Serializable failure reported after a durable wake delivery finishes.
+ *
+ * The settlement crosses an independent one-way RPC hop, so preserve the
+ * lifecycle flags the stream uses to distinguish a dead Durable Object from
+ * an application failure. Error prototypes and arbitrary properties do not
+ * survive that hop reliably.
+ */
+export type StreamWakeDeliveryError = {
+  name: string;
+  message: string;
+  durableObjectReset?: true;
+  overloaded?: true;
+  retryable?: true;
 };
 
 /**

--- a/docs/preview-e2e-flake-hunt.md
+++ b/docs/preview-e2e-flake-hunt.md
@@ -108,6 +108,24 @@ alarm, proves the worker-side and host-side readbacks equal the exact scheduled
 time, and immediately disarms it. A second near-term fire added no distinct
 platform coverage and made a due timer the synchronization primitive.
 
+### Round 12 proof restart after #2270
+
+PR #2270 merged that alarm-test fix to `main` at
+`78ba8ad61b3eeeba0cbdd77193510061f8466865`. Its final exact-head preview check
+ran all five app suites with zero failures and zero retries in a 254-second
+Depot run envelope: run `gdkz9dw86w`, attempt `c7zv439zvz`. The changed alarm
+test passed first try in 33.4 seconds.
+
+PostHog recorded 310 preview outcomes and 3,046 unit outcomes on that head with
+zero failures or retries. Both finalizers were complete: the preview job found
+all 9 expected artifact sources, and the unit job found all 10 expected
+workspaces. The `depot`, `github-actions`, and `github-reviews` source syncs
+were all fresh and healthy.
+
+That run accepted the fix before its squash merge; it is not part of the
+post-merge consecutive proof. The strict counter restarts at 0/25 on a fresh
+PR head based exactly on `78ba8ad61b3eeeba0cbdd77193510061f8466865`.
+
 ## Round 11 (2026-07-23, post-#2265)
 
 This round starts from `origin/main` at

--- a/packages/iterate/src/itx-api.generated.ts
+++ b/packages/iterate/src/itx-api.generated.ts
@@ -2050,8 +2050,12 @@ export type StreamSubscriberWakeRequest = {
 export type StreamSubscriberWakeResponse = {
   /** The processor's durable checkpoint offset — replay resumes after it. */
   checkpointOffset: number;
-  /** The live delivery callback the stream retains and invokes per batch. */
-  sink: ProcessEventBatch;
+  /**
+   * The live delivery callback the stream retains and invokes per batch.
+   * Calls are one-way; each batch reports completion through its independent
+   * `settleDelivery` capability.
+   */
+  sink: ProcessStreamWakeEventBatch;
   /**
    * Serializable subscriber identity (validated against
    * `StreamSubscriberDescriptor` by the stream) appended as the
@@ -3252,6 +3256,9 @@ export type ProcessorSnapshot<State> = {
   state: State;
 };
 
+/** Durable wake-mode sink. Its call result is always disposed unpulled. */
+export type ProcessStreamWakeEventBatch = (batch: StreamWakeEventBatch) => unknown;
+
 /**
  * A structural patch turning a previous JSON value into the next one. Two
  * shapes, discriminated by whether the `set` key is present:
@@ -3625,10 +3632,10 @@ export type ConnectionRuntimeState = {
   lastDeliveredAt?: string;
   /**
    * Commit-to-settled latency, stream clock only: `createdAt` of the newest
-   * event in a batch → the pulled batch result settling (the subscriber's
-   * ingest resolved). Durable (wake) lane only — ephemeral results are
-   * disposed unpulled, so ephemeral consumption is self-reported by the host
-   * through `getRuntimeState` instead. Absent until a sample exists.
+   * event in a batch → the subscriber's explicit settlement callback.
+   * Durable (wake) lane only — ephemeral results are disposed unpulled, so
+   * ephemeral consumption is self-reported by the host through
+   * `getRuntimeState` instead. Absent until a sample exists.
    */
   settleLatencyMs?: LatencyStats;
   /** Mutual-ping transport RTT to this subscriber (observer-driven sampling). Absent until pinged. */
@@ -3641,7 +3648,7 @@ export type ConnectionRuntimeState = {
    */
   subscriber?: StreamSubscriberDescriptor;
   /**
-   * True while the last batch handed to this connection's sink is unsettled —
+   * True while any batch handed to this connection's sink is unsettled —
    * exactly the signal idle teardown consults to classify a sink as wedged.
    */
   hasPendingDelivery: boolean;
@@ -3714,6 +3721,11 @@ export type StreamPingInput = { t0: number };
  * ping failures drop the sample and never affect delivery or liveness.
  */
 export type StreamPingReply = { t0: number; t1: number; t2: number };
+
+/** Internal wake-mode frame: an ordinary batch plus its one-shot settlement door. */
+export type StreamWakeEventBatch = StreamEventBatch & {
+  settleDelivery: SettleStreamWakeDelivery;
+};
 
 /** `StreamEventInput` with `type`/`payload` narrowed to one event definition. */
 type TypedStreamEventInput<Type extends string = string, Payload = Record<string, unknown>> = Omit<
@@ -3925,6 +3937,15 @@ export type ThroughputReport = {
   series: ThroughputSeries;
 };
 
+/**
+ * One-shot acknowledgement capability owned by a single durable wake batch.
+ *
+ * It is deliberately independent of the sink call's return value. A
+ * processor may append back to the stream that delivered the batch; making
+ * the stream pull that sink result creates a cyclic actor-drain dependency.
+ */
+export type SettleStreamWakeDelivery = (settlement: StreamWakeDeliverySettlement) => unknown;
+
 /** One Cloudflare Images transform step (width, height, fit, rotate, …),
  * passed through to the Images binding verbatim. */
 export type CfImageTransformOptions = { [x: string]: unknown };
@@ -3992,6 +4013,11 @@ export type ThroughputSeries = {
   bytes: number[];
 };
 
+/** The subscriber's terminal verdict for one durable wake delivery. */
+export type StreamWakeDeliverySettlement =
+  | { outcome: "ok" }
+  | { outcome: "error"; error: StreamWakeDeliveryError };
+
 /** Serializable `createApp` input. The generated browser bundles and explicit
  * text assets are retained in the host and served by worker-bundler's own
  * asset handler. ArrayBuffer assets and the esbuild plugin callback are the
@@ -4012,6 +4038,22 @@ export type WorkerBundlerCreateWorkerOptions = WorkerBundlerOptions & {
   files: WorkerFileSource;
   entryPoint?: string;
   virtualModules?: Record<string, string>;
+};
+
+/**
+ * Serializable failure reported after a durable wake delivery finishes.
+ *
+ * The settlement crosses an independent one-way RPC hop, so preserve the
+ * lifecycle flags the stream uses to distinguish a dead Durable Object from
+ * an application failure. Error prototypes and arbitrary properties do not
+ * survive that hop reliably.
+ */
+export type StreamWakeDeliveryError = {
+  name: string;
+  message: string;
+  durableObjectReset?: true;
+  overloaded?: true;
+  retryable?: true;
 };
 
 /**

--- a/packages/iterate/src/processors/rpc-types.ts
+++ b/packages/iterate/src/processors/rpc-types.ts
@@ -114,6 +114,44 @@ export type StreamEventBatch = {
 export type ProcessEventBatch = (batch: StreamEventBatch) => unknown;
 
 /**
+ * Serializable failure reported after a durable wake delivery finishes.
+ *
+ * The settlement crosses an independent one-way RPC hop, so preserve the
+ * lifecycle flags the stream uses to distinguish a dead Durable Object from
+ * an application failure. Error prototypes and arbitrary properties do not
+ * survive that hop reliably.
+ */
+export type StreamWakeDeliveryError = {
+  name: string;
+  message: string;
+  durableObjectReset?: true;
+  overloaded?: true;
+  retryable?: true;
+};
+
+/** The subscriber's terminal verdict for one durable wake delivery. */
+export type StreamWakeDeliverySettlement =
+  | { outcome: "ok" }
+  | { outcome: "error"; error: StreamWakeDeliveryError };
+
+/**
+ * One-shot acknowledgement capability owned by a single durable wake batch.
+ *
+ * It is deliberately independent of the sink call's return value. A
+ * processor may append back to the stream that delivered the batch; making
+ * the stream pull that sink result creates a cyclic actor-drain dependency.
+ */
+export type SettleStreamWakeDelivery = (settlement: StreamWakeDeliverySettlement) => unknown;
+
+/** Internal wake-mode frame: an ordinary batch plus its one-shot settlement door. */
+export type StreamWakeEventBatch = StreamEventBatch & {
+  settleDelivery: SettleStreamWakeDelivery;
+};
+
+/** Durable wake-mode sink. Its call result is always disposed unpulled. */
+export type ProcessStreamWakeEventBatch = (batch: StreamWakeEventBatch) => unknown;
+
+/**
  * The batch a PUSH subscription's receiver is invoked with: the delivery
  * coordinates and events, plus the fields an at-least-once stateless receiver
  * needs to dedupe and self-configure. Deliberately NOT the live lanes'
@@ -247,8 +285,12 @@ export type StreamSubscriberWakeRequest = {
 export type StreamSubscriberWakeResponse = {
   /** The processor's durable checkpoint offset — replay resumes after it. */
   checkpointOffset: number;
-  /** The live delivery callback the stream retains and invokes per batch. */
-  sink: ProcessEventBatch;
+  /**
+   * The live delivery callback the stream retains and invokes per batch.
+   * Calls are one-way; each batch reports completion through its independent
+   * `settleDelivery` capability.
+   */
+  sink: ProcessStreamWakeEventBatch;
   /**
    * Serializable subscriber identity (validated against
    * `StreamSubscriberDescriptor` by the stream) appended as the

--- a/packages/iterate/src/processors/stream-processor-registry.ts
+++ b/packages/iterate/src/processors/stream-processor-registry.ts
@@ -38,6 +38,10 @@
 //      time);
 //   3. building each runner's `durability` adapters from `ctx`
 //      (durable-object-processor-durability.ts);
+//   4. the DO transport boundary — wake sink calls return immediately and
+//      their eventual runner outcome crosses an independent one-way
+//      settlement capability. This must remain transport adaptation only;
+//      frame semantics stay in the runner.
 //
 // plus the two responsibilities that live ABOVE any single runner and so
 // cannot move into one: the node's LIVE-STATE assembly and the catch-up door.
@@ -70,10 +74,16 @@
 // retry-forever.
 
 import * as cloudflareWorkers from "cloudflare:workers";
+import { disposeIgnoredRpcResult, retainCallback } from "../sdk/capnweb/live-state/retain.ts";
 import { LiveState } from "../sdk/capnweb/live-state/engine.ts";
 import type { ProcessorStream } from "./stream-handle.ts";
 import type { StreamEvent } from "./schemas.ts";
-import type { StreamSubscriberWakeRequest, StreamSubscriberWakeResponse } from "./rpc-types.ts";
+import type {
+  StreamSubscriberWakeRequest,
+  StreamSubscriberWakeResponse,
+  StreamWakeDeliveryError,
+  StreamWakeDeliverySettlement,
+} from "./rpc-types.ts";
 import type { ProcessorState } from "./processor-contracts.ts";
 import type { ProcessorReads, StreamProcessor } from "./stream-processor.ts";
 import { StreamProcessorRunner } from "./stream-processor-runner.ts";
@@ -158,6 +168,54 @@ type RegistryEntry = {
   processor: RegisterableProcessor;
   runner: StreamProcessorRunner<any>;
 };
+
+function serializeWakeDeliveryError(error: unknown): StreamWakeDeliveryError {
+  const candidate =
+    typeof error === "object" && error !== null
+      ? (error as {
+          durableObjectReset?: unknown;
+          message?: unknown;
+          name?: unknown;
+          overloaded?: unknown;
+          retryable?: unknown;
+        })
+      : undefined;
+  return {
+    name: typeof candidate?.name === "string" ? candidate.name : "Error",
+    message:
+      typeof candidate?.message === "string"
+        ? candidate.message
+        : String(error) || "unknown delivery failure",
+    ...(candidate?.durableObjectReset === true ? { durableObjectReset: true as const } : {}),
+    ...(candidate?.overloaded === true ? { overloaded: true as const } : {}),
+    ...(candidate?.retryable === true ? { retryable: true as const } : {}),
+  };
+}
+
+/**
+ * Report one terminal wake-delivery outcome without pulling the report call's
+ * result. The report itself is the message; waiting for its return value would
+ * merely move the actor-drain cycle to the acknowledgement lane.
+ */
+function reportWakeDeliverySettlement(
+  settleDelivery: (settlement: StreamWakeDeliverySettlement) => unknown,
+  settlement: StreamWakeDeliverySettlement,
+): void {
+  let result: unknown;
+  try {
+    result = settleDelivery(settlement);
+  } catch (error) {
+    console.warn("stream wake delivery settlement could not be dispatched", { error });
+    return;
+  }
+  try {
+    disposeIgnoredRpcResult(result);
+  } catch (error) {
+    // The message was already dispatched. Cleanup failure must not turn a
+    // completed processor attempt into a second, contradictory failure.
+    console.warn("stream wake delivery settlement result disposal failed", { error });
+  }
+}
 
 export type StreamProcessorRegistry<Live extends object = Record<string, unknown>> = {
   readonly stream: ProcessorStream;
@@ -579,11 +637,17 @@ export function createStreamProcessorRegistry<Live extends object = Record<strin
       }
       const name = resolveProcessorName(args);
       const entry = requireEntry(name);
-      // The runner's sink IS the handshake sink: it already serializes and
-      // offset-dedupes frames, tracks the WHOLE attempt on the keepalive, and
-      // runs the trailing type-unfiltered pull behind a consumes-filtered
-      // batch left short of the raw head (codex review #1) — the registry
-      // must not wrap it in a second copy of any of that.
+      // The runner owns all frame semantics: serialization, offset dedupe,
+      // whole-attempt keepalive, and the trailing unfiltered catch-up. The
+      // registry adds only the transport boundary: the stream's sink call
+      // returns immediately, while this DO reports the eventual attempt
+      // outcome through the batch's independent one-shot capability.
+      //
+      // That separation is load-bearing. Processor blockers routinely append
+      // back to the same stream that delivered them. Returning `attempt` from
+      // this RPC makes the stream pull a result that cannot settle until the
+      // nested append reaches the stream again — a cyclic actor-drain tree
+      // that workerd can retain until idle teardown.
       const opened = await entry.runner.openDelivery();
       // The capability assembles runtime state from its two honest sources:
       // the SNAPSHOT from the runner (the cursor owner) and the runtime bag +
@@ -599,7 +663,60 @@ export function createStreamProcessorRegistry<Live extends object = Record<strin
         // watermark, and a reduction-pinned offset could skip events whose
         // effects were never acknowledged (codex review §2).
         checkpointOffset: opened.checkpointOffset,
-        sink: opened.sink,
+        sink: (batch) => {
+          const { settleDelivery, ...frame } = batch;
+          let retainedSettlement;
+          try {
+            // This callback parameter must outlive the one-way sink call. One
+            // retained duplicate is owned by exactly this frame and released
+            // immediately after its terminal report.
+            retainedSettlement = retainCallback<StreamWakeDeliverySettlement>(settleDelivery);
+          } catch (error) {
+            // Do not process a frame whose result can never be reported. The
+            // stream keeps it pending and its bounded idle recovery re-pokes
+            // from the processor's unchanged durable checkpoint.
+            console.error("stream wake delivery settlement capability could not be retained", {
+              error,
+            });
+            return;
+          }
+
+          let attempt: Promise<void>;
+          try {
+            attempt = opened.sink(frame);
+          } catch (error) {
+            attempt = Promise.reject(error);
+          }
+          const report = attempt.then(
+            () =>
+              reportWakeDeliverySettlement(retainedSettlement, {
+                outcome: "ok",
+              }),
+            (error: unknown) =>
+              reportWakeDeliverySettlement(retainedSettlement, {
+                outcome: "error",
+                error: serializeWakeDeliveryError(error),
+              }),
+          );
+          // The sink response is already complete, but the subscriber
+          // incarnation must survive long enough to send its independent
+          // terminal report. The runner separately tracks the actual attempt
+          // and its crash-recovery alarm.
+          ctx.waitUntil(
+            report.finally(() => {
+              try {
+                retainedSettlement[Symbol.dispose]();
+              } catch (error) {
+                // The terminal report was already dispatched. A cleanup
+                // failure is observable, but cannot rewrite its verdict or
+                // reject the hosting waitUntil continuation.
+                console.warn("stream wake delivery settlement capability disposal failed", {
+                  error,
+                });
+              }
+            }),
+          );
+        },
         subscriber: {
           processor: { announcement: announceContract(entry.processor.contract) },
         },

--- a/packages/iterate/src/processors/stream-processor-runner.ts
+++ b/packages/iterate/src/processors/stream-processor-runner.ts
@@ -16,8 +16,9 @@
 // anything incarnation-shaped through the optional `keepAlive` hook.
 //
 // Delivery: `openDelivery()` answers the wake handshake — a resume cursor plus
-// a `sink`. The sink IS the `processEventBatch` wire callback the transport
-// invokes per delivered frame; transport batching stays entirely inside it.
+// a frame-attempt `sink`. A host transport may wrap that sink (production
+// wake RPC does so to return one-way and report settlement independently),
+// but transport batching stays entirely inside it.
 // The runner reduces/processes ONE EVENT AT A TIME, so batch division is
 // invisible to processor semantics (the harness pins this: one batch,
 // singletons, or random partitions of the same journal must produce identical
@@ -300,9 +301,10 @@ export class StreamProcessorRunner<
    * its delivery watermark, and resuming from a reduction-pinned snapshot
    * offset could skip events whose effects were never acknowledged.
    *
-   * The sink is the internal `processEventBatch` wire callback — the ONLY
-   * place transport batching exists; inside it the runner reduces and
-   * processes one event at a time.
+   * The sink is the internal frame-attempt callback — the ONLY place
+   * transport batching exists; inside it the runner reduces and processes
+   * one event at a time. A hosting transport may adapt how its promise is
+   * observed, but must not duplicate these semantics.
    */
   async openDelivery(): Promise<{
     checkpointOffset: number;

--- a/packages/iterate/src/sdk/capnweb/live-state/retain.ts
+++ b/packages/iterate/src/sdk/capnweb/live-state/retain.ts
@@ -18,7 +18,8 @@ export type RetainedCallback<Arg> = ((arg: Arg) => unknown) &
  * Web stubs expose no own property descriptors and a Workers RPC property access
  * can fabricate a pipelined method that rejects at call time, so we wire whatever
  * the stub claims and swallow registration failures. `onRpcBroken` is only a
- * prompt hint; observing a delivery rejection is the reliable death signal.
+ * prompt hint; callers that need a terminal verdict must model one explicitly
+ * (for example, the durable wake lane's independent settlement capability).
  */
 export function retainCallback<Arg>(callback: (arg: Arg) => unknown): RetainedCallback<Arg> {
   const retainable = callback as ((arg: Arg) => unknown) &


### PR DESCRIPTION
## Summary

- Removes a cyclic Durable Object RPC lifecycle from durable stream wake delivery.
- Keeps wake delivery non-gating: the stream sends a one-way batch, while the processor reports its eventual durable outcome through an independent one-way settlement capability.
- Preserves the existing failure contract: success records settle latency; serialized failures and broken transports enter the same bounded backoff, redelivery, and parking state machine.
- Adds regression coverage for unpulled batch results, asynchronous settlement, lifecycle error classification, pending/wedged delivery recovery, stale-settlement fencing, and broken-transport backoff.

No test is skipped or quarantined by this PR. The implementation is 15 files and +836/-234 lines total (+602/-135 significant), not a new service or builder subsystem.

## Why this was necessary

Round 12's first exact-head preview run passed all canonical suites with zero retries, but took 302 seconds and failed the strict `<300s` budget.

The outlier was `web › repl-examples.spec.ts › journal-is-the-record`:

- total test: 65 seconds;
- project fixture: 60.812 seconds;
- historical project-fixture p50/p95: 7.99s / 12.34s;
- config-repo `repos/created` commit to root-stream cross-post: 52.311 seconds.

Cloudflare trace `27d035233c12db457d4ce86d0d3b1b96` showed the config Stream Durable Object alarm remaining open for 299.907 seconds, including a 247.710-second Durable Object subrequest. The processor's useful RPC work was only 2.026 seconds; the request tree did no useful work for roughly 50 seconds before the cross-post resumed.

Trace: https://dash.cloudflare.com/376ef7ed81b0573f93524de763666c15/observability/traces/27d035233c12db457d4ce86d0d3b1b96

The old wake protocol returned the processor attempt promise from the sink call. The stream pulled that result as its liveness signal. Processors commonly append back to the same stream while completing the attempt, so workerd could retain this cycle:

`stream delivery → processor attempt → append to stream → original delivery result`

The cycle consumed little CPU but kept the actor/request-drain tree alive until an idle lifecycle boundary released it. That explains the isolated 52-second tail despite low runner load.

## New protocol

For each durable wake batch:

1. The stream creates a one-shot `settleDelivery` capability and marks the delivery pending.
2. The stream invokes the processor sink and disposes its result unpulled.
3. The processor retains the settlement capability, starts the ordinary runner attempt, and returns from the sink immediately.
4. When durable processing finishes, the processor reports either `{ outcome: "ok" }` or a serialized error through the independent capability; that report's result is also disposed unpulled.
5. The stream records success or enters its existing retry/park state machine on failure.

The durable checkpoint remains authoritative. If a transport dies before settlement arrives, the delivery stays pending; bounded idle teardown classifies it as wedged and re-pokes from the unchanged checkpoint. A late settlement is fenced to the exact connection that created it and cannot close a replacement connection.

Broken transports are also fail-closed. `onRpcBroken` now enters the same nack/backoff/park machine before closing the connection, so disposing the one-way result cannot create a hot `poke → deliver → close → poke` loop.

## The six-second false green

The six-second preview check on PR #2262 was invalid. Deployment reuse had incorrectly promoted a prior head's result by skipping both redeployment **and the tests**.

That was fixed and merged separately in #2263 (`707903ca7`): reuse may skip an unchanged deployment, but every explicitly triggered PR head must still execute the canonical tests. Missing testable state or a missing lease now fails closed.

This PR proves that correction as well: Dummy Petshop reused its unchanged deployment in 51ms, then still ran and passed all six tests in 5.167s. The other apps deployed and tested normally.

## Validation before preview

- `pnpm typecheck` — passed.
- `pnpm lint` — passed with zero warnings/errors.
- `pnpm test` — passed across the monorepo.
- OS unit suite — 233 files passed; 2,285 passed, 6 expected failures, 1 pre-existing skip; 43.66s.
- Focused final stream-subscriber suite — 47/47 passed in 563ms.
- Formatting and diff checks — passed.

## Exact-head preview acceptance

Head: `576157256bb3da73e5e7f488f0d4c8f07dd41313`

- GitHub check: https://github.com/iterate/iterate/actions/runs/297064800705252
- Depot workflow: https://depot.dev/orgs/0p91s0lz49/workflows/1w2np2p7w2?job=2xswh11402
- Check duration: **3m47s** (`05:44:55Z–05:48:42Z`).
- Depot-observed attempt: **3m40s** (`05:44:57Z–05:48:37Z`).
- One attempt; every required check green; zero unresolved review threads.
- Final preview result: `tests finished: 4 passed, 0 failed`.

| App | Deploy | Test | Result |
| --- | ---: | ---: | --- |
| OS | 61.377s | 145.115s | Playwright 63/63; Vitest 164 passed, 1 expected failure, 5 pre-existing skips; smoke/rollout lanes passed |
| Streams Example App | 24.209s | 92.577s | Playwright 31 passed, 1 pre-existing skip; Vitest 21/21 |
| Auth | 15.746s | 12.818s | 5/5 |
| Dummy Petshop | 0.051s reused | 5.167s | 6/6; tests executed despite deployment reuse |

The original tail target returned to its normal envelope:

- `journal-is-the-record` Playwright: **11.232s** (was 65s).
- The same example under Vitest: **7.639s**.
- Both recorded zero retries.

## Telemetry proof

The preview uploaded nine artifacts and normalized 6,713 CI events. A PostHog query scoped to workflow run `297064800705252` found:

- 3,349 final test records;
- **3,342 passed, 7 explicit pre-existing skips, 0 failed**;
- **0 passed-after-retry and 0 retries**;
- 166 separately recorded test attempts, all attempt index 0 and none marked retry or failed.

The final `os-preview-16` worker version was `f0250fdb-bee9-46e2-89c3-c48bd192b6b7`. Its Cloudflare telemetry window showed:

- no invalid wake-settlement event;
- one deliberately induced Durable Object reset reaching the changed wake path;
- that reset classified as the warning `stream durable sink unavailable; backing off before re-poke`, with `reason: delivery-failed`, not as an error;
- no repeated warning or hot-loop signature; the affected suite completed green with zero retry.

The wider preview test window also contains the existing failure-injection signals from tests that deliberately kill Durable Objects, assert rejected itx calls/Slack failure paths, and erase disposable projects. No new error fingerprint tied to the settlement protocol appeared.

Runner capacity was not the constraint: preview CPU averaged 12.7% and peaked at 52.5%; memory averaged 10.0% and peaked at 22.3%.

## Remaining path to 3m30

This run is safely below five minutes but **17 seconds above** the 3m30 stretch target. The critical path is now ordinary OS work rather than the removed 50-second actor-drain tail:

- OS deploy: 37.0s command + 24.3s readiness.
- OS E2E: 145.1s, dominated by the 139s Playwright lane.
- OS Vitest wall time: 60.2s; the ITX concurrency case is 47.2s and the examples matrix is 58.8s, but these run in parallel with Playwright.
- Long Playwright fixtures remain in the resilience/project scenarios; the slowest recorded final test was 104.3s including setup.
- Streams Example App remains a 92.6s parallel lane.

A larger runner is unlikely to buy the missing 17 seconds by itself because the preview box is mostly idle. The next best candidates are shortening OS readiness polling and removing deliberate waits/setup from the longest Playwright lane while retaining its actual resilience coverage.

Formal post-fix streak: **1/25** clean canonical runs.

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-23T06:01:12.198Z",
      "deployedAt": "2026-07-23T05:45:44.529Z",
      "headSha": "576157256bb3da73e5e7f488f0d4c8f07dd41313",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-16.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/297064800705252",
      "shortSha": "5761572",
      "cleanupDurationMs": 15730,
      "deployDurationMs": 61377,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 37033,
      "deployReadinessDurationMs": 24341,
      "deployedWorkerName": "os-preview-16",
      "deployedWorkerVersion": "f0250fdb-bee9-46e2-89c3-c48bd192b6b7",
      "testDurationMs": 145115,
      "testRetries": null,
      "workerSizeKib": 19787.58,
      "workerGzipKib": 5006.08,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5013.56
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-23T06:01:00.140Z",
      "deployedAt": "2026-07-23T05:45:23.213Z",
      "headSha": "576157256bb3da73e5e7f488f0d4c8f07dd41313",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-16.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/297064800705252",
      "shortSha": "5761572",
      "cleanupDurationMs": 3669,
      "deployDurationMs": 15746,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 15714,
      "deployReadinessDurationMs": 28,
      "deployedWorkerName": "auth-preview-16",
      "deployedWorkerVersion": "a9228761-3d8d-4781-8a1a-8d0af14960c5",
      "testDurationMs": 12818,
      "testRetries": null,
      "workerSizeKib": 3965.97,
      "workerGzipKib": 811.3,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-23T06:01:06.430Z",
      "deployedAt": "2026-07-23T05:45:19.959Z",
      "headSha": "576157256bb3da73e5e7f488f0d4c8f07dd41313",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-16.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/297064800705252",
      "shortSha": "5761572",
      "cleanupDurationMs": 9958,
      "deployDurationMs": 24209,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 12458,
      "deployReadinessDurationMs": 11745,
      "deployedWorkerName": "streams-example-app-preview-16",
      "deployedWorkerVersion": "481188d7-805e-4cd1-ac31-344443f343a4",
      "testDurationMs": 92577,
      "testRetries": null,
      "workerSizeKib": 5161.87,
      "workerGzipKib": 1473.57,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-23T06:00:57.447Z",
      "deployedAt": "2026-07-23T04:35:34.127Z",
      "headSha": "576157256bb3da73e5e7f488f0d4c8f07dd41313",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-16.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/297064800705252",
      "shortSha": "5761572",
      "cleanupDurationMs": 971,
      "deployDurationMs": 51,
      "deployConfigDurationMs": 7,
      "deployReuseProofDurationMs": 12,
      "deployedWorkerName": "dummy-petshop-preview-16",
      "deployedWorkerVersion": "7cf4637f-ff02-44a9-a886-a4f44382b4ee",
      "testDurationMs": 5167,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `5761572` | [https://auth.iterate-preview-16.com](https://auth.iterate-preview-16.com) | 811.3 KiB | 15.7s | 12.8s |  | 3.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/297064800705252) | 2026-07-23T06:01:00.140Z | Preview app released. |
| Dummy Petshop | released | `5761572` | [https://dummy-petshop.iterate-preview-16.com](https://dummy-petshop.iterate-preview-16.com) | 198.3 KiB | 51ms | 5.2s |  | 971ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/297064800705252) | 2026-07-23T06:00:57.447Z | Preview app released. |
| OS | released | `5761572` | [https://os.iterate-preview-16.com](https://os.iterate-preview-16.com) | 4.89 MiB (-7.5 KiB vs main) | 61.4s | 145.1s |  | 15.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/297064800705252) | 2026-07-23T06:01:12.198Z | Preview app released. |
| Streams Example App | released | `5761572` | [https://streams.iterate-preview-16.com](https://streams.iterate-preview-16.com) | 1.44 MiB | 24.2s | 92.6s |  | 10.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/297064800705252) | 2026-07-23T06:01:06.430Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 576157256bb3da73e5e7f488f0d4c8f07dd41313. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +346 -154 | +212 -77 🟩🟩🟩🟩🟥 |
| Tests | +294 -43 | +264 -33 🟩🟩🟩🟩🟥 |
| Docs | +46 -20 | +42 -20 🟩⬜⬜⬜⬜ |
| Generated | +150 -17 | +84 -5 🟩⬜⬜⬜⬜ |
| **Total** | **+836 -234** | **+602 -135** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 78ba8ad and 5761572, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->