### PR TITLE
Fail worker builds on unresolved imports instead of shipping "No such module"

### DIFF
--- a/apps/os/e2e/vitest/worker-build.e2e.test.ts
+++ b/apps/os/e2e/vitest/worker-build.e2e.test.ts
@@ -96,3 +96,87 @@ test("Worker builds let worker-bundler install and bundle package dependencies",
 
   await expect(worker.format("hello worker bundler")).resolves.toBe("helloWorkerBundler");
 });
+
+// An import the bundler cannot resolve must fail at BUILD time with the
+// specifier named — not ship an artifact that dies at instantiation with a
+// cryptic `No such module`, parking every subscription that pushes into it
+// (the 2026-07-23 config-worker-stalled incident: 22 prod projects).
+test("Worker build fails loudly on unresolved imports", async () => {
+  using session = withItxSession();
+  using itx = session.authenticate({
+    type: "admin-secret",
+    secret: adminSecret(),
+  });
+  using project = await itx.projects
+    .get(`unresolved-import-${crypto.randomUUID().slice(0, 8)}`)
+    .create({});
+
+  using broken = project.workers.get({
+    entrypoint: "Broken",
+    path: "/",
+    source: {
+      createWorker: {
+        entryPoint: "worker.ts",
+        files: {
+          files: {
+            "worker.ts": [
+              'import { WorkerEntrypoint } from "cloudflare:workers";',
+              'import { missing } from "this-package-is-not-installed";',
+              "export class Broken extends WorkerEntrypoint { poke() { return missing; } }",
+              `// build salt ${crypto.randomUUID()}`,
+            ].join("\n"),
+          },
+          type: "inline",
+        },
+      },
+    },
+    type: "stateless",
+  }) as unknown as { poke(): Promise<unknown> } & Disposable;
+
+  const error = await (broken.poke() as Promise<unknown>).then(
+    () => Promise.reject(new Error("build unexpectedly succeeded")),
+    (thrown: Error) => thrown,
+  );
+  expect(error.message).toContain("Failed to resolve 'this-package-is-not-installed'");
+  expect(error.message).toContain("No such module");
+});
+
+// The runtime provides node builtins (nodejs_compat) and scheme'd modules, so
+// those imports legitimately stay external and must keep building and running.
+test("Worker builds keep runtime-provided imports working", async () => {
+  using session = withItxSession();
+  using itx = session.authenticate({
+    type: "admin-secret",
+    secret: adminSecret(),
+  });
+  using project = await itx.projects
+    .get(`builtin-import-${crypto.randomUUID().slice(0, 8)}`)
+    .create({});
+
+  using worker = project.workers.get({
+    entrypoint: "Builtins",
+    path: "/",
+    source: {
+      createWorker: {
+        entryPoint: "worker.ts",
+        files: {
+          files: {
+            "worker.ts": [
+              'import { WorkerEntrypoint } from "cloudflare:workers";',
+              'import { Buffer } from "node:buffer";',
+              // Bare (unprefixed) builtin on purpose: it resolves to nothing at
+              // build time and only exists in the runtime's module registry.
+              'import path from "path";',
+              'export class Builtins extends WorkerEntrypoint { greet() { return `${path.join("a", "b")}:${Buffer.from("ok").toString()}`; } }',
+              `// build salt ${crypto.randomUUID()}`,
+            ].join("\n"),
+          },
+          type: "inline",
+        },
+      },
+    },
+    type: "stateless",
+  }) as unknown as { greet(): Promise<string> } & Disposable;
+
+  await expect(worker.greet()).resolves.toBe("a/b:ok");
+});

--- a/apps/os/src/domains/workers/build-backend.test.ts
+++ b/apps/os/src/domains/workers/build-backend.test.ts
@@ -217,4 +217,58 @@ describe("executeWorkerBuild", () => {
       warnings: ["This comparison is always false"],
     });
   });
