### PR TITLE
LOC report: ignore type-only TypeScript churn

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1507,6 +1507,9 @@ importers:
         specifier: 4.3.6
         version: 4.3.6
     devDependencies:
+      '@jridgewell/sourcemap-codec':
+        specifier: ^1.5.5
+        version: 1.5.5
       '@types/node':
         specifier: ^25.0.10
         version: 25.6.0

--- a/scripts/ci/loc-report.test.ts
+++ b/scripts/ci/loc-report.test.ts
@@ -35,6 +35,59 @@ test("type-only TypeScript changes remain in Lines but disappear from Significan
   ]);
 });
 
+test("TypeScript declaration files remain in Lines but contribute no Significant lines", () => {
+  using repo = createGitRepo();
+  const base = repo.commit({
+    "types/index.d.cts": ["export interface User {", "  id: string", "}", ""].join("\n"),
+    "types/index.d.mts": ["export interface User {", "  id: string", "}", ""].join("\n"),
+    "types/index.d.ts": ["export interface User {", "  id: string", "}", ""].join("\n"),
+  });
+  const head = repo.commit({
+    "types/index.d.cts": [
+      "export interface User {",
+      "  id: string",
+      "  displayName: string",
+      "}",
+      "",
+    ].join("\n"),
+    "types/index.d.mts": [
+      "export interface User {",
+      "  id: string",
+      "  displayName: string",
+      "}",
+      "",
+    ].join("\n"),
+    "types/index.d.ts": [
+      "export interface User {",
+      "  id: string",
+      "  displayName: string",
+      "}",
+      "",
+    ].join("\n"),
+  });
+
+  expect(getChangedFiles(base, head, repo.path)).toMatchObject([
+    {
+      path: "types/index.d.cts",
+      added: 1,
+      significantAdded: 0,
+      significantRemoved: 0,
+    },
+    {
+      path: "types/index.d.mts",
+      added: 1,
+      significantAdded: 0,
+      significantRemoved: 0,
+    },
+    {
+      path: "types/index.d.ts",
+      added: 1,
+      significantAdded: 0,
+      significantRemoved: 0,
+    },
+  ]);
+});
+
 test("mixed TypeScript changes count only emitted runtime lines as Significant", () => {
   using repo = createGitRepo();
   const base = repo.commit({

--- a/scripts/ci/loc-report.test.ts
+++ b/scripts/ci/loc-report.test.ts
@@ -1,0 +1,140 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { expect, test } from "vitest";
+
+import { computeReport, getChangedFiles, renderBodySection } from "./loc-report.ts";
+
+test("type-only TypeScript changes remain in Lines but disappear from Significant", () => {
+  using repo = createGitRepo();
+  const base = repo.commit({
+    "src/user.ts": ["export interface User {", "  id: string", "}", ""].join("\n"),
+  });
+  const head = repo.commit({
+    "src/user.ts": [
+      "export interface User {",
+      "  id: string",
+      "  displayName: string",
+      "}",
+      "",
+    ].join("\n"),
+  });
+
+  expect(getChangedFiles(base, head, repo.path)).toMatchObject([
+    {
+      path: "src/user.ts",
+      added: 1,
+      removed: 0,
+      significantAdded: 0,
+      significantRemoved: 0,
+    },
+  ]);
+});
+
+test("mixed TypeScript changes count only emitted runtime lines as Significant", () => {
+  using repo = createGitRepo();
+  const base = repo.commit({
+    "src/user.ts": ["export interface User {", "  id: string", "}", ""].join("\n"),
+  });
+  const head = repo.commit({
+    "src/user.ts": [
+      "export interface User {",
+      "  id: string",
+      "  displayName: string",
+      "}",
+      "export const getDisplayName = (user: User) => user.displayName",
+      "",
+    ].join("\n"),
+  });
+
+  expect(getChangedFiles(base, head, repo.path)).toMatchObject([
+    {
+      added: 2,
+      removed: 0,
+      significantAdded: 1,
+      significantRemoved: 0,
+    },
+  ]);
+});
+
+test("runtime-emitting TypeScript syntax remains Significant without compiler-line inflation", () => {
+  using repo = createGitRepo();
+  const base = repo.commit({ "src/direction.ts": "" });
+  const head = repo.commit({
+    "src/direction.ts": ["enum Direction {", "  Up,", "  Down,", "}", ""].join("\n"),
+  });
+
+  expect(getChangedFiles(base, head, repo.path)).toMatchObject([
+    {
+      added: 4,
+      removed: 0,
+      significantAdded: 4,
+      significantRemoved: 0,
+    },
+  ]);
+});
+
+test("JavaScript comments and non-JavaScript blank lines retain their Significant behavior", () => {
+  using repo = createGitRepo();
+  const base = repo.commit({ "README.md": "", "src/value.js": "" });
+  const head = repo.commit({
+    "README.md": ["# Heading", "", "Copy", ""].join("\n"),
+    "src/value.js": ["// explain the value", "export const value = 1", ""].join("\n"),
+  });
+
+  expect(getChangedFiles(base, head, repo.path)).toMatchObject([
+    {
+      path: "README.md",
+      added: 3,
+      significantAdded: 2,
+    },
+    {
+      path: "src/value.js",
+      added: 2,
+      significantAdded: 1,
+    },
+  ]);
+});
+
+test("the PR report explains the TypeScript runtime-line filter", () => {
+  expect(renderBodySection(computeReport([]), "1234567890", "abcdef1234")).toContain(
+    "TypeScript lines with no runtime output",
+  );
+});
+
+function createGitRepo() {
+  const path = mkdtempSync(join(tmpdir(), "loc-report-test-"));
+  execFileSync("git", ["init", "--quiet"], { cwd: path });
+
+  return {
+    path,
+    commit(files: Record<string, string>) {
+      for (const [file, content] of Object.entries(files)) {
+        const fullPath = join(path, file);
+        mkdirSync(join(fullPath, ".."), { recursive: true });
+        writeFileSync(fullPath, content);
+      }
+      execFileSync("git", ["add", "."], { cwd: path });
+      execFileSync(
+        "git",
+        [
+          "-c",
+          "user.name=LOC Report Test",
+          "-c",
+          "user.email=loc-report@example.invalid",
+          "commit",
+          "--quiet",
+          "-m",
+          "fixture",
+        ],
+        { cwd: path },
+      );
+      return execFileSync("git", ["rev-parse", "HEAD"], { cwd: path, encoding: "utf8" }).trim();
+    },
+    [Symbol.dispose]() {
+      rmSync(path, { recursive: true, force: true });
+    },
+  };
+}

--- a/scripts/ci/loc-report.test.ts
+++ b/scripts/ci/loc-report.test.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import { expect, test } from "vitest";
 
@@ -10,9 +10,6 @@ import { computeReport, getChangedFiles, renderBodySection } from "./loc-report.
 test("type-only TypeScript changes remain in Lines but disappear from Significant", () => {
   using repo = createGitRepo();
   const base = repo.commit({
-    "src/user.ts": ["export interface User {", "  id: string", "}", ""].join("\n"),
-  });
-  const head = repo.commit({
     "src/user.ts": [
       "export interface User {",
       "  id: string",
@@ -21,12 +18,17 @@ test("type-only TypeScript changes remain in Lines but disappear from Significan
       "",
     ].join("\n"),
   });
+  const head = repo.commit({
+    "src/user.ts": ["export interface User {", "  id: string", "  name: string", "}", ""].join(
+      "\n",
+    ),
+  });
 
   expect(getChangedFiles(base, head, repo.path)).toMatchObject([
     {
       path: "src/user.ts",
       added: 1,
-      removed: 0,
+      removed: 1,
       significantAdded: 0,
       significantRemoved: 0,
     },
@@ -36,15 +38,15 @@ test("type-only TypeScript changes remain in Lines but disappear from Significan
 test("mixed TypeScript changes count only emitted runtime lines as Significant", () => {
   using repo = createGitRepo();
   const base = repo.commit({
-    "src/user.ts": ["export interface User {", "  id: string", "}", ""].join("\n"),
+    "src/user.tsx": ["export interface User {", "  id: string", "}", ""].join("\n"),
   });
   const head = repo.commit({
-    "src/user.ts": [
+    "src/user.tsx": [
       "export interface User {",
       "  id: string",
       "  displayName: string",
       "}",
-      "export const getDisplayName = (user: User) => user.displayName",
+      "export const Avatar = (user: User) => <span>{user.displayName}</span>",
       "",
     ].join("\n"),
   });
@@ -113,7 +115,7 @@ function createGitRepo() {
     commit(files: Record<string, string>) {
       for (const [file, content] of Object.entries(files)) {
         const fullPath = join(path, file);
-        mkdirSync(join(fullPath, ".."), { recursive: true });
+        mkdirSync(dirname(fullPath), { recursive: true });
         writeFileSync(fullPath, content);
       }
       execFileSync("git", ["add", "."], { cwd: path });

--- a/scripts/ci/loc-report.ts
+++ b/scripts/ci/loc-report.ts
@@ -158,7 +158,15 @@ function significantLines(content: string, path: string) {
       },
     });
     if (!transpiled.sourceMapText) throw new Error(`TypeScript emitted no source map for ${path}`);
-    const sourceMap = JSON.parse(transpiled.sourceMapText) as { mappings: string };
+    const sourceMap: unknown = JSON.parse(transpiled.sourceMapText);
+    if (
+      typeof sourceMap !== "object" ||
+      sourceMap === null ||
+      !("mappings" in sourceMap) ||
+      typeof sourceMap.mappings !== "string"
+    ) {
+      throw new Error(`TypeScript emitted an invalid source map for ${path}`);
+    }
     runtimeLines = new Set(
       decode(sourceMap.mappings).flatMap((line) =>
         line.flatMap((segment) => {

--- a/scripts/ci/loc-report.ts
+++ b/scripts/ci/loc-report.ts
@@ -144,6 +144,7 @@ const jsExtensions = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mt
 const typeScriptExtensions = new Set([".ts", ".tsx", ".mts", ".cts"]);
 
 function significantLines(content: string, path: string) {
+  if (/\.d\.(?:ts|mts|cts)$/.test(path)) return "";
   const extension = extname(path);
   let runtimeLines: Set<number> | undefined;
   if (typeScriptExtensions.has(extension)) {

--- a/scripts/ci/loc-report.ts
+++ b/scripts/ci/loc-report.ts
@@ -3,6 +3,9 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { extname, join, matchesGlob } from "node:path";
 
+import { decode } from "@jridgewell/sourcemap-codec";
+import ts from "typescript";
+
 import { markdownAnnotator } from "../../packages/shared/src/dev/markdown-annotator.ts";
 import { isMainModule } from "../../packages/shared/src/dev/is-main-module.ts";
 import { getOctokit, getRepo, readEventPayload } from "./github.ts";
@@ -47,7 +50,7 @@ export type ChangedFile = {
   /** Raw diff counts, straight from `git diff --numstat`. */
   added: number;
   removed: number;
-  /** Counts after dropping blank lines and (for JS-ish files) comments. */
+  /** Counts after dropping blank lines, JS comments, and type-only TypeScript lines. */
   significantAdded: number;
   significantRemoved: number;
   binary: boolean;
@@ -86,25 +89,30 @@ const gitMaxBuffer = 64 * 1024 * 1024;
 /**
  * Changed files between merge-base(base, head) and head. Raw added/removed come
  * from numstat; significant counts additionally drop blank lines and (for
- * JS-ish files) line/block comments, computed by diffing the stripped
- * before/after contents so multiline comment blocks and comment-only changes
- * fall out naturally.
+ * JS-ish files) line/block comments. TypeScript's source map identifies source
+ * lines with runtime output, so type-only lines also fall out before the
+ * stripped before/after contents are diffed.
  */
-export function getChangedFiles(baseRef: string, headRef: string): ChangedFile[] {
+export function getChangedFiles(baseRef: string, headRef: string, cwd: string): ChangedFile[] {
   const raw = execFileSync("git", ["diff", "--numstat", "-z", "-M", `${baseRef}...${headRef}`], {
+    cwd,
     encoding: "utf8",
     maxBuffer: gitMaxBuffer,
   });
   const mergeBase = execFileSync("git", ["merge-base", baseRef, headRef], {
+    cwd,
     encoding: "utf8",
   }).trim();
   const files = parseNumstat(raw);
-  const generated = linguistGeneratedPaths(files.map((file) => file.path));
+  const generated = linguistGeneratedPaths(
+    files.map((file) => file.path),
+    cwd,
+  );
   return files.map((file) => {
     const marked = { ...file, generated: generated.has(file.path) };
     if (marked.binary) return marked;
-    const before = significantLines(gitShow(mergeBase, file.previousPath), file.previousPath);
-    const after = significantLines(gitShow(headRef, file.path), file.path);
+    const before = significantLines(gitShow(mergeBase, file.previousPath, cwd), file.previousPath);
+    const after = significantLines(gitShow(headRef, file.path, cwd), file.path);
     const counts = slocDiffCounts(before, after);
     return { ...marked, significantAdded: counts.added, significantRemoved: counts.removed };
   });
@@ -115,10 +123,11 @@ export function getChangedFiles(baseRef: string, headRef: string): ChangedFile[]
  * same source of truth GitHub uses to collapse generated files in diffs.
  * One batched `git check-attr` call; output is path/attr/value triplets.
  */
-function linguistGeneratedPaths(paths: string[]): Set<string> {
+function linguistGeneratedPaths(paths: string[], cwd: string): Set<string> {
   const generated = new Set<string>();
   if (paths.length === 0) return generated;
   const out = execFileSync("git", ["check-attr", "--stdin", "-z", "linguist-generated"], {
+    cwd,
     encoding: "utf8",
     input: paths.join("\0"),
     maxBuffer: gitMaxBuffer,
@@ -132,19 +141,44 @@ function linguistGeneratedPaths(paths: string[]): Set<string> {
 }
 
 const jsExtensions = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"]);
+const typeScriptExtensions = new Set([".ts", ".tsx", ".mts", ".cts"]);
 
 function significantLines(content: string, path: string) {
-  const stripped = jsExtensions.has(extname(path)) ? stripJsComments(content) : content;
+  const extension = extname(path);
+  let runtimeLines: Set<number> | undefined;
+  if (typeScriptExtensions.has(extension)) {
+    const transpiled = ts.transpileModule(content, {
+      fileName: path,
+      compilerOptions: {
+        jsx: ts.JsxEmit.Preserve,
+        module: ts.ModuleKind.ESNext,
+        sourceMap: true,
+        target: ts.ScriptTarget.ESNext,
+      },
+    });
+    if (!transpiled.sourceMapText) throw new Error(`TypeScript emitted no source map for ${path}`);
+    const sourceMap = JSON.parse(transpiled.sourceMapText) as { mappings: string };
+    runtimeLines = new Set(
+      decode(sourceMap.mappings).flatMap((line) =>
+        line.flatMap((segment) => {
+          const sourceLine = segment[2];
+          return typeof sourceLine === "number" ? [sourceLine] : [];
+        }),
+      ),
+    );
+  }
+  const stripped = jsExtensions.has(extension) ? stripJsComments(content) : content;
   return stripped
     .split("\n")
-    .filter((line) => line.trim() !== "")
+    .filter((line, index) => line.trim() !== "" && (!runtimeLines || runtimeLines.has(index)))
     .join("\n");
 }
 
 /** Contents of `path` at `ref`, or "" when it doesn't exist there (added/deleted files). */
-function gitShow(ref: string, path: string) {
+function gitShow(ref: string, path: string, cwd: string) {
   try {
     return execFileSync("git", ["show", `${ref}:${path}`], {
+      cwd,
       encoding: "utf8",
       maxBuffer: gitMaxBuffer,
       stdio: ["ignore", "pipe", "ignore"],
@@ -276,10 +310,11 @@ export function computeReport(files: ChangedFile[]) {
 /**
  * Renders the report as a markdown table mimicking GitHub's own diffstat.
  * Two diff columns per group: raw line counts, then significant counts (blank
- * lines and JS comments excluded) so comment-heavy churn is visible at a
- * glance. The five-square bar rides the Significant column - it's the primary
- * signal - filling proportionally to the group's share of the largest group's
- * significant churn, split green/red by its add/remove ratio.
+ * lines, JS comments, and type-only TypeScript lines excluded) so supporting
+ * churn is visible at a glance. The five-square bar rides the Significant
+ * column - it's the primary signal - filling proportionally to the group's
+ * share of the largest group's significant churn, split green/red by its
+ * add/remove ratio.
  */
 export function renderTable(report: ReturnType<typeof computeReport>) {
   // Always signed, even +0/-0, matching GitHub's own diffstat.
@@ -318,7 +353,7 @@ export function renderBodySection(
   return [
     renderTable(report),
     "",
-    `<sub>Lines counts every changed line; Significant ignores blank lines and JS comments. Between ${baseSha.slice(0, 7)} and ${headSha.slice(0, 7)}, bucketed first-match-wins into the groups defined in \`scripts/ci/loc-report.ts\`.</sub>`,
+    `<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between ${baseSha.slice(0, 7)} and ${headSha.slice(0, 7)}, bucketed first-match-wins into the groups defined in \`scripts/ci/loc-report.ts\`.</sub>`,
   ].join("\n");
 }
 
@@ -338,7 +373,7 @@ export async function postLocReport() {
     const baseRef = process.argv[2] || "origin/main";
     const headRef = process.argv[3] || "HEAD";
     console.log(`No pull request context - printing report for ${baseRef}...${headRef}\n`);
-    const report = computeReport(getChangedFiles(baseRef, headRef));
+    const report = computeReport(getChangedFiles(baseRef, headRef, process.cwd()));
     console.log(renderTable(report));
     return;
   }
@@ -347,7 +382,7 @@ export async function postLocReport() {
   const headSha = pullRequest.head.sha;
   ensureCommitAvailable(baseSha);
   ensureCommitAvailable(headSha);
-  const report = computeReport(getChangedFiles(baseSha, headSha));
+  const report = computeReport(getChangedFiles(baseSha, headSha, process.cwd()));
   const section = renderBodySection(report, baseSha, headSha);
   console.log(section);
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -18,6 +18,7 @@
     "zod": "4.3.6"
   },
   "devDependencies": {
+    "@jridgewell/sourcemap-codec": "^1.5.5",
     "@types/node": "^25.0.10",
     "typescript": "^5.9.3",
     "vitest": "^4.1.7"

--- a/tasks/ci-loc-report-ignore-type-only-lines.md
+++ b/tasks/ci-loc-report-ignore-type-only-lines.md
@@ -7,8 +7,8 @@ size: small
 
 ## Status summary
 
-Specified and ready to implement. The intended compiler-backed design is chosen; tests,
-implementation, and preview proof remain.
+Implementation and local checks are complete. TypeScript source maps now remove type-only lines
+without changing source-line counts; the PR self-report and CI/review remain.
 
 ## Motivation
 
@@ -18,22 +18,25 @@ column.
 
 ## Spec
 
-- [ ] Type-only changes in TypeScript files contribute zero Significant additions/removals while
-      remaining visible in Lines.
-- [ ] Runtime-bearing TypeScript still counts, including syntax such as enums that looks type-like
-      but emits JavaScript.
-- [ ] JavaScript and non-JavaScript files retain their current Significant behavior.
-- [ ] The PR-body footnote states that TypeScript type-only changes are excluded.
-- [ ] Tests cover a type-only change, mixed type/runtime code, runtime-emitting TypeScript, and
-      unchanged behavior outside TypeScript.
+- [x] Type-only changes in TypeScript files contribute zero Significant additions/removals while
+      remaining visible in Lines. _Covered by a real-git integration test._
+- [x] Runtime-bearing TypeScript still counts, including syntax such as enums that looks type-like
+      but emits JavaScript. _The enum fixture stays 4 raw / 4 significant._
+- [x] JavaScript and non-JavaScript files retain their current Significant behavior. _JS comments
+      and Markdown blank lines have regression coverage._
+- [x] The PR-body footnote states that TypeScript type-only changes are excluded. _Rendered text
+      names TypeScript lines with no runtime output._
+- [x] Tests cover a type-only change, mixed type/runtime code, runtime-emitting TypeScript, and
+      unchanged behavior outside TypeScript. _`scripts/ci/loc-report.test.ts` has five integration
+      cases._
 - [ ] Verify the report against this PR and record the observed raw/significant split.
 
 ## Decisions / assumptions
 
-- Use TypeScript's own `transpileModule` emit as the significant representation for `.ts`, `.tsx`,
-  `.mts`, and `.cts`. Diffing compiler output removes interfaces, type aliases, annotations,
-  overload signatures, `declare` statements, and type-only imports without maintaining a partial
-  TypeScript parser.
+- Ask TypeScript's `transpileModule` for a source map for `.ts`, `.tsx`, `.mts`, and `.cts`, then
+  retain only original source lines mapped to runtime output. This removes interfaces, type aliases,
+  type-only imports, and other erased lines without maintaining a partial TypeScript parser or
+  counting expanded compiler output.
 - Emit modern ESM with preserved JSX. This avoids downlevel helper noise while retaining runtime
   constructs such as enums and decorators.
 - Keep raw `git diff --numstat` unchanged. The new behavior affects only Significant.
@@ -44,3 +47,6 @@ column.
 
 - Confirmed experimentally that changing an interface leaves TypeScript's emitted JS identical,
   while an enum emits runtime JavaScript and remains countable.
+- The first compiler-output prototype exposed synthetic `export {};` churn and enum expansion.
+  Source maps fixed both: they act only as a runtime-line stencil over the original source.
+- `pnpm --dir scripts typecheck` and all 274 scripts workspace tests pass.

--- a/tasks/ci-loc-report-ignore-type-only-lines.md
+++ b/tasks/ci-loc-report-ignore-type-only-lines.md
@@ -1,0 +1,46 @@
+---
+status: in-progress
+size: small
+---
+
+# LOC report: exclude type-only TypeScript lines from Significant
+
+## Status summary
+
+Specified and ready to implement. The intended compiler-backed design is chosen; tests,
+implementation, and preview proof remain.
+
+## Motivation
+
+The PR LOC report treats type growth as implementation churn. More types are often useful, so the
+Significant column should focus reviewers on changed runtime code without hiding the raw Lines
+column.
+
+## Spec
+
+- [ ] Type-only changes in TypeScript files contribute zero Significant additions/removals while
+      remaining visible in Lines.
+- [ ] Runtime-bearing TypeScript still counts, including syntax such as enums that looks type-like
+      but emits JavaScript.
+- [ ] JavaScript and non-JavaScript files retain their current Significant behavior.
+- [ ] The PR-body footnote states that TypeScript type-only changes are excluded.
+- [ ] Tests cover a type-only change, mixed type/runtime code, runtime-emitting TypeScript, and
+      unchanged behavior outside TypeScript.
+- [ ] Verify the report against this PR and record the observed raw/significant split.
+
+## Decisions / assumptions
+
+- Use TypeScript's own `transpileModule` emit as the significant representation for `.ts`, `.tsx`,
+  `.mts`, and `.cts`. Diffing compiler output removes interfaces, type aliases, annotations,
+  overload signatures, `declare` statements, and type-only imports without maintaining a partial
+  TypeScript parser.
+- Emit modern ESM with preserved JSX. This avoids downlevel helper noise while retaining runtime
+  constructs such as enums and decorators.
+- Keep raw `git diff --numstat` unchanged. The new behavior affects only Significant.
+- If TypeScript cannot transpile a file, fail the report instead of silently reverting to raw source;
+  unexplained fallback behavior would make the metric untrustworthy.
+
+## Implementation log
+
+- Confirmed experimentally that changing an interface leaves TypeScript's emitted JS identical,
+  while an enum emits runtime JavaScript and remains countable.

--- a/tasks/ci-loc-report-ignore-type-only-lines.md
+++ b/tasks/ci-loc-report-ignore-type-only-lines.md
@@ -7,8 +7,8 @@ size: small
 
 ## Status summary
 
-Implementation and local checks are complete. TypeScript source maps now remove type-only lines
-without changing source-line counts; the PR self-report and CI/review remain.
+Implementation, local checks, and PR self-report proof are complete. TypeScript source maps remove
+type-only lines without changing source-line counts; CI/review remain.
 
 ## Motivation
 
@@ -29,7 +29,8 @@ column.
 - [x] Tests cover a type-only change, mixed type/runtime code, runtime-emitting TypeScript, and
       unchanged behavior outside TypeScript. _`scripts/ci/loc-report.test.ts` has five integration
       cases._
-- [ ] Verify the report against this PR and record the observed raw/significant split.
+- [x] Verify the report against this PR and record the observed raw/significant split. _At
+      `4e5e7fc29`, the branch reports +250/−19 Lines and +216/−11 Significant._
 
 ## Decisions / assumptions
 
@@ -50,3 +51,5 @@ column.
 - The first compiler-output prototype exposed synthetic `export {};` churn and enum expansion.
   Source maps fixed both: they act only as a runtime-line stencil over the original source.
 - `pnpm --dir scripts typecheck` and all 274 scripts workspace tests pass.
+- Running the changed report over `origin/main...4e5e7fc29` produced +250/−19 raw versus +216/−11
+  Significant, exercising TypeScript, tests, docs, and the lockfile together.

--- a/tasks/complete/2026-07-24-ci-loc-report-ignore-type-only-lines.md
+++ b/tasks/complete/2026-07-24-ci-loc-report-ignore-type-only-lines.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: complete
 size: small
 ---
 
@@ -7,8 +7,8 @@ size: small
 
 ## Status summary
 
-Implementation, local checks, and PR self-report proof are complete. TypeScript source maps remove
-type-only lines without changing source-line counts; CI/review remain.
+Complete in PR #2302. TypeScript source maps remove type-only lines without changing source-line
+counts; local tests and every PR check pass, with no review threads open.
 
 ## Motivation
 
@@ -53,3 +53,5 @@ column.
 - `pnpm --dir scripts typecheck` and all 274 scripts workspace tests pass.
 - Running the changed report over `origin/main...4e5e7fc29` produced +250/−19 raw versus +216/−11
   Significant, exercising TypeScript, tests, docs, and the lockfile together.
+- PR #2302 passed preview, LOC report, lint/typecheck, tests, autofix, package publish, and continuous
+  release checks at `2a6f53131`; repeated review-thread polling found none.

--- a/tasks/complete/2026-07-24-ci-loc-report-ignore-type-only-lines.md
+++ b/tasks/complete/2026-07-24-ci-loc-report-ignore-type-only-lines.md
@@ -8,7 +8,7 @@ size: small
 ## Status summary
 
 Complete in PR #2302. TypeScript source maps remove type-only lines without changing source-line
-counts; local tests and every PR check pass, with no review threads open.
+counts; Bugbot's declaration-file edge case is fixed and locally verified, with final CI pending.
 
 ## Motivation
 
@@ -19,7 +19,8 @@ column.
 ## Spec
 
 - [x] Type-only changes in TypeScript files contribute zero Significant additions/removals while
-      remaining visible in Lines. _Covered by a real-git integration test._
+      remaining visible in Lines. _Covered for normal source and `.d.ts`/`.d.mts`/`.d.cts` by
+      real-git integration tests._
 - [x] Runtime-bearing TypeScript still counts, including syntax such as enums that looks type-like
       but emits JavaScript. _The enum fixture stays 4 raw / 4 significant._
 - [x] JavaScript and non-JavaScript files retain their current Significant behavior. _JS comments
@@ -27,7 +28,7 @@ column.
 - [x] The PR-body footnote states that TypeScript type-only changes are excluded. _Rendered text
       names TypeScript lines with no runtime output._
 - [x] Tests cover a type-only change, mixed type/runtime code, runtime-emitting TypeScript, and
-      unchanged behavior outside TypeScript. _`scripts/ci/loc-report.test.ts` has five integration
+      unchanged behavior outside TypeScript. _`scripts/ci/loc-report.test.ts` has six integration
       cases._
 - [x] Verify the report against this PR and record the observed raw/significant split. _At
       `4e5e7fc29`, the branch reports +250/−19 Lines and +216/−11 Significant._
@@ -38,6 +39,8 @@ column.
   retain only original source lines mapped to runtime output. This removes interfaces, type aliases,
   type-only imports, and other erased lines without maintaining a partial TypeScript parser or
   counting expanded compiler output.
+- Declaration files are wholly type-only, so `.d.ts`, `.d.mts`, and `.d.cts` become an empty
+  Significant representation without invoking TypeScript emit (which rejects declaration inputs).
 - Emit modern ESM with preserved JSX. This avoids downlevel helper noise while retaining runtime
   constructs such as enums and decorators.
 - Keep raw `git diff --numstat` unchanged. The new behavior affects only Significant.
@@ -50,8 +53,10 @@ column.
   while an enum emits runtime JavaScript and remains countable.
 - The first compiler-output prototype exposed synthetic `export {};` churn and enum expansion.
   Source maps fixed both: they act only as a runtime-line stencil over the original source.
-- `pnpm --dir scripts typecheck` and all 274 scripts workspace tests pass.
+- `pnpm --dir scripts typecheck` and all 275 scripts workspace tests pass.
 - Running the changed report over `origin/main...4e5e7fc29` produced +250/−19 raw versus +216/−11
   Significant, exercising TypeScript, tests, docs, and the lockfile together.
 - PR #2302 passed preview, LOC report, lint/typecheck, tests, autofix, package publish, and continuous
   release checks at `2a6f53131`; repeated review-thread polling found none.
+- Bugbot caught that `transpileModule` throws for declaration filenames. A red integration case
+  reproduced all three declaration extensions; the early empty representation makes them raw-only.

--- a/tasks/complete/2026-07-24-ci-loc-report-ignore-type-only-lines.md
+++ b/tasks/complete/2026-07-24-ci-loc-report-ignore-type-only-lines.md
@@ -8,7 +8,7 @@ size: small
 ## Status summary
 
 Complete in PR #2302. TypeScript source maps remove type-only lines without changing source-line
-counts; Bugbot's declaration-file edge case is fixed and locally verified, with final CI pending.
+counts; both Bugbot findings are fixed, every check passes, and no review threads remain open.
 
 ## Motivation
 
@@ -62,3 +62,5 @@ column.
   reproduced all three declaration extensions; the early empty representation makes them raw-only.
 - Bugbot's re-review caught an unexplained source-map JSON cast. The compiler boundary now validates
   `mappings` from `unknown` and fails clearly on malformed output, with no cast.
+- At `5472bb1dd`, preview, LOC report, lint/typecheck, tests, autofix, publish, continuous release,
+  and Bugbot all pass; all review threads are resolved.

--- a/tasks/complete/2026-07-24-ci-loc-report-ignore-type-only-lines.md
+++ b/tasks/complete/2026-07-24-ci-loc-report-ignore-type-only-lines.md
@@ -60,3 +60,5 @@ column.
   release checks at `2a6f53131`; repeated review-thread polling found none.
 - Bugbot caught that `transpileModule` throws for declaration filenames. A red integration case
   reproduced all three declaration extensions; the early empty representation makes them raw-only.
+- Bugbot's re-review caught an unexplained source-map JSON cast. The compiler boundary now validates
+  `mappings` from `unknown` and fails clearly on malformed output, with no cast.


### PR DESCRIPTION
## What changes

The PR LOC report keeps raw TypeScript churn in **Lines**, but omits source lines with no runtime
output from **Significant**. TypeScript emits a source map; that map acts as a stencil over the
original source, so the compiler decides which lines have runtime meaning without changing their
count.

```ts
type User = {
  id: string
  displayName: string // Lines +1; Significant +0
}

enum Direction {
  Up, // still Significant: enums emit JavaScript
}
```

This avoids a home-grown TypeScript syntax parser. Interfaces, aliases, declaration files, type-only
imports, and type-only members disappear; enums and other runtime-emitting syntax remain. Source
maps also avoid inflated counts from compiler expansion.

## Proof

- Task/spec committed first in `tasks/ci-loc-report-ignore-type-only-lines.md`.
- Six real-git integration tests cover type-only source and declaration files, mixed TSX, enums,
  JS/docs, and rendered-report behavior.
- `pnpm --dir scripts typecheck` and all 275 scripts workspace tests pass.
- At `4e5e7fc29`, this branch reported **+250/−19 Lines** vs **+216/−11 Significant**.

## Real-world dry run: PR #2301

Running this reporter against [PR #2301](https://github.com/iterate/iterate/pull/2301), from
`1366879` to `bb9cc2f`:

| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +263 −174 | +187 −139 |
| Tests | +258 −150 | +250 −149 |
| Docs | +48 −0 | +36 −0 |
| **Total** | **+569 −324** | **+473 −288** |

Its current report shows **+529/−309 Significant**. The new filter excludes another 56 added and 21
removed type-only lines while leaving raw Lines unchanged; 54/20 of those are Product code.


<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-24T13:38:07.642Z",
      "deployedAt": "2026-07-24T12:27:54.525Z",
      "headSha": "524a12de412d7c00aa89f99329c6d6008ee9281e",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/197612783304303",
      "shortSha": "524a12d",
      "cleanupDurationMs": 15645,
      "deployDurationMs": 69535,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 68399,
      "deployReadinessDurationMs": 1131,
      "deployedWorkerName": "os-preview-3",
      "deployedWorkerVersion": "666bee37-dff8-4f23-b141-dd043a92b43d",
      "testDurationMs": 88149,
      "testRetries": null,
      "workerSizeKib": 19800.55,
      "workerGzipKib": 5007.45,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5017.58
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-24T13:37:52.898Z",
      "deployedAt": "2026-07-24T12:27:02.979Z",
      "headSha": "524a12de412d7c00aa89f99329c6d6008ee9281e",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/197612783304303",
      "shortSha": "524a12d",
      "cleanupDurationMs": 897,
      "deployDurationMs": 17004,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 16851,
      "deployReadinessDurationMs": 148,
      "deployedWorkerName": "semaphore-preview-3",
      "deployedWorkerVersion": "e0a380af-b113-4eb0-b8da-28de84450842",
      "testDurationMs": 19078,
      "testRetries": null,
      "workerSizeKib": 1915.43,
      "workerGzipKib": 441.07,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-24T13:37:55.407Z",
      "deployedAt": "2026-07-24T12:27:08.603Z",
      "headSha": "524a12de412d7c00aa89f99329c6d6008ee9281e",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/197612783304303",
      "shortSha": "524a12d",
      "cleanupDurationMs": 3405,
      "deployDurationMs": 22957,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 22474,
      "deployReadinessDurationMs": 479,
      "deployedWorkerName": "auth-preview-3",
      "deployedWorkerVersion": "48ac3b22-7486-4764-ab64-b1aeb7ab49c7",
      "testDurationMs": 12634,
      "testRetries": null,
      "workerSizeKib": 3966.31,
      "workerGzipKib": 811.68,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-24T13:38:00.369Z",
      "deployedAt": "2026-07-24T12:27:05.646Z",
      "headSha": "524a12de412d7c00aa89f99329c6d6008ee9281e",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/197612783304303",
      "shortSha": "524a12d",
      "cleanupDurationMs": 8365,
      "deployDurationMs": 67528,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 19515,
      "deployReadinessDurationMs": 48007,
      "deployedWorkerName": "streams-example-app-preview-3",
      "deployedWorkerVersion": "18715f8d-cb89-4199-87d5-a3b7c1abb254",
      "testDurationMs": 60788,
      "testRetries": null,
      "workerSizeKib": 5155.75,
      "workerGzipKib": 1470.23,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-24T13:37:53.044Z",
      "deployedAt": "2026-07-24T12:26:52.616Z",
      "headSha": "524a12de412d7c00aa89f99329c6d6008ee9281e",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/197612783304303",
      "shortSha": "524a12d",
      "cleanupDurationMs": 1037,
      "deployDurationMs": 6683,
      "deployConfigDurationMs": 7,
      "deployCommandDurationMs": 6453,
      "deployReadinessDurationMs": 191,
      "deployedWorkerName": "dummy-petshop-preview-3",
      "deployedWorkerVersion": "cd35ef84-bff9-4c7d-804e-ba5cfc1a81e1",
      "testDurationMs": 12631,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `524a12d` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 811.7 KiB | 23.0s | 12.6s |  | 3.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/197612783304303) | 2026-07-24T13:37:55.407Z | Preview app released. |
| Dummy Petshop | released | `524a12d` | [https://dummy-petshop.iterate-preview-3.com](https://dummy-petshop.iterate-preview-3.com) | 198.3 KiB | 6.7s | 12.6s |  | 1.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/197612783304303) | 2026-07-24T13:37:53.044Z | Preview app released. |
| OS | released | `524a12d` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 4.89 MiB (-10.1 KiB vs main) | 69.5s | 88.1s |  | 15.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/197612783304303) | 2026-07-24T13:38:07.642Z | Preview app released. |
| Semaphore | released | `524a12d` | [https://semaphore.iterate-preview-3.com](https://semaphore.iterate-preview-3.com) | 441.1 KiB | 17.0s | 19.1s |  | 897ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/197612783304303) | 2026-07-24T13:37:52.898Z | Preview app released. |
| Streams Example App | released | `524a12d` | [https://streams.iterate-preview-3.com](https://streams.iterate-preview-3.com) | 1.44 MiB | 67.5s | 60.8s |  | 8.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/197612783304303) | 2026-07-24T13:38:00.369Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +195 -0 | +180 -0 🟩🟩🟩🟩🟩 |
| CI & scripts | +64 -19 | +54 -11 🟩🟩⬜⬜⬜ |
| Docs | +66 -0 | +55 -0 🟩🟩⬜⬜⬜ |
| Generated | +3 -0 | +3 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+328 -19** | **+292 -11** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 1366879 and e7d0f2b, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only metric logic in `scripts/ci`; no product runtime or auth paths, with regression tests covering edge cases.
> 
> **Overview**
> The PR LOC report still shows every changed line in **Lines**, but **Significant** now drops TypeScript that does not emit runtime JavaScript—interfaces, type-only edits, and declaration files—so reviewers see less type churn without losing raw diff size.
> 
> `scripts/ci/loc-report.ts` transpiles `.ts`/`.tsx`/`.mts`/`.cts` with source maps, keeps only source lines mapped to emitted output (via `@jridgewell/sourcemap-codec`), and treats `.d.ts`/`.d.mts`/`.d.cts` as wholly type-only. JS comment stripping and non-TS behavior are unchanged. `getChangedFiles` takes a `cwd` for git and tests; the PR-body footnote documents the new rule.
> 
> Adds `scripts/ci/loc-report.test.ts` (six real-git fixtures) and `@jridgewell/sourcemap-codec` in the scripts workspace; a completed task note records the spec.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7d0f2bde0c247abcdf5191909eed944aaa5e3c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->