### PR TITLE
Icon buttons: hover text + a11y lint rule

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -113,6 +113,7 @@
     "iterate/no-capnweb-http-batch": "error",
     "iterate/import-rules": "warn",
     "iterate/no-sr-only-data-attributes": "error",
+    "iterate/icon-button-has-hover-text": "error",
     "iterate/relative-import-extensions": "error",
     "iterate/zod-schema-naming": "error",
     "iterate/no-raw-durable-object-binding-access": "error",

--- a/lint/oxlint-plugin-icon-button.test.ts
+++ b/lint/oxlint-plugin-icon-button.test.ts
@@ -1,0 +1,164 @@
+// Tests for iterate/icon-button-has-hover-text: icon-size <Button>s render no
+// visible text, so they must carry an aria-label (or title) — the design
+// system's Button turns the aria-label into a title attribute, giving hover
+// text for free. The popular off-the-shelf rule for this
+// (jsx-a11y/control-has-associated-label) deliberately assumes any
+// uppercase-component child (like a lucide icon) might render a text label,
+// so it never flags `<Button size="icon"><Trash /></Button>` — hence this
+// custom rule.
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import assert from "node:assert/strict";
+
+import { test } from "vitest";
+
+test("flags an icon-size Button with no label", () => {
+  using fixture = createOxlintFixture();
+  fixture.write(
+    "unlabeled.tsx",
+    [
+      "declare const Button: any, Trash: any;",
+      "export const remove = (",
+      '  <Button size="icon-sm" variant="outline">',
+      "    <Trash />",
+      "  </Button>",
+      ");",
+      "",
+    ].join("\n"),
+  );
+
+  const result = fixture.runOxlint(["unlabeled.tsx"], { expectFailure: true });
+  assert.match(result.stdout + result.stderr, /Add aria-label/);
+});
+
+test("flags all icon sizes, including in render props", () => {
+  using fixture = createOxlintFixture();
+  fixture.write(
+    "render-prop.tsx",
+    [
+      "declare const Button: any, DialogClose: any, X: any;",
+      "export const close = (",
+      '  <DialogClose render={<Button size="icon-xs" />}>',
+      "    <X />",
+      "  </DialogClose>",
+      ");",
+      "",
+    ].join("\n"),
+  );
+
+  fixture.runOxlint(["render-prop.tsx"], { expectFailure: true });
+});
+
+test("accepts aria-label, title, dynamic labels, spreads, and non-icon sizes", () => {
+  using fixture = createOxlintFixture();
+  fixture.write(
+    "labeled.tsx",
+    [
+      "declare const Button: any, Trash: any, Plus: any, props: any, label: string;",
+      "export const ok = (",
+      "  <>",
+      '    <Button size="icon-sm" aria-label="Delete row">',
+      "      <Trash />",
+      "    </Button>",
+      '    <Button size="icon" title="Delete row">',
+      "      <Trash />",
+      "    </Button>",
+      '    <Button size="icon-lg" aria-label={label}>',
+      "      <Trash />",
+      "    </Button>",
+      '    <Button size="icon-sm" {...props}>',
+      "      <Trash />",
+      "    </Button>",
+      '    <Button size="sm">',
+      "      <Plus />",
+      "      Connect",
+      "    </Button>",
+      "  </>",
+      ");",
+      "",
+    ].join("\n"),
+  );
+
+  fixture.runOxlint(["labeled.tsx"]);
+});
+
+test("rejects an empty aria-label", () => {
+  using fixture = createOxlintFixture();
+  fixture.write(
+    "empty-label.tsx",
+    [
+      "declare const Button: any, Trash: any;",
+      "export const remove = (",
+      '  <Button size="icon-sm" aria-label=" ">',
+      "    <Trash />",
+      "  </Button>",
+      ");",
+      "",
+    ].join("\n"),
+  );
+
+  fixture.runOxlint(["empty-label.tsx"], { expectFailure: true });
+});
+
+const repoRoot = resolve(import.meta.dirname, "..");
+const pluginPath = join(repoRoot, "lint", "oxlint-plugin-iterate.ts");
+const oxlintBin = join(repoRoot, "node_modules", ".bin", "oxlint");
+
+/** Same fixture shape as oxlint-plugin-itx-script.test.ts: a temp project
+ * with the real plugin armed, linted by the real oxlint binary. */
+function createOxlintFixture() {
+  const root = mkdtempSync(join(tmpdir(), "iterate-oxlint-icon-button-"));
+  const configPath = join(root, ".oxlintrc.json");
+
+  writeFileSync(
+    configPath,
+    JSON.stringify(
+      {
+        categories: {
+          correctness: "off",
+          nursery: "off",
+          pedantic: "off",
+          perf: "off",
+          restriction: "off",
+          style: "off",
+          suspicious: "off",
+        },
+        env: {
+          builtin: true,
+          node: true,
+        },
+        jsPlugins: [pluginPath],
+        rules: { "iterate/icon-button-has-hover-text": "error" },
+      },
+      null,
+      2,
+    ),
+  );
+
+  return {
+    root,
+    [Symbol.dispose]() {
+      rmSync(root, { force: true, recursive: true });
+    },
+    runOxlint(args: string[], options: { expectFailure?: boolean } = {}) {
+      const result = spawnSync(
+        oxlintBin,
+        [...args, "--config", configPath, "--threads", "1", "--format", "stylish"],
+        { cwd: root, encoding: "utf8" },
+      );
+      if (options.expectFailure) {
+        assert.notEqual(result.status, 0, result.stderr || result.stdout);
+      } else {
+        assert.equal(result.status, 0, result.stderr || result.stdout);
+      }
+      return result;
+    },
+    write(path: string, contents: string) {
+      mkdirSync(dirname(join(root, path)), { recursive: true });
+      writeFileSync(join(root, path), contents);
+    },
+  };
+}