+
+  it.each([
+    // The incident shape: installed package whose entry the import no longer matches.
+    "Failed to resolve 'iterate/live-state' from worker.ts: the installed 'iterate' package does not provide this entry (kept as an external import)",
+    // Never-installed package (not declared in package.json).
+    "Failed to resolve 'lodash' from worker.ts: package 'lodash' is not installed (kept as an external import)",
+    // Scoped package subpath.
+    "Failed to resolve '@acme/sdk/deep' from apps/todo/server.tsx: the installed '@acme/sdk' package does not provide this entry (kept as an external import)",
+    // The transform lane's stock message shape (bundle: false).
+    "Failed to resolve './missing.ts' from main.js: Cannot resolve relative import './missing.ts' from 'main.js'",
+    // A traversed file the transform lane could not read.
+    "File not found: apps/todo/shared/model.ts",
+  ])(
+    "rejects output whose imports would fail at startup with No such module: %s",
+    async (warning) => {
+      createWorker.mockResolvedValueOnce({
+        result: {
+          mainModule: "bundle.js",
+          modules: { "bundle.js": 'import "whatever";' },
+          warnings: [warning],
+        },
+      });
+
+      const error = await execute({ "worker.ts": "source" }).then(
+        () => Promise.reject(new Error("build unexpectedly succeeded")),
+        (thrown: Error) => thrown,
+      );
+      expect(error).toMatchObject({ name: "WorkerBuildFailedError" });
+      expect(error.message).toContain(warning);
+      expect(error.message).toContain("No such module");
+    },
+  );
+
+  it.each([
+    // nodejs_compat provides bare node builtins at runtime — external is correct.
+    "Failed to resolve 'fs' from worker.ts: package 'fs' is not installed (kept as an external import)",
+    "Failed to resolve 'stream/web' from worker.ts: package 'stream' is not installed (kept as an external import)",
+    // Scheme'd specifiers are runtime modules (defense in depth: the patched
+    // resolver does not warn about these in the first place).
+    "Failed to resolve 'cloudflare:workers' from worker.ts: package 'cloudflare:workers' is not installed (kept as an external import)",
+    "Failed to resolve 'node:fs' from worker.ts: package 'node:fs' is not installed (kept as an external import)",
+  ])("keeps runtime-provided externals as ordinary warnings: %s", async (warning) => {
+    createWorker.mockResolvedValueOnce({
+      result: {
+        mainModule: "bundle.js",
+        modules: { "bundle.js": "export default {};" },
+        warnings: [warning],
+      },
+    });
+
+    await expect(execute({ "worker.ts": "source" })).resolves.toMatchObject({
+      warnings: [warning],
+    });
+  });
 });

--- a/apps/os/src/domains/workers/build-backend.ts
+++ b/apps/os/src/domains/workers/build-backend.ts
@@ -15,18 +15,100 @@ export const WORKER_BUNDLER_VERSION = "0.2.1";
 export const WORKER_COMPATIBILITY_DATE = "2026-05-01";
 export const WORKER_COMPATIBILITY_FLAGS = ["nodejs_compat"];
 
-// worker-bundler currently reports dependency-install failures as warnings
-// and can still return an esbuild output containing unresolved bare imports.
-// Such output is not a usable artifact: Worker Loader rejects it only when
-// the first request tries to instantiate the module graph. Keep ordinary
+// worker-bundler reports dependency-install failures as warnings, and (via
+// our patch — see patches/@cloudflare__worker-bundler@0.2.1.patch) warns when
+// its resolver keeps an unresolvable import external. Either way the output
+// is not a usable artifact: Worker Loader rejects it only when the first
+// request tries to instantiate the module graph, which surfaces as a cryptic
+// `No such module` delivery failure instead of a build error. Keep ordinary
 // compiler warnings, but fail the build boundary on every install-warning
-// shape emitted by worker-bundler's installer.
+// shape emitted by worker-bundler's installer and on unresolved imports
+// (below).
 const DEPENDENCY_INSTALL_FAILURE_WARNING_PATTERNS = [
   /^Failed to parse package\.json\b/,
   /^Could not resolve version for\b/,
   /^Version .+ not found for\b/,
   /^Failed to install\b/,
 ] as const;
