### PR TITLE
tasks: os-shell sidebar, Cmd+Enter close, instant + stable redlines

### DIFF
--- a/apps/tasks/src/components/app-sidebar.tsx
+++ b/apps/tasks/src/components/app-sidebar.tsx
@@ -1,10 +1,11 @@
 import { Link, useNavigate, useRouterState } from "@tanstack/react-router";
 import { useEffect, useMemo, useState } from "react";
-import { FolderGit2Icon, PlusIcon } from "lucide-react";
+import { ChevronsLeft, FolderGit2Icon, PlusIcon } from "lucide-react";
 import { IterateLogo } from "@iterate-com/ui/components/iterate-logo";
 import {
   Sidebar,
   SidebarContent,
+  SidebarFooter,
   SidebarRail,
   SidebarGroup,
   SidebarGroupAction,
@@ -14,10 +15,12 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  useSidebar,
 } from "@iterate-com/ui/components/sidebar";
 import { DEFAULT_REPO_PATH, newCheckoutId } from "../lib/checkout-shared.ts";
 import { listCheckouts, listRepos } from "../lib/use-checkout.ts";
 import type { CheckoutIndexEntry } from "../lib/tasks-api.ts";
+import { CloseMobileSidebarOnNavigate } from "~/components/close-mobile-sidebar-on-navigate.tsx";
 
 /**
  * The two-stage navigation: repos are the top-level hierarchy, checkouts the
@@ -94,22 +97,29 @@ export function AppSidebar() {
   };
 
   return (
-    <Sidebar collapsible="icon">
-      <SidebarHeader>
-        <SidebarMenu>
-          <SidebarMenuItem>
-            <SidebarMenuButton size="lg" render={<Link to="/" />} tooltip="Tasks home">
-              <span className="flex aspect-square size-8 items-center justify-center rounded-md bg-black">
-                <IterateLogo className="size-6 rounded-sm" />
-              </span>
-              <span className="grid flex-1 text-left text-sm leading-tight">
-                <span className="truncate font-medium">iterate</span>
-                <span className="truncate text-xs text-muted-foreground">tasks</span>
-              </span>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-        </SidebarMenu>
-      </SidebarHeader>
+    <>
+      {/* Outside <Sidebar>: on mobile the children live in a Sheet that
+          remounts when opened (see the os AppSidebar). */}
+      <CloseMobileSidebarOnNavigate />
+      <Sidebar collapsible="icon">
+        {/* Collapsed: nudge the logo down so its center lines up with the h-11
+            page header row — the same transition the os sidebar uses so the
+            padding offset and the button's height change move together. */}
+        <SidebarHeader className="transition-[padding] group-data-[collapsible=icon]:pt-3">
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton size="lg" render={<Link to="/" />} tooltip="Tasks home">
+                <span className="flex aspect-square size-8 items-center justify-center rounded-md bg-black">
+                  <IterateLogo className="size-6" />
+                </span>
+                <span className="grid flex-1 text-left text-sm leading-tight">
+                  <span className="truncate font-medium">iterate</span>
+                  <span className="truncate text-xs text-muted-foreground">tasks</span>
+                </span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarHeader>
       <SidebarContent>
         {groups.map(([repoPath, entries]) => (
           <SidebarGroup key={repoPath} className="group-data-[collapsible=icon]:hidden">
@@ -163,8 +173,34 @@ export function AppSidebar() {
           </SidebarGroup>
         ))}
       </SidebarContent>
-      <SidebarRail />
-    </Sidebar>
+        <SidebarFooter>
+          <AppSidebarCollapseButton />
+        </SidebarFooter>
+        <SidebarRail />
+      </Sidebar>
+    </>
+  );
+}
+
+function AppSidebarCollapseButton() {
+  const { state, toggleSidebar } = useSidebar();
+  const isCollapsed = state === "collapsed";
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <SidebarMenuButton
+          type="button"
+          size="sm"
+          className="text-sidebar-foreground/70"
+          tooltip={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+          onClick={toggleSidebar}
+        >
+          <ChevronsLeft className={isCollapsed ? "rotate-180" : undefined} />
+          <span>Collapse sidebar</span>
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+    </SidebarMenu>
   );
 }
 

