### PR TITLE
Pointer poll rides the quiet lane — a hiccup must not dispose the shared WS

### DIFF
--- a/apps/tasks/src/lib/pointer-presence.ts
+++ b/apps/tasks/src/lib/pointer-presence.ts
@@ -123,7 +123,11 @@ export function usePointerPresence(
     const poll = async (): Promise<void> => {
       while (!stopped) {
         try {
-          const snapshot = await lane((ws) => ws.pointerWait(generation));
+          // ONE quiet try on the live session: withProject's retry lane
+          // DISPOSES the shared WS on failure — a pointer poll hiccup must
+          // never tear down the board's session (the board poll heals it;
+          // this loop's backoff rides the healed session next iteration).
+          const snapshot = await lane((ws) => ws.pointerWait(generation), true);
           if (stopped) return;
           failures = 0;
           generation = snapshot.generation;


### PR DESCRIPTION
Follow-up to #2293, caught proving it out in prod: the pointer long-poll used `withProject`, whose failure path disposes the shared WS to force a re-dial — so any transient `pointerWait` error (deploy roll, eviction, pre-rollout method miss) tore down the board's own session mid-seed with "RPC session was shut down by disposing the main stub". Now `withProjectOnce` (single quiet try, no dispose) + the loop's existing backoff; the board's own poll heals the shared session and the next iteration rides it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to pointer presence polling only; aligns receive path with send/teardown already using the quiet lane.
> 
> **Overview**
> **Pointer receive loop** now calls `pointerWait` through the **quiet** project lane (`withProjectOnce`) instead of the retry lane that **disposes the shared WebSocket** on failure.
> 
> Transient pointer poll errors (deploy roll, eviction, etc.) no longer tear down the board’s RPC session mid-seed; the board’s own poll keeps healing the session while this loop’s existing backoff retries on the healed connection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e76f9d60dd591ed3bc720fe7bb75d0526823050b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +5 -1 | +1 -1 🟩🟩🟩🟥🟥 |
| **Total** | **+5 -1** | **+1 -1** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between d33522b and e76f9d6, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->