+
+/**
+ * Bare node builtins nodejs_compat provides at runtime (WORKER_COMPATIBILITY_FLAGS
+ * above): imports of these legitimately stay external, everything else external
+ * is a startup failure. Base names only — subpath imports like `stream/web` or
+ * `fs/promises` share their base's entry.
+ */
+const NODE_BUILTIN_BASE_NAMES = new Set([
+  "assert",
+  "async_hooks",
+  "buffer",
+  "child_process",
+  "cluster",
+  "console",
+  "constants",
+  "crypto",
+  "dgram",
+  "diagnostics_channel",
+  "dns",
+  "domain",
+  "events",
+  "fs",
+  "http",
+  "http2",
+  "https",
+  "inspector",
+  "module",
+  "net",
+  "os",
+  "path",
+  "perf_hooks",
+  "process",
+  "punycode",
+  "querystring",
+  "readline",
+  "repl",
+  "stream",
+  "string_decoder",
+  "sys",
+  "timers",
+  "tls",
+  "trace_events",
+  "tty",
+  "url",
+  "util",
+  "v8",
+  "vm",
+  "wasi",
+  "worker_threads",
+  "zlib",
+]);
+
+/**
+ * The warnings that mean the artifact cannot instantiate: unresolved imports
+ * kept external (`Failed to resolve '<specifier>' from <importer>` — emitted
+ * by our worker-bundler patch in the esbuild lane and by the stock transform
+ * lane) and files the transform lane could not read at all. Scheme'd
+ * specifiers (`node:*`, `cloudflare:*`) and bare node builtins are exempt —
+ * the runtime provides those.
+ */
+function unresolvedImportFailures(warnings: readonly string[]): string[] {
+  const failures: string[] = [];
+  for (const warning of warnings) {
+    if (warning.startsWith("File not found: ")) {
+      failures.push(warning);
+      continue;
+    }
+    const match = /^Failed to resolve '([^']+)' from /.exec(warning);
+    if (match === null) continue;
+    const specifier = match[1]!;
+    if (/^[a-zA-Z][\w+.-]*:/.test(specifier)) continue;
+    const base = specifier.startsWith("@")
+      ? specifier.split("/").slice(0, 2).join("/")
+      : specifier.split("/")[0]!;
+    if (NODE_BUILTIN_BASE_NAMES.has(base)) continue;
+    failures.push(warning);
+  }
+  return failures;
+}
 
 const PACKAGE_DEPENDENCY_FIELDS = [
   "dependencies",
@@ -141,14 +223,27 @@ function unwrapBuildResult<T>(result: { error: string } | { result: T }): T {
     "warnings" in built &&
     Array.isArray(built.warnings)
   ) {
-    const dependencyInstallFailures = built.warnings.filter(
-      (warning): warning is string =>
-        typeof warning === "string" &&
-        DEPENDENCY_INSTALL_FAILURE_WARNING_PATTERNS.some((pattern) => pattern.test(warning)),
+    const warnings = built.warnings.filter(
+      (warning): warning is string => typeof warning === "string",
+    );
+    const dependencyInstallFailures = warnings.filter((warning) =>
+      DEPENDENCY_INSTALL_FAILURE_WARNING_PATTERNS.some((pattern) => pattern.test(warning)),
     );
     if (dependencyInstallFailures.length > 0) {
       throw new WorkerBuildFailedError(
         buildFailureMessageFromError(dependencyInstallFailures.join("\n")),
+      );
+    }
+    const unresolvedImports = unresolvedImportFailures(warnings);
+    if (unresolvedImports.length > 0) {
+      throw new WorkerBuildFailedError(
+        buildFailureMessageFromError(
+          [
+            "The built worker would fail at startup with `No such module` — it contains imports that do not resolve:",
+            ...unresolvedImports.map((warning) => `  ${warning}`),
+            "Declare the missing dependency in package.json, or update the import if the installed package no longer provides that entry. Node builtins can be imported with the `node:` prefix.",
+          ].join("\n"),
+        ),
       );
     }
   }

--- a/patches/@cloudflare__worker-bundler@0.2.1.patch
+++ b/patches/@cloudflare__worker-bundler@0.2.1.patch
@@ -1,8 +1,70 @@
+diff --git a/dist/index.js b/dist/index.js
+index ec1f8602518e51ae151a238e5a51fe3c0dbc2e72..f5e2058fbccc0c1f15cc20c08ee6305b2a632261 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -254,26 +254,51 @@ async function bundleWithEsbuild(options) {
+ 						path: args.path,
+ 						external: true
+ 					};
++					// Iterate patch: an import the resolver cannot satisfy used to be
++					// SILENTLY marked external, shipping a bundle that fails at worker
++					// startup with `No such module`. Attach a warning so the build
++					// boundary can refuse the artifact. Scheme'd specifiers
++					// (cloudflare:*, node:*) and dynamic imports stay silent: the
++					// runtime may provide the former, and a guarded `await import()`
++					// is a legitimate pattern for the latter.
++					const warnUnresolved = (reason) => {
++						if (args.kind === "dynamic-import") return [];
++						if (/^[a-zA-Z][\w+.-]*:/.test(args.path)) return [];
++						return [{ text: `Failed to resolve '${args.path}' from ${args.importer || "entry"}: ${reason} (kept as an external import)` }];
++					};
+ 					try {
+ 						const result = resolveModule(args.path, { files });
+ 						if (!result.external) return {
+ 							path: result.path,
+ 							namespace: "virtual"
+ 						};
+-					} catch {}
+-					return {
+-						path: args.path,
+-						external: true
+-					};
++						const packageName = args.path.startsWith("@") ? args.path.split("/").slice(0, 2).join("/") : args.path.split("/")[0];
++						const installed = files.read(`node_modules/${packageName}/package.json`) !== null;
++						return {
++							path: args.path,
++							external: true,
++							warnings: warnUnresolved(installed ? `the installed '${packageName}' package does not provide this entry` : `package '${packageName}' is not installed`)
++						};
++					} catch (error) {
++						return {
++							path: args.path,
++							external: true,
++							warnings: warnUnresolved(error instanceof Error ? error.message : String(error))
++						};
++					}
+ 				}
+ 				const normalizedPath = args.path.startsWith("/") ? args.path.slice(1) : args.path;
+ 				if (files.read(normalizedPath) !== null) return {
+ 					path: normalizedPath,
+ 					namespace: "virtual"
+ 				};
++				// Iterate patch (same rationale as the bare-specifier branch above):
++				// only "./" and "/" paths that failed to resolve reach here, and an
++				// unresolvable relative import always fails at worker startup.
+ 				return {
+ 					path: args.path,
+-					external: true
++					external: true,
++					warnings: args.kind === "dynamic-import" ? [] : [{ text: `Failed to resolve '${args.path}' from ${args.importer || "entry"}: file does not exist (kept as an external import)` }]
+ 				};
+ 			});
+ 			build.onLoad({
 diff --git a/dist/installer-Ns4ivVf5.js b/dist/installer-Ns4ivVf5.js
-index 0220df7c889d58e6a670214eb1b6e1aa10215b2f..47627a3aad06d1de1f732ed48ccdf7e82197805a 100644
+index 0220df7c889d58e6a670214eb1b6e1aa10215b2f..5d7ad46ff85fb9cfeb752e4d440a9c60e03aae54 100644
 --- a/dist/installer-Ns4ivVf5.js
 +++ b/dist/installer-Ns4ivVf5.js
-@@ -75,20 +75,40 @@ async function installPackage(name, versionRange, result, fileSystem, installedP
+@@ -75,22 +75,42 @@ async function installPackage(name, versionRange, result, fileSystem, installedP
  	if (existing) return existing;
  	const installPromise = (async () => {
  		try {
@@ -55,6 +117,8 @@ index 0220df7c889d58e6a670214eb1b6e1aa10215b2f..47627a3aad06d1de1f732ed48ccdf7e8
 +				"zod"
 +			].includes(dependency))) : dependencies;
  			await Promise.all(Object.entries(deps).map(([depName, depVersion]) => installPackage(depName, depVersion, result, fileSystem, installedPackages, inProgress, registry)));
+ 		} catch (error) {
+ 			const message = error instanceof Error ? error.message : String(error);
 @@ -104,6 +124,25 @@ async function installPackage(name, versionRange, result, fileSystem, installedP
  		inProgress.delete(name);
  	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ patchedDependencies:
     hash: ea669d99cbc7919697d6388129b469e444d53f36b4a76b77ed91e172e38ad724
     path: patches/@cloudflare__sandbox@0.12.3.patch
   '@cloudflare/worker-bundler@0.2.1':
-    hash: 73256eb6fd3dcae81991c5c1730c823d847cb51938ee0cdb524018a167f938c9
+    hash: f39a50f1ade4d1d29fc948f70eae8d247734e183cd09c2e1b08199ac532d287f
     path: patches/@cloudflare__worker-bundler@0.2.1.patch
   '@cloudflare/workers-types@4.20260621.1':
     hash: ae8908e1d45f2ea02ffeabf1230701598cc2878240ef700403ff76df72677af2
@@ -547,7 +547,7 @@ importers:
         version: 0.3.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@tanstack/ai@0.10.2)(ai@6.0.159(zod@4.3.6))(zod@4.3.6)
       '@cloudflare/worker-bundler':
         specifier: 0.2.1
-        version: 0.2.1(patch_hash=73256eb6fd3dcae81991c5c1730c823d847cb51938ee0cdb524018a167f938c9)
+        version: 0.2.1(patch_hash=f39a50f1ade4d1d29fc948f70eae8d247734e183cd09c2e1b08199ac532d287f)
       '@codemirror/autocomplete':
         specifier: ^6.20.1
         version: 6.20.1
@@ -14554,7 +14554,7 @@ snapshots:
       - utf-8-validate
       - workerd
 
-  '@cloudflare/worker-bundler@0.2.1(patch_hash=73256eb6fd3dcae81991c5c1730c823d847cb51938ee0cdb524018a167f938c9)':
+  '@cloudflare/worker-bundler@0.2.1(patch_hash=f39a50f1ade4d1d29fc948f70eae8d247734e183cd09c2e1b08199ac532d287f)':
     dependencies:
       '@typescript/vfs': 1.6.4(typescript@6.0.3)
       es-module-lexer: 2.1.0

--- a/tasks/complete/2026-07-24-fail-builds-on-unresolved-imports.md
+++ b/tasks/complete/2026-07-24-fail-builds-on-unresolved-imports.md
@@ -1,5 +1,5 @@
 ---
-status: done-pending-review
+status: complete
 size: medium
 ---
 

--- a/tasks/fail-builds-on-unresolved-imports.md
+++ b/tasks/fail-builds-on-unresolved-imports.md
@@ -1,0 +1,100 @@
+---
+status: in-progress
+size: medium
+---
+
+# Fail worker builds on unresolved imports instead of shipping "No such module"
+
+## Status summary
+
+Diagnosed; prod remediated (all 22 parked config-worker feeds fixed and
+drained). Code fix in progress: make the build fail loudly when the bundle
+contains an import that cannot resolve, instead of shipping an artifact that
+dies at instantiation with a cryptic `No such module` and parks the config
+feed.
+
+## Incident (2nd "Config worker stalled", 2026-07-23)
+
+`misha-kaletsky-s-organization` (and, it turned out, 21 other prod projects)
+showed the red "Config worker stalled" warning. Thanks to the previous task
+([2026-07-23-config-worker-stalled](complete/2026-07-23-config-worker-stalled.md)),
+the sheet now showed the recorded error:
+
+```
+No such module "iterate/live-state".
+ imported from "bundle.js"
+```
+
+## Root cause chain
+
+1. Seeded config-repo `worker.ts` (old template) imports
+   `iterate/live-state`.
+2. The project's `package.json` floats on
+   `iterate: https://pkg.pr.new/iterate/iterate/iterate@main`.
+3. iterate#2167 (2026-07-21) moved LiveState to `iterate/sdk/capnweb` and
+   removed the old entry points, deliberately without compatibility aliases.
+4. On the next rebuild, worker-bundler's esbuild resolver hit the removed
+   subpath: `resolveExports` throws, the plugin's `catch {}` **silently marks
+   the import external**, and the build "succeeds" with a warning-free
+   artifact whose `bundle.js` still says `import ... from "iterate/live-state"`.
+5. Worker Loader injects nothing beyond the artifact's own modules, so
+   instantiation fails with `No such module`; every push delivery to
+   `processEventBatch` fails; three skip-verdicts later the subscription
+   parks. Red sidebar until a human intervenes.
+
+## Prod remediation (done, 2026-07-23)
+
+- One-line fix per affected repo (`repo.edit`): `iterate/live-state` →
+  `iterate/sdk/capnweb` (both symbols exist there), where the repo still had
+  the old import; then `subscription-resumed` on `/` for every parked
+  `project-worker` feed across all prod projects.
+- All 22 drained to lag 0. The only remaining park is `parked-proof-26600`
+  with recorded error "intentional poison: parked-warning prd proof" — a
+  deliberate UI-proof project, left as is.
+
+## The platform fix
+
+The build boundary must refuse artifacts that cannot instantiate. Design:
+
+- [ ] Extend `patches/@cloudflare__worker-bundler@0.2.1.patch`: in the
+      esbuild virtual-fs plugin's bare-specifier `onResolve`, when
+      `resolveModule` THROWS (installed package with an unmatched subpath,
+      invalid package.json, unresolvable relative path), attach an esbuild
+      warning `Failed to resolve '<specifier>' from <importer>: <reason>` to
+      the external fallback instead of staying silent. Scheme'd specifiers
+      (`cloudflare:*`, `node:*`) never reach the throw path; dynamic imports
+      stay silent (a guarded `await import()` is a legitimate pattern).
+      Also warn (`package not installed`) for static bare imports of packages
+      that are simply absent from `node_modules` — schemes excluded.
+- [ ] `build-backend.ts`: fail the build (`WorkerBuildFailedError`) on
+      `Failed to resolve '...'` warnings — from the patched esbuild lane and
+      the transform lane (`bundle: false`), which already emits them — and on
+      `File not found:` warnings. Exempt bare node builtins (`fs`,
+      `stream/web`, …) since nodejs_compat provides them at runtime; keep the
+      exemption list in reviewable TS, not in the patch.
+- [ ] Clear, actionable failure message: name each unresolved specifier and
+      its importer, say the worker would fail at startup with
+      `No such module`, and hint at the causes (package not declared in
+      package.json; the installed package no longer provides that entry —
+      update the import; node builtins may use the `node:` prefix).
+- [ ] Tests: build-backend failure/exemption table (mocked bundler warnings);
+      real worker-bundler run over in-memory files (prebuilt fake
+      `node_modules`, no network) proving the patch emits the warning for a
+      removed subpath and stays quiet for `node:*`/`cloudflare:*`/dynamic
+      imports — if esbuild-wasm cooperates in vitest; otherwise the mocked
+      table stands alone.
+
+## Explicitly out of scope
+
+- Compatibility aliases for removed `iterate` entry points (#2167 chose not
+  to have them; not relitigating here).
+- Pinning projects' `iterate` spec at seed time instead of floating `@main` —
+  bigger product question (floating keeps projects on the latest platform;
+  pinning trades that for build reproducibility). Worth a separate task.
+- Rebuild-and-verify sweeps that would proactively rebuild every project on
+  SDK changes.
+
+## Implementation log
+
+- 2026-07-23: diagnosis + prod sweep (see above), via
+  `doppler run --config prd -- pnpm cli itx run ...`.

--- a/tasks/fail-builds-on-unresolved-imports.md
+++ b/tasks/fail-builds-on-unresolved-imports.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done-pending-review
 size: medium
 ---
 
@@ -7,11 +7,11 @@ size: medium
 
 ## Status summary
 
-Diagnosed; prod remediated (all 22 parked config-worker feeds fixed and
-drained). Code fix in progress: make the build fail loudly when the bundle
-contains an import that cannot resolve, instead of shipping an artifact that
-dies at instantiation with a cryptic `No such module` and parks the config
-feed.
+Done, pending review (PR #2292). Prod remediated (all 22 parked config-worker
+feeds fixed and drained). The build now fails loudly when the bundle contains
+an import that cannot resolve, instead of shipping an artifact that dies at
+instantiation with a cryptic `No such module` and parks the config feed.
+Verified end-to-end against the real bundler in workerd (new e2e tests).
 
 ## Incident (2nd "Config worker stalled", 2026-07-23)
 
@@ -56,33 +56,33 @@ No such module "iterate/live-state".
 
 The build boundary must refuse artifacts that cannot instantiate. Design:
 
-- [ ] Extend `patches/@cloudflare__worker-bundler@0.2.1.patch`: in the
-      esbuild virtual-fs plugin's bare-specifier `onResolve`, when
-      `resolveModule` THROWS (installed package with an unmatched subpath,
-      invalid package.json, unresolvable relative path), attach an esbuild
-      warning `Failed to resolve '<specifier>' from <importer>: <reason>` to
-      the external fallback instead of staying silent. Scheme'd specifiers
-      (`cloudflare:*`, `node:*`) never reach the throw path; dynamic imports
-      stay silent (a guarded `await import()` is a legitimate pattern).
-      Also warn (`package not installed`) for static bare imports of packages
-      that are simply absent from `node_modules` — schemes excluded.
-- [ ] `build-backend.ts`: fail the build (`WorkerBuildFailedError`) on
-      `Failed to resolve '...'` warnings — from the patched esbuild lane and
-      the transform lane (`bundle: false`), which already emits them — and on
-      `File not found:` warnings. Exempt bare node builtins (`fs`,
-      `stream/web`, …) since nodejs_compat provides them at runtime; keep the
-      exemption list in reviewable TS, not in the patch.
-- [ ] Clear, actionable failure message: name each unresolved specifier and
-      its importer, say the worker would fail at startup with
-      `No such module`, and hint at the causes (package not declared in
-      package.json; the installed package no longer provides that entry —
-      update the import; node builtins may use the `node:` prefix).
-- [ ] Tests: build-backend failure/exemption table (mocked bundler warnings);
-      real worker-bundler run over in-memory files (prebuilt fake
-      `node_modules`, no network) proving the patch emits the warning for a
-      removed subpath and stays quiet for `node:*`/`cloudflare:*`/dynamic
-      imports — if esbuild-wasm cooperates in vitest; otherwise the mocked
-      table stands alone.
+- [x] Extend `patches/@cloudflare__worker-bundler@0.2.1.patch`: the esbuild
+      virtual-fs plugin's bare-specifier `onResolve` now attaches a
+      `Failed to resolve '<specifier>' from <importer>: <reason>` warning to
+      the external fallback — distinguishing "the installed '<pkg>' package
+      does not provide this entry" (the incident shape) from "package '<pkg>'
+      is not installed" — and the relative-path fallthrough warns
+      "file does not exist". Scheme'd specifiers (`cloudflare:*`, `node:*`)
+      and dynamic imports stay silent (a guarded `await import()` is
+      legitimate). _Regenerated via `pnpm patch`/`patch-commit`; installer
+      hunks preserved._
+- [x] `build-backend.ts`: `unresolvedImportFailures` fails the build
+      (`WorkerBuildFailedError`) on those warnings — from the patched esbuild
+      lane and the stock transform lane (`bundle: false`) — and on
+      `File not found:` warnings. Bare node builtins (`fs`, `stream/web`, …)
+      exempt via `NODE_BUILTIN_BASE_NAMES` in reviewable TS.
+- [x] Clear, actionable failure message: names each unresolved specifier and
+      importer, says the worker would fail at startup with `No such module`,
+      and hints at the fixes (declare the dependency; update the import;
+      `node:` prefix for builtins).
+- [x] Tests: build-backend failure/exemption tables (mocked warnings), plus
+      two new e2e tests in `worker-build.e2e.test.ts` running the REAL
+      patched bundler in workerd: an unresolved bare import fails the build
+      with the specifier named, and bare `path` + `node:buffer` +
+      `cloudflare:workers` keep building and running. _worker-bundler cannot
+      run under plain node (wasm module import), so the in-memory unit-test
+      idea was replaced by the e2e lane; also re-ran the overlay and
+      itx-workers e2e suites green as template regression cover._
 
 ## Explicitly out of scope
 


### PR DESCRIPTION
## What

A worker build whose bundle contains an import that cannot resolve now **fails loudly at build time**, instead of producing an artifact that dies at instantiation with `No such module "..."` — which is how 22 prod projects' config-worker feeds silently parked.

## The incident

After #2279 deployed, the "Config worker stalled" sheet finally showed *why* a parked project was parked:

```
No such module "iterate/live-state".
 imported from "bundle.js"
```

The chain: old seeded `worker.ts` imports `iterate/live-state` → the project floats on `iterate@main` → #2167 moved LiveState to `iterate/sdk/capnweb` and removed the old entry → on rebuild, worker-bundler's esbuild resolver hit the removed subpath, and its `catch {}` **silently marked the import external** → the "successful" artifact can never instantiate → every delivery fails → parked. This had happened to every project seeded with the old template (22 parked feeds in prod, all now fixed and drained; details in `tasks/fail-builds-on-unresolved-imports.md`).

## The fix

Two layers:

- **Patched resolver warns instead of silently punting** (`patches/@cloudflare__worker-bundler@0.2.1.patch`): when the bare-specifier resolver *knows* an import is broken (installed package without that entry, invalid package.json) or the package simply isn't installed, the external fallback now carries a `Failed to resolve '<specifier>' from <importer>` warning. Scheme'd specifiers (`node:*`, `cloudflare:*`) and dynamic imports stay silent — a guarded `await import()` is legitimate.
- **Build boundary fails on those warnings** (`build-backend.ts`): `Failed to resolve` / `File not found` warnings become `WorkerBuildFailedError` with an actionable message (which import, which module, what to do). Bare node builtins (`fs`, `stream/web`, …) are exempt — nodejs_compat provides them at runtime; the exemption list lives in reviewable TypeScript, not the patch.

Result: the failure surfaces at build time in the build/repo UI with the exact import named, the previous good artifact keeps serving, and the config feed never parks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +104 -9 | +80 -4 🟩🟩🟩🟩⬜ |
| Tests | +138 -0 | +112 -0 🟩🟩🟩🟩🟩 |
| Docs | +100 -0 | +83 -0 🟩🟩🟩🟩⬜ |
| Other | +66 -2 | +66 -2 🟩🟩🟩⬜⬜ |
| Generated | +3 -3 | +3 -3 🟩⬜⬜⬜⬜ |
| **Total** | **+411 -14** | **+344 -9** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between ecc8d1f and e6c84af, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-24T10:35:56.496Z",
      "deployedAt": "2026-07-24T10:18:47.558Z",
      "headSha": "f7afea90b69dffb19e198f91aada773081aec36f",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-15.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/247556553573774",
      "shortSha": "f7afea9",
      "cleanupDurationMs": 12398,
      "deployDurationMs": 63556,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 62441,
      "deployReadinessDurationMs": 1111,
      "deployedWorkerName": "os-preview-15",
      "deployedWorkerVersion": "28a33baa-d7d6-4b53-9414-b29847af6ec7",
      "testDurationMs": 74577,
      "testRetries": null,
      "workerSizeKib": 19793.42,
      "workerGzipKib": 5007.5,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5022.56
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-24T10:35:45.303Z",
      "deployedAt": "2026-07-24T10:17:59.910Z",
      "headSha": "f7afea90b69dffb19e198f91aada773081aec36f",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-15.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/247556553573774",
      "shortSha": "f7afea9",
      "cleanupDurationMs": 1202,
      "deployDurationMs": 14988,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 14791,
      "deployReadinessDurationMs": 193,
      "deployedWorkerName": "semaphore-preview-15",
      "deployedWorkerVersion": "43573de9-20ec-4351-8544-c0bd8bf76066",
      "testDurationMs": 21057,
      "testRetries": null,
      "workerSizeKib": 1915.32,
      "workerGzipKib": 441.04,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-24T10:35:48.263Z",
      "deployedAt": "2026-07-24T10:18:05.786Z",
      "headSha": "f7afea90b69dffb19e198f91aada773081aec36f",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-15.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/247556553573774",
      "shortSha": "f7afea9",
      "cleanupDurationMs": 4161,
      "deployDurationMs": 20947,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 20665,
      "deployReadinessDurationMs": 277,
      "deployedWorkerName": "auth-preview-15",
      "deployedWorkerVersion": "2c46d2bb-5328-4bf4-a797-05963f7bedbc",
      "testDurationMs": 10011,
      "testRetries": null,
      "workerSizeKib": 3966.04,
      "workerGzipKib": 811.6,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-24T10:35:52.288Z",
      "deployedAt": "2026-07-24T10:18:28.100Z",
      "headSha": "f7afea90b69dffb19e198f91aada773081aec36f",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-15.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/247556553573774",
      "shortSha": "f7afea9",
      "cleanupDurationMs": 8183,
      "deployDurationMs": 43810,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 42978,
      "deployReadinessDurationMs": 826,
      "deployedWorkerName": "streams-example-app-preview-15",
      "deployedWorkerVersion": "3a6f7c0e-7767-4299-a52a-d85b4e0f7c3f",
      "testDurationMs": 59791,
      "testRetries": null,
      "workerSizeKib": 5162.64,
      "workerGzipKib": 1473.77,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-24T10:35:45.234Z",
      "deployedAt": "2026-07-24T10:17:50.661Z",
      "headSha": "f7afea90b69dffb19e198f91aada773081aec36f",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-15.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/247556553573774",
      "shortSha": "f7afea9",
      "cleanupDurationMs": 1127,
      "deployDurationMs": 5777,
      "deployConfigDurationMs": 8,
      "deployCommandDurationMs": 5497,
      "deployReadinessDurationMs": 231,
      "deployedWorkerName": "dummy-petshop-preview-15",
      "deployedWorkerVersion": "6503bd2e-a961-4d2d-8ec1-809e2f1ca269",
      "testDurationMs": 5798,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `f7afea9` | [https://auth.iterate-preview-15.com](https://auth.iterate-preview-15.com) | 811.6 KiB | 20.9s | 10.0s |  | 4.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/247556553573774) | 2026-07-24T10:35:48.263Z | Preview app released. |
| Dummy Petshop | released | `f7afea9` | [https://dummy-petshop.iterate-preview-15.com](https://dummy-petshop.iterate-preview-15.com) | 198.3 KiB | 5.8s | 5.8s |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/247556553573774) | 2026-07-24T10:35:45.234Z | Preview app released. |
| OS | released | `f7afea9` | [https://os.iterate-preview-15.com](https://os.iterate-preview-15.com) | 4.89 MiB (-15.1 KiB vs main) | 63.6s | 74.6s |  | 12.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/247556553573774) | 2026-07-24T10:35:56.496Z | Preview app released. |
| Semaphore | released | `f7afea9` | [https://semaphore.iterate-preview-15.com](https://semaphore.iterate-preview-15.com) | 441.0 KiB | 15.0s | 21.1s |  | 1.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/247556553573774) | 2026-07-24T10:35:45.303Z | Preview app released. |
| Streams Example App | released | `f7afea9` | [https://streams.iterate-preview-15.com](https://streams.iterate-preview-15.com) | 1.44 MiB | 43.8s | 59.8s |  | 8.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/247556553573774) | 2026-07-24T10:35:52.288Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the worker build contract for all dynamic workers; incorrect exemptions could false-negative (still ship bad bundles) or false-positive (reject valid externals).
> 
> **Overview**
> Worker builds that would instantiate with **`No such module`** now **fail at build time** with the unresolved specifier named, instead of shipping a bundle whose broken imports were silently marked external.
> 
> The **`@cloudflare/worker-bundler`** patch emits **`Failed to resolve`** warnings when the esbuild resolver keeps unresolvable bare or relative imports external (distinguishing missing packages vs wrong subpaths). **`build-backend.ts`** treats those warnings plus **`File not found:`** as **`WorkerBuildFailedError`**, with an actionable message, while still allowing **`node:`**, **`cloudflare:`**, and bare Node builtins that **`nodejs_compat`** provides at runtime.
> 
> Coverage adds parameterized unit tests on warning classification and two e2e tests against the real patched bundler in workerd.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6c84af75e71005583eb0c240b59445b0b766f04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->