--- a/apps/tasks/src/components/workspace-task-editor.tsx
+++ b/apps/tasks/src/components/workspace-task-editor.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { EditorView, keymap, placeholder } from "@codemirror/view";
 import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 import { useCollabEditor } from "../lib/use-collab-editor.ts";
@@ -16,6 +16,7 @@ export function WorkspaceTaskEditor({
   focusHeadline,
   onLiveContent,
   onStatus,
+  onRequestClose,
   apiRef,
 }: {
   checkoutId: string;
@@ -26,11 +27,29 @@ export function WorkspaceTaskEditor({
   apiRef?: { current: import("../lib/collab-editor-api.ts").CollabEditorApi | null };
   onLiveContent: (path: string, content: string) => void;
   onStatus?: (status: string) => void;
+  /** Cmd/Ctrl+Enter: done editing — close the sheet. */
+  onRequestClose?: () => void;
 }) {
+  // Through a ref so the keymap (inside the deps-free extensions memo) always
+  // sees the current handler without rebuilding the editor state.
+  const requestCloseRef = useRef(onRequestClose);
+  useEffect(() => {
+    requestCloseRef.current = onRequestClose;
+  }, [onRequestClose]);
   const extensions = useMemo(
     () => [
       history(),
-      keymap.of([...defaultKeymap, ...historyKeymap]),
+      keymap.of([
+        {
+          key: "Mod-Enter",
+          run: () => {
+            requestCloseRef.current?.();
+            return true;
+          },
+        },
+        ...defaultKeymap,
+        ...historyKeymap,
+      ]),
       EditorView.lineWrapping,
       placeholder("Write the task as markdown…"),
       EditorView.theme({

--- a/apps/tasks/src/components/workspace-task-sheet.tsx
+++ b/apps/tasks/src/components/workspace-task-sheet.tsx
@@ -114,6 +114,7 @@ export function WorkspaceTaskSheet({
             onChangeLabels={onChangeLabels}
             onRevert={onRevert}
             onDelete={onDelete}
+            onRequestClose={onClose}
           />
         )}
       </SheetContent>
@@ -139,6 +140,7 @@ function SheetBody({
   onChangeLabels,
   onRevert,
   onDelete,
+  onRequestClose,
 }: {
   task: BoardTask;
   checkoutId: string;
@@ -162,6 +164,8 @@ function SheetBody({
   onChangeLabels: (labels: string[]) => void;
   onRevert: () => void;
   onDelete: () => void;
+  /** Cmd/Ctrl+Enter inside the editor: done editing — close the sheet. */
+  onRequestClose: () => void;
 }) {
   const [status, setStatus] = useState("connecting…");
   // The path is editable in place; SheetBody is keyed by task.path, so a
@@ -312,6 +316,7 @@ function SheetBody({
           apiRef={editorApiRef}
           onLiveContent={onLiveContent}
           onStatus={setStatus}
+          onRequestClose={onRequestClose}
         />
       </Suspense>
         </TabsContent>

--- a/apps/tasks/src/lib/collab-redline.ts
+++ b/apps/tasks/src/lib/collab-redline.ts
@@ -8,7 +8,7 @@ import {
   type Tooltip,
   type ViewUpdate,
 } from "@codemirror/view";
-import { RangeSetBuilder } from "@codemirror/state";
+import { RangeSetBuilder, Transaction, type Range } from "@codemirror/state";
 import { getSyncedVersion, sendableUpdates } from "@codemirror/collab";
 import type { CollabConnection } from "./collab-client.ts";
 import type { CollabChangeSegment } from "./tasks-api.ts";
@@ -114,6 +114,17 @@ class DeletionFlag extends WidgetType {
   }
 }
 
+function insertionMark(clientId: string, createdAt: number | undefined): Decoration {
+  return Decoration.mark({
+    attributes: {
+      "data-author": clientId,
+      "data-when": String(createdAt ?? ""),
+      style: `background: ${authorColor(clientId, 0.18)}; border-bottom: 2px solid ${authorColor(clientId, 0.9)}`,
+    },
+    class: "cm-redline-ins",
+  });
+}
+
 function decorate(segments: CollabChangeSegment[], docLength: number): DecorationSet {
   const builder = new RangeSetBuilder<Decoration>();
   // RangeSetBuilder demands ascending positions; the server sorts, but
@@ -144,18 +155,7 @@ function decorate(segments: CollabChangeSegment[], docLength: number): Decoratio
       const from = Math.min(segment.from, docLength);
       const to = Math.min(segment.to, docLength);
       if (from >= to) continue;
-      builder.add(
-        from,
-        to,
-        Decoration.mark({
-          attributes: {
-            "data-author": segment.clientId,
-            "data-when": String(segment.createdAt ?? ""),
-            style: `background: ${authorColor(segment.clientId, 0.18)}; border-bottom: 2px solid ${authorColor(segment.clientId, 0.9)}`,
-          },
-          class: "cm-redline-ins",
-        }),
-      );
+      builder.add(from, to, insertionMark(segment.clientId, segment.createdAt));
     }
   }
   return builder.finish();
@@ -202,6 +202,29 @@ export function redlineExtension(connection: CollabConnection) {
         if (!update.docChanged) return;
         // Keep marks visually anchored while the authoritative fold catches up.
         this.decorations = this.decorations.map(update.changes);
+        // Own keystrokes wear marks IMMEDIATELY — the authoritative fold
+        // replaces them with the server's identical segments once edits
+        // settle, so tracking never lags typing. Remote batches skip the
+        // optimism: their authors' marks arrive with the refresh.
+        if (update.transactions.every((tr) => !tr.annotation(Transaction.remote))) {
+          const now = Date.now();
+          const adds: Range<Decoration>[] = [];
+          update.changes.iterChanges((fromA, toA, fromB, toB, inserted) => {
+            const deleted = update.startState.doc.sliceString(fromA, toA);
+            if (deleted.length > 0) {
+              adds.push(
+                Decoration.widget({
+                  side: -1,
+                  widget: new DeletionFlag(connection.clientId, deleted, now),
+                }).range(fromB),
+              );
+            }
+            if (inserted.length > 0) {
+              adds.push(insertionMark(connection.clientId, now).range(fromB, toB));
+            }
+          });
+          if (adds.length > 0) this.decorations = this.decorations.update({ add: adds, sort: true });
+        }
         this.futile = 0;
         if (this.timer) clearTimeout(this.timer);
         this.timer = setTimeout(() => void this.refresh(), REFRESH_DEBOUNCE_MS);

--- a/apps/tasks/src/lib/use-collab-editor.ts
+++ b/apps/tasks/src/lib/use-collab-editor.ts
@@ -4,11 +4,15 @@ import { getSyncedVersion, sendableUpdates } from "@codemirror/collab";
 import { EditorView } from "@codemirror/view";
 import { CollabConnection, peerExtension, setCollabDisplayName } from "./collab-client.ts";
 import { whoami } from "./use-checkout.ts";
+import { redlineExtension } from "./collab-redline.ts";
+import type { CollabEditorApi } from "./collab-editor-api.ts";
 
 // The PROMISE is the memo: a second editor mounting mid-lookup awaits the
-// same whoami instead of opening with the default display slug.
+// same whoami instead of opening with the default display slug. Exported so
+// the board can warm it while the sheet is still closed — the first editor
+// open then skips the whoami round trip.
 let identityPromise: Promise<void> | null = null;
-function ensureCollabIdentity(): Promise<void> {
+export function ensureCollabIdentity(): Promise<void> {
   identityPromise ??= (async () => {
     try {
       const me = await whoami();
@@ -20,8 +24,6 @@ function ensureCollabIdentity(): Promise<void> {
   })();
   return identityPromise;
 }
-import { redlineExtension } from "./collab-redline.ts";
-import type { CollabEditorApi } from "./collab-editor-api.ts";
 
 /**
  * The ONE collaborative-editor state machine, shared by every surface that

--- a/apps/tasks/src/routes/c.$checkoutId.tsx
+++ b/apps/tasks/src/routes/c.$checkoutId.tsx
@@ -197,7 +197,7 @@ function CheckoutPage() {
       ) : (
         <div className="flex flex-col gap-3">
           <header className="flex h-11 shrink-0 items-center gap-2 border-b bg-background px-3">
-            <SidebarTrigger className="-ml-1" />
+            <SidebarTrigger className="-ml-1 md:hidden" />
             <CheckoutBreadcrumbs repoPath={repoPath} checkoutId={checkoutId} />
           </header>
           <div className="flex flex-1 flex-col items-center gap-3 bg-muted/30 p-4">
@@ -470,7 +470,7 @@ function ReadyCheckout({
   return (
     <>
       <header className="flex h-11 shrink-0 items-center gap-2 border-b bg-background px-3">
-        <SidebarTrigger className="-ml-1" />
+        <SidebarTrigger className="-ml-1 md:hidden" />
         <CheckoutBreadcrumbs repoPath={repoPath} checkoutId={checkoutId} />
         <div className="ml-auto flex shrink-0 items-center gap-1.5">
           <PresenceAvatars provider={provider} peers={peers} me={me} />

--- a/apps/tasks/src/routes/index.tsx
+++ b/apps/tasks/src/routes/index.tsx
@@ -46,7 +46,7 @@ function Home() {
   return (
     <div className="flex h-full min-h-0 flex-col">
       <header className="flex h-11 shrink-0 items-center gap-2 border-b bg-background px-3">
-        <SidebarTrigger className="-ml-1" />
+        <SidebarTrigger className="-ml-1 md:hidden" />
         <CheckoutBreadcrumbs />
       </header>
       {!loaded ? (

--- a/apps/tasks/src/routes/w.$checkoutId.tsx
+++ b/apps/tasks/src/routes/w.$checkoutId.tsx
@@ -26,6 +26,7 @@ import {
   fallbackCommitMessage,
   isTaskFilePath,
   newTaskFile,
+  parseTaskCard,
   setTaskCardLabels,
   setTaskCardState,
   taskColumnState,
@@ -71,14 +72,14 @@ function WorkspaceBoardPage() {
   // Track changes (redlines) is a board-level setting, default on.
   const [trackChanges, setTrackChanges] = useState(true);
   // A just-created task: the editor opens with the headline selected and the
-  // filename trails the title until the first commit (same UX as the Yjs
-  // board).
+  // filename trails the title — settled at REST POINTS (sheet close, commit),
+  // never mid-typing: on this lane a rename is write+delete, which ends the
+  // file's collab session and wipes its redline fold, so renaming under the
+  // open editor forced a remount that flashed the sheet and dropped the marks.
   const [draftPath, setDraftPath] = useState<string | null>(null);
-  /** How the editor should focus when the DRAFT's sheet (re)mounts:
-   * "select" = fresh draft (typing replaces the headline), "end" = renamed
-   * while the caret was in the headline, {caret} = renamed while typing in
-   * the body (restore the offset), undefined = don't steal focus. */
-  const draftFocusRef = useRef<"select" | "end" | { caret: number } | undefined>(undefined);
+  /** Fresh draft only: the editor opens with the headline selected so typing
+   * replaces it. Cleared on close/commit — reopening is an ordinary open. */
+  const draftFocusRef = useRef<"select" | undefined>(undefined);
   // The open sheet's live-doc API: mutations of the OPEN file go through the
   // live document (the board mirror is 200ms behind it — writing board state
   // over a live path would drop the newest keystrokes).
@@ -98,10 +99,19 @@ function WorkspaceBoardPage() {
   // on every keystroke reflect and poll tick).
   const boardRef = useRef(board);
   const searchTaskRef = useRef(search.task);
+  const draftPathRef = useRef(draftPath);
   useEffect(() => {
     boardRef.current = board;
     searchTaskRef.current = search.task;
+    draftPathRef.current = draftPath;
   });
+  // Warm the editor stack while the board renders: the CM6 chunk and the
+  // whoami identity round trip come off the first sheet-open's critical path.
+  useEffect(() => {
+    void import("../lib/use-collab-editor.ts").then(
+      (module) => void module.ensureCollabIdentity(),
+    );
+  }, []);
   /** Prune expired claims and answer whether a path is spoken for. */
   const isTaken = useCallback((path: string): boolean => {
     const now = Date.now();
@@ -192,8 +202,11 @@ function WorkspaceBoardPage() {
       setCommitError(null);
       setCommitPending(true);
       try {
+        // A draft's filename settles to its title BEFORE the commit records
+        // it — afterwards would leave a rename as instant new dirtiness.
+        await settleDraft();
         const result = await board.commit(
-          message?.trim() || fallbackCommitMessage(board.taskChanges),
+          message?.trim() || fallbackCommitMessage(boardRef.current.taskChanges),
         );
         // The redline baseline advanced: reseat an open editor so committed
         // work stops wearing marks (same lever revert/discard use). The
@@ -318,89 +331,46 @@ function WorkspaceBoardPage() {
     columnsRef.current = columns;
   });
 
-  // While the draft's sheet is open and it is still an uncommitted add, its
-  // filename trails the headline (debounced so half-typed titles don't churn
-  // paths). Dependencies are the TITLE and folder — not the board object,
-  // which changes every render and would reset the 700ms timer forever.
-  const draftTask = useMemo(
-    () =>
-      draftPath !== null && search.task === draftPath && board.changes.get(draftPath) === "added"
-        ? (board.tasks.find((candidate) => candidate.path === draftPath) ?? null)
-        : null,
-    [board.changes, board.tasks, draftPath, search.task],
-  );
-  const draftTitle = draftTask?.title;
-  const draftFolder = draftTask?.folder;
-  useEffect(() => {
-    if (draftPath === null || draftTitle === undefined || draftFolder === undefined) return;
-    const desired = taskPathInFolder(taskPathForTitle(draftTitle), draftFolder);
-    if (desired === draftPath) return;
-    let timer: ReturnType<typeof setTimeout>;
-    let cancelled = false;
-    const attempt = () => {
-      if (cancelled) return;
-      // Another rename lane holds the lock (a drag, a path edit on another
-      // task): re-arm instead of stalling until the next title change.
-      if (renamingRef.current) {
-        timer = setTimeout(attempt, 700);
-        return;
-      }
+  /** Settle a draft's title-trailing rename at a rest point. The live source
+   * (read before the editor unmounted) wins over the board mirror, which
+   * trails typing by up to 200ms. */
+  const settleDraftRename = useCallback(
+    async (path: string, liveSource: string | null): Promise<void> => {
       const current = boardRef.current;
-      const task = current.tasks.find((candidate) => candidate.path === draftPath);
-      if (task === undefined || current.changes.get(draftPath) !== "added") return;
-      // The LIVE doc, not the board mirror — the mirror is debounced and a
-      // rename must never persist a version missing the newest keystrokes.
-      const source = sourceOf(task);
-      // A sibling with this title already exists: suffix instead of bailing
-      // (the filename must keep trailing the title) — and never collapse.
+      // Only an uncommitted add still trails its title; and never interleave
+      // with another rename lane (a drag, a path-input edit).
+      if (current.changes.get(path) !== "added" || renamingRef.current) return;
+      const source = liveSource ?? current.files?.[path];
+      if (source === undefined) return;
+      const folder = path.split("/").slice(0, -1).join("/");
+      const desired = taskPathInFolder(taskPathForTitle(parseTaskCard(path, source).title), folder);
+      if (desired === path) return;
+      // A sibling with this title already exists: suffix, never collapse.
       const target = claimPath(desired);
-      // Navigation waits for the write to land (never open a not-yet-created
-      // path); on failure nothing moved, so nothing to roll back.
       renamingRef.current = true;
-      // Only steal focus back to the headline if the caret was still IN the
-      // headline when the rename fired — body typing keeps its flow.
-      const headlineEnd = (() => {
-        const heading = /^#\s+.*$/m.exec(source);
-        return heading === null ? -1 : heading.index + heading[0].length;
-      })();
-      const caret = editorApiRef.current?.path === draftPath
-        ? editorApiRef.current.selectionHead()
-        : -1;
-      // Three intents, not a boolean: headline-caret renames park at the
-      // headline end; body-caret renames RESTORE the body offset; a closed
-      // sheet steals nothing.
-      const focusIntent: "end" | { caret: number } | undefined =
-        caret < 0 ? undefined : caret <= headlineEnd ? "end" : { caret };
-      void current
-        .renameTask(draftPath, target, source, (final) => final, async () => {
-          // Flush the still-mounted editor FIRST: the hook awaits this, so
-          // the carry read sees the final keystrokes.
-          if (editorApiRef.current?.path === draftPath) {
-            await editorApiRef.current.flushPending();
-          }
-          draftFocusRef.current = focusIntent;
-          setDraftPath((currentDraft) => (currentDraft === draftPath ? target : currentDraft));
-          // Navigate by CURRENT truth: if the sheet still shows the source
-          // (even under a newer title effect), it must follow the moved file
-          // — but a closed sheet stays closed.
-          if (searchTaskRef.current === draftPath) patchSearch({ task: target });
-        })
-        .then((error) => {
-          // A failed rename left the draft in place — keep trailing the
-          // title instead of stalling until it changes again. Never past
-          // this effect's cleanup: a newer title owns the next attempt.
-          if (error !== null && !cancelled) timer = setTimeout(attempt, 700);
-        })
-        .finally(() => {
-          renamingRef.current = false;
+      try {
+        await current.renameTask(path, target, source, (final) => final, () => {
+          // A sheet still showing the source (commit keeps it open) follows
+          // the moved file; a closed sheet stays closed.
+          if (searchTaskRef.current === path) patchSearch({ task: target });
         });
-    };
-    timer = setTimeout(attempt, 700);
-    return () => {
-      cancelled = true;
-      clearTimeout(timer);
-    };
-  }, [draftPath, draftTitle, draftFolder, claimPath, patchSearch, sourceOf]);
+      } finally {
+        renamingRef.current = false;
+      }
+    },
+    [claimPath, patchSearch],
+  );
+
+  /** The commit-side rest point: flush the open editor's final keystrokes,
+   * then settle the filename, so the commit records the title's name. */
+  const settleDraft = useCallback(async (): Promise<void> => {
+    const path = draftPathRef.current;
+    if (path === null) return;
+    const api = editorApiRef.current;
+    const liveSource = api !== null && api.path === path ? api.source() : null;
+    if (api !== null && api.path === path) await api.flushPending().catch(() => {});
+    await settleDraftRename(path, liveSource);
+  }, [settleDraftRename]);
 
   // The sheet's path field: any rename the board can represent is allowed —
   // the file must stay a task (.md under a folder named "tasks").
@@ -444,7 +414,7 @@ function WorkspaceBoardPage() {
   return (
     <>
       <header className="flex h-11 shrink-0 items-center gap-2 border-b bg-background px-3">
-        <SidebarTrigger className="-ml-1" />
+        <SidebarTrigger className="-ml-1 md:hidden" />
         <CheckoutBreadcrumbs repoPath={repoPath} checkoutId={checkoutId} />
         <div className="ml-auto flex shrink-0 items-center gap-1.5">
           <div className="hidden items-center gap-1.5 sm:flex">
@@ -585,11 +555,20 @@ function WorkspaceBoardPage() {
           }
         }}
         onClose={() => {
-          // Closing ends the draft ritual (Yjs-board parity): reopening the
-          // same task is an ordinary open, no focus steal, no title trail.
+          // Closing ends the draft ritual AND settles the filename to the
+          // title — the rename runs now, with nothing mounted to flash, never
+          // under the open editor. Reopening is an ordinary open.
+          const path = draftPathRef.current;
+          const api = editorApiRef.current;
+          const liveSource = path !== null && api?.path === path ? api.source() : null;
+          const flushed =
+            path !== null && api?.path === path
+              ? api.flushPending().catch(() => {})
+              : Promise.resolve();
           setDraftPath(null);
           draftFocusRef.current = undefined;
           patchSearch({ task: "" });
+          if (path !== null) void flushed.then(() => settleDraftRename(path, liveSource));
         }}
       />
     </>

--- a/apps/tasks/tsconfig.json
+++ b/apps/tasks/tsconfig.json
@@ -12,7 +12,11 @@
     "allowImportingTsExtensions": true,
     "jsx": "react-jsx",
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
-    "types": ["@cloudflare/workers-types", "node", "vite/client"]
+    "types": ["@cloudflare/workers-types", "node", "vite/client"],
+    "paths": {
+      "~/*": ["../os/src/*"]
+    }
   },
+  // apps/os sources under ../os/src ride in transitively via the `~` alias.
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/apps/tasks/vite.config.ts
+++ b/apps/tasks/vite.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import viteReact from "@vitejs/plugin-react";
 import { cloudflare } from "@cloudflare/vite-plugin";
@@ -6,6 +7,15 @@ import { defineConfig } from "vite";
 import captunVite from "captun/vite";
 
 export default defineConfig({
+  resolve: {
+    // Shared apps/os code rides the same `~` alias streams-example-app uses:
+    // os files become part of THIS app's module graph (their bare imports
+    // resolve here), which is what keeps react single-instance — a workspace
+    // dependency on apps/os would resolve os's own copy.
+    alias: {
+      "~": fileURLToPath(new URL("../os/src", import.meta.url)),
+    },
+  },
   server: {
     // The vessel is served through reverse proxies (a project's config
     // worker, a captun tunnel) whose Host headers vite's default allowlist

--- a/knip.ts
+++ b/knip.ts
@@ -116,6 +116,9 @@ function makeTasksWorkspace(): WorkspaceConfig {
     ],
     project: ["src/**/*.{ts,tsx}!", "scripts/**/*.mjs", "!dist/**!"],
     vite: false,
+    paths: {
+      "~/*": ["../os/src/*"],
+    },
     // tailwindcss backs the @tailwindcss/vite plugin and the ui package's
     // globals.css; nothing imports it from TS. `cloudflare:workers` parses as
     // the "cloudflare" package — same posture as the other app workspaces.


### PR DESCRIPTION
Fixes the three UX reports on the /w board.

## 1. Sidebar = the apps/os shell
Header logo with the os icon-mode nudge, footer collapse button, mobile sheet auto-close — with `CloseMobileSidebarOnNavigate` imported **from apps/os** via the `~` alias pattern streams-example-app established (os files join this app's module graph; react stays single-instance). Desktop header trigger goes `md:hidden` like os (rail + footer own desktop collapse).

## 2. Cmd/Ctrl+Enter closes the editor sheet
New `Mod-Enter` keymap wired to the sheet's `onClose`.

## 3. New-card editor jank — three mechanisms, three fixes
- **Template late**: the CM6 chunk and the whoami identity RPC sat inside the first sheet-open. Both warm while the board renders.
- **Tracking lag**: redlines waited for the 500ms-debounced server fold. Own keystrokes now get optimistic marks the instant they land (`Transaction.remote` filters remote batches); the authoritative fold replaces them with identical segments, so nothing jumps.
- **Flicker then untracked**: the 700ms title-trailing rename is write+delete on this lane — it ended the collab session, remounted the entire sheet (`SheetBody` keys on path) and wiped the fold. Draft renames now settle at **rest points** (sheet close, commit) only. Mid-typing the path never changes → no remount, no vanishing marks. The filename still trails the title.

The focus-carry machinery ("end"/{caret} intents) existed only for mid-typing remounts — deleted.

## Verified live (dev vessel against the prod platform, authed proxy + browser automation)
Add card → template + selected headline in ~1.5s → typing over the title shows the ⌫ flag + tinted insert **instantly** → marks stable through fold refreshes at +2.5s → Cmd+Enter closes → reopen shows `tasks/hi-there.md`. Screenshots in the session; collapsed/expanded sidebar matches os.

All gates: oxlint --deny-warnings clean, 17-workspace typecheck, tests, knip, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Draft rename and collab/redline timing changed on the workspace lane; the `~` alias couples tasks to apps/os source layout but stays UI/editor scoped.
> 
> **Overview**
> Aligns the **tasks** app sidebar with **apps/os**: footer collapse control, icon-mode header padding, mobile auto-close via shared `CloseMobileSidebarOnNavigate` (imported through a new `~` → `../os/src` alias in Vite/tsconfig/knip), and **desktop** pages hide `SidebarTrigger` at `md+` so rail/footer handle collapse.
> 
> **Workspace board editor UX:** **Cmd/Ctrl+Enter** in the task sheet closes the editor (wired through `onRequestClose`). **Redlines** apply optimistic insertion/deletion marks on local keystrokes immediately; server fold still replaces them once synced. **New-task drafts** no longer debounce-rename the file while typing (that path remounted the sheet and killed collab/redlines); filename now settles from the headline only on **rest points** (sheet close and pre-commit), with `ensureCollabIdentity` warmed on board mount to speed first open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f61d0ffd7a6ad373dd2c4dbfb3baf9655997166. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +124 -110 | +88 -76 🟩🟩🟩🟥🟥 |
| UI components | +81 -21 | +74 -21 🟩🟩🟥⬜⬜ |
| Config | +5 -1 | +5 -1 🟩⬜⬜⬜⬜ |
| Other | +3 -0 | +3 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+213 -132** | **+170 -98** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 0d8f96f and 7f61d0f, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->