### PR TITLE
Auth sessions: 60-day rolling expiry — silent OAuth bounces instead of monthly re-logins

### DIFF
--- a/apps/auth/src/server/auth.ts
+++ b/apps/auth/src/server/auth.ts
@@ -66,6 +66,16 @@ export const auth = betterAuth({
   secret: config.betterAuthSecret.exposeSecret(),
   session: {
     storeSessionInDatabase: true,
+    // A LONG rolling session: any authenticated touch within `updateAge`
+    // granularity extends it, so interactive login is needed only after 60
+    // days of complete inactivity. The 60-day floor is deliberate: relying
+    // parties' refresh-token chains hit their hard ~30-day ceiling and
+    // bounce back through /authorize — with this session still alive, that
+    // bounce is a silent redirect instead of a Google login. (Before this,
+    // the 7-day default was almost always dead by the time a bounce
+    // happened, forcing a full re-login roughly every token ceiling.)
+    expiresIn: 60 * 24 * 60 * 60,
+    updateAge: 24 * 60 * 60,
     cookieCache: {
       enabled: true,
       maxAge: 5 * 60,


### PR DESCRIPTION
## The re-login treadmill

Users are forced through a full interactive Google login roughly monthly (and any time they touch auth.iterate.com after a week away). Two lifetimes interact:

1. **Relying parties (os.iterate.com) hold a 30-day-capped session.** The `iterate_session` cookie lasts 30 days when a refresh token exists, but the refresh-token chain (`@better-auth/oauth-provider`, rotating) carries a hard ~30-day expiry from first issue — so roughly monthly, the RP must bounce through `auth.iterate.com/authorize` to re-authenticate.
2. **auth.iterate.com's own better-auth session ran on the 7-day default** (`session.expiresIn` unset), and it is only ever *touched* during those bounces. By the time a bounce happened, the auth session was always long dead → the bounce rendered the login page (with Google `prompt: select_account` forcing the account picker) instead of silently redirecting.

## The fix

```ts
session: {
  storeSessionInDatabase: true,
  expiresIn: 60 * 24 * 60 * 60, // 60 days — outlives the RP token ceiling
  updateAge: 24 * 60 * 60,      // rolling: any touch within 60d extends
  cookieCache: { enabled: true, maxAge: 5 * 60, strategy: "compact" },
},
```

The 60-day floor is deliberate: it must **outlive the ~30-day refresh-token ceiling**, so that when an RP hits its ceiling and bounces, the auth session is still alive and `/authorize` silently re-issues. Net behavior: interactive login only after 60 days of complete inactivity; everything else is silent.

## Not changed (deliberately)

- `prompt: "select_account"` on Google stays — when the auth session IS genuinely dead, the account picker is the right safety for multi-account users.
- The RP cookie/refresh lifetimes stay: 30-day rotation with reuse-theft detection is a sound posture; the auth-side session is the correct place to absorb the ceiling.
- `cookieCache` stays at 5 minutes — that is claim freshness, not login persistence.

## Testing

- All 70 auth unit tests pass (`pnpm test` in apps/auth).
- better-auth applies `expiresIn` to both the DB session row and the session cookie's `Max-Age`, and `updateAge` re-extends on use — the standard rolling-session configuration per its docs.
- Verification after deploy: log in once, return the next day (session extended — check `Set-Cookie` on any authenticated request), and confirm an OAuth bounce with a live auth session silently redirects without rendering the login page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Lengthens central auth session persistence, which affects security posture if a session is compromised, but scope is limited to session TTL configuration with no changes to OAuth providers or RP token logic.
> 
> **Overview**
> Configures **better-auth** session lifetime in `apps/auth/src/server/auth.ts` so auth.iterate.com keeps a live session across relying-party OAuth bounces instead of falling back to interactive Google login every ~30 days.
> 
> Adds **`expiresIn: 60 * 24 * 60 * 60`** (60 days) and **`updateAge: 24 * 60 * 60`** (daily rolling extension on use), replacing the implicit ~7-day default. **`cookieCache`** and DB session storage are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e9e30a266f7f74d4cc6e763ad3f5207ea764097. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +10 -0 | +2 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+10 -0** | **+2 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between b5fbfde and 7e9e30a, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-23T08:13:10.428Z",
      "deployedAt": "2026-07-23T08:08:06.374Z",
      "headSha": "7e9e30a266f7f74d4cc6e763ad3f5207ea764097",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/209282088157328",
      "shortSha": "7e9e30a",
      "cleanupDurationMs": 9866,
      "deployDurationMs": 71055,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 69920,
      "deployReadinessDurationMs": 1133,
      "deployedWorkerName": "os-preview-12",
      "deployedWorkerVersion": "cf789797-d3d0-48e8-b99f-135be8849044",
      "testDurationMs": 169763,
      "testRetries": "1 retried: append after idle teardown re-wakes configured subscriber from its checkpoint (vitest x1) — stream-unavailable: Internal error in Durable Object storage caused object to be reset; reference = qrsbrkjk2fgojl70ous8u6i8",
      "workerSizeKib": 19789.48,
      "workerGzipKib": 5006.59,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5016.07
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-23T08:13:03.400Z",
      "deployedAt": "2026-07-23T08:07:15.504Z",
      "headSha": "7e9e30a266f7f74d4cc6e763ad3f5207ea764097",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/209282088157328",
      "shortSha": "7e9e30a",
      "cleanupDurationMs": 2834,
      "deployDurationMs": 19512,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 19046,
      "deployReadinessDurationMs": 461,
      "deployedWorkerName": "auth-preview-12",
      "deployedWorkerVersion": "a79bda24-bf45-42eb-bdb7-d27375b9f963",
      "testDurationMs": 10713,
      "testRetries": null,
      "workerSizeKib": 3966.02,
      "workerGzipKib": 811.48,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-23T08:13:01.330Z",
      "deployedAt": "2026-07-23T08:07:02.946Z",
      "headSha": "7e9e30a266f7f74d4cc6e763ad3f5207ea764097",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/209282088157328",
      "shortSha": "7e9e30a",
      "cleanupDurationMs": 763,
      "deployDurationMs": 6796,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 6452,
      "deployReadinessDurationMs": 303,
      "deployedWorkerName": "dummy-petshop-preview-12",
      "deployedWorkerVersion": "e29bdc63-1606-4862-ada8-478b22899ff0",
      "testDurationMs": 28520,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `7e9e30a` | [https://auth.iterate-preview-12.com](https://auth.iterate-preview-12.com) | 811.5 KiB | 19.5s | 10.7s |  | 2.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/209282088157328) | 2026-07-23T08:13:03.400Z | Preview app released. |
| Dummy Petshop | released | `7e9e30a` | [https://dummy-petshop.iterate-preview-12.com](https://dummy-petshop.iterate-preview-12.com) | 198.3 KiB | 6.8s | 28.5s |  | 763ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/209282088157328) | 2026-07-23T08:13:01.330Z | Preview app released. |
| OS | released | `7e9e30a` | [https://os.iterate-preview-12.com](https://os.iterate-preview-12.com) | 4.89 MiB (-9.5 KiB vs main) | 71.1s | 169.8s | 1 retried: append after idle teardown re-wakes configured subscriber from its checkpoint (vitest x1) — stream-unavailable: Internal error in Durable Object storage caused object to be reset; reference = qrsbrkjk2fgojl70ous8u6i8 | 9.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/209282088157328) | 2026-07-23T08:13:10.428Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->