### PR TITLE
probe-rpc: carry auth on the RPC upgrade so project hosts work as documented

### DIFF
--- a/apps/tasks/scripts/probe-rpc.mjs
+++ b/apps/tasks/scripts/probe-rpc.mjs
@@ -46,9 +46,12 @@ const humanFiles = () => humanDoc.getMap("files");
 const humanMeta = () => humanDoc.getMap("meta");
 
 // --- the agent: a live capnweb session on /api -------------------------------
+// Authed upgrade: the vessel host ignores it (authenticate(token) is the
+// credential there), but a project host's config-worker gate rejects a bare
+// upgrade before the vessel ever sees it.
 const wsUrl = new URL("/api", base);
 wsUrl.protocol = base.protocol === "https:" ? "wss:" : "ws:";
-const socket = new NodeWebSocket(wsUrl.toString());
+const socket = new AuthedWebSocket(wsUrl.toString());
 const api = newWebSocketRpcSession(socket);
 
 // Pipelined: authenticate → project stub, no explicit await needed between.


### PR DESCRIPTION
One-liner found while proving the consolidated tasks build (#2285) in prod through the real project proxy: `probe-rpc.mjs` documents that `baseUrl` may be a project host (`tasks--<slug>.iterate.app`), but only its Yjs socket carried the auth headers — the capnweb `/api` upgrade went out bare, so the config-worker gate rejected it before the vessel ever saw it. The vessel host never noticed because `authenticate(token)` is the credential on that lane.

With the fix, the full agent-lane lifecycle (seed → live two-way collab → commit → cleanup) runs green through `tasks--iterate.iterate.app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test/probe script only; no production runtime behavior changes.
> 
> **Overview**
> **`probe-rpc.mjs`** now opens the capnweb **`/api`** WebSocket with the existing **`AuthedWebSocket`** helper (project cookie + **`x-itx-project-id`**) instead of a bare **`NodeWebSocket`**, matching how the Yjs lane in the same script already authenticates.
> 
> That lets the agent-lane probe run against **project hosts** (`tasks--<slug>.iterate.app`), where the config-worker gate requires auth on the upgrade; vessel hosts are unchanged because RPC auth still goes through **`authenticate(token)`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 802cdfec03084593f05170e3755bea52b83e4e3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| CI & scripts | +4 -1 | +1 -1 🟩🟩🟩🟥🟥 |
| **Total** | **+4 -1** | **+1 -1** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 9c13bde and 802cdfe, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->