--- a/lint/oxlint-plugin-iterate.ts
+++ b/lint/oxlint-plugin-iterate.ts
@@ -548,6 +548,48 @@ const plugin: StrictPlugin = {
         };
       },
     },
+    "icon-button-has-hover-text": {
+      meta: {
+        docs: {
+          description:
+            "Require icon-size <Button>s to carry an aria-label (or title); Button turns it into hover text. " +
+            "The off-the-shelf jsx-a11y/control-has-associated-label rule can't do this: it assumes any " +
+            "uppercase-component child (e.g. a lucide icon) might render a text label.",
+        },
+        type: "problem",
+      },
+      create: (context) => {
+        return {
+          JSXOpeningElement: (node: any) => {
+            if (node.name.type !== "JSXIdentifier" || node.name.name !== "Button") return;
+            // A spread might supply size and/or aria-label; can't tell statically.
+            if (node.attributes.some((attribute: any) => attribute.type !== "JSXAttribute")) return;
+
+            const findAttribute = (name: string) =>
+              node.attributes.find(
+                (attribute: any) => getJSXAttributeName(attribute.name) === name,
+              );
+            const sizeAttribute = findAttribute("size");
+            const size = sizeAttribute?.value;
+            if (size?.type !== "Literal" || typeof size.value !== "string") return;
+            if (!size.value.startsWith("icon")) return;
+
+            const hasLabel = ["aria-label", "aria-labelledby", "title"].some((name) => {
+              const value = findAttribute(name)?.value;
+              // Static string must be non-empty; assume any expression provides a label.
+              return value?.type === "Literal" ? !!String(value.value).trim() : value != null;
+            });
+            if (hasLabel) return;
+            context.report({
+              node,
+              message:
+                `An icon-only <Button size="${size.value}"> has no visible text, so screen readers and ` +
+                `hovering users get nothing. Add aria-label="..." - Button renders it as title (hover text) too.`,
+            });
+          },
+        };
+      },
+    },
     "no-single-use-types": {
       meta: {
         type: "suggestion",

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -46,11 +46,15 @@ function Button({
   size = "default",
   ...props
 }: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+  // Icon-only buttons have no visible text, so give them hover text from
+  // their aria-label unless the caller passes an explicit title.
+  const title = props.title || (size?.startsWith("icon") ? props["aria-label"] : undefined);
   return (
     <ButtonPrimitive
       data-slot="button"
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
+      title={title}
     />
   );
 }

--- a/packages/ui/src/components/combobox.tsx
+++ b/packages/ui/src/components/combobox.tsx
@@ -228,7 +228,7 @@ function ComboboxChip({
       {children}
       {showRemove && (
         <ComboboxPrimitive.ChipRemove
-          render={<Button variant="ghost" size="icon-xs" />}
+          render={<Button variant="ghost" size="icon-xs" aria-label="Remove" />}
           className="-ml-1 opacity-50 hover:opacity-100"
           data-slot="combobox-chip-remove"
         >

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -59,10 +59,16 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            render={<Button variant="ghost" className="absolute top-2 right-2" size="icon-sm" />}
+            render={
+              <Button
+                variant="ghost"
+                className="absolute top-2 right-2"
+                size="icon-sm"
+                aria-label="Close"
+              />
+            }
           >
             <XIcon />
-            <span className="sr-only">Close</span>
           </DialogPrimitive.Close>
         )}
       </DialogPrimitive.Popup>

--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -62,10 +62,16 @@ function SheetContent({
         {showCloseButton && (
           <SheetPrimitive.Close
             data-slot="sheet-close"
-            render={<Button variant="ghost" className="absolute top-3 right-3" size="icon-sm" />}
+            render={
+              <Button
+                variant="ghost"
+                className="absolute top-3 right-3"
+                size="icon-sm"
+                aria-label="Close"
+              />
+            }
           >
             <XIcon />
-            <span className="sr-only">Close</span>
           </SheetPrimitive.Close>
         )}
       </SheetPrimitive.Popup>

--- a/tasks/complete/2026-07-23-icon-button-hover-text.md
+++ b/tasks/complete/2026-07-23-icon-button-hover-text.md
@@ -1,5 +1,5 @@
 ---
-status: in-review
+status: done
 size: small
 ---
 

--- a/tasks/icon-button-hover-text.md
+++ b/tasks/icon-button-hover-text.md
@@ -1,0 +1,45 @@
+---
+status: in-progress
+size: small
+---
+
+# Icon buttons: hover text + lint rule
+
+## Status summary
+
+Spec fleshed out, implementation not started. Main pieces: Button auto-title in
+the design system, jsx-a11y lint enforcement, fix violations.
+
+## Ask
+
+Icon-only buttons (e.g. the Activity/Unplug buttons on integration connection
+rows) have `aria-label`s but no hover text — hovering tells you nothing about
+what the button does. Add hover text, and add a lint rule so unlabeled icon
+buttons can't sneak in again. Prefer a popular off-the-shelf lint rule.
+
+## Decisions (assumptions made while Misha is AFK)
+
+- **Hover text mechanism**: native `title` attribute derived automatically from
+  `aria-label` in the design-system `Button` when `size` is an icon size and no
+  explicit `title` is passed. One change gives every labeled icon button hover
+  text; no per-callsite churn, no DOM-structure change (a styled Tooltip wrapper
+  would risk breaking `render`-prop composition and adds provider ceremony).
+  Explicit `title` still wins.
+- **Lint rule**: the popular off-the-shelf option is `eslint-plugin-jsx-a11y`'s
+  `control-has-associated-label`. oxlint's native jsx-a11y plugin doesn't
+  implement that rule, but this repo already runs ESLint plugins inside oxlint
+  via `jsPlugins`, so load `eslint-plugin-jsx-a11y` there (aliased, since the
+  bare name is reserved by oxlint) with `settings.jsx-a11y.components` mapping
+  `Button -> button` so the custom component is checked too.
+- If the off-the-shelf rule proves unworkable under oxlint (settings not
+  forwarded, false-positive storm), fall back to a small custom rule in
+  `lint/oxlint-plugin-iterate.ts` — but only after demonstrating the
+  off-the-shelf route fails, and note why in this file.
+
+## Checklist
+
+- [ ] `Button`: derive `title` from `aria-label` for icon sizes
+- [ ] load `eslint-plugin-jsx-a11y` into oxlint config, enable
+      `control-has-associated-label` with `Button` component mapping
+- [ ] fix all violations the rule finds (add `aria-label`s)
+- [ ] confirm `pnpm lint` red on an unlabeled icon button, green after fix

--- a/tasks/icon-button-hover-text.md
+++ b/tasks/icon-button-hover-text.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: in-review
 size: small
 ---
 
@@ -7,8 +7,11 @@ size: small
 
 ## Status summary
 
-Spec fleshed out, implementation not started. Main pieces: Button auto-title in
-the design system, jsx-a11y lint enforcement, fix violations.
+Done, pending review. Button now derives `title` (hover text) from `aria-label`
+on icon sizes; a custom oxlint rule (`iterate/icon-button-has-hover-text`)
+enforces labels on icon-size Buttons; the three violations it found are fixed.
+The off-the-shelf rule turned out to be structurally unable to catch this —
+details below.
 
 ## Ask
 
@@ -25,21 +28,30 @@ buttons can't sneak in again. Prefer a popular off-the-shelf lint rule.
   text; no per-callsite churn, no DOM-structure change (a styled Tooltip wrapper
   would risk breaking `render`-prop composition and adds provider ceremony).
   Explicit `title` still wins.
-- **Lint rule**: the popular off-the-shelf option is `eslint-plugin-jsx-a11y`'s
-  `control-has-associated-label`. oxlint's native jsx-a11y plugin doesn't
-  implement that rule, but this repo already runs ESLint plugins inside oxlint
-  via `jsPlugins`, so load `eslint-plugin-jsx-a11y` there (aliased, since the
-  bare name is reserved by oxlint) with `settings.jsx-a11y.components` mapping
-  `Button -> button` so the custom component is checked too.
-- If the off-the-shelf rule proves unworkable under oxlint (settings not
-  forwarded, false-positive storm), fall back to a small custom rule in
-  `lint/oxlint-plugin-iterate.ts` — but only after demonstrating the
-  off-the-shelf route fails, and note why in this file.
+- **Lint rule — off-the-shelf didn't survive contact**: the popular option is
+  `eslint-plugin-jsx-a11y`'s `control-has-associated-label`, but its
+  `mayHaveAccessibleLabel` helper assumes any uppercase-component child *might*
+  render a text label and bails (`isReactComponent → return true`). Since icon
+  buttons' only child is a lucide icon component, the rule can never flag
+  `<Button size="icon"><Trash /></Button>`. oxlint's native jsx-a11y plugin
+  doesn't implement the rule at all. So: a small custom rule
+  (`iterate/icon-button-has-hover-text`) in the existing oxlint JS plugin —
+  flags icon-size `<Button>`s with no `aria-label`/`aria-labelledby`/`title`;
+  dynamic values and spreads are assumed to provide one.
 
 ## Checklist
 
-- [ ] `Button`: derive `title` from `aria-label` for icon sizes
-- [ ] load `eslint-plugin-jsx-a11y` into oxlint config, enable
-      `control-has-associated-label` with `Button` component mapping
-- [ ] fix all violations the rule finds (add `aria-label`s)
-- [ ] confirm `pnpm lint` red on an unlabeled icon button, green after fix
+- [x] `Button`: derive `title` from `aria-label` for icon sizes — _`packages/ui/src/components/button.tsx`_
+- [x] ~~load `eslint-plugin-jsx-a11y` into oxlint config, enable `control-has-associated-label`~~ — _the rule structurally can't flag icon-component children (see decision above); custom rule instead_
+- [x] lint rule enforcing labeled icon buttons — _`iterate/icon-button-has-hover-text` in `lint/oxlint-plugin-iterate.ts`, tests in `lint/oxlint-plugin-icon-button.test.ts`_
+- [x] fix all violations the rule finds — _3 found, all in `packages/ui`: dialog + sheet close buttons (moved `sr-only` span label to `aria-label` so they get hover text too), combobox chip-remove (was fully unlabeled — genuine catch)_
+- [x] confirm `pnpm lint` red on an unlabeled icon button, green after fix — _rule tests spawn the real oxlint binary against fixture files; repo lint green_
+
+## Implementation log
+
+- The integrations-page buttons from the screenshot already had `aria-label`s,
+  so they get hover text purely from the Button change — no callsite edits.
+- `eslint-plugin-jsx-a11y` was installed and then removed after reading its
+  rule source ruled it out (see decision above).
+- Rule message points people at `aria-label` and notes Button renders it as
+  `title`, so the fix is self-explanatory at the lint error.


### PR DESCRIPTION
Icon-only buttons (like the Activity/Unplug buttons on integration connection rows) had `aria-label`s but showed nothing on hover.

1. **Design system**: `Button` now derives a native `title` from `aria-label` for icon sizes — every labeled icon button in the app gets hover text at once, no callsite churn. Explicit `title` still wins.
2. **Lint**: new `iterate/icon-button-has-hover-text` oxlint rule — icon-size `<Button>`s must have `aria-label`/`aria-labelledby`/`title` (dynamic values and spreads assumed fine).

```tsx
// before: hover shows nothing
<Button size="icon-sm" aria-label="Disconnect misha-nustom-com"><Unplug /></Button>
// after: same JSX, hover shows "Disconnect misha-nustom-com"

// and this now fails lint:
<Button size="icon-sm"><Unplug /></Button>
```

**Why not the popular off-the-shelf rule?** The obvious candidate is `eslint-plugin-jsx-a11y`'s `control-has-associated-label` (oxlint's native jsx-a11y plugin doesn't implement it, but this repo can run ESLint plugins via `jsPlugins`). Its `mayHaveAccessibleLabel` helper *assumes any uppercase-component child might render a text label* and bails — so `<Button size="icon"><Trash /></Button>` with a lucide icon child is never flagged. It structurally can't catch the case we care about. The custom rule is ~40 lines in the existing `lint/oxlint-plugin-iterate.ts`, tested against the real oxlint binary in `lint/oxlint-plugin-icon-button.test.ts`.

The rule found 3 real violations, all in `packages/ui`: dialog + sheet close buttons (labeled via `sr-only` span, so screen-reader-fine but hover-silent — label moved to `aria-label`) and the combobox chip-remove button, which had no label at all.

Task file: `tasks/icon-button-hover-text.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

> [!CAUTION]
> This PR is a draft, so it doesn't claim a preview slot. To get previews: add the `preview` label, mark the PR ready for review, or dispatch the Cloudflare Previews workflow for a one-off run.

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": "This PR is a draft, so it doesn't claim a preview slot. To get previews: add the `preview` label, mark the PR ready for review, or dispatch the Cloudflare Previews workflow for a one-off run."
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| UI components | +21 -5 | +19 -5 🟩⬜⬜⬜⬜ |
| Tests | +164 -0 | +140 -0 🟩🟩🟩🟩🟩 |
| Docs | +57 -0 | +46 -0 🟩🟩⬜⬜⬜ |
| Other | +43 -0 | +39 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+285 -5** | **+244 -5** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between aa68ee0 and 88a665c, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI a11y and lint enforcement; Button `title` behavior only affects icon sizes and respects an explicit `title`.
> 
> **Overview**
> Icon-only **Button**s now get native hover text: for `size` values starting with `icon`, the component sets `title` from `aria-label` when no explicit `title` is passed, so existing labeled icon buttons gain tooltips without callsite changes.
> 
> A new **`iterate/icon-button-has-hover-text`** oxlint rule (enabled repo-wide) requires icon-size `<Button>` elements to have `aria-label`, `aria-labelledby`, or `title`; spreads and dynamic labels are treated as OK. **Dialog** and **sheet** close controls move their label from `sr-only` text to `aria-label` on the icon button; **combobox** chip remove gets `aria-label="Remove"`. Tests run the real oxlint binary against fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88a665cddef2a8adb6e8712a05913115c30907f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->