### PR TITLE
fix(os): avoid Artifacts create-read race

### DIFF
--- a/apps/os/src/domains/repos/artifact-creation.test.ts
+++ b/apps/os/src/domains/repos/artifact-creation.test.ts
@@ -13,12 +13,18 @@ test("an existing seeded repo reports its last push", async () => {
     defaultBranch: "main",
   });
 
-  expect(result).toEqual({ created: false, lastPushAt: "2026-07-20T12:00:00.000Z" });
+  expect(result).toEqual({
+    created: false,
+    initialWriteToken: null,
+    lastPushAt: "2026-07-20T12:00:00.000Z",
+  });
 });
 
-test("a new repo is created with its default branch", async () => {
+test("a new repo preserves create's initial write token without reading it back", async () => {
   const artifacts = {
-    create: vi.fn(async () => {}),
+    create: vi.fn(async () => ({
+      token: "art_v1_initial?expires=1760000000",
+    })),
     get: vi.fn(),
   };
 
@@ -26,7 +32,11 @@ test("a new repo is created with its default branch", async () => {
     defaultBranch: "trunk",
   });
 
-  expect(result).toEqual({ created: true, lastPushAt: null });
+  expect(result).toEqual({
+    created: true,
+    initialWriteToken: "art_v1_initial",
+    lastPushAt: null,
+  });
   expect(artifacts.create).toHaveBeenCalledExactlyOnceWith("project-repo", {
     setDefaultBranch: "trunk",
   });
@@ -45,7 +55,88 @@ test("an unseeded existing repo remains eligible for recovery", async () => {
     defaultBranch: "main",
   });
 
-  expect(result).toEqual({ created: false, lastPushAt: null });
+  expect(result).toEqual({
+    created: false,
+    initialWriteToken: null,
+    lastPushAt: null,
+  });
+});
+
+test("an ambiguous create waits for the existing repo to become readable", async () => {
+  vi.useFakeTimers();
+  try {
+    const artifacts = {
+      create: vi.fn(async () => {
+        throw artifactError("ALREADY_EXISTS");
+      }),
+      get: vi
+        .fn()
+        .mockRejectedValueOnce(artifactError("NOT_FOUND"))
+        .mockRejectedValueOnce(artifactError("NOT_FOUND"))
+        .mockResolvedValueOnce({ lastPushAt: null }),
+    };
+
+    const result = getOrCreateArtifact(artifacts, "project-repo", {
+      defaultBranch: "main",
+    });
+    await vi.runAllTimersAsync();
+
+    await expect(result).resolves.toEqual({
+      created: false,
+      initialWriteToken: null,
+      lastPushAt: null,
+    });
+    expect(artifacts.create).toHaveBeenCalledOnce();
+    expect(artifacts.get).toHaveBeenCalledTimes(3);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("an existing repo that never materializes remains a retryable obligation", async () => {
+  vi.useFakeTimers();
+  try {
+    const artifacts = {
+      create: vi.fn(async () => {
+        throw artifactError("ALREADY_EXISTS");
+      }),
+      get: vi.fn(async () => {
+        throw artifactError("NOT_FOUND");
+      }),
+    };
+
+    const result = getOrCreateArtifact(artifacts, "project-repo", {
+      defaultBranch: "main",
+    });
+    const rejection = expect(result).rejects.toMatchObject({
+      name: "RepoNotSeededError",
+    });
+    await vi.runAllTimersAsync();
+
+    await rejection;
+    expect(artifacts.create).toHaveBeenCalledOnce();
+    expect(artifacts.get.mock.calls.length).toBeGreaterThan(1);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("an existing repo does not hide a real Artifacts read failure", async () => {
+  const artifacts = {
+    create: vi.fn(async () => {
+      throw artifactError("ALREADY_EXISTS");
+    }),
+    get: vi.fn(async () => {
+      throw artifactError("INTERNAL_ERROR");
+    }),
+  };
+
+  await expect(
+    getOrCreateArtifact(artifacts, "project-repo", {
+      defaultBranch: "main",
+    }),
+  ).rejects.toMatchObject({ code: "INTERNAL_ERROR" });
+  expect(artifacts.get).toHaveBeenCalledOnce();
 });
 
 function artifactError(code: string) {

--- a/apps/os/src/domains/repos/artifact-creation.ts
+++ b/apps/os/src/domains/repos/artifact-creation.ts
@@ -1,22 +1,92 @@
+import { isRepoNotSeededError, RepoNotSeededError } from "./utils.ts";
+
+// Project birth has one 60s sibling barrier. Keep this protocol-level
+// readiness wait inside it so a still-broken repo returns to the durable
+// redelivery lane instead of pinning the project frame indefinitely.
+const EXISTING_ARTIFACT_READY_TIMEOUT_MS = 45_000;
+const EXISTING_ARTIFACT_READY_INITIAL_RETRY_MS = 250;
+const EXISTING_ARTIFACT_READY_MAX_RETRY_MS = 4_000;
+
+export type GetOrCreateArtifactResult =
+  | {
+      created: true;
+      initialWriteToken: string;
+      lastPushAt: null;
+    }
+  | {
+      created: false;
+      initialWriteToken: null;
+      lastPushAt: string | null;
+    };
+
 /**
  * Create an Artifacts repository idempotently and report whether it has
  * already received a push.
+ *
+ * A successful create returns the initial write token Cloudflare minted with
+ * the repo. Preserve it: immediately calling get()+createToken() is both
+ * redundant and a create/read consistency race.
+ *
+ * An ALREADY_EXISTS response can mean a prior attempt committed but its
+ * response was lost. In that case the create plane may reserve the name
+ * before get() can observe the repo. Wait here with bounded exponential
+ * backoff rather than repeatedly hammering create and surfacing every
+ * not-ready observation through the durable processor error path.
  */
 export async function getOrCreateArtifact(
   artifacts: {
-    create(name: string, input: { setDefaultBranch: string }): Promise<unknown>;
+    create(
+      name: string,
+      input: { setDefaultBranch: string },
+    ): Promise<Pick<ArtifactsCreateRepoResult, "token">>;
     get(name: string): Promise<{ lastPushAt: string | null }>;
   },
   name: string,
   input: { defaultBranch: string },
-): Promise<{ created: boolean; lastPushAt: string | null }> {
+): Promise<GetOrCreateArtifactResult> {
   try {
-    await artifacts.create(name, { setDefaultBranch: input.defaultBranch });
-    return { created: true, lastPushAt: null };
+    const created = await artifacts.create(name, { setDefaultBranch: input.defaultBranch });
+    return {
+      created: true,
+      initialWriteToken: stripArtifactTokenExpiry(created.token),
+      lastPushAt: null,
+    };
   } catch (error) {
     if ((error as { code?: string }).code !== "ALREADY_EXISTS") throw error;
   }
 
-  const existing = await artifacts.get(name);
-  return { created: false, lastPushAt: existing.lastPushAt };
+  const existing = await waitForExistingArtifact(artifacts, name);
+  return { created: false, initialWriteToken: null, lastPushAt: existing.lastPushAt };
+}
+
+async function waitForExistingArtifact(
+  artifacts: { get(name: string): Promise<{ lastPushAt: string | null }> },
+  name: string,
+): Promise<{ lastPushAt: string | null }> {
+  const deadline = Date.now() + EXISTING_ARTIFACT_READY_TIMEOUT_MS;
+  let lastError: unknown;
+  let retryDelayMs = EXISTING_ARTIFACT_READY_INITIAL_RETRY_MS;
+
+  for (;;) {
+    try {
+      return await artifacts.get(name);
+    } catch (error) {
+      if (!isRepoNotSeededError(error)) throw error;
+      lastError = error;
+    }
+
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) break;
+    await new Promise((resolve) => setTimeout(resolve, Math.min(retryDelayMs, remainingMs)));
+    retryDelayMs = Math.min(retryDelayMs * 2, EXISTING_ARTIFACT_READY_MAX_RETRY_MS);
+  }
+
+  throw new RepoNotSeededError(
+    `Artifact ${name} did not become readable within ${EXISTING_ARTIFACT_READY_TIMEOUT_MS}ms.`,
+    { cause: lastError },
+  );
+}
+
+export function stripArtifactTokenExpiry(token: string): string {
+  return token.split("?expires=")[0] ?? token;
 }

--- a/apps/os/src/domains/repos/artifact-creation.ts
+++ b/apps/os/src/domains/repos/artifact-creation.ts
@@ -1,8 +1,8 @@
 import { isRepoNotSeededError, RepoNotSeededError } from "./utils.ts";
 
-// Project birth has one 60s sibling barrier. Keep this protocol-level
-// readiness wait inside it so a still-broken repo returns to the durable
-// redelivery lane instead of pinning the project frame indefinitely.
+// Keep this protocol-level readiness wait bounded so a still-broken repo
+// returns to the durable redelivery lane instead of pinning the project frame
+// indefinitely. Project.create() has a separate, tighter caller deadline.
 const EXISTING_ARTIFACT_READY_TIMEOUT_MS = 45_000;
 const EXISTING_ARTIFACT_READY_INITIAL_RETRY_MS = 250;
 const EXISTING_ARTIFACT_READY_MAX_RETRY_MS = 4_000;

--- a/apps/os/src/domains/repos/repo-durable-object.ts
+++ b/apps/os/src/domains/repos/repo-durable-object.ts
@@ -72,7 +72,11 @@ import {
 import { SingleFlightValue } from "./single-flight-value.ts";
 import { githubFastForwardTransferDepth, githubSyncBaseCommitOid } from "./github-sync-utils.ts";
 import { importGithubArtifactWithInitialPushCapture } from "./artifact-import.ts";
-import { getOrCreateArtifact } from "./artifact-creation.ts";
+import {
+  getOrCreateArtifact,
+  stripArtifactTokenExpiry,
+  type GetOrCreateArtifactResult,
+} from "./artifact-creation.ts";
 
 const REPO_WRITE_TOKEN_TTL_SECONDS = 365 * 24 * 60 * 60;
 const ARTIFACT_HEAD_VISIBILITY_RETRIES = 5;
@@ -1735,7 +1739,7 @@ export class RepoDurableObject extends DurableObject<Env> {
   private async createEmptyArtifactRepo() {
     const artifactName = this.artifactName();
     const timing = { projectId: this.#name.projectId, path: this.#name.path };
-    const { lastPushAt } = await timedStep("create-timing", timing, "artifact-get-or-create", () =>
+    const artifact = await timedStep("create-timing", timing, "artifact-get-or-create", () =>
       this.getOrCreateArtifact(artifactName),
     );
     const defaultBranch = REPO_DEFAULT_BRANCH;
@@ -1744,11 +1748,18 @@ export class RepoDurableObject extends DurableObject<Env> {
     // A prior push is authoritative evidence that an existing Artifact is
     // already seeded. Recovery only needs to journal repos/created; cloning the
     // whole repo to rediscover that fact can exceed a Repo DO's memory limit.
-    if (lastPushAt !== null) return { artifactName, defaultBranch, remote };
+    if (artifact.lastPushAt !== null) return { artifactName, defaultBranch, remote };
 
-    const token = await timedStep("create-timing", timing, "artifact-token", () =>
-      artifactToken(this.requireArtifacts(), artifactName),
-    );
+    // create() already minted the initial write token. Using it avoids an
+    // immediate get()+createToken() against a repository whose create result
+    // is authoritative but whose read replica may not have caught up. A
+    // recovered ALREADY_EXISTS drive has no access to that one-time token, so
+    // only that path mints a replacement after its readiness barrier.
+    const token =
+      artifact.initialWriteToken ??
+      (await timedStep("create-timing", timing, "artifact-token", () =>
+        artifactToken(this.requireArtifacts(), artifactName),
+      ));
 
     const seeded = await timedStep("create-timing", timing, "artifact-seed", () =>
       seedArtifactRepo({
@@ -1804,9 +1815,7 @@ export class RepoDurableObject extends DurableObject<Env> {
     };
   }
 
-  private async getOrCreateArtifact(
-    name: string,
-  ): Promise<{ created: boolean; lastPushAt: string | null }> {
+  private async getOrCreateArtifact(name: string): Promise<GetOrCreateArtifactResult> {
     return await getOrCreateArtifact(this.requireArtifacts(), name, {
       defaultBranch: REPO_DEFAULT_BRANCH,
     });
@@ -1831,7 +1840,7 @@ export class RepoDurableObject extends DurableObject<Env> {
 async function artifactToken(artifacts: Artifacts, name: string) {
   const repo = await artifacts.get(name);
   const { plaintext } = await repo.createToken("write", REPO_WRITE_TOKEN_TTL_SECONDS);
-  return plaintext.split("?expires=")[0] ?? plaintext;
+  return stripArtifactTokenExpiry(plaintext);
 }
 
 async function seedArtifactRepo(input: {

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -421,6 +421,7 @@ const PARALLEL_API_BASE_URL = "https://api.parallel.ai";
 // A wedged processor must fail the caller loudly instead of parking an RPC
 // forever; the durable birth events remain committed for ordinary redelivery.
 const PROCESSOR_BIRTH_WAIT_TIMEOUT_MS = 75_000;
+const PROJECT_CREATE_READY_TIMEOUT_MS = 15_000;
 
 function parallelOpenApiTarget(input: { egress: FetchOnly; parent: string }): OpenApiRpc {
   if (!parseConfig(env).integrations.parallel?.apiKey) {
@@ -5200,6 +5201,7 @@ export class ProjectRpcTarget extends IterateRpcTarget<"Project"> {
     args: { organizationSlug?: string; projectId?: string } = {},
     options?: { waitUntilReady?: boolean },
   ): Promise<ProjectRpcTarget> {
+    const projectCreateDeadline = Date.now() + PROJECT_CREATE_READY_TIMEOUT_MS;
     if ("projectId" in this.#props && this.#capabilityHost.path !== "/") {
       throw new Error("project create() is only available on the project-root handle");
     }
@@ -5304,10 +5306,10 @@ export class ProjectRpcTarget extends IterateRpcTarget<"Project"> {
           },
         );
     // Both lanes drive processor birth through the same wait; they differ
-    // only in who pays for it. A create must never leave its caller parked
-    // behind a wedged processor indefinitely: one project birth frame has a
-    // shared 60s sibling-barrier deadline; 75s leaves 15s for
-    // durable-delivery backoff and transport redial.
+    // only in who pays for it. The processor acknowledgement has its own
+    // bounded recovery window, while the ready lane below gives the caller a
+    // much tighter project-level deadline. The birth facts remain committed
+    // and durable delivery can finish the project after a caller times out.
     const driveBirth = (step: string) =>
       timedStep("create-timing", timing, step, () =>
         Promise.all([
@@ -5333,14 +5335,20 @@ export class ProjectRpcTarget extends IterateRpcTarget<"Project"> {
       return this;
     }
 
-    // Ready lane: the birth events are already committed and durable delivery
-    // is already driving both processors, so the seed's own barrier and the
-    // birth wait overlap safely — sequencing them would only add latency.
+    // Ready lane: start the terminal project/ready wait alongside the sibling
+    // work. Its deadline is measured from entry to create(), so a slow
+    // processor or control-plane call fails the caller after roughly 15s
+    // instead of consuming an entire test timeout. Promise.all rejects at that
+    // boundary; the already-committed birth facts continue through durable
+    // delivery and an explicit caller/test retry can redial cleanly.
+    const remainingReadyTimeoutMs = Math.max(1, projectCreateDeadline - Date.now());
     await Promise.all([
       timedStep("create-timing", timing, "seed-project-api-key", seedProjectApiKey),
       driveBirth("wait-project-birth"),
+      timedStep("create-timing", timing, "wait-project-ready", () =>
+        this.waitUntilReady({ timeoutMs: remainingReadyTimeoutMs }),
+      ),
     ]);
-    await timedStep("create-timing", timing, "wait-project-ready", () => this.waitUntilReady());
     return this;
   }
 
@@ -5428,7 +5436,7 @@ export class ProjectRpcTarget extends IterateRpcTarget<"Project"> {
       // Tight on purpose: the saga should complete in seconds (see
       // tasks/os-cold-create-latency.md for the cold-slot outliers that must
       // be fixed, not waited out). Preview CI warms slots before the suites.
-      timeoutMs: args?.timeoutMs ?? 60_000,
+      timeoutMs: args?.timeoutMs ?? PROJECT_CREATE_READY_TIMEOUT_MS,
     });
   }
 


### PR DESCRIPTION
## Summary

Fix the Artifacts repository creation race exposed by the preview flake-athon under full e2e concurrency.

A successful `ARTIFACTS.create()` already returns the authoritative initial write token. The OS discarded it, immediately performed `get()` plus `createToken()`, and could therefore hit the documented window where the create plane had committed the repository but the read plane did not yet consider it ready.

This change:

- preserves and uses the initial token returned by `create()`;
- removes the redundant immediate `get()` plus `createToken()` from every normal repository creation;
- measures the public ready-path deadline from entry to `project.create()`, starts the terminal readiness wait in parallel with sibling birth work, and fails the caller after 15 seconds so a framework retry can redial while durable delivery finishes;
- handles the ambiguous `ALREADY_EXISTS` recovery case with one explicit, bounded 45-second durable-recovery barrier;
- propagates real Artifacts errors immediately and leaves a still-unready repository as a durable retryable obligation rather than hiding it;
- adds regression coverage for the normal path, delayed readiness, bounded non-materialization, and non-retryable errors.

There are no test retries, enlarged test timeouts, or recursive recovery layers in this change.

## Evidence

Round 13 run 3 failed after 311 seconds with 13 absorbed retries and three hard project-creation failures. Cloudflare traces showed three independent config repositories receiving an internal create error, then `ALREADY_EXISTS`, while immediate reads still returned repository-not-found. That held three sibling project-readiness chains until the public 60-second deadline and generated 30 downstream stream-delivery failures.

The same `artifact-get-or-create` operation compared across adjacent immutable deployments:

| deployment | operations | failures | p50 | p95 | max |
| --- | ---: | ---: | ---: | ---: | ---: |
| clean A | 216 | 0 | 1.34s | 3.16s | 6.28s |
| clean B | 214 | 0 | 1.35s | 2.59s | 4.87s |
| failed | 218 | 35 | 1.34s | 39.54s | 40.10s |

That isolates the failure to the Artifacts create/read consistency boundary rather than general project concurrency, deployment readiness, or an individual test.

## Local validation

- `pnpm install --frozen-lockfile --prefer-offline`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm test`
- focused regression suite: 6/6 passing
- OS unit suite: 233 files, 2,288 passing, 6 expected failures, 1 existing skip

## Preview acceptance

Exact-head merge proof for `ac6d07bb6ddbb3bbca608fdf87671c3af2929d18`:

- [Depot preview run](https://depot.dev/orgs/0p91s0lz49/workflows/n59xzb6ctv?job=53t0crwrg3): **green in 4m07 wall time**, with all five apps deployed at this head and every runnable e2e lane executed.
- PostHog recorded **310 tests, 0 failures, 2 retried tests, and 2 retry attempts**. The finalizer was complete: 9/9 sources matched, with no missing, incomplete, or foreign sources.
- The two recovered failures were explicit `stream-wait-timeout` outcomes at 13.361s and 4.531s. They demonstrate the new fail-fast boundary and both recovered on the framework retry. This run is green merge proof, but is deliberately excluded from the 25-run zero-retry stability streak.
- Exact Worker version `020a5e35-25ea-4722-aec7-e4699e63287e` recorded 20/20 successful `artifact-get-or-create` operations in the sampled trace set, p50 1.314s, p95 2.237s, max 4.527s. There were no normal-path `artifact-token` calls, no durable sink delivery failures, and no Artifacts errors.
- Two earlier attempts stopped before tests because Cloudflare returned D1 control-plane error 7500 while applying Auth migrations. A direct remote migration read immediately succeeded with no migrations pending; the subsequent full attempt completed normally. These attempts did not silently pass or reuse test results.
- Required `Lint and Typecheck / lint-typecheck` and `Test / test` checks passed on this exact head. Local validation also passed typecheck, lint, formatting, the focused 6-test regression suite, and the full 2,288-test unit suite.

Merge acceptance here is a real all-lane green preview under five minutes with complete telemetry. Marathon streak qualification remains stricter: zero failures and zero absorbed retries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches project creation and artifact seeding on a known consistency boundary; behavior is more correct but changes timeouts and token sourcing on the hot path.
> 
> **Overview**
> Fixes preview e2e flakes where Artifacts `create()` had committed a repo but immediate `get()` / `createToken()` still saw “not found.”
> 
> **`getOrCreateArtifact`** now returns the initial write token from a successful `create()` (expiry stripped) and skips `get` on that path. On `ALREADY_EXISTS`, it polls `get()` with bounded exponential backoff (45s cap) and surfaces non-retryable errors immediately; if the repo never becomes readable it throws `RepoNotSeededError` for durable retry.
> 
> **Repo DO** seeds new artifacts with `initialWriteToken` when present and only runs the `artifact-token` step on `ALREADY_EXISTS` recovery.
> 
> **`Project.create()`** runs `waitUntilReady` in parallel with birth work under a **15s** project deadline (shared constant with default `waitUntilReady`), so callers fail faster while committed birth events still finish via durable delivery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac6d07bb6ddbb3bbca608fdf87671c3af2929d18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +96 -17 | +69 -16 🟩🟩🟩🟩🟥 |
| Tests | +96 -5 | +88 -5 🟩🟩🟩🟩🟩 |
| **Total** | **+192 -22** | **+157 -21** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 8990fa9 and 9688ec7, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-23T08:04:08.981Z",
      "deployedAt": "2026-07-23T07:53:13.262Z",
      "headSha": "ac6d07bb6ddbb3bbca608fdf87671c3af2929d18",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/39973429790163",
      "shortSha": "ac6d07b",
      "cleanupDurationMs": 12670,
      "deployDurationMs": 40769,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 39798,
      "deployReadinessDurationMs": 967,
      "deployedWorkerName": "os-preview-8",
      "deployedWorkerVersion": "020a5e35-25ea-4722-aec7-e4699e63287e",
      "testDurationMs": 186259,
      "testRetries": "2 retried: append accepts an offset assertion on a subscription-configured core event (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 13361ms (the public deadline expired while recovery re-armed one-shot waits). · stream-resume-after-suspend.spec.ts › feed resumes after the /api WebSocket dies (clean close) › preview-resilience (playwright x1) — Error: stream-wait-timeout: Timed out waiting for stream event after 4531ms (the public deadline expired while recovery re-armed one-shot waits).",
      "workerSizeKib": 19789.48,
      "workerGzipKib": 5006.59,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5015.72
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-23T08:04:00.196Z",
      "deployedAt": "2026-07-23T07:53:11.617Z",
      "headSha": "ac6d07bb6ddbb3bbca608fdf87671c3af2929d18",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/39973429790163",
      "shortSha": "ac6d07b",
      "cleanupDurationMs": 3882,
      "deployDurationMs": 38181,
      "deployConfigDurationMs": 7,
      "deployCommandDurationMs": 38147,
      "deployReadinessDurationMs": 27,
      "deployedWorkerName": "auth-preview-8",
      "deployedWorkerVersion": "36b5dfe5-59ff-427c-b226-14c92df28f5e",
      "testDurationMs": 37669,
      "testRetries": null,
      "workerSizeKib": 3965.97,
      "workerGzipKib": 811.52,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-23T08:03:57.298Z",
      "deployedAt": "2026-07-23T07:52:39.102Z",
      "headSha": "ac6d07bb6ddbb3bbca608fdf87671c3af2929d18",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/39973429790163",
      "shortSha": "ac6d07b",
      "cleanupDurationMs": 981,
      "deployDurationMs": 5890,
      "deployConfigDurationMs": 9,
      "deployCommandDurationMs": 5588,
      "deployReadinessDurationMs": 251,
      "deployedWorkerName": "dummy-petshop-preview-8",
      "deployedWorkerVersion": "0cb1bd4a-8297-4682-a767-3d5539bfbe23",
      "testDurationMs": 60726,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-23T08:03:57.491Z",
      "deployedAt": "2026-07-23T07:52:46.001Z",
      "headSha": "ac6d07bb6ddbb3bbca608fdf87671c3af2929d18",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/39973429790163",
      "shortSha": "ac6d07b",
      "cleanupDurationMs": 1172,
      "deployDurationMs": 12756,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 12533,
      "deployReadinessDurationMs": 218,
      "deployedWorkerName": "semaphore-preview-8",
      "deployedWorkerVersion": "bf9075eb-8be2-4d4e-9433-8f5a39dafe2e",
      "testDurationMs": 88184,
      "testRetries": null,
      "workerSizeKib": 1915.22,
      "workerGzipKib": 440.99,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-23T08:04:05.423Z",
      "deployedAt": "2026-07-23T07:52:45.794Z",
      "headSha": "ac6d07bb6ddbb3bbca608fdf87671c3af2929d18",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/39973429790163",
      "shortSha": "ac6d07b",
      "cleanupDurationMs": 9101,
      "deployDurationMs": 28716,
      "deployConfigDurationMs": 8,
      "deployCommandDurationMs": 12322,
      "deployReadinessDurationMs": 16386,
      "deployedWorkerName": "streams-example-app-preview-8",
      "deployedWorkerVersion": "16ffc87e-c7d9-423b-86b6-ecdc81de8cc4",
      "testDurationMs": 112288,
      "testRetries": null,
      "workerSizeKib": 5162.14,
      "workerGzipKib": 1473.65,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `ac6d07b` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 811.5 KiB | 38.2s | 37.7s |  | 3.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/39973429790163) | 2026-07-23T08:04:00.196Z | Preview app released. |
| Dummy Petshop | released | `ac6d07b` | [https://dummy-petshop.iterate-preview-8.com](https://dummy-petshop.iterate-preview-8.com) | 198.3 KiB | 5.9s | 60.7s |  | 981ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/39973429790163) | 2026-07-23T08:03:57.298Z | Preview app released. |
| OS | released | `ac6d07b` | [https://os.iterate-preview-8.com](https://os.iterate-preview-8.com) | 4.89 MiB (-9.1 KiB vs main) | 40.8s | 186.3s | 2 retried: append accepts an offset assertion on a subscription-configured core event (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 13361ms (the public deadline expired while recovery re-armed one-shot waits). · stream-resume-after-suspend.spec.ts › feed resumes after the /api WebSocket dies (clean close) › preview-resilience (playwright x1) — Error: stream-wait-timeout: Timed out waiting for stream event after 4531ms (the public deadline expired while recovery re-armed one-shot waits). | 12.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/39973429790163) | 2026-07-23T08:04:08.981Z | Preview app released. |
| Semaphore | released | `ac6d07b` | [https://semaphore.iterate-preview-8.com](https://semaphore.iterate-preview-8.com) | 441.0 KiB | 12.8s | 88.2s |  | 1.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/39973429790163) | 2026-07-23T08:03:57.491Z | Preview app released. |
| Streams Example App | released | `ac6d07b` | [https://streams.iterate-preview-8.com](https://streams.iterate-preview-8.com) | 1.44 MiB | 28.7s | 112.3s |  | 9.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/39973429790163) | 2026-07-23T08:04:05.423Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

