### PR TITLE
Bump worker-build artifact schema to v11 so pre-patch broken bundles rebuild

### DIFF
--- a/apps/os/src/domains/workers/artifact-store.ts
+++ b/apps/os/src/domains/workers/artifact-store.ts
@@ -4,9 +4,14 @@ import type { WorkerBundlerAssetConfig } from "./schemas.ts";
 
 // v10 invalidates artifacts emitted after dependency-install warnings. Those
 // bundles could retain unresolved bare imports and were never runnable.
+// v11 invalidates artifacts built before the worker-bundler patch that warns
+// on every unresolved import (#2292): pre-patch bundles could carry silently
+// externalized imports that fail at instantiation with `No such module`, and
+// without a bump their build keys would keep serving them from KV for up to
+// the 30-day TTL, never reaching the new build-time gate.
 // Failures are deliberately not cached: the bundler cannot distinguish
 // broken source from transient infrastructure.
-export const WORKER_BUILD_ARTIFACT_SCHEMA_VERSION = 10;
+export const WORKER_BUILD_ARTIFACT_SCHEMA_VERSION = 11;
 
 const ARTIFACT_TTL_SECONDS = 30 * 24 * 60 * 60;
 const KV_PREFIX = `worker-build/v${WORKER_BUILD_ARTIFACT_SCHEMA_VERSION}`;


### PR DESCRIPTION
## What

Follow-up to #2292, addressing the Bugbot finding posted there just before merge: the new unresolved-import build gate only runs on a cache miss, and neither `WORKER_BUILD_ARTIFACT_SCHEMA_VERSION` nor `WORKER_BUNDLER_VERSION` changed with the bundler patch — so artifacts built **before** the patch, including ones carrying silently externalized imports that die at instantiation with `No such module`, would keep serving from KV for up to the 30-day TTL without ever reaching the gate.

One-line fix, same remedy as the existing v10 bump (which invalidated install-warning bundles for the same never-runnable reason): bump the artifact schema version to v11 so every cached artifact rebuilds under the patched bundler and the new gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant bump plus comments; only affects KV cache keying and triggers rebuilds, with no auth, data, or runtime logic changes.
> 
> **Overview**
> Bumps **`WORKER_BUILD_ARTIFACT_SCHEMA_VERSION`** from **10 → 11**, which changes the KV prefix (`worker-build/v11/...`) so existing cached worker build artifacts are treated as misses.
> 
> This forces rebuilds for bundles that were produced **before** the worker-bundler unresolved-import warning patch (#2292). Those older artifacts could still be served for up to the 30-day TTL and would never hit the new build-time gate, leading to runtime `No such module` failures.
> 
> Adds an inline comment documenting the v11 invalidation rationale, mirroring the earlier v10 bump for install-warning bundles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06796763baf0c24c2f1f67deb3ad4d51333df024. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +6 -1 | +1 -1 🟩🟩🟩🟥🟥 |
| **Total** | **+6 -1** | **+1 -1** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between 79a7b33 and 0679676, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-24T10:48:44.612Z",
      "deployedAt": "2026-07-24T10:38:53.020Z",
      "headSha": "06796763baf0c24c2f1f67deb3ad4d51333df024",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/377722400366031",
      "shortSha": "0679676",
      "cleanupDurationMs": 10824,
      "deployDurationMs": 68444,
      "deployConfigDurationMs": 1,
      "deployCommandDurationMs": 66422,
      "deployReadinessDurationMs": 2020,
      "deployedWorkerName": "os-preview-8",
      "deployedWorkerVersion": "9a5fc4cf-deef-4e37-832d-3e8714c739ac",
      "testDurationMs": 204068,
      "testRetries": "1 retried: repl-examples.spec.ts › itx REPL catalogue examples › runs \"scheduler-basics\" through the project REPL › web (playwright x1) — \u001b[31mTest timeout of 90000ms exceeded.\u001b[39m",
      "workerSizeKib": 19821.23,
      "workerGzipKib": 5013.67,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5023.46
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-24T10:48:36.418Z",
      "deployedAt": "2026-07-24T10:38:09.308Z",
      "headSha": "06796763baf0c24c2f1f67deb3ad4d51333df024",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/377722400366031",
      "shortSha": "0679676",
      "cleanupDurationMs": 2627,
      "deployDurationMs": 23038,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 22707,
      "deployReadinessDurationMs": 328,
      "deployedWorkerName": "auth-preview-8",
      "deployedWorkerVersion": "14f84098-404b-43db-9562-519f5e19743e",
      "testDurationMs": 14543,
      "testRetries": null,
      "workerSizeKib": 3966.31,
      "workerGzipKib": 811.62,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-24T10:48:34.488Z",
      "deployedAt": "2026-07-24T10:37:52.663Z",
      "headSha": "06796763baf0c24c2f1f67deb3ad4d51333df024",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/377722400366031",
      "shortSha": "0679676",
      "cleanupDurationMs": 695,
      "deployDurationMs": 6337,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 6026,
      "deployReadinessDurationMs": 271,
      "deployedWorkerName": "dummy-petshop-preview-8",
      "deployedWorkerVersion": "975ccd8c-7cd9-4ff4-8877-9e78c896e050",
      "testDurationMs": 32221,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `0679676` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 811.6 KiB | 23.0s | 14.5s |  | 2.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/377722400366031) | 2026-07-24T10:48:36.418Z | Preview app released. |
| Dummy Petshop | released | `0679676` | [https://dummy-petshop.iterate-preview-8.com](https://dummy-petshop.iterate-preview-8.com) | 198.3 KiB | 6.3s | 32.2s |  | 695ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/377722400366031) | 2026-07-24T10:48:34.488Z | Preview app released. |
| OS | released | `0679676` | [https://os.iterate-preview-8.com](https://os.iterate-preview-8.com) | 4.90 MiB (-9.8 KiB vs main) | 68.4s | 204.1s | 1 retried: repl-examples.spec.ts › itx REPL catalogue examples › runs "scheduler-basics" through the project REPL › web (playwright x1) — [31mTest timeout of 90000ms exceeded.[39m | 10.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/377722400366031) | 2026-07-24T10:48:44.612Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->