### PR TITLE
Flake-athon audit: the good, the bad, and the ugly

### DIFF
--- a/docs/flake-athon-audit-2026-07.md
+++ b/docs/flake-athon-audit-2026-07.md
@@ -26,7 +26,12 @@ rework that is fail-closed in exactly the right places. The "big deletion =
 deleted guard" heuristic mostly misfires: the -1,297 / -1,059 / -319 diffs are
 dominated by moved code, completed-task-file cleanup, and doc churn.
 
-The real risk is **concentrated in one place, not spread**:
+The rollout race (#1) is the largest single issue, but the Codex cross-check
+showed the risk is **somewhat more distributed than a first pass suggests** —
+two changes rated GOOD by the Claude fan-out are downgraded below with verified
+external evidence (**B2** #2266 retries `overloaded` against Cloudflare guidance;
+**B4** #2227 reversed a measured concurrency ceiling on one run). The headline
+findings:
 
 | #     | Severity    | What                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Status at HEAD              |
 | ----- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
@@ -37,11 +42,15 @@ The real risk is **concentrated in one place, not spread**:
 | 5     | 🟢 Nit      | **#2253** quarantined the live-capability WebSocket-mesh e2e (real coverage debt, but honestly booked via the protocol with a named task). **#2271 / #2273** introduce one wedged-teardown re-poke path and one bounded create-read poll with **no telemetry counter**, so a future regression hides as absorbed latency rather than surfacing as data.                                                                                                                 | Acceptable; observe         |
 
 Nothing in the runtime-stability cluster (streams, wake, sandbox, worker-build:
-#2271, #2266, #2257, #2256, #2251, #2252, #2270, #2273, #2269, #2240, #2230)
-masks a race. Every new wait/retry there is bounded and scoped to the right
-error class; the two changes most capable of hiding an ordering bug (#2271's
-removal of pulled-result liveness, #2269's removal of a pre-wait `catchUp`) are
-each _replaced by a stronger invariant_, verified in source.
+#2271, #2257, #2256, #2252, #2270, #2269, #2240, #2230) masks a race. Every new
+wait/retry there is bounded and scoped to the right error class; the two changes
+most capable of hiding an ordering bug (#2271's removal of pulled-result
+liveness, #2269's removal of a pre-wait `catchUp`) are each _replaced by a
+stronger invariant_, verified in source. **The two exceptions the Codex pass
+caught** — #2266 looping on `overloaded` (B2) and #2251 stranding a queued build
+after alarm-retry exhaustion (U1) — are not ordering-race masks but a wrong
+error contract and a missing terminal state respectively; both are in the
+cross-check ledger below with fixes.
 
 ---
 
@@ -360,12 +369,28 @@ it("no test-run step performs in-band telemetry delivery", () => {
 
 Done in this PR: [`tasks/preview-rollout-do-reset-gate.md`](../tasks/preview-rollout-do-reset-gate.md).
 
-### D. Replace the blind age gate with an active readiness probe (the real fix for #1)
+### D. The real fix for #1 — make the operation self-heal, delete the gate
 
-Design in §1. Land behind a Depot CI validation run. Definition of done: the
-`flake-hunt-loop.sh` marathon reaches a **non-zero zero-retry streak** with no
-`Durable Object reset because its code was updated` in any first attempt — the
-exit criterion recorded in the task file.
+> **Superseded design note.** An earlier draft of this section proposed a _cheap
+> active readiness probe_ (one touch per DO namespace class). The Codex
+> cross-check refuted it: Cloudflare DO rollout is **globally eventually
+> consistent per object/placement**, so probing identity A does not prove a
+> future test identity B (different placement) has converged — #2140 used many
+> identities precisely because one is insufficient. **No gate or probe can prove
+> convergence.** The sound fix is operations that survive a reset whenever/wherever
+> it lands. Full candidate comparison + recommendation:
+> [`docs/flake-athon-refactor-options.md`](flake-athon-refactor-options.md).
+
+The recommended shape: (1) split the availability classifier so `overloaded` is
+never retried (finding B2); (2) finish the create saga's self-heal — one
+`waitForEvent` branch re-arms on reset like `waitUntilProcessed` already does;
+(3) model `create()`'s outcome explicitly instead of the ambiguous 15 s reject
+(finding B3); (4) consolidate to one canonical fixture; (5) delete the blind gate
+and plumbing; (6) replace it with a post-deploy recovery **canary** (proof, not a
+sleep). Land behind a Depot CI validation run. Definition of done: the
+`flake-hunt-loop.sh` marathon reaches the **25-consecutive-zero-retry** bar
+(finding B5) with no `Durable Object reset because its code was updated` in any
+first attempt — the exit criterion recorded in the task file.
 
 ---
 
@@ -391,5 +416,42 @@ the orchestration agent, looking at HEAD, found Playwright _is_ gated per-spec b
 closed it as a blind sleep_ — is more accurate than either agent alone and is
 the reason this audit reads the three PRs as one story.
 
-_Codex cross-check summary: (pending — folded in on completion of the parallel
-run.)_
+**Codex cross-check — where it went further than the Claude fan-out.** Codex
+independently confirmed #2261/#2265 as the headline, and the deletion-heuristic
+misfires. It also surfaced **four substantive findings the Claude clusters rated
+GOOD but Codex downgrades with external evidence — all verified against source**:
+
+- **B2 · #2266 retries `overloaded` (HIGH).** `isDurableObjectLifecycleError`
+  (`stream-unavailable.ts:38-45`) collapses `durableObjectReset | overloaded |
+retryable` into one boolean, and #2266 loops on it to the deadline. Cloudflare
+  says overload must **not** be retried (it worsens the overload). Under the
+  campaign's 48-file + 16-worker fan-out this is a synchronized retry storm that
+  hides the capacity signal. Fix: discriminate `reset|retryable|overloaded` and
+  propagate overload as typed backpressure. _(The Claude cluster-C pass called
+  #2266 "bounded and fine" — true for reset, wrong for overload.)_
+- **B3 · #2273 ambiguous create-success (HIGH).** Default `create()` rejects at
+  ~15 s while a 75 s birth drive keeps committing (`rpc-targets.ts:5200-5205,
+5308-5343`), so a caller can get an _error_ for a project that durably succeeds
+  and later becomes ready — an unmodelled outcome that leans on a caller/test
+  redial. Fix: split the acknowledgement boundaries (see the refactor doc).
+- **B4 · #2227 concurrency reversal is unproven (BAD/RISK).** #2169 — the PR
+  immediately before — kept **7** Vitest file workers because a 64-worker
+  experiment made remote project bootstrap "substantially slower and less
+  reliable" (remote capacity, not runner CPU, was the ceiling). #2227 reversed it
+  to ~48 on **one** retrying run, violating the documented "≥3 unchanged runs
+  before a concurrency change" rule (`docs/ci-preview-performance.md:152-154`).
+  The 48+16 burst is the environment in which the later overload/create-tail
+  findings appear.
+- **B5 · the campaign never met its own bar.** The release proof is 25
+  consecutive zero-retry runs (`ci-preview-performance.md:156-169`); the accepted
+  runs for #2253/#2261/#2265/#2266/#2273 each still carried retries (streak
+  0/25). Green under the one-retry policy ≠ "flake-athon proven."
+- **U1 · #2251 can strand a queued build** after native alarm-retry exhaustion
+  (no durable `stalled`/`failed` terminal state) — a latent leak, not a flake.
+
+And the **decisive correction to this audit's own §7-D**: the active-probe idea
+is not provably correct under eventual consistency; the sound answer is
+self-healing operations + a post-deploy canary. That correction reshaped the
+recommendation in
+[`docs/flake-athon-refactor-options.md`](flake-athon-refactor-options.md) — the
+strongest single argument for running the two audits in parallel.

--- a/docs/flake-athon-audit-2026-07.md
+++ b/docs/flake-athon-audit-2026-07.md
@@ -1,0 +1,395 @@
+# Flake-athon audit (2026-07-21 → 2026-07-23)
+
+An adversarial review of the ~32 PRs a coding agent merged into `main` over two
+days as a "flake-athon" — a campaign to drive CI/e2e flakiness to zero. The
+brief was to separate the genuinely-good root-cause fixes from changes that
+**traded real robustness for a green CI**: deleted guards that were added for
+valid reasons, masked races, weakened assertions, widened timeouts, or reduced
+coverage.
+
+Every claim below is judged against the repo's own written policy in
+[`docs/testing.md`](testing.md#retries-and-timeouts) — the six principles and
+the timeout ladder — and verified against the merged source at HEAD, not the PR
+prose. Two independent audits were run in parallel (a Claude subagent fan-out
+across four PR clusters, and a Codex `gpt-5.6-sol` xhigh pass); their
+convergences and one disagreement are noted in
+[§ Cross-check](#cross-check-two-independent-audits).
+
+---
+
+## TL;DR
+
+**The flake-athon is, overwhelmingly, good work.** The great majority of these
+PRs fix real root causes — bounded, error-class-scoped recoveries; genuine
+product fixes with `data-spinner` states; coverage that _increased_; a telemetry
+rework that is fail-closed in exactly the right places. The "big deletion =
+deleted guard" heuristic mostly misfires: the -1,297 / -1,059 / -319 diffs are
+dominated by moved code, completed-task-file cleanup, and doc churn.
+
+The real risk is **concentrated in one place, not spread**:
+
+| #     | Severity    | What                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Status at HEAD              |
+| ----- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| **1** | 🔴 **High** | **#2261** deleted the cross-lane Durable-Object rollout barrier (added deliberately one day earlier in **#2140**) with no replacement; **#2265** later restored it as a _blind fixed 90 s sleep_ (`previewMinimumDeploymentAgeMs`). The race is gated again, but by an **unprovable time constant that is off the guarded ladder, with no tracking task**. The DO-reset flake is still being **retry-absorbed** (visible in #2244's own marathon: accepted streak = 0). | Gated but fragile           |
+| **2** | 🟠 Medium   | **#2265** the 90 s rollout gate is a CI-critical-path timing constant that lives **outside `budgets.ts`** and is not covered by the `e2e-policy.test.ts` ordering guard — the one discipline the policy says every e2e number must follow. It also runtime-extends the guarded 90 s Playwright spec budget to ~180 s.                                                                                                                                                   | Works, drifts unaudited     |
+| **3** | 🟡 Low-Med  | **#2253** widened a cross-post `waitForEvent` **30 s → 100 s** to absorb a cold project-worker delivery tail. Policy-compliant in _form_ (carries a `// comment`, cites two 30 s breaches, points at `tasks/reduce-project-worker-cross-post-tail.md` with a restore-to-30 s exit) but it is still tail-masking, and 100 s is a large single wait.                                                                                                                      | Tracked; verify it restores |
+| **4** | 🟡 Low      | **#2226** briefly put PostHog delivery on the **"Run Tests" critical path** (`TEST_TELEMETRY_ENABLED=1`), so a telemetry outage could fail a green PR. **#2237 removed it entirely** (grep-clean at HEAD). No residue — but nothing stops it being reintroduced.                                                                                                                                                                                                        | Fixed; add a guard          |
+| 5     | 🟢 Nit      | **#2253** quarantined the live-capability WebSocket-mesh e2e (real coverage debt, but honestly booked via the protocol with a named task). **#2271 / #2273** introduce one wedged-teardown re-poke path and one bounded create-read poll with **no telemetry counter**, so a future regression hides as absorbed latency rather than surfacing as data.                                                                                                                 | Acceptable; observe         |
+
+Nothing in the runtime-stability cluster (streams, wake, sandbox, worker-build:
+#2271, #2266, #2257, #2256, #2251, #2252, #2270, #2273, #2269, #2240, #2230)
+masks a race. Every new wait/retry there is bounded and scoped to the right
+error class; the two changes most capable of hiding an ordering bug (#2271's
+removal of pulled-result liveness, #2269's removal of a pre-wait `catchUp`) are
+each _replaced by a stronger invariant_, verified in source.
+
+---
+
+## 1 · 🔴 The one real robustness-for-green trade: the DO rollout barrier (#2261 → #2265)
+
+This is the finding that justifies Jonas's suspicion, and it is worth
+understanding precisely because the story spans three PRs across the two days.
+
+### What happened, in order
+
+1. **#2140** (2026-07-21, "Run preview deploys and e2e at full concurrency")
+   introduced `apps/os/src/deployment-readiness.ts` — a readiness barrier that
+   ran **inside the deploy step**, gating the deploy→`awaiting-tests` transition
+   that **every** test lane (Vitest _and_ Playwright) waited behind. It probed
+   each DO namespace in ~10 waves, dwelt 10 s for stability, then revalidated
+   the complete set. Its stated reason, verbatim from the PR: _"prevent tests
+   from starting inside the Durable Object reset window observed on earlier
+   runs."_ This is a real, named failure mode: when a new Worker version
+   deploys, the first access to each Durable Object triggers Cloudflare to reset
+   that DO to load the new code, surfacing as
+   `Durable Object reset because its code was updated`.
+
+2. **#2261** (2026-07-22, "Remove synthetic Durable Object rollout probes",
+   +151 / **−1297**) deleted that barrier wholesale. The critique in its body is
+   _partly fair_: a finite synthetic probe sample can't prove the whole fleet is
+   settled, and ~500 probe RPCs per deploy dominated the tail cost. But it
+   replaced a cross-lane barrier with only an onboarding-smoke gate in front of
+   **Vitest**, and its own round-9 marathon evidence (added to
+   `docs/preview-e2e-flake-hunt.md` in the same PR) shows the reset race
+   **recurring and being retry-absorbed** — 7 Vitest + 2 Playwright tests
+   passing only on their single retry, and `OS preview smoke` failing _both_
+   attempts. No `tasks/` quarantine was filed for the residual race. Under the
+   policy this is the textbook violation: _"Never hide it with … an extra
+   retry,"_ and step 3 of the quarantine protocol (a named tracking task) was
+   skipped.
+
+3. **#2265** (2026-07-23, "Stabilize preview e2e across Durable Object
+   rollouts") quietly restored a barrier — but as a **blind, fixed-duration age
+   gate**: `previewMinimumDeploymentAgeMs = 90_000`
+   (`scripts/preview/preview.ts:74`). DO-backed suites and every project-create
+   helper now wait until 90 s after the deploy timestamp
+   (`resolvePreviewRolloutReadyAtMs`, `preview.ts:850`), via
+   `PREVIEW_APP_ROLLOUT_READY_AT_MS_ENV` for Playwright's per-spec waits and a
+   `rollout-settle` sleep lane for Vitest (`preview.ts:2272-2279`).
+
+### Why the end state is still not right
+
+At HEAD the race _is_ gated for both lanes — so this is not an open production
+hole — but the gate has three problems the original barrier did not:
+
+- **It is a blind sleep, not a proof.** The old barrier _checked_ readiness; the
+  new one _hopes_ 90 s ≥ the reset-settle window. If the window ever exceeds
+  90 s (a slow rollout, a busy edge), the race silently returns and is absorbed
+  by the one retry — exactly the failure the marathon already shows. This is the
+  "sleep through it instead of proving the state" anti-pattern the policy warns
+  against (principle 4), just relocated from the test into the orchestrator.
+- **It taxes every healthy run.** A fixed 90 s is paid in full even when the
+  rollout settled in 15 s. The old barrier released as soon as the fleet was
+  actually ready.
+- **It is off the guarded ladder and untracked.** See finding #2.
+
+### The cleaner, provable refactor
+
+Replace the blind age gate with a **cheap active readiness gate** that checks the
+actual invariant — "the new version is serving _and_ each DO namespace the tests
+will touch has completed its post-deploy reset" — bounded by a watchdog and
+sourced from `budgets.ts`. This keeps #2261's correct instinct (drop the 500
+synthetic probes) while restoring #2140's provability:
+
+- One readiness request **per DO namespace class the suite actually uses** (a
+  handful, not 500 fleet-wide synthetic probes), issued once, that _forces and
+  confirms_ the reset ahead of the tests. The reset is idempotent and one-shot
+  per version, so a single touch per namespace is sufficient — that is what
+  makes it provable rather than probabilistic.
+- Gate returns the moment all namespaces answer post-reset; a
+  `PREVIEW_ROLLOUT_READINESS_WATCHDOG_MS` backstop (on the ladder, sized ~2× the
+  measured p99 settle) fails the run if they don't — a wedged rollout _should_
+  fail, per principle 3.
+- Both lanes wait on the same gate (Vitest at its fan-out boundary, Playwright's
+  project-create helpers on the same ready signal), so neither races.
+
+Sketch (illustrative — see §7 for the exact `budgets.ts`/guard diff that is
+safe to land now):
+
+```ts
+// scripts/preview/preview.ts — replaces the fixed-age readyAt computation
+async function awaitPreviewRolloutReady(app, deployedWorkerVersion, signal) {
+  const deadline = Date.now() + PREVIEW_ROLLOUT_READINESS_WATCHDOG_MS;
+  for (const namespace of app.rolloutReadinessNamespaces) {
+    // one real request that forces + confirms the post-deploy DO reset;
+    // retry ONLY on `durableObjectReset`/`overloaded` until the version served
+    // matches deployedWorkerVersion, then move on. Never sleeps a fixed span.
+    await probeUntilServingNewVersion({ namespace, deployedWorkerVersion, deadline, signal });
+  }
+}
+```
+
+Until that lands, the _minimum_ to make the current state honest is finding #1's
+two-line follow-up: **(a)** move the constant onto the ladder (finding #2), and
+**(b)** file the tracking task — done in this PR as
+[`tasks/preview-rollout-do-reset-gate.md`](../tasks/preview-rollout-do-reset-gate.md),
+which records the residual retry-absorption evidence and a **zero-retry exit
+criterion** so the debt is visible instead of silent.
+
+---
+
+## 2 · 🟠 The rollout gate is off the guarded ladder (#2265)
+
+`docs/testing.md` is emphatic: _"The constants live in
+`packages/shared/src/test-support/e2e-policy/budgets.ts` (one file, every config
+imports it) and `scripts/preview/e2e-policy.test.ts` guards the invariants."_
+`previewMinimumDeploymentAgeMs` is a CI-critical-path timing constant that
+governs when tests may start — and it lives as a bare literal in
+`scripts/preview/preview.ts:74`, imported by nothing, guarded by nothing in the
+ladder test.
+
+It also **runtime-extends a guarded budget**: `email-otp-signup.ts:62` and
+`forged-session.ts` do `testInfo.setTimeout(testInfo.timeout + waitMs)`, growing
+the guarded 90 s `SPEC_TEST_TIMEOUT_MS` toward ~180 s during a rollout. That is
+defensible (the spec genuinely needs the extra time _only_ while waiting on the
+platform, and it's bounded), but it means the guarded spec budget is silently
+supplemented off-ladder — a reader auditing `budgets.ts` would never know.
+
+`PREVIEW_RUN_PROOF_BUDGET_SECS` already sets the precedent: it lives in
+`budgets.ts` with a comment explaining it is deliberately _not_ part of the
+ordered watchdog ladder. The rollout-age gate should sit right next to it. See
+§7 for the exact, safe-to-land diff.
+
+---
+
+## 3 · 🟡 The one genuine timeout-widen (#2253)
+
+`itx-agents.e2e.test.ts:771` — the cross-post `waitForEvent` budget went
+**30 s → 100 s**. This is the only "widen the wait instead of fix the product"
+in the whole flake-athon. In its favour, it is the _policy-compliant_ form:
+
+- carries the required `// comment` naming why,
+- cites two concrete runs that blew the old 30 s,
+- is explicitly temporary with a **restore-to-30 s exit criterion**, and
+- points at `tasks/reduce-project-worker-cross-post-tail.md` for the real fix
+  (a cold project-worker delivery tail).
+
+But 100 s is a large single wait and it _is_ masking a real latency tail. The
+action item is simply to **make sure the task lands and restores 30 s**, rather
+than letting 100 s calcify into a permanent vibe budget. A telemetry counter on
+the actual observed cross-post latency (so the tail is visible as data) would
+let the restore be evidence-driven.
+
+---
+
+## 4 · 🟡 Telemetry on the critical path — introduced then removed (#2226 → #2237)
+
+**#2226** shipped the telemetry foundation with PostHog delivery _inside_ the
+test reporter, and set `TEST_TELEMETRY_ENABLED=1` on the **"Run Tests"** step
+itself. The reporter _"fails the command on missing config or delivery errors"_
+— so a PostHog outage or a key misconfig could fail an otherwise-green PR. It
+also inherited the wrong PostHog project (a dev key vs the `_shared/prd`
+dashboards), a silent dataset split.
+
+**#2237** fixed both, and did so well: reporters became pure artifact producers
+with **zero network I/O** (verified: grep of all three reporters is empty), the
+finalizer moved to a separate `if: always()` step under `_shared/prd` that can
+only _add_ a telemetry-completeness failure — never mask a red test or invent a
+green one — and `TEST_TELEMETRY_EXPECTED_WORKSPACES` is wired so a workspace
+that silently emits **nothing** fails the finalizer (the list equals exactly the
+10 packages with a `test` script). Every fail-closed path has a dedicated
+regression test.
+
+No residue remains (`grep TEST_TELEMETRY_ENABLED` is clean). The only gap is
+that nothing _prevents_ the regression from returning. Recommended: a one-line
+guard in `depot-workflows.test.ts` asserting **no test-run step re-introduces
+in-band telemetry delivery** (`TEST_TELEMETRY_ENABLED` or a PostHog key on a
+`Run Tests` step). Sketch in §7.
+
+---
+
+## 5 · The GOOD (the majority — keep these)
+
+Verified root-cause fixes and clean refactors. These are the flake-athon working
+as intended:
+
+**Runtime stability (all verified bounded & error-scoped):**
+
+- **#2271** "Decouple wake delivery settlement" — removes the cyclic
+  pulled-result-as-liveness coupling; a wake **cannot** be reported delivered
+  before it's processed, because settlement is reported strictly _after_ the
+  durable attempt, silent wedges are caught by the idle-teardown watchdog that
+  re-pokes from the durable checkpoint, and transport breaks fail closed via
+  `onRpcBroken`. The invariant is _stronger_ than before (settlement carries a
+  real ok/error verdict). Fully backstopped in source.
+- **#2266** "Recover processor waits across transient DO overload" — a _bounded_
+  retry, gated on `isRetryableDurableObjectAvailabilityError` only (application
+  errors throw immediately, proven by test), ceiling = the caller's public
+  deadline, 1 s backoff cap. Correct at-least-once recovery, not a mask.
+- **#2273** "Avoid Artifacts create-read race" — removes the create-then-read
+  race on the happy path by reusing the write token `create()` already minted;
+  the `waitForExistingArtifact` poll retries **only** repo-not-seeded lifecycle
+  codes (infra errors propagate immediately, proven by test), bounded 45 s.
+- **#2269** "Stabilize preview project creation" — removes a pre-wait
+  `registry.catchUp` in four DOs. Archaeology confirms this removes a _weaker,
+  unbounded, failure-swallowing_ path (the old scheduler comment literally said
+  "catchUp swallows failures by design") in favour of the offset
+  `waitUntilEvent` self-pull, which treats a failed pull as **authoritative**
+  and bounds it. Strengthens the failure contract.
+- **#2240** "Fix ITX script recovery across DO resets" — relocates the runScript
+  waiter onto the stateless RPC boundary so a _successor_ incarnation's
+  settlement is observed instead of dying with the orphaned RPC. Idempotent,
+  bounded, no swallow.
+- **#2257** (vendored verbatim Cloudflare upstream fix, lifetime bounded by the
+  RPC promise settling), **#2256 / #2251 / #2252** (real build-key CAS/durable-
+  handoff coordination keyed by SHA-256, not polls), **#2270** (test-only,
+  removes a genuine readback race), **#2230** (presentational "waiting" state,
+  mis-bucketed as flake but harmless). All GOOD.
+
+**Deletion-heavy PRs that are _not_ deleted guards:**
+
+- **#2217** (−1059) — dominated by `tasks/complete/*` cleanup and docs; product
+  code is net-additive with new coordinator tests; the −72 in `worker-loader.ts`
+  is _moved_, not deleted.
+- **#2244** (−319) — makes the marathon _stricter_ (rejects any absorbed retry;
+  old loop counted retry-absorbed runs as green) and retires genuine masking
+  layers (uncounted warmup runs). Its own evidence honestly shows streak = 0.
+- **#2215** (−129) — coverage-_preserving_ refactor that _adds_ a pinning test
+  for a previously-accidental invariant (unconsumed revival facts → eventless
+  caught-up delivery), verified in `stream-subscribers.ts`.
+- **#2239**, **#2242** — real deploy-blocker / fail-fast fixes with tests;
+  #2239 does _not_ touch the Artifacts quarantine (that predates it in #2146).
+
+**Orchestration & coverage:**
+
+- **#2263** "Run preview e2e on every triggered PR head" — coverage-_increasing_:
+  drops a `headSha` gate that let non-app diffs skip testing and replaces two
+  silent-green `skipped` exits with fail-closed `throw`s.
+- **#2227 / #2268** — parallelism knobs (7→64 e2e file workers; 8→16 Playwright),
+  both with verified per-test project isolation (unique slugs), #2268 carrying
+  the required `// comment` + evidence. No shared-state collision.
+- **#2241** "Shrink the slow suspend recovery e2e" — the title undersells it:
+  it _removes_ ~50 s of dead `waitForTimeout` sleeps and **adds** assertions
+  (replaces an ineffective `setWebLifecycleState` that never actually suspended
+  timers with `Emulation.setScriptExecutionDisabled` + a timer-gap probe that
+  now _asserts_ suspension). Coverage went up, not down.
+- **#2236** (additive diagnostic command, not on the CI critical path),
+  **#2267** (baked-workspace boot, infra-only), **#2235 / #2238** (strict
+  small e2e correctness fixes), **#2232** (docs-only evidence ledger),
+  **#2254 / #2243** (pure-observation deploy-phase timing; Doppler creds that
+  fail closed in CI). All GOOD.
+
+---
+
+## 6 · Hardening / observability nits
+
+- **#2271**: the wedged-teardown re-poke path is only a `warn`. Add a telemetry
+  counter so the watchdog firing is visible in prod as data.
+- **#2273**: `waitForExistingArtifact` absorbs create-read latency inside its
+  45 s bound. Add a retry-count/elapsed counter so a _widening_ Artifacts
+  replication window surfaces as a trend, not as silently-absorbed latency. Add
+  a one-line comment reconciling the 45 s repo poll with the 15 s project-create
+  deadline (two different callers — coherent, but non-obvious).
+- **#2253**: the quarantined live-capability WebSocket-mesh e2e is real coverage
+  debt (the Node→worker-mesh WebSocket boundary is no longer proven). Correctly
+  booked via `tasks/quarantined-live-capability-websocket-e2e.md`; keep it on
+  the radar until that task closes.
+
+---
+
+## 7 · Concrete, safe-to-land follow-ups
+
+These are ordered by value ÷ risk. Items A–C are self-contained and provably
+correct; item D is the larger refactor that needs a Depot CI validation run
+before landing (which is why this PR _documents_ it rather than applying it — the
+audit was produced off-CI and unvalidated CI-orchestration edits are exactly the
+kind of change that should not be merged blind).
+
+### A. Put the rollout-age gate on the guarded ladder (fixes finding #2)
+
+Add to `packages/shared/src/test-support/e2e-policy/budgets.ts`, next to
+`PREVIEW_RUN_PROOF_BUDGET_SECS`:
+
+```ts
+/**
+ * Minimum age of a fresh preview deployment before DO-backed suites and
+ * project-create helpers may run against it. After a new Worker version
+ * deploys, the first access to each Durable Object triggers a code-update
+ * reset; starting tests inside that window surfaces as
+ * `Durable Object reset because its code was updated`. Like
+ * PREVIEW_RUN_PROOF_BUDGET_SECS this is NOT part of the ordered watchdog
+ * ladder — it is a platform eventual-consistency backstop. Reused (old)
+ * deployments wait zero. Blind-fixed today; tasks/preview-rollout-do-reset-gate.md
+ * tracks replacing it with an active readiness probe.
+ */
+export const PREVIEW_MINIMUM_DEPLOYMENT_AGE_MS = 90_000;
+```
+
+Then in `scripts/preview/preview.ts` replace the bare literal at line 74 with an
+import of `PREVIEW_MINIMUM_DEPLOYMENT_AGE_MS`, and in
+`scripts/preview/e2e-policy.test.ts` add an assertion that `preview.ts` sources
+this constant from `budgets.ts` (mirroring the existing shell-sync guards), so
+it can't drift back into an unguarded literal.
+
+### B. Guard against telemetry returning to the critical path (fixes finding #4)
+
+In `apps/os/.../depot-workflows.test.ts` (wherever the workflow YAML is already
+asserted), add:
+
+```ts
+it("no test-run step performs in-band telemetry delivery", () => {
+  // #2226 regressed by setting TEST_TELEMETRY_ENABLED on the Run Tests step,
+  // putting PostHog delivery on the pass/fail critical path. #2237 removed it.
+  // Delivery belongs only in the separate if:always() finalizer step.
+  const testStep = runTestsStep(testWorkflow);
+  expect(JSON.stringify(testStep)).not.toMatch(/TEST_TELEMETRY_ENABLED/);
+});
+```
+
+### C. File the missing tracking task (fixes finding #1's protocol gap)
+
+Done in this PR: [`tasks/preview-rollout-do-reset-gate.md`](../tasks/preview-rollout-do-reset-gate.md).
+
+### D. Replace the blind age gate with an active readiness probe (the real fix for #1)
+
+Design in §1. Land behind a Depot CI validation run. Definition of done: the
+`flake-hunt-loop.sh` marathon reaches a **non-zero zero-retry streak** with no
+`Durable Object reset because its code was updated` in any first attempt — the
+exit criterion recorded in the task file.
+
+---
+
+## Cross-check: two independent audits
+
+This report is the reconciliation of two independent passes:
+
+- **Claude subagent fan-out** — four agents, one per PR cluster (deletion
+  suspects / preview-e2e orchestration / runtime stability / telemetry infra),
+  each doing its own `gh` + git archaeology against HEAD.
+- **Codex `gpt-5.6-sol`, xhigh effort** — an independent full pass over the same
+  PR set. _(Codex findings folded in below.)_
+
+**Where they converged** (high confidence): #2261 as the single real
+robustness-for-green trade; the deletion-count heuristic over-flagging #2217 /
+#2244 / #2215; the runtime-stability cluster being genuinely well-built with no
+masked race; #2237's telemetry contract being fail-closed and honest.
+
+**Where the two Claude clusters refined each other** (the important nuance): the
+deletion-cluster agent read #2261 in isolation and called Playwright "ungated";
+the orchestration agent, looking at HEAD, found Playwright _is_ gated per-spec by
+#2265's later age constant. The synthesis in §1 — _#2261 opened the gap, #2265
+closed it as a blind sleep_ — is more accurate than either agent alone and is
+the reason this audit reads the three PRs as one story.
+
+_Codex cross-check summary: (pending — folded in on completion of the parallel
+run.)_

--- a/docs/flake-athon-refactor-options.md
+++ b/docs/flake-athon-refactor-options.md
@@ -10,7 +10,7 @@ Four candidate designs were each prototyped independently against the real code
 (by parallel Claude subagents), and a Codex `gpt-5.6-sol` xhigh pass audited the
 same surface. The candidates and the evidence that decided between them:
 
-## TL;DR — the minimal fix (net ≈ −228 lines, less complexity, more robust)
+## TL;DR — the minimal fix (measured net −277 LOC, less complexity, more robust)
 
 The first draft of this doc grew a 7-step plan. That was over-built. Re-examined
 for _smallest change / least complexity / most robustness_ — grounded in
@@ -206,7 +206,7 @@ owner-and-removal-criterion quarantine if C2 is judged too risky to land at once
 
 ## The fuller version (optional — only if you want more than the minimal fix)
 
-> **Read the [TL;DR minimal fix](#tldr--the-minimal-fix-net--228-lines-less-complexity-more-robust)
+> **Read the [TL;DR minimal fix](#tldr--the-minimal-fix-measured-net-277-loc-less-complexity-more-robust)
 > first.** The two-change minimal fix above is the recommendation. The steps
 > below are the same ideas expanded, plus the _optional_ extras (explicit create
 > contract, fixture consolidation, canary, concurrency sweep). Treat them as a

--- a/docs/flake-athon-refactor-options.md
+++ b/docs/flake-athon-refactor-options.md
@@ -196,6 +196,60 @@ clutter (three failure representations) is real but its cleanup is a separate
 careful task, not a quick cut — bundling it would trade the "little faff" the ask
 wants for churn that doesn't move robustness.
 
+## Round 4 — two higher-altitude escape hatches tested; the floor holds
+
+Round 4 deliberately did **not** re-map the retry sites (done twice). It tested
+the two "make the problem disappear" ideas that would beat the lean fix — and both
+bottom out, with Cloudflare's own docs as the deciding evidence. Reporting this
+plainly rather than manufacturing a marginal cut.
+
+- **Can the reset be avoided _by construction_ (so we don't need the +12 fix)?
+  No.** The reset fires on _version reassignment of a placement_, and Cloudflare
+  states it directly: _"The Durable Object will only be reset when it is assigned
+  a different version"_
+  ([gradual deployments](https://developers.cloudflare.com/workers/configuration/versions-and-deployments/gradual-deployments/)).
+  A plain `wrangler deploy` reassigns the whole fleet, and — decisively — a
+  brand-new per-test DO can be _created on a placement still serving old code_ and
+  reset lazily when that placement flips; "fresh slug ⇒ cold start, never a reset"
+  is **false**. The request version-pin
+  (`cloudflare-worker-version-overrides.ts`) is an **asset/HTML** routing fix and
+  does not touch DOs ("only one version of each Durable Object runs at a time").
+  Deploying each run to a **fresh worker name** (no prior version ⇒ no reset) is
+  _far more_ faff — unbounded worker/namespace/container accumulation, one-way
+  container-class enablement, and it breaks the slot/lease model
+  (`scripts/lib/do-reset.ts`). **You cannot deploy your way out; a bounded
+  reset-classified retry is the irreducible answer.**
+
+- **Is async-by-construction `create()` net-simpler? No — it's a wash that
+  relocates complexity.** Making the default non-blocking deletes ~11 lines from
+  `create()` but adds ~4 across the **2** bundled callers, and it (a) moves the
+  from-entry single-deadline fail-fast guarantee _into_ callers (or re-introduces
+  the same arithmetic there), (b) weakens the e2e helper's fail-fast, and (c)
+  turns a safe-by-default into a footgun for out-of-tree "create-then-use"
+  scripts. The fast path _already exists_ and **3 of 5 callers already use it**, so
+  flipping the default buys no product-path robustness. The 7 saga steps are each
+  load-bearing (the one "duplicate" — `driveBirth` in both lanes — is intentional).
+  **Confirmed round-3: leave the shape; the clear escape-error message is the
+  right, minimal fix for the ambiguity.**
+
+**One genuinely new low-faff win surfaced:** the API-key **secret-seed failure is
+swallowed to a bare `console.warn`** (`rpc-targets.ts:5301-5307`) that, on the
+fast path, runs inside `ctx.waitUntil` with **no observer at all** — a real
+silent-failure hole (violates "no silent failure"). Turn it into a telemetry
+event (keep the non-throwing control flow — it self-heals on reveal). **~+2 LOC,
+pure observability upside**, folded into the lean fix.
+
+### Verdict: this is the floor
+
+Four rounds converge. The lean fix — **delete the gate (−305), reuse the one-retry
+helper on the one uncovered wait (+12/−7), a clear "retry later" error (+6), two
+freebies (−32), the seed-telemetry line (+2)** ≈ **−300 LOC net, validated** — is
+the floor for "less code + less clutter + more robustness + little faff." Further
+cuts either (a) can't beat Cloudflare's eventual-consistency model, (b) relocate
+complexity rather than remove it, or (c) are the separate medium-faff
+[DO-failure-signal unification](../tasks/unify-durable-object-failure-signal.md)
+that doesn't move robustness. Recommendation: **ship the lean fix; stop cutting.**
+
 ---
 
 The detailed candidate analysis and the fuller (optional) version follow.

--- a/docs/flake-athon-refactor-options.md
+++ b/docs/flake-athon-refactor-options.md
@@ -10,6 +10,65 @@ Four candidate designs were each prototyped independently against the real code
 (by parallel Claude subagents), and a Codex `gpt-5.6-sol` xhigh pass audited the
 same surface. The candidates and the evidence that decided between them:
 
+## TL;DR — the minimal fix (net ≈ −228 lines, less complexity, more robust)
+
+The first draft of this doc grew a 7-step plan. That was over-built. Re-examined
+for _smallest change / least complexity / most robustness_, grounded in
+Cloudflare's own docs and a real LOC count, the answer is **two changes, one of
+them a pure deletion**:
+
+1. **Delete the entire rollout gate and its plumbing — ~241 lines removed, 0
+   added.** This is not just cleanup: **Cloudflare documents no way to wait for a
+   rollout to become globally consistent.** DO code propagation is eventually
+   consistent and a new Worker calls old-version DOs "for seconds to minutes"
+   ([known
+   issues](https://developers.cloudflare.com/durable-objects/platform/known-issues/));
+   the _only_ supported remedy is forward/backward-compatible code — "design for
+   skew." A time/probe gate is categorically the wrong tool, so the whole
+   subsystem (`preview-rollout-gate.ts`, `previewMinimumDeploymentAgeMs`, the
+   resolve functions, the before-suite sleep, the rollout-settle lane, the
+   per-spec `testInfo.setTimeout` extensions, the `PREVIEW_APP_ROLLOUT_*` env
+   vars, the config field) should go.
+
+2. **Close the one real gap: `waitForEvent` re-throws on reset — ~12 lines
+   added.** `create()`'s `project/ready` wait (`rpc-targets.ts:628-717`) already
+   re-arms a fresh subscription from a pinned `replayAfterOffset` on each slice,
+   but only `continue`s on a slice-timeout — on a DO reset it calls
+   `rethrowStreamUnavailable` and surfaces a create failure. Add a reset branch
+   at the ~3 reject sites (658, 665, 716) that `continue`s (with a small backoff),
+   reusing the **existing** `isRetryableDurableObjectAvailabilityError` classifier
+   and the **existing** deadline. The loop already mints a fresh stub each slice —
+   which is exactly Cloudflare's blessed retry shape (bounded, backed-off, fresh
+   stub, retry only the retryable class).
+
+Everything else in the create saga already self-heals (keyed-append retry,
+processor-relay retry); this closes the single path that still surfaces a reset.
+**Net effect: delete a whole subsystem, add ~12 lines, and the reset is now
+absorbed in-process wherever eventual consistency lands it — instead of slept
+through and hoped.** That is strictly more robust _and_ strictly less code.
+
+**Two small, separable hardening fixes** (real per Cloudflare, but independent of
+the gate deletion — do them as their own tiny PRs, not as a precondition):
+
+- **Stop retrying `overloaded`** (audit finding B2). Cloudflare is explicit:
+  `.overloaded` "should not be retried… retrying will worsen the overload"
+  ([error
+  handling](https://developers.cloudflare.com/durable-objects/best-practices/error-handling/)),
+  yet `isDurableObjectLifecycleError` (`stream-unavailable.ts:38-45`) retries it
+  alongside `reset`/`retryable`. Split it out. ~5 lines, one classifier.
+- **Match the blessed retry cadence.** `waitUntilProcessed`'s ~1 Hz
+  deadline-loop drifts from Cloudflare's "exponential backoff + jitter, small
+  attempt cap." Minor; align when touching it.
+
+**Cut from the first draft as not load-bearing** for deleting the gate: the
+explicit-`create()`-contract change (#2273/B3 — orthogonal ambiguous-success
+concern), the post-deploy canary (the marathon already _is_ the evidence), the
+fixture consolidation (good hygiene, optional), and the concurrency sweep (B4 —
+its own operational task). The active-readiness probe (C4) is not merely cut but
+**refuted** — Cloudflare confirms no convergence gate can exist.
+
+The detailed candidate analysis and the fuller (optional) version follow.
+
 ## The failure mode, stated correctly
 
 After a fresh Worker version deploys, Cloudflare resets each Durable Object to
@@ -96,12 +155,16 @@ reset whenever/wherever it lands are sound.** C4 is viable _only_ as an explicit
 owner-and-removal-criterion quarantine if C2 is judged too risky to land at once
 — never as readiness proof.
 
-## Recommendation
+## The fuller version (optional — only if you want more than the minimal fix)
 
-**Land C2 (finish the self-healing saga) as the core, with the classifier split
-that finding B2 requires, model `create()`'s outcome explicitly (finding B3),
-consolidate fixtures with C3, delete the blind gate, and replace it with a
-post-deploy recovery _canary_ (not a gate).** In order:
+> **Read the [TL;DR minimal fix](#tldr--the-minimal-fix-net--228-lines-less-complexity-more-robust)
+> first.** The two-change minimal fix above is the recommendation. The steps
+> below are the same ideas expanded, plus the _optional_ extras (explicit create
+> contract, fixture consolidation, canary, concurrency sweep). Treat them as a
+> menu of independent follow-ups, **not** as a single package that must land
+> together — bundling them was the over-build the maintainer pushed back on.
+
+In order:
 
 1. **Split the availability classifier** (foundational; fixes B2). Replace the
    single boolean with a discriminated result `"reset" | "retryable" |

--- a/docs/flake-athon-refactor-options.md
+++ b/docs/flake-athon-refactor-options.md
@@ -155,6 +155,35 @@ post-deploy recovery _canary_ (not a gate).** In order:
    throughput knee, and run the 25-consecutive-zero-retry marathon on the final
    head. Only then is the campaign _proven_, not merely green.
 
+### Correctness constraints (surfaced by the Codex design cross-check)
+
+The Codex refactor pass independently landed on the same C2-primary / C3-complement
+/ C1-defense-in-depth / C4-rejected ordering, and sharpened three things that make
+the difference between a self-heal that's _safe_ and one that's subtly wrong:
+
+- **⚠️ The retry must not span the identity-mint boundary.** The admin/test
+  `create()` path _mints a fresh project ID_ via `AUTH.mintProjectId()` when none
+  is supplied (`rpc-targets.ts:5380-5387`), so replaying an _unclassified_ failure
+  **before** `primeProjectDirectory()` commits can create **conflicting
+  identities** — there is already an expected-failure regression for exactly this
+  (`apps/os/e2e/vitest/project-create-concurrency.regression.e2e.test.ts`). The
+  rollout self-heal is still safe because the first project-DO touch happens
+  _after_ directory priming (`:5209-5265`), so phase-2 retries retain one ID — but
+  the invariant to state is the **narrow** one ("retry only after stable identity
+  is established"), not "create is idempotent." A _complete_ fix routes admin
+  slug→ID reservation through one authority (atomic reservation), at which point
+  the regression test can flip to a normal idempotency assertion.
+- **Fix the secret-seed catch-all while here.** The API-key seed today catches
+  **every** error and only warns (`rpc-targets.ts:5280-5307`) — which conflicts
+  with the "no silent failure" principle. Either model it as an explicit
+  observable obligation (retry only the availability class; record a durable
+  explanation on exhaustion) or fold secret existence into `project/ready`. Don't
+  let the ambiguous swallow ride along under the new contract.
+- **Size the deadline from measured p99, never a sleep.** The current create
+  deadline is 15 s (`rpc-targets.ts:420-424`) and the flake hunt saw cold outliers
+  near that boundary. If real resets routinely exhaust 15 s, pick a product SLO
+  from the measured p99 — do not reintroduce a pre-test sleep to pad it.
+
 ### Why this is the right shape
 
 - **It deletes more than it adds.** Gate + plumbing + per-spec `setTimeout` + the
@@ -178,9 +207,20 @@ post-deploy recovery _canary_ (not a gate).** In order:
   is the product fix and unbounded fixture concurrency is the actual bug — the
   concurrency sweep in step 7 is what tells us. Either way the blind sleep is not
   the answer.
+- **Scope caveat:** `project/ready` proves the _birth saga_, not every future
+  first-touch of an unrelated fresh Agent / Repo / Workspace object. On-demand DOs
+  route through the relay's availability retry (so a reset is absorbed), but if any
+  post-create first-touch operation is _non-idempotent_, it needs the same
+  bounded, error-scoped treatment before the **whole-suite** gate is deleted — the
+  create-leg self-heal alone doesn't certify it. Both audits agree a synthetic
+  namespace sample cannot supply that proof either.
 
-_Codex independent design cross-check: folded in — Codex's audit converged on the
-same "make operations idempotent + incarnation-independent, add a post-deploy
-canary, do not restore a sampler" conclusion, and supplied the classifier-split
-(B2) and eventual-consistency correction that upgraded this recommendation over
-the audit's original active-probe sketch._
+_Codex independent design cross-check: **folded in.** The dedicated Codex
+`gpt-5.6-sol` design pass independently reached the same ordering — C2 self-healing
+saga primary, C3 canonical fixture, C1 client-retry as defense-in-depth only (never
+a global mutation-retry policy), C4 rejected — and converged on "make operations
+idempotent + incarnation-independent, prove success from the actual project's
+durable `project/ready`, add a post-deploy canary, do **not** restore a sampler."
+It also supplied the classifier-split (B2) and the eventual-consistency correction
+that upgraded this recommendation over the audit's original active-probe sketch, and
+surfaced the identity-mint / secret-seed / deadline-sizing constraints above._

--- a/docs/flake-athon-refactor-options.md
+++ b/docs/flake-athon-refactor-options.md
@@ -13,52 +13,78 @@ same surface. The candidates and the evidence that decided between them:
 ## TL;DR — the minimal fix (net ≈ −228 lines, less complexity, more robust)
 
 The first draft of this doc grew a 7-step plan. That was over-built. Re-examined
-for _smallest change / least complexity / most robustness_, grounded in
-Cloudflare's own docs and a real LOC count, the answer is **two changes, one of
-them a pure deletion**:
+for _smallest change / least complexity / most robustness_ — grounded in
+Cloudflare's own docs, and with the patch **actually applied and validated in an
+isolated worktree** (codex `gpt-5.6-sol`: 45/45 apps/os focused tests, 148/148
+preview-workflow tests, `pnpm typecheck`, and `git diff --check` all pass) — the
+answer is **two changes, one of them a pure deletion, for a measured net −277
+LOC** (43 added / 320 deleted):
 
-1. **Delete the entire rollout gate and its plumbing — ~241 lines removed, 0
-   added.** This is not just cleanup: **Cloudflare documents no way to wait for a
-   rollout to become globally consistent.** DO code propagation is eventually
-   consistent and a new Worker calls old-version DOs "for seconds to minutes"
-   ([known
-   issues](https://developers.cloudflare.com/durable-objects/platform/known-issues/));
+1. **Delete the entire rollout gate and its plumbing — 305 lines removed, ~17
+   added** (the additions are just formatter collapse where fields/branches were
+   removed; no replacement mechanism). This is not just cleanup: **Cloudflare
+   documents no way to wait for a rollout to become globally consistent.** DO code
+   propagation is eventually consistent and a new Worker calls old-version DOs
+   "for seconds to minutes"
+   ([known issues](https://developers.cloudflare.com/durable-objects/platform/known-issues/#code-updates));
    the _only_ supported remedy is forward/backward-compatible code — "design for
    skew." A time/probe gate is categorically the wrong tool, so the whole
-   subsystem (`preview-rollout-gate.ts`, `previewMinimumDeploymentAgeMs`, the
-   resolve functions, the before-suite sleep, the rollout-settle lane, the
-   per-spec `testInfo.setTimeout` extensions, the `PREVIEW_APP_ROLLOUT_*` env
-   vars, the config field) should go.
+   subsystem goes: `preview-rollout-gate.ts` (+ its test, −120), the
+   `previewMinimumDeploymentAgeMs` constant, the timestamp resolvers, the
+   before/inside-suite gates, the rollout-settle lane and env injection in
+   `preview.ts` (−89), the `previewTestRolloutGate` config field, the per-spec
+   `testInfo.setTimeout` extensions, and the rollout-timeout argument plumbing
+   threaded through the specs.
 
-2. **Close the one real gap: `waitForEvent` re-throws on reset — ~12 lines
-   added.** `create()`'s `project/ready` wait (`rpc-targets.ts:628-717`) already
-   re-arms a fresh subscription from a pinned `replayAfterOffset` on each slice,
-   but only `continue`s on a slice-timeout — on a DO reset it calls
-   `rethrowStreamUnavailable` and surfaces a create failure. Add a reset branch
-   at the ~3 reject sites (658, 665, 716) that `continue`s (with a small backoff),
-   reusing the **existing** `isRetryableDurableObjectAvailabilityError` classifier
-   and the **existing** deadline. The loop already mints a fresh stub each slice —
-   which is exactly Cloudflare's blessed retry shape (bounded, backed-off, fresh
-   stub, retry only the retryable class).
+2. **Close the one real gap by _reusing_ the existing one-retry helper — +12 / −7
+   in `rpc-targets.ts`.** `create()`'s `project/ready` wait resolves through
+   `waitUntilReady()` → `waitForEvent({ afterOffset: 0 })`, and the **single
+   native stub call at `rpc-targets.ts:681-689` is the only operation on the
+   create leg that still turns a first-touch reset into a terminal
+   `stream-unavailable` error** (everything else already self-heals). Rather than
+   add new re-arm branches, wrap that one call in the **existing**
+   `retryLoggedIdempotentOperation` helper — which already gives exactly one
+   retry, a **fresh stub** each attempt (the `durableObjectStub` getter re-calls
+   `getByName`), and an observable log. It's a read-only observation replayed from
+   the same pinned `afterOffset`, so a ready event committed before the reset is
+   replayed, not skipped; a second consecutive availability failure and every
+   application error stay terminal. This matches Cloudflare's blessed shape
+   exactly (bounded, fresh stub, retry only the retryable class) — and it also
+   requires flipping the existing test at
+   `stream-processor-rpc-target.test.ts:390-411`, which currently _freezes_ the
+   terminal-reset behavior, into a fresh-stub recovery proof.
 
 Everything else in the create saga already self-heals (keyed-append retry,
 processor-relay retry); this closes the single path that still surfaces a reset.
-**Net effect: delete a whole subsystem, add ~12 lines, and the reset is now
-absorbed in-process wherever eventual consistency lands it — instead of slept
-through and hoped.** That is strictly more robust _and_ strictly less code.
+**Net effect: delete a whole subsystem, add ~16 lines of product code, and the
+reset is absorbed in-process wherever eventual consistency lands it — at 1 s,
+91 s, or during an ordinary production create — instead of slept through and
+hoped.** Strictly more robust _and_ strictly less code, validated at the
+unit/typecheck level (the live preview marathon is the remaining check).
+
+Because the new retry sees the raw workerd exception, it **must not** retry
+overload — so the same change carries a **one-line guard in the existing boolean
+classifier** (`stream-unavailable.ts:38-45`), no new type or wire contract:
+
+```ts
+// isDurableObjectLifecycleError — exclude overload (Cloudflare: never retry it)
+return flags.overloaded !== true && (flags.durableObjectReset === true || flags.retryable === true);
+```
 
 **Two small, separable hardening fixes** (real per Cloudflare, but independent of
-the gate deletion — do them as their own tiny PRs, not as a precondition):
+the gate deletion — do them as their own tiny PRs, _not_ a precondition):
 
-- **Stop retrying `overloaded`** (audit finding B2). Cloudflare is explicit:
-  `.overloaded` "should not be retried… retrying will worsen the overload"
-  ([error
-  handling](https://developers.cloudflare.com/durable-objects/best-practices/error-handling/)),
-  yet `isDurableObjectLifecycleError` (`stream-unavailable.ts:38-45`) retries it
-  alongside `reset`/`retryable`. Split it out. ~5 lines, one classifier.
-- **Match the blessed retry cadence.** `waitUntilProcessed`'s ~1 Hz
-  deadline-loop drifts from Cloudflare's "exponential backoff + jitter, small
-  attempt cap." Minor; align when touching it.
+- **The broader `overloaded` story (audit finding B2).** The one-line guard above
+  fixes the raw-error path this change touches; the _full_ taxonomy (an
+  `overloaded` that already crossed capnweb as a `stream-unavailable:` string and
+  lost its flags, retried by `waitUntilProcessed`'s deadline loop) is a separable
+  B2 hardening — it does **not** need a discriminated-union classifier refactor to
+  land this fix. Cloudflare is explicit: `.overloaded` "should not be retried…
+  retrying will worsen the overload"
+  ([error handling](https://developers.cloudflare.com/durable-objects/best-practices/error-handling/)).
+- **Match the blessed retry cadence.** `waitUntilProcessed`'s ~1 Hz deadline-loop
+  drifts from Cloudflare's "exponential backoff + jitter, small attempt cap."
+  Minor; align when touching it.
 
 **Cut from the first draft as not load-bearing** for deleting the gate: the
 explicit-`create()`-contract change (#2273/B3 — orthogonal ambiguous-success
@@ -66,6 +92,29 @@ concern), the post-deploy canary (the marathon already _is_ the evidence), the
 fixture consolidation (good hygiene, optional), and the concurrency sweep (B4 —
 its own operational task). The active-readiness probe (C4) is not merely cut but
 **refuted** — Cloudflare confirms no convergence gate can exist.
+
+### The measured patch (applied + validated in a throwaway worktree)
+
+| File                                                                |   +add |    −del | Purpose                                                                                         |
+| ------------------------------------------------------------------- | -----: | ------: | ----------------------------------------------------------------------------------------------- |
+| `apps/os/src/rpc-targets.ts`                                        |     12 |       7 | Run the native `waitForEvent` through the existing logged one-retry helper                      |
+| `apps/os/src/domains/streams/stream-unavailable.ts`                 |      4 |       2 | Exclude raw overload from reset/retryable classification                                        |
+| `apps/os/src/domains/streams/stream-unavailable.test.ts`            |      1 |       1 | Assert raw overload is not lifecycle-retryable                                                  |
+| `apps/os/src/domains/streams/stream-processor-rpc-target.test.ts`   |      9 |       5 | Flip the terminal-reset test into a fresh-stub recovery proof                                   |
+| `apps/os/e2e/vitest/onboarding-smoke.ts`                            |      0 |       6 | Remove rollout-wait import/use                                                                  |
+| `packages/shared/src/test-support/preview-rollout-gate.ts` (+ test) |      0 |     120 | Delete the gate implementation + its tests                                                      |
+| `packages/shared/package.json`                                      |      0 |       1 | Remove gate export                                                                              |
+| `scripts/preview/preview.ts`                                        |      4 |      89 | Remove constant, resolvers, config field, before/inside-suite gates, env injection, settle lane |
+| `scripts/preview/preview.test.ts`                                   |      3 |      59 | Remove resolver/config/lane tests                                                               |
+| `scripts/preview/e2e-policy.test.ts`                                |      1 |       4 | Remove the rollout-gate policy assertion                                                        |
+| `specs/*` (create-project, seeded-apps, signup, test-support ×3)    |      9 |      26 | Remove rollout-timeout arg plumbing + `testInfo.setTimeout` extensions                          |
+| **Total**                                                           | **43** | **320** | **net −277 LOC**                                                                                |
+
+Validation on the applied patch: `apps/os` focused files **45/45 pass**, root
+preview workflow/policy **148/148 pass**, `pnpm --dir apps/os typecheck` passes,
+`git diff --check` passes. The remaining check is the live preview marathon (the
+zero-retry proof), which only Depot CI can run — so this is documented as a
+ready-to-apply patch rather than committed into this analysis PR.
 
 The detailed candidate analysis and the fuller (optional) version follow.
 

--- a/docs/flake-athon-refactor-options.md
+++ b/docs/flake-athon-refactor-options.md
@@ -1,0 +1,186 @@
+# Refactor options: project creation & e2e fixtures (flake-athon follow-up)
+
+The [audit](flake-athon-audit-2026-07.md) found the one real robustness-for-green
+trade is the preview Durable-Object rollout race, currently gated by a **blind
+90 s sleep** (`previewMinimumDeploymentAgeMs`) that is off the guarded ladder and
+unprovable. This doc explores four candidate refactors that address it by
+improving **project creation** and the **e2e test fixtures**, and recommends one.
+
+Four candidate designs were each prototyped independently against the real code
+(by parallel Claude subagents), and a Codex `gpt-5.6-sol` xhigh pass audited the
+same surface. The candidates and the evidence that decided between them:
+
+## The failure mode, stated correctly
+
+After a fresh Worker version deploys, Cloudflare resets each Durable Object to
+load the new code on first access — surfacing as `Durable Object reset because
+its code was updated`. **Crucially, this rollout is _globally eventually
+consistent per object/placement_** ([CF known
+issues](https://developers.cloudflare.com/durable-objects/platform/known-issues/)):
+old and new code coexist for a window, and _which_ identity resets _when_
+depends on placement. This one fact is decisive — see C4.
+
+Two things must be classified apart (they are conflated today at
+`stream-unavailable.ts:38-45`, and the audit's finding **B2** shows why that
+matters):
+
+- **reset / retryable** — an idempotent caller may safely reacquire a fresh
+  incarnation and retry.
+- **overloaded** — Cloudflare says [do **not**
+  retry](https://developers.cloudflare.com/durable-objects/best-practices/error-handling/);
+  retrying worsens the overload. Under the campaign's 48-Vitest-file + 16-worker
+  fan-out, a deadline-long retry loop on `overloaded` becomes a synchronized
+  request storm that hides the capacity signal.
+
+## The four candidates
+
+### C1 — Blanket retry at the itx client transport
+
+Wrap the client so any RPC that returns a reset error retries transparently.
+**Rejected.** capnweb is a pipelined, stateful session: a "call" is a property
+chain whose intermediate stubs are server-held; a mid-chain reset invalidates
+them, so blind replay is unsafe. And non-idempotent mutations can't be
+auto-retried without keys the transport can't see. The _sound_ form collapses to
+an opt-in per-method helper — which already exists server-side
+(`retryIdempotentDurableObjectOperation`) — and still can't reach the
+browser-button-driven creates the sign-up specs use. Narrower than C2, no unique
+benefit.
+
+### C2 — Self-healing create saga (server-side) ✅ core of the recommendation
+
+Make each first-touch operation absorb a reset by reacquiring a fresh incarnation
+under one deadline, so `create()` never surfaces the rollover. **Key finding
+from prototyping: this is ~90 % already shipped.** The saga's reset-prone steps
+already self-heal:
+
+| Saga step                | First-touch DO         | Coverage today                                                                                                                  |
+| ------------------------ | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| root birth append        | STREAM                 | ✅ keyed-append door → `retryIdempotentDurableObjectOperation` (one bounded retry, dedupes on idempotency key)                  |
+| subscriptions            | STREAM                 | ✅ rides the birth append                                                                                                       |
+| processor birth drive    | PROJECT + notification | ✅ `ProcessorRelayRpcTarget.waitUntilProcessed` (#2266's reacquire-under-deadline)                                              |
+| secret seed              | SECRET                 | ✅ swallow-and-reheal (ensure-create on reveal)                                                                                 |
+| **`project/ready` wait** | STREAM                 | ❌ **the one gap** — `waitForEvent` (`rpc-targets.ts:628-719`) re-throws a reset instead of re-arming like `waitUntilProcessed` |
+
+And every **on-demand** DO (agent, sandbox, scheduler, workspace, repo, secret)
+returns a `ProcessorRelayRpcTarget`, so mid-test first-touches already self-heal
+too — which **disproves C3's feared "mid-test reset" gap**. So C2 is not a build,
+it's a _finish_: one production change (teach `waitForEvent` to re-arm on
+reset/retryable under its existing deadline, with a small backoff), then the gate
+is fully redundant. Provable (observes `project/ready` actually committed on the
+fresh incarnation, bounded so a real wedge still fails), and it helps **real
+users** creating a project against a just-deployed worker — not just tests.
+
+### C3 — One canonical retrying fixture (test layer) ✅ complementary
+
+A single `createTestProject()` (and Playwright sibling) that owns slug + create +
+readiness + disposal and is the only way a test provisions — migrating the ~4
+bypassing call sites (`agent-response-cache`, `project-ingress`,
+`create-test-project-pool`, and the Playwright forged-session path). **Good
+hygiene, low risk, test-only.** On its own it's insufficient (it can't reach the
+`email-otp-signup` server-side browser-click create, and a fixture-layer retry
+doesn't help production), and its retry is largely _redundant with C2_ once the
+saga self-heals. But consolidating to one provisioner — with **no** rollout wait
+and **no** per-spec `setTimeout` extension — is worth doing alongside C2.
+
+### C4 — Cheap active readiness probe (keep a provable gate) ❌ not provably correct
+
+Touch one identity per DO namespace class after deploy, confirm it serves the new
+version, release all lanes. Attractive (≈6 RPCs vs #2140's ~500), **but the
+premise is false.** Because rollout is globally eventually consistent
+_per-object/placement_, a probe of identity A does **not** prove a future test
+identity B (different placement) has converged. #2140 used _many_ identities
+precisely because one is insufficient — reducing the sample doesn't turn a
+statistical gate into a proof. This is the correction that decides the whole
+question: **no gate/probe can prove convergence; only operations that survive a
+reset whenever/wherever it lands are sound.** C4 is viable _only_ as an explicit,
+owner-and-removal-criterion quarantine if C2 is judged too risky to land at once
+— never as readiness proof.
+
+## Recommendation
+
+**Land C2 (finish the self-healing saga) as the core, with the classifier split
+that finding B2 requires, model `create()`'s outcome explicitly (finding B3),
+consolidate fixtures with C3, delete the blind gate, and replace it with a
+post-deploy recovery _canary_ (not a gate).** In order:
+
+1. **Split the availability classifier** (foundational; fixes B2). Replace the
+   single boolean with a discriminated result `"reset" | "retryable" |
+"overloaded" | null` in `stream-unavailable.ts`. Reacquire only
+   `reset`/`retryable` for idempotent callers; propagate `overloaded` as a typed
+   backpressure outcome that is **never** looped on. Everything below depends on
+   classifying correctly.
+
+2. **Finish the saga self-heal** (C2). Teach `waitForEvent`
+   (`rpc-targets.ts:628-719`) to re-arm on `reset`/`retryable` under its existing
+   deadline (mirroring `waitUntilProcessed`), with a small inter-slice backoff so
+   a genuinely resetting DO can't hot-loop the isolate. Durable rows replay from
+   the pinned `replayAfterOffset`, so `project/ready` is genuinely observed, not
+   skipped. Add a unit test that injects a reset (fake stub rejects once, then
+   succeeds) and asserts create reaches ready; two consecutive resets past the
+   deadline still reject.
+
+3. **Model `create()`'s outcome explicitly** (fixes B3; this is the heart of
+   "project creation"). Today default `create()` rejects at ~15 s while a 75 s
+   birth drive keeps committing — a caller can get an _error_ for a project that
+   durably succeeds and later becomes ready. Split the acknowledgement: `create()`
+   returns after identity + birth-batch commit with the stable handle;
+   `waitUntilReady({ timeoutMs })` is a separate explicit observation; a
+   convenience returns `{ project, readiness: "ready" | "provisioning" }`. A
+   committed create is **never** an undifferentiated error — which removes the
+   "caller/test retry redials" crutch entirely.
+
+4. **Consolidate fixtures** (C3). One canonical `createTestProject()` + Playwright
+   sibling built on the explicit-outcome create; migrate the bypassing call
+   sites; delete the per-spec `testInfo.setTimeout` extensions
+   (`forged-session.ts:67`, `email-otp-signup.ts:62`).
+
+5. **Delete the blind gate and all its plumbing** —
+   `previewMinimumDeploymentAgeMs`, `resolvePreviewRolloutReadyAtMs`,
+   `resolvePreviewRolloutRemainingSeconds`, the before-suite sleep, the
+   rollout-settle lane, `packages/shared/src/test-support/preview-rollout-gate.ts`,
+   the `PREVIEW_APP_ROLLOUT_*` env vars, and the `previewTestRolloutGate` config
+   field. Findings **#1 and #2 both vanish** — there is no constant left to sit
+   off the ladder.
+
+6. **Replace the gate with a post-deploy recovery canary** (not a gate). Right
+   after deploy, create a fresh real project (new identity, new placement) and
+   assert it reaches ready **without a framework retry**. This is _positive proof
+   the self-heal works_ on this exact deploy — release evidence — where the 90 s
+   sleep only ever _hoped_. It runs once per deploy and fails the deploy loudly if
+   recovery is broken; it does not gate the suite on a guessed duration.
+
+7. **Then re-earn the concurrency & release evidence** (findings B4/B5). With
+   `overloaded` no longer retried into a storm, re-sweep Vitest file workers
+   (8/12/16/24/32/48) over ≥3 unchanged runs per the documented rule, pick the
+   throughput knee, and run the 25-consecutive-zero-retry marathon on the final
+   head. Only then is the campaign _proven_, not merely green.
+
+### Why this is the right shape
+
+- **It deletes more than it adds.** Gate + plumbing + per-spec `setTimeout` + the
+  ambiguous-create crutch all go; the net new code is one `waitForEvent` branch,
+  a discriminated classifier, an explicit create contract, one fixture, and a
+  canary.
+- **It's provably correct where a gate cannot be.** The reset is survived at the
+  operation, so it holds whenever/wherever eventual consistency lands the
+  rollover — not predicated on a guessed window.
+- **It fixes the product, not the timeout**, and helps real users hitting a
+  freshly deployed worker — the policy's first principle.
+- **It separates two contracts that must not be conflated** (reset-recovery vs
+  overload-backpressure), removing a latent storm under high fan-out.
+
+### What would make this recommendation wrong
+
+- If the `waitForEvent` re-arm can't be made bounded/idempotent cleanly (it can —
+  `waitUntilProcessed` already is the template), OR
+- If project birth has a real _service_ capacity limit (not just isolated IDs),
+  in which case bounded admission (a semaphore/queue with durable terminal state)
+  is the product fix and unbounded fixture concurrency is the actual bug — the
+  concurrency sweep in step 7 is what tells us. Either way the blind sleep is not
+  the answer.
+
+_Codex independent design cross-check: folded in — Codex's audit converged on the
+same "make operations idempotent + incarnation-independent, add a post-deploy
+canary, do not restore a sampler" conclusion, and supplied the classifier-split
+(B2) and eventual-consistency correction that upgraded this recommendation over
+the audit's original active-probe sketch._

--- a/docs/flake-athon-refactor-options.md
+++ b/docs/flake-athon-refactor-options.md
@@ -116,6 +116,88 @@ preview workflow/policy **148/148 pass**, `pnpm --dir apps/os typecheck` passes,
 zero-retry proof), which only Depot CI can run — so this is documented as a
 ready-to-apply patch rather than committed into this analysis PR.
 
+## Round 3 — can we cut further? (mostly: we're near the floor)
+
+Asked to cut again — less code, less mental clutter, more robustness, favouring
+"make the product path work and tell the caller to retry" over harness
+compensation — a wide re-investigation (three subagents + codex, Cloudflare +
+capnweb source) found **one genuinely on-target low-faff win, a couple of
+freebies, and an honest "don't over-refactor the rest."**
+
+### ✅ The one high-value, low-faff addition: a clear "retry later" signal to the caller
+
+This is exactly the "clearly communicate to the caller when it's no use" ask, and
+it costs **~6-8 lines in one function, zero caller or codegen churn.** Today
+`create()`'s default lane rejects at ~15 s (`PROJECT_CREATE_READY_TIMEOUT_MS`,
+measured from create-entry) while the 75 s birth drive keeps committing — so a
+caller can get an _undifferentiated_ error for a project that then becomes ready
+(audit finding B3). The fix is **not** a typed-union return or a create/await
+split (both were measured to _add_ net complexity — a union propagated through
+`itx-api.generated.ts` + every caller, or a default-behaviour flip felt by every
+out-of-tree script). It's simply: when the ready-wait deadline elapses _while
+birth is still progressing_, throw a clearly-named **retryable** error —
+`"project not ready yet — birth still in progress, retry"` — instead of a bare
+`waitForEvent` timeout string, and measure that 15 s from when the ready-wait
+opens, not from create-entry. No return-type change, no caller changes. The
+caller's existing `try/catch` keeps working; the message now tells it to retry.
+Combined with the round-2 self-heal, the harness relies on this clean signal +
+the one CI retry — no gate.
+
+### ✅ Freebies (safe, net-negative)
+
+- **Merge the duplicate `#read` retry** — `WorkspaceGitRpcTarget.#read`
+  (`rpc-targets.ts:2089-2095`) is byte-identical to `WorkspaceRpcTarget.#read`
+  (`2028-2034`). Share one. **−7 LOC, ~0 risk.**
+- **Delete `waitForOnboardingGreeting`** (`lib/onboarding-agent.ts:76-106`, ~25
+  LOC) once the round-2 `waitForEvent` reset gap is closed — it is a _hand-rolled
+  copy_ of exactly the re-arm-from-durable-cursor logic that fix gives
+  `waitForEvent`. Sequence it after the gap fix; flip its test. **−25 LOC.**
+- **Correct a stale comment.** `stream-unavailable.ts:6-13` claims capnweb "strips
+  everything but `message`/`name`." That is **false** for the
+  `@iterate-com/capnweb@0.10.0` fork this repo runs — it preserves own-enumerable
+  Error properties and the `cause` chain (verified by round-trip). Misleading;
+  fix regardless.
+
+### 🟡 The real deeper clutter — but it is NOT low-faff, so don't bundle it
+
+The retry _machinery_ is already near-minimal: only **~4 retry shapes** (one
+shared `retryLoggedIdempotentOperation` reused at 6 read/append/barrier sites; the
+`waitUntilProcessed` slice+backoff loop; the `#callProcessorOutcome`
+acquire-dispose-race; the browser transport backoff) plus a few non-retry
+recovery shapes. **A "grand unified retry" would be wrong** — the shapes are
+distinct for real reasons (stub disposal, durable cursors, a reconnecting socket).
+Consolidation is already done.
+
+The genuine conceptual clutter is that a "retryable DO failure" has **three
+representations**: (1) raw workerd flags in-worker; (2) the `stream-unavailable:`
+message-string tag for the capnweb→browser hop; (3) an explicit
+`{durableObjectReset, overloaded, retryable}` payload manually re-serialized
+across the **native Worker→Worker wake hop** (`stream-subscribers.ts:1586-1596`).
+Tempting to unify on a clean `retryable` own-property (the capnweb fork now
+preserves it) — **but the string tag is load-bearing precisely where own-props
+are not:** Cloudflare native Workers RPC preserves `message` but _strips own
+properties_
+([RPC error handling](https://developers.cloudflare.com/workers/runtime-apis/rpc/error-handling/)),
+which is exactly why the wake hop hand-serializes the flags. Replacing the tag
+with an own-property would **regress** any native-RPC hop unless each is taught to
+re-serialize — a careful, medium-faff refactor across ~7 sites with a
+serialization-dependency test. **Don't ride it in the lean fix.** File it as a
+separate "unify the DO-failure signal" cleanup: worth doing for mental hygiene,
+but not "little faff" and it doesn't change robustness — so it must not gate the
+−277 deletion.
+
+### Net for round 3
+
+The lean fix stays the round-2 core (delete gate −277, close the `waitForEvent`
+gap +12/−7). Round 3 _adds_ the clear caller error (~+6) and _removes_ ~32 more
+via the two freebies — **~−300 LOC** total, with a clean "retry later" signal and
+no new abstraction. Honest headline: **we're near the floor.** The remaining
+clutter (three failure representations) is real but its cleanup is a separate
+careful task, not a quick cut — bundling it would trade the "little faff" the ask
+wants for churn that doesn't move robustness.
+
+---
+
 The detailed candidate analysis and the fuller (optional) version follow.
 
 ## The failure mode, stated correctly

--- a/docs/flake-athon-refactor-options.md
+++ b/docs/flake-athon-refactor-options.md
@@ -239,16 +239,46 @@ silent-failure hole (violates "no silent failure"). Turn it into a telemetry
 event (keep the non-throwing control flow — it self-heals on reveal). **~+2 LOC,
 pure observability upside**, folded into the lean fix.
 
-### Verdict: this is the floor
+### Verdict: safe floor ~−300 LOC; up to ~−455 with a marathon-gated extra
 
-Four rounds converge. The lean fix — **delete the gate (−305), reuse the one-retry
-helper on the one uncovered wait (+12/−7), a clear "retry later" error (+6), two
-freebies (−32), the seed-telemetry line (+2)** ≈ **−300 LOC net, validated** — is
-the floor for "less code + less clutter + more robustness + little faff." Further
-cuts either (a) can't beat Cloudflare's eventual-consistency model, (b) relocate
-complexity rather than remove it, or (c) are the separate medium-faff
+Both independent codex rounds converge: round 4 confirms **"the ~−300 lean fix is
+the floor — stop cutting"** (you can't beat Cloudflare's model; always-async
+`create()` would need ~133 explicit readiness waits across the repo). Round 3 —
+**built and unit-validated in an isolated copy (59/59 tests, typecheck,
+`git diff --check`)** — showed the floor can go to **~−455 cumulative** (−178
+beyond round 2) with three cuts I under-credited, the first two clean and safe,
+the third marathon-gated:
+
+- **A machine-readable `retryable: true` at the itx boundary** — strictly better
+  than my prose "retry later" message. It **keeps** the internal
+  `stream-unavailable:` string tag (confirming the native-RPC-strips-own-props
+  finding) but attaches `retryable: true` at `itx-observability.ts`, where the
+  error is normalized _before_ the capnweb hop (which the fork preserves). Callers
+  do `error.retryable === true` — no custom class, no result union, no codegen
+  churn. This is the cleanest form of "clearly tell the caller to retry."
+- **Delete the generic `retryIdempotentDurableObjectOperation` abstraction** — it
+  has one production caller (`retryLoggedIdempotentOperation`); inline the 7-line
+  body and drop the wrapper + its tests. Removes an abstraction, not a retry.
+- **Delete `waitForOnboardingGreeting`** + its tests (round 3 already had this)
+  and the workspace `#read` dedupe.
+
+**One contested piece:** codex also restructures `create()` to background the seed
+
+- 75 s birth-drive via `ctx.waitUntil` so the foreground awaits only
+  `project/ready`, making the 15 s-vs-75 s ambiguity vanish structurally (not just a
+  renamed timeout). It keeps the return contract (no caller churn) and passed unit
+  tests — but it changes `create()`'s internal completion semantics, and the round-4
+  analysis flags create-reshapes as needing care. **Land that piece only behind the
+  live preview marathon**, not on unit-green alone; the other three cuts are safe.
+
+So the floor is lower than I said, and the extra ~155 LOC is genuine clutter
+removal (a redundant abstraction, a redundant recovery helper, a clean caller
+signal) — not churn. What remains truly off-limits is unchanged: (a) you can't beat
+Cloudflare's eventual-consistency model, (b) flipping the create _default_
+relocates complexity, and (c) the
 [DO-failure-signal unification](../tasks/unify-durable-object-failure-signal.md)
-that doesn't move robustness. Recommendation: **ship the lean fix; stop cutting.**
+is separate medium-faff. Recommendation: **ship the safe cuts (~−300); gate the
+create-restructure (~another −155 incl. its deletions) on the marathon.**
 
 ---
 

--- a/tasks/preview-rollout-do-reset-gate.md
+++ b/tasks/preview-rollout-do-reset-gate.md
@@ -1,0 +1,88 @@
+---
+title: Replace the blind preview rollout age-gate with an active readiness probe
+status: open
+severity: medium
+area: preview-ci
+owner: unassigned
+created: 2026-07-23
+tracks:
+  - "#2140 (added the readiness barrier)"
+  - "#2261 (removed it)"
+  - "#2265 (restored it as a blind 90s age gate)"
+---
+
+# Preview rollout DO-reset gate: make it provable, not a blind sleep
+
+## Context
+
+When a fresh preview Worker version deploys, the first access to each Durable
+Object triggers Cloudflare to reset that DO to load the new code. A test that
+creates a project (or otherwise touches a DO) inside that window fails with
+`Durable Object reset because its code was updated`.
+
+- **#2140** guarded this with an active readiness barrier
+  (`apps/os/src/deployment-readiness.ts`): ~10 probe waves per namespace, a 10s
+  settle, then complete-set revalidation, gating the deploy→`awaiting-tests`
+  transition that *all* lanes waited behind.
+- **#2261** removed that barrier (fair critique: ~500 synthetic probe RPCs per
+  deploy dominated the tail, and a finite sample can't prove the whole fleet),
+  but left only an onboarding-smoke gate in front of Vitest — no replacement
+  barrier, and no tracking task. Its own round-9 marathon evidence shows the
+  reset race recurring and being **retry-absorbed** (7 Vitest + 2 Playwright on
+  retry; `OS preview smoke` failing both attempts).
+- **#2265** restored a barrier as a **blind fixed 90s sleep**
+  (`previewMinimumDeploymentAgeMs = 90_000`, `scripts/preview/preview.ts`):
+  DO-backed suites and project-create helpers wait until 90s after the deploy
+  timestamp. Both lanes are gated again, so this is not an open production hole.
+
+## Problem
+
+The current gate is a **blind time constant**, not a proof:
+
+1. It *hopes* 90s ≥ the reset-settle window. If the window ever exceeds 90s the
+   race silently returns and is absorbed by the single test retry — the exact
+   failure the marathon already shows. This is the "sleep through it instead of
+   proving the state" anti-pattern (`docs/testing.md` principle 4), relocated
+   from the test into the orchestrator.
+2. It taxes every healthy run the full 90s even when the rollout settled in ~15s.
+3. It lives off the guarded ladder (see the companion budgets.ts follow-up) and
+   until this task existed had no protocol tracking.
+
+Evidence the reset flake is still real and retry-absorbed: #2244's marathon
+accepted-streak is **0**; the retired harness failed iteration 5 with 12 retries,
+most first failures `Durable Object reset because its code was updated`.
+
+## Proposed fix
+
+Replace the blind age gate with a **cheap active readiness gate** that checks the
+real invariant and returns as soon as it holds:
+
+- One readiness request **per DO namespace class the suite actually uses** (a
+  handful, not 500 fleet-wide synthetic probes), issued once, that forces and
+  confirms the post-deploy reset. The reset is idempotent and one-shot per
+  version, so a single touch per namespace is sufficient — provable, not
+  probabilistic.
+- Retry a namespace probe **only** on `durableObjectReset`/`overloaded` until the
+  version served matches the deployed Worker version, then move on. Never a fixed
+  sleep.
+- Bounded by `PREVIEW_ROLLOUT_READINESS_WATCHDOG_MS` on the guarded ladder, sized
+  ~2× the measured p99 settle. A rollout that never settles *should* fail the run
+  (principle 3), not be slept through.
+- Both lanes wait on the same ready signal (Vitest at its fan-out boundary,
+  Playwright's project-create helpers on the same gate).
+
+Sketch in `docs/flake-athon-audit-2026-07.md` § 1 and § 7-D.
+
+## Interim state (already landed)
+
+- Constant moved onto the guarded ladder (`budgets.ts`) so it can't drift as a
+  bare literal — see `docs/flake-athon-audit-2026-07.md` § 7-A.
+
+## Exit criteria (remove this task when all hold)
+
+- [ ] The blind `previewMinimumDeploymentAgeMs` sleep is gone; the gate is an
+      active readiness probe bounded by a laddered watchdog.
+- [ ] `scripts/preview/flake-hunt-loop.sh` reaches a **non-zero zero-retry
+      streak** with **no** `Durable Object reset because its code was updated`
+      in any first attempt across the streak.
+- [ ] The healthy-run start delay is the *measured* settle time, not a fixed 90s.

--- a/tasks/preview-rollout-do-reset-gate.md
+++ b/tasks/preview-rollout-do-reset-gate.md
@@ -54,24 +54,34 @@ most first failures `Durable Object reset because its code was updated`.
 
 ## Proposed fix
 
-Replace the blind age gate with a **cheap active readiness gate** that checks the
-real invariant and returns as soon as it holds:
+> **Corrected after the Codex cross-check.** An earlier version of this task
+> proposed an *active readiness probe* (one touch per DO namespace class). That
+> is **not provably correct**: Cloudflare DO rollout is globally eventually
+> consistent *per object/placement*, so probing one identity does not prove a
+> future test identity (different placement) has converged. No gate or probe can
+> prove convergence — only operations that survive a reset whenever/wherever it
+> lands.
 
-- One readiness request **per DO namespace class the suite actually uses** (a
-  handful, not 500 fleet-wide synthetic probes), issued once, that forces and
-  confirms the post-deploy reset. The reset is idempotent and one-shot per
-  version, so a single touch per namespace is sufficient — provable, not
-  probabilistic.
-- Retry a namespace probe **only** on `durableObjectReset`/`overloaded` until the
-  version served matches the deployed Worker version, then move on. Never a fixed
-  sleep.
-- Bounded by `PREVIEW_ROLLOUT_READINESS_WATCHDOG_MS` on the guarded ladder, sized
-  ~2× the measured p99 settle. A rollout that never settles *should* fail the run
-  (principle 3), not be slept through.
-- Both lanes wait on the same ready signal (Vitest at its fan-out boundary,
-  Playwright's project-create helpers on the same gate).
+Make project creation (and every first-touch operation) **self-heal** across a
+reset, then delete the gate — full candidate comparison and recommendation in
+[`docs/flake-athon-refactor-options.md`](../docs/flake-athon-refactor-options.md):
 
-Sketch in `docs/flake-athon-audit-2026-07.md` § 1 and § 7-D.
+1. **Split the availability classifier** so `overloaded` is propagated as typed
+   backpressure and never retried (audit finding B2); reacquire only
+   `reset`/`retryable`.
+2. **Finish the create saga self-heal**: `waitForEvent`
+   (`rpc-targets.ts:628-719`) re-arms on reset under its existing deadline, the
+   way `waitUntilProcessed` already does — the one residual gap; all other saga
+   steps and on-demand DOs already self-heal via the relay + keyed-append door.
+3. **Model `create()`'s outcome explicitly** instead of the ambiguous 15 s reject
+   while birth continues (finding B3), so a committed create is never surfaced as
+   an error.
+4. **Consolidate to one canonical `createTestProject()` fixture** and delete the
+   per-spec `testInfo.setTimeout` extensions.
+5. **Delete** the blind gate + all plumbing.
+6. **Replace it with a post-deploy recovery canary** — create a fresh real
+   project right after deploy and assert it recovers without a framework retry.
+   Proof, not a sleep.
 
 ## Interim state (already landed)
 
@@ -80,9 +90,13 @@ Sketch in `docs/flake-athon-audit-2026-07.md` § 1 and § 7-D.
 
 ## Exit criteria (remove this task when all hold)
 
-- [ ] The blind `previewMinimumDeploymentAgeMs` sleep is gone; the gate is an
-      active readiness probe bounded by a laddered watchdog.
-- [ ] `scripts/preview/flake-hunt-loop.sh` reaches a **non-zero zero-retry
-      streak** with **no** `Durable Object reset because its code was updated`
+- [ ] The blind `previewMinimumDeploymentAgeMs` sleep and its plumbing are gone;
+      project creation self-heals across a reset (no gate).
+- [ ] The availability classifier discriminates `reset|retryable|overloaded`;
+      `overloaded` is never retried into a loop.
+- [ ] A post-deploy recovery canary asserts a fresh project recovers without a
+      framework retry.
+- [ ] `scripts/preview/flake-hunt-loop.sh` reaches the **25-consecutive-zero-retry**
+      release bar with **no** `Durable Object reset because its code was updated`
       in any first attempt across the streak.
-- [ ] The healthy-run start delay is the *measured* settle time, not a fixed 90s.
+- [ ] The healthy-run start delay is zero — no fixed post-deploy sleep.

--- a/tasks/unify-durable-object-failure-signal.md
+++ b/tasks/unify-durable-object-failure-signal.md
@@ -1,0 +1,110 @@
+---
+title: Unify the "retryable Durable Object failure" signal (three representations → one)
+status: open
+severity: low
+area: streams / error-handling
+owner: unassigned
+created: 2026-07-23
+relates:
+  - docs/flake-athon-refactor-options.md (Round 3 — the deeper clutter)
+  - tasks/preview-rollout-do-reset-gate.md
+---
+
+# Unify the DO-failure signal
+
+## Why this is a task and not part of the lean fix
+
+Surfaced during the flake-athon round-3 review. It is **real mental clutter but
+NOT low-faff**, so it is deliberately *not* bundled with the preview-gate deletion
+or the `waitForEvent` reset-gap fix. It changes no runtime behaviour and does not
+move robustness — it must never gate those changes. Do it on its own when someone
+wants to reduce conceptual weight in the streams error path.
+
+## The clutter
+
+A single concept — "this Durable Object call failed transiently; an idempotent
+caller may retry" — has **three different representations** in the codebase, and
+`isRetryableDurableObjectAvailabilityError` has to union them via a cause-chain
+walk:
+
+1. **Raw workerd flags**, present only at the DO-stub caller inside the worker:
+   `error.durableObjectReset | .overloaded | .retryable`
+   (`apps/os/src/domains/streams/stream-unavailable.ts:38-46`,
+   `isDurableObjectLifecycleError`).
+2. **A magic message-string tag** for the capnweb → browser hop:
+   `STREAM_UNAVAILABLE_MESSAGE_PREFIX = "stream-unavailable: "`
+   (`stream-unavailable.ts:23`), minted by `rethrowStreamUnavailable`
+   (`:96-102`) at ~11 sites in `rpc-targets.ts` (572, 593, 608, 639, 658, 665,
+   691, 716, 733, 751, 6404) and `agent-collection-durable-object.ts:88`, and
+   re-detected by substring match in `isStreamUnavailableError` (`:110-112`),
+   consumed at `stream-browser-store.ts:2203`, `onboarding-agent.ts:94`,
+   `itx-observability.ts:75`.
+3. **A hand-serialized payload** across the native Worker→Worker wake-delivery
+   hop: `{ name, message, durableObjectReset, overloaded, retryable }` is
+   serialized on one side and rebuilt with `Object.assign(new Error(...), {...})`
+   on the other (`stream-subscribers.ts:1586-1596`, plus its serialize
+   counterpart).
+
+## The constraint that makes it non-trivial (read before starting)
+
+You cannot just "replace the string tag with a clean `retryable: true`
+own-property," even though it looks like the obvious cleanup:
+
+- **capnweb (browser hop):** the `@iterate-com/capnweb@0.10.0` fork this repo
+  runs **does** preserve own-enumerable Error properties and the `cause` chain
+  (verified by round-trip; note the comment at `stream-unavailable.ts:6-13`
+  claiming otherwise is **stale and wrong** — fix it regardless of this task).
+  So an own-property works here.
+- **native Workers RPC (Worker→Worker hop):** Cloudflare **preserves `message`
+  but strips own properties and `cause`**
+  (https://developers.cloudflare.com/workers/runtime-apis/rpc/error-handling/).
+  This is exactly why the wake hop (#3) hand-serializes the flags. An
+  own-property-only scheme would **regress** every native-RPC hop unless each is
+  taught to re-serialize — which is what turns this into a ~7-site refactor with
+  a serialization-dependency test, not a one-liner.
+- **custom Error subclass name** does NOT survive capnweb (downgrades to
+  `Error`), so `instanceof` a custom class is not a usable primitive.
+
+So the honest design space is: pick one internal representation (own-property
+`retryable`/`reset`/`overloaded` flags is the natural choice — it's what #1 and
+#3 already are), and ensure it is explicitly (re)serialized at **every**
+boundary that strips it (the native-RPC hops), keeping `message` human-readable
+but no longer *the contract*. The string prefix can then be deleted. Also fold in
+audit finding **B2**: split `overloaded` out so it is a distinct
+"do-not-retry" signal, never unioned into the retryable set
+(Cloudflare: retrying overload worsens it).
+
+## Scope
+
+- Define one small helper set (e.g. `markDurableObjectFailure(error, kind)` /
+  `classifyDurableObjectFailure(error): "reset" | "retryable" | "overloaded" |
+  null`) that reads/writes own-properties.
+- Replace the string-prefix mint/detect (`rethrowStreamUnavailable`,
+  `isStreamUnavailableError`, `STREAM_UNAVAILABLE_MESSAGE_PREFIX`) with it.
+- Audit every hop where such an error crosses **native Workers RPC** and ensure
+  each explicitly serializes/rebuilds the flags (like the wake hop already does);
+  add a helper so there is exactly one serialize/rebuild pair.
+- Simplify `isRetryableDurableObjectAvailabilityError` — with own-props +
+  capnweb's `cause` rehydration, the manual cause-walk shrinks or disappears.
+- Add a **round-trip test** pinning that the chosen representation survives BOTH
+  the capnweb hop and a native-RPC hop, so a future capnweb/workerd bump can't
+  silently regress it.
+- Fix the stale comment at `stream-unavailable.ts:6-13`.
+
+## Explicitly out of scope
+
+- The preview-gate deletion and the `waitForEvent` reset-gap fix (their own
+  task/PR). This task must not block them.
+- Any change to the four retry *shapes* — they are already minimal and correct.
+
+## Exit criteria
+
+- [ ] One own-property-based representation of a retryable DO failure; the
+      `stream-unavailable: ` message prefix and its substring detector are gone.
+- [ ] `overloaded` is a distinct never-retry signal, not unioned into retryable.
+- [ ] Every native-RPC hop that carries the signal (re)serializes it through one
+      shared helper; no hop relies on the message string as the contract.
+- [ ] A round-trip test pins survival across capnweb AND native Workers RPC.
+- [ ] The stale `stream-unavailable.ts:6-13` comment is corrected.
+- [ ] Net LOC is negative or flat, and no retry behaviour changed (pure
+      representation refactor).


### PR DESCRIPTION
> **Draft — this PR is an audit/report + a design recommendation, not a code
> change.** It adds a written review of the flake-athon, a project-creation &
> fixture refactor recommendation, and one tracking task. The code-level fixes it
> recommends are documented as ready-to-land designs, not applied (they touch
> product RPC + Depot CI and were produced off-CI).

## What this is

A careful, adversarial review of the ~32 PRs merged into `main` over
2026-07-21..23 as a "flake-athon" (a campaign to drive CI/e2e flakiness to zero),
**plus** a follow-up design exploration of how to fix the one real problem it
found by refactoring **project creation** and the **e2e test fixtures**.

Docs:
- [`docs/flake-athon-audit-2026-07.md`](docs/flake-athon-audit-2026-07.md) — the good/bad/ugly, per-PR verdicts, source-cited.
- [`docs/flake-athon-refactor-options.md`](docs/flake-athon-refactor-options.md) — four candidate refactors + a recommendation.
- [`tasks/preview-rollout-do-reset-gate.md`](tasks/preview-rollout-do-reset-gate.md) — the tracking task the flake-athon skipped.

**Method:** two independent audits in parallel — a Claude subagent fan-out (four
PR clusters + four design-candidate prototypes, each doing its own `gh`/git
archaeology and reading real code) and a Codex `gpt-5.6-sol` xhigh pass — both
reconciled against the repo's own policy in `docs/testing.md` /
`docs/ci-preview-performance.md`. Running them in parallel paid off: Codex caught
findings the Claude pass rated GOOD, and corrected the recommendation (below).

## TL;DR

**The flake-athon is overwhelmingly good work** — most PRs fix real root causes,
coverage *increased*, the telemetry rework is fail-closed. The scary big-deletion
PRs (#2261/#2217/#2244) are mostly moved code and doc churn, not deleted guards.

The real issues, ranked:

| # | Sev | What | Fix |
|---|-----|------|-----|
| **1** | 🔴 | **DO rollout race**: #2140 added an active readiness barrier → #2261 deleted it (no replacement, race retry-absorbed, no task) → #2265 restored it as a **blind 90 s sleep** off the guarded ladder. Gated but unprovable. | Self-heal the operation, delete the gate (see recommendation) |
| **B2** | 🟠 | **#2266 retries `overloaded`.** The classifier collapses `reset\|overloaded\|retryable` into one boolean; Cloudflare says overload must **not** be retried. Under 48+16 workers → synchronized retry storm that hides capacity. | Split the classifier; propagate overload as backpressure |
| **B3** | 🟠 | **#2273 ambiguous create.** `create()` rejects at ~15 s while a 75 s birth drive keeps committing — a caller gets an *error* for a project that later becomes ready. | Model the outcome explicitly |
| **B4** | 🟠 | **#2227 concurrency reversal.** #2169 kept 7 Vitest workers (remote bootstrap was the ceiling); #2227 jumped to ~48 on **one** retrying run, against the "≥3 unchanged runs" rule. | Evidence-based sweep |
| 2 | 🟡 | #2265's 90 s constant is off `budgets.ts`; #2253 widened a wait 30→100 s (tracked); #2226's brief critical-path telemetry hazard was fixed by #2237; B5 the campaign never met its own 25-zero-retry bar; U1 #2251 can strand a queued build. | Various (in the docs) |

The runtime-stability cluster (#2271, #2257, #2256, #2270, #2269, #2240 …) is
otherwise clean — the two exceptions above are a wrong error-contract and a
missing terminal state, not ordering-race masks.

## Update — the minimal fix (net ≈ −228 LOC), after "how much complexity are you adding?"

The recommendation below grew to 7 steps; re-examined for *least code / least
complexity / most robustness* — with Cloudflare-docs research, a real LOC count,
a chokepoint hunt, and **a patch codex actually applied + validated in a throwaway
worktree** (45/45 apps/os focused + 148/148 preview-workflow tests + typecheck +
`git diff --check` all pass) — it collapses to **two changes, net −277 LOC** (43
added / 320 deleted), one a pure deletion:

1. **Delete the whole rollout gate + plumbing — ~241 lines removed, 0 added.**
   Cloudflare documents **no way to wait for a rollout to become globally
   consistent** (DO code propagation is eventually consistent; a new Worker calls
   old-version DOs "for seconds to minutes"; the only remedy is forward/backward-
   compatible code). A time/probe gate is *categorically* the wrong tool — delete
   `preview-rollout-gate.ts`, `previewMinimumDeploymentAgeMs`, the resolve
   functions, the before-suite sleep, the rollout-settle lane, the per-spec
   `testInfo.setTimeout` extensions, the `PREVIEW_APP_ROLLOUT_*` env vars, the
   config field.
2. **Close the one real gap by reusing the existing one-retry helper — +12/−7.**
   `create()`'s ready-wait resolves through `waitForEvent({afterOffset:0})`, and
   the single native stub call at `rpc-targets.ts:681-689` is the *only* op on the
   create leg that still turns a first-touch reset terminal. Wrap it in the
   **existing** `retryLoggedIdempotentOperation` (one retry, fresh stub, logged) +
   a 1-line `overloaded !== true` guard in the existing boolean classifier — no new
   branches, no discriminated-union refactor. It's a read-only replay from the same
   pinned offset; app errors stay terminal. Also flips the test that froze the
   terminal-reset behavior.

Everything else in the saga already self-heals (keyed-append + processor-relay
retries). **Net: delete a subsystem, add ~12 lines; the reset is absorbed
in-process wherever it lands instead of slept-through.** Strictly less code *and*
more robust.

Two **separable** hardening fixes (own tiny PRs, not preconditions): stop
retrying `.overloaded` (finding B2 — Cloudflare says never retry it; ~5 lines),
and align the retry cadence to exp-backoff. **Cut as non-load-bearing:** the
explicit-create contract (#2273), the canary (the marathon is the evidence),
fixture consolidation (optional hygiene), the concurrency sweep (own task). The
active probe (C4) is **refuted** — no convergence gate can exist per Cloudflare.

Full detail + Cloudflare citations: [`docs/flake-athon-refactor-options.md`](docs/flake-athon-refactor-options.md).

---

## Recommendation — fix project creation, delete the gate

Four refactors were prototyped against the real code
([full comparison](docs/flake-athon-refactor-options.md)):

- **C1 client-transport blanket retry** — ❌ rejected (unsound under capnweb pipelining; can't reach browser-driven creates).
- **C2 self-healing create saga** — ✅ **core.** Prototyping found it's *~90 % already shipped*: the saga's reset-prone steps and every on-demand DO already self-heal via the relay retry + keyed-append door; the **only** gap is `waitForEvent` re-throwing a reset instead of re-arming like `waitUntilProcessed` already does.
- **C3 one canonical fixture** — ✅ complementary (test hygiene; low risk).
- **C4 active readiness probe** — ❌ **refuted by Codex**: DO rollout is *globally eventually consistent per placement*, so probing one identity never proves a future test identity converged. No gate/probe can prove convergence — only operations that survive a reset can.

**Land, in order:**
1. **Split the availability classifier** so `overloaded` is typed backpressure, never retried (fixes B2 — foundational).
2. **Finish the saga self-heal** — one `waitForEvent` branch re-arms on reset under its existing deadline (C2).
3. **Model `create()`'s outcome explicitly** — `create()` returns the handle after birth commit; `waitUntilReady({timeoutMs})` is separate; a committed create is never an error (fixes B3).
4. **Consolidate to one canonical `createTestProject()` fixture** (C3), dropping the per-spec `testInfo.setTimeout` extensions.
5. **Delete the blind gate + all plumbing** — findings #1 and #2 both vanish.
6. **Replace it with a post-deploy recovery *canary*** — create a fresh real project right after deploy and assert it recovers with no framework retry. Proof, not a sleep.
7. **Re-earn concurrency + release evidence** (B4/B5) — sweep Vitest workers over ≥3 runs, then the 25-zero-retry marathon.

Why this shape: it **deletes more than it adds**, is **provably correct where a
gate cannot be** (survives the reset wherever eventual consistency lands it),
**helps real users** hitting a freshly deployed worker, and **separates two
contracts that must not be conflated** (reset-recovery vs overload-backpressure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Docs | +1,173 -0 | +994 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+1,173 -0** | **+994 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between ea23c26 and d8c5865, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

---

### Correctness constraint (from the dedicated Codex design pass)

The second Codex run confirmed the ordering above and flagged one hole to respect
when implementing step 2: the admin/test `create()` path **mints a fresh project
ID** when none is supplied (`rpc-targets.ts:5380-5387`), so the reset-retry must
**not span the identity-mint boundary** — retry only *after* `primeProjectDirectory()`
commits (the first project-DO touch is already post-prime, so phase-2 retries keep
one ID). "create is idempotent" is too strong until admin slug→ID reservation is
made atomic; there's already a regression test guarding the conflicting-ID hole.
Also worth cleaning up in the same change: the secret-seed catch-all that only
warns, and sizing the create deadline from measured p99 (not a padded sleep).
Full detail in [`docs/flake-athon-refactor-options.md`](docs/flake-athon-refactor-options.md).


