### PR TITLE
Parked egress holds survive stream Durable Object restarts

### DIFF
--- a/apps/os/e2e/vitest/egress-approvals.e2e.test.ts
+++ b/apps/os/e2e/vitest/egress-approvals.e2e.test.ts
@@ -309,6 +309,93 @@ test("an agent codemode script carries one durable source through bare and scope
   }
 }, 120_000);
 
+// The incident this reproduces (tasks/script-runs-survive-parked-egress-holds.md):
+// a script run's fetch parks at the egress door for however long a human takes
+// to answer — minutes, not milliseconds. If the stream Durable Object behind
+// the door's resolution wait restarts meanwhile (connection recycle, eviction,
+// deploy reset), the door must re-arm from its durable cursor, not fail the
+// parked fetch and with it the whole run. `kill()` is the public chaos
+// operator injecting exactly that rejection class deterministically.
+test("a script run's parked hold survives a stream Durable Object restart", async () => {
+  const echo = await startEgressEcho();
+  using session = withItxSession();
+  using itx = session.authenticate({ type: "admin-secret", secret: adminSecret() });
+
+  try {
+    using project = await itx.projects.get(`egress-hold-restart-${crypto.randomUUID()}`).create({});
+    const root = project.streams.get("/");
+    const agent = await project.agents.get("/agents/patient-agent").create();
+    const echoHost = new URL(echo.url).hostname;
+    await root.append({
+      type: RULES_CONFIGURED,
+      payload: {
+        rules: [
+          {
+            ruleKey: "needs-human",
+            description: "POSTs to the echo need a human",
+            match: { hosts: [echoHost], methods: ["POST"] },
+            verdict: "hold",
+            approvalTimeoutMs: 60_000,
+          },
+        ],
+      },
+    });
+    await waitForCondition(
+      async () => (await project.processor.snapshot()).state.egressRules.length === 1,
+      { description: "project processor to fold the hold rule" },
+    );
+
+    const code = `async (itx) => {
+      const response = await fetch(${JSON.stringify(echo.url)}, {
+        method: "POST",
+        body: "still here after the restart",
+      });
+      return response.status;
+    }`;
+    const execution = agent.capabilityHost.runScript(code);
+
+    const requested = await root.waitForEvent({
+      afterOffset: 0,
+      eventTypes: [REQUESTED],
+      timeoutMs: 30_000,
+    });
+
+    // Restart only once the door's resolution wait is armed on the stream DO
+    // (its one-shot waiter is an ephemeral "waitForEvent" connection; this
+    // test holds no live wait of its own here), so the restart deterministically
+    // lands mid-hold instead of racing the arming.
+    await waitForCondition(
+      async () => {
+        const state = await root.runtimeState();
+        return Object.values(state.runtime.connections).some(
+          (connection) => connection.subscriber?.description === "waitForEvent",
+        );
+      },
+      { description: "the egress door's resolution wait to be armed" },
+    );
+    // The abort rejects the in-flight kill() call itself — expected.
+    await root.kill().catch(() => undefined);
+
+    await root.append({
+      type: GRANTED,
+      payload: { approvalRequestEventOffset: requested.offset },
+    });
+
+    await expect(execution).resolves.toMatchObject({ result: 200 });
+    const settled = await root.waitForEvent({
+      afterOffset: requested.offset,
+      eventTypes: [SETTLED],
+      timeoutMs: 30_000,
+    });
+    expect(settled.payload).toMatchObject({
+      approvalRequestEventOffset: requested.offset,
+      status: 200,
+    });
+  } finally {
+    await echo.close();
+  }
+}, 120_000);
+
 test("approved worker WebSocket egress stays on the fetch-native transport", async () => {
   await using echo = await startWebSocketEcho();
   using session = withItxSession();

--- a/apps/os/src/domains/projects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/project-durable-object.ts
@@ -39,6 +39,7 @@ import { readProjectById } from "../../project-directory.ts";
 import { EmailProcessor } from "../email/email-processor-implementation.ts";
 import { EmailProcessorContract } from "../email/email-processor-contract.ts";
 import { NotificationProcessor } from "../notifications/notification-processor-implementation.ts";
+import { isRetryableDurableObjectAvailabilityError } from "../streams/stream-unavailable.ts";
 import type { ProjectEgressIntercept, ProjectEgressInterceptor } from "./egress.ts";
 import {
   buildApprovalMessage,
@@ -516,6 +517,7 @@ export class ProjectDurableObject extends DurableObject<Env> {
     let cursor = input.approvalRequestEventOffset;
 
     // Live phase: chunked one-shot waits until the wall-clock deadline.
+    let availabilityBackoffMs = 200;
     while (Date.now() < input.deadline) {
       let event;
       try {
@@ -526,15 +528,30 @@ export class ProjectDurableObject extends DurableObject<Env> {
         });
       } catch (error) {
         // waitForEvent is a one-shot, not a durable waiter: chunk timeouts
-        // (and transient stream restarts) just re-arm from the same cursor.
+        // just re-arm from the same cursor.
         if (
           error instanceof Error &&
           error.message.includes("Timed out waiting for stream event")
         ) {
           continue;
         }
+        // A hold spans minutes of human latency, so the stream DO behind the
+        // wait WILL sometimes restart mid-chunk (connection recycle, eviction,
+        // deploy reset, explicit kill). By the stream-unavailable contract
+        // those rejections are retryable — the incarnation reboots on the next
+        // call and durable resolutions replay from the cursor — so re-arm
+        // instead of failing the parked fetch (which killed whole script runs:
+        // tasks/script-runs-survive-parked-egress-holds.md). Backoff keeps a
+        // hard-down stream from hot-looping; the deadline still bounds the
+        // hold, and expiry remains the safe direction.
+        if (isRetryableDurableObjectAvailabilityError(error)) {
+          await this.#sleep(Math.min(availabilityBackoffMs, input.deadline - Date.now()));
+          availabilityBackoffMs = Math.min(availabilityBackoffMs * 2, 5_000);
+          continue;
+        }
         throw error;
       }
+      availabilityBackoffMs = 200;
       cursor = event.offset;
       const verdict = await this.#judgeResolution(event, input);
       if (verdict !== null) return verdict;

--- a/tasks/complete/2026-07-26-script-runs-survive-parked-egress-holds.md
+++ b/tasks/complete/2026-07-26-script-runs-survive-parked-egress-holds.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 size: medium
 ---
 
@@ -7,7 +7,7 @@ size: medium
 
 ## Status summary
 
-Done pending review (PR #2312). Reproduction e2e committed red (script run
+Done (PR #2312, merged). Reproduction e2e committed red (script run
 dies with `stream-unavailable: kill requested`, mirroring production's
 `stream-unavailable: Network connection lost`), then the fix commit makes it
 green: the egress door's hold loop now re-arms on retryable stream

--- a/tasks/script-runs-survive-parked-egress-holds.md
+++ b/tasks/script-runs-survive-parked-egress-holds.md
@@ -7,10 +7,12 @@ size: medium
 
 ## Status summary
 
-Spec + root-cause analysis done; reproduction test and fix in progress. The
-failing seam is identified in code (the egress door's hold loop treats a
-transient stream Durable Object restart as fatal). Missing: the committed
-red test, then the fix commit.
+Done pending review (PR #2312). Reproduction e2e committed red (script run
+dies with `stream-unavailable: kill requested`, mirroring production's
+`stream-unavailable: Network connection lost`), then the fix commit makes it
+green: the egress door's hold loop now re-arms on retryable stream
+availability errors with bounded backoff. Remaining: CI + review, and the
+named out-of-scope follow-ups below.
 
 ## Problem
 
@@ -65,24 +67,30 @@ busiest/most likely to recycle connections; B was a mid-chunk connection loss.
 
 New e2e test alongside `apps/os/e2e/vitest/egress-approvals.e2e.test.ts`:
 
-- [ ] park a fetch on a hold rule; observe `human-approval-requested`
-- [ ] `stream.kill()` the project root stream — the public chaos operator
+- [x] park a fetch on a hold rule; observe `human-approval-requested` _a
+      full `runScript` with a bare held fetch, matching the incident shape —
+      "a script run's parked hold survives a stream Durable Object restart"
+      in `apps/os/e2e/vitest/egress-approvals.e2e.test.ts`_
+- [x] `stream.kill()` the project root stream — the public chaos operator
       that injects the same DO-lifecycle rejection class the incidents hit
       ("Abort the current Durable Object incarnation; the next request boots
-      it again")
-- [ ] grant the approval afterwards
-- [ ] assert the parked fetch still resolves 200 with the upstream response
-      and `human-approval-settled` lands
-- [ ] confirm the test is RED before the fix (fetch fails with
-      `stream-unavailable`), commit it, then fix in a follow-up commit
+      it again") _kill lands deterministically mid-hold: the test first waits
+      for the door's ephemeral "waitForEvent" connection in `runtimeState()`_
+- [x] grant the approval afterwards _plain grant, no keys enrolled_
+- [x] assert the parked fetch still resolves 200 with the upstream response
+      and `human-approval-settled` lands _asserts the run's `result: 200` too_
+- [x] confirm the test is RED before the fix (fetch fails with
+      `stream-unavailable`), commit it, then fix in a follow-up commit _red
+      confirmed twice: run rejected `stream-unavailable: kill requested`_
 
 ## Fix (follow-up commit)
 
-- [ ] `#awaitApprovalResolution`: also re-arm from the same cursor on
+- [x] `#awaitApprovalResolution`: also re-arm from the same cursor on
       retryable availability errors (`isRetryableDurableObjectAvailabilityError`),
       with the existing `#sleep` backoff pattern (cf. `#judgeResolution`'s
       key-state catch-up loop) so a hard-down stream doesn't hot-loop; the
       hold deadline still bounds everything, expiry stays the safe direction
+      _200ms doubling to a 5s cap, reset once a wait yields an event_
 
 ## Out of scope (named residual risks, follow-up tasks)
 
@@ -109,3 +117,20 @@ New e2e test alongside `apps/os/e2e/vitest/egress-approvals.e2e.test.ts`:
   already get one availability retry via `retryLoggedIdempotentOperation`;
   the unkeyed `human-approval-requested` append happens before parking, so a
   failure there fails fast without stranding anything.
+- The test's `kill()` call itself rejects with "kill requested" (aborting the
+  DO rejects the in-flight RPC) — every existing kill-using e2e swallows
+  that; ours does too.
+- Incidentally observed: `CapabilityHostRpcTarget.runScript`'s
+  `retryLoggedIdempotentOperation` classifies a run whose SETTLEMENT ERROR
+  TEXT merely contains `stream-unavailable: ` (e.g. a script whose own fetch
+  died that way) as an availability failure of the runScript call and
+  replays it — the replay dedupes on the request key and re-reads the same
+  failed settlement, so it's two wasted round trips and a misleading
+  "script run rejoining after stream Durable Object reset" log, not
+  corruption. Message-prefix classification can't tell "transport failed"
+  from "result faithfully reports a nested failure". Left alone: harmless
+  today, worth keeping in mind if the tag ever drives bigger decisions.
+- Local-laptop pre-existing failure (documented in tasks/grouped-approvals.md
+  too): `egress-approvals.e2e.test.ts › approved worker WebSocket egress...`
+  fails with "WebSocket echo failed" on this machine's dev servers,
+  reproducing at merge-base — unrelated to this change.

--- a/tasks/script-runs-survive-parked-egress-holds.md
+++ b/tasks/script-runs-survive-parked-egress-holds.md
@@ -1,0 +1,111 @@
+---
+status: in-progress
+size: medium
+---
+
+# Script runs must survive parked egress holds
+
+## Status summary
+
+Spec + root-cause analysis done; reproduction test and fix in progress. The
+failing seam is identified in code (the egress door's hold loop treats a
+transient stream Durable Object restart as fatal). Missing: the committed
+red test, then the fix commit.
+
+## Problem
+
+Reproduced twice on preview 7 (evidence in `tasks/grouped-approvals.md`,
+"Script runs don't reliably survive parked egress holds"): a script run whose
+egress fetches are parked awaiting human approval settles
+`failed / stream-unavailable: Network connection lost` while the human is
+still deciding. Once the caller is dead, the eventually-granted holds race
+cancellation — some release and settle 200, the rest strand as
+"submitted — awaiting the egress door…" zombies until the 10-minute expiry.
+
+- Incident A (run `f708de82`): died 56s into the wait, the same second the 12
+  grants landed; 9/12 settled, 3 stranded.
+- Incident B (`agent-output:313`): died ~19s into the wait, 1s BEFORE the
+  grants; 8/12 settled, 4 stranded. The immediate retry run completed 12/12 —
+  a race, not a hard limit.
+
+Egress approvals are meaningless if a parked fetch cannot survive MINUTES of
+human latency.
+
+## Root cause (found by code reading, confirmed by the error's shape)
+
+The error text `stream-unavailable: Network connection lost` is minted in
+exactly one place: `rethrowStreamUnavailable`
+(`apps/os/src/domains/streams/stream-unavailable.ts`) tagging a workerd
+DO-lifecycle rejection on a stream stub call. By explicit contract
+(`STREAM_UNAVAILABLE_MESSAGE_PREFIX` docs) these rejections are RETRYABLE:
+the stream Durable Object reboots on the next call.
+
+`StreamRpcTarget.waitForEvent` (`apps/os/src/rpc-targets.ts`) deliberately
+does NOT hide lifecycle failures behind its own slice-recovery loop — it
+rethrows them tagged, leaving retry policy to callers.
+
+But the egress door's hold loop —
+`ProjectDurableObject#awaitApprovalResolution`
+(`apps/os/src/domains/projects/project-durable-object.ts`) — only re-arms its
+chunked wait on the slice-timeout message. Its own comment claims
+"(and transient stream restarts) just re-arm from the same cursor", but the
+code never checks for stream-unavailable / DO-lifecycle errors. So one
+transient stream DO restart/connection loss during a minutes-long hold:
+
+1. rejects the in-flight `waitForEvent` chunk, tagged `stream-unavailable:`,
+2. propagates out of `#holdForHumanApproval`, failing the parked fetch,
+3. rejects the script's `Promise.all`, settling the whole run `failed`,
+4. leaves the granted-but-unreleased holds to race caller cancellation —
+   the zombie approvals the approver UI shows until expiry.
+
+Incident timing fits: a 12-grant burst (A) is exactly when the stream DO is
+busiest/most likely to recycle connections; B was a mid-chunk connection loss.
+
+## Reproduction (the deliverable test)
+
+New e2e test alongside `apps/os/e2e/vitest/egress-approvals.e2e.test.ts`:
+
+- [ ] park a fetch on a hold rule; observe `human-approval-requested`
+- [ ] `stream.kill()` the project root stream — the public chaos operator
+      that injects the same DO-lifecycle rejection class the incidents hit
+      ("Abort the current Durable Object incarnation; the next request boots
+      it again")
+- [ ] grant the approval afterwards
+- [ ] assert the parked fetch still resolves 200 with the upstream response
+      and `human-approval-settled` lands
+- [ ] confirm the test is RED before the fix (fetch fails with
+      `stream-unavailable`), commit it, then fix in a follow-up commit
+
+## Fix (follow-up commit)
+
+- [ ] `#awaitApprovalResolution`: also re-arm from the same cursor on
+      retryable availability errors (`isRetryableDurableObjectAvailabilityError`),
+      with the existing `#sleep` backoff pattern (cf. `#judgeResolution`'s
+      key-state catch-up loop) so a hard-down stream doesn't hot-loop; the
+      hold deadline still bounds everything, expiry stays the safe direction
+
+## Out of scope (named residual risks, follow-up tasks)
+
+- The caller→egress-door leg: the script isolate's fetch into the project DO
+  is itself a long-open connection; if workerd recycles THAT, no in-door
+  retry can save the run. Not what the incidents showed (their error carries
+  the stream tag), but for multi-minute holds it deserves its own design
+  (resumable/idempotent release, or heartbeats).
+- A terminal fact for holds whose caller vanished (zombie approvals sooner
+  than the 10-min expiry) — mostly mooted when runs stop dying, but the
+  cancellation race at release time still exists.
+- `subscription "project-worker" skipped poison event … Unable to deserialize
+  cloned data` seen in the same trials — separate preview stream-DO
+  instability (see `tasks/project-creation-wedge-preview7.md`).
+
+## Findings log
+
+- 2026-07-25: traced the incident error string to `rethrowStreamUnavailable`;
+  confirmed `#awaitApprovalResolution`'s catch matches only
+  `"Timed out waiting for stream event"` while its comment promises restart
+  tolerance. `StreamRpcTarget.waitForEvent` line comments confirm lifecycle
+  rejections are intentionally the caller's retry responsibility.
+- The expiry sweep's `getEvents` and the keyed appends (`expired`, `settled`)
+  already get one availability retry via `retryLoggedIdempotentOperation`;
+  the unkeyed `human-approval-requested` append happens before parking, so a
+  failure there fails fast without stranding anything.


### PR DESCRIPTION
## Problem

A script run whose egress fetches are parked awaiting human approval can settle `failed / stream-unavailable: Network connection lost` while the human is still deciding (reproduced twice on preview 7 — see `tasks/grouped-approvals.md` on #2309, incidents A and B). Once the run is dead, the eventually-granted holds race cancellation: some release and settle 200, the rest strand as zombie approvals ("submitted — awaiting the egress door…") until the 10-minute expiry. Egress approvals must tolerate MINUTES of human latency.

## Root cause

The egress door's hold loop (`ProjectDurableObject#awaitApprovalResolution`) live-tails the project stream in ~25s chunks, but only re-armed on the slice-timeout rejection. A workerd DO-lifecycle failure on the stream stub call (connection recycle, eviction, deploy reset — retryable by the `stream-unavailable:` contract, which `StreamRpcTarget.waitForEvent` deliberately leaves to callers) propagated out instead, failing the parked fetch and with it the whole script run. The loop's own comment already promised "(and transient stream restarts) just re-arm from the same cursor"; the code didn't.

## Changes

Commit 2 — **reproduction e2e** (committed red on pre-fix code): runs a real script whose fetch parks on a hold rule, waits for the door's resolution wait to be armed (its ephemeral `waitForEvent` connection is visible in the stream's `runtimeState()`), `kill()`s the project root stream DO — the public chaos operator injecting the same rejection class as the incidents — then grants. Before the fix the run died with:

```
promise rejected "Error: stream-unavailable: kill requested" instead of resolving
# production showed: failed / stream-unavailable: Network connection lost
```

Commit 3 — **fix**: the hold loop also re-arms from the same durable cursor on `isRetryableDurableObjectAvailabilityError`, with 200ms→5s backoff so a hard-down stream doesn't hot-loop; the hold deadline still bounds everything, so expiry stays the safe deny direction. Test goes green: the parked fetch releases with the real upstream 200, the run returns `result: 200`, and `human-approval-settled` lands.

## Verification

- New e2e red twice pre-fix, green post-fix; the other egress-approvals e2e lanes pass. (`approved worker WebSocket egress…` fails on this laptop's dev servers at merge-base too — the pre-existing local issue already documented in `tasks/grouped-approvals.md`.)
- `pnpm typecheck`, `pnpm lint`, projects+streams unit suites green.

## Out of scope (named in the task file)

- The caller→door leg: the script isolate's fetch into the project DO is itself a long-open connection; both incidents' error text carried the stream tag, so this wasn't the observed killer, but multi-minute holds deserve their own design there (resumable release / heartbeats).
- A terminal fact for holds whose caller vanished (zombie approvals sooner than expiry) — mostly mooted when runs stop dying, but the release-time cancellation race still exists.
- Incidental find, left alone: `CapabilityHostRpcTarget.runScript`'s idempotent-retry classifier replays a run whose settlement error TEXT merely contains `stream-unavailable:` — harmless (keyed dedupe) but a misleading "rejoining" log.

Task file: `tasks/script-runs-survive-parked-egress-holds.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session id: `975162d3-49cc-4c1e-9925-9f4f04ba079f`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-26T07:25:24.634Z",
      "deployedAt": "2026-07-26T07:23:42.204Z",
      "headSha": "f67f588c6fe991444a4a72a4ce8459d5e5e38a02",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/242126657554847",
      "shortSha": "f67f588",
      "cleanupDurationMs": 8385,
      "deployDurationMs": 67919,
      "deployConfigDurationMs": 1,
      "deployCommandDurationMs": 66412,
      "deployReadinessDurationMs": 1503,
      "deployedWorkerName": "os-preview-9",
      "deployedWorkerVersion": "19d22799-ccc5-4181-8de4-56af8f992d20",
      "workerSizeKib": 19787.96,
      "workerGzipKib": 5004.6,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5014.94
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-26T07:25:18.887Z",
      "deployedAt": "2026-07-26T07:22:57.988Z",
      "headSha": "f67f588c6fe991444a4a72a4ce8459d5e5e38a02",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/242126657554847",
      "shortSha": "f67f588",
      "cleanupDurationMs": 2635,
      "deployDurationMs": 22497,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 22193,
      "deployReadinessDurationMs": 300,
      "deployedWorkerName": "auth-preview-9",
      "deployedWorkerVersion": "1fd43986-45b7-4fee-becf-754556180fe8",
      "workerSizeKib": 3971.05,
      "workerGzipKib": 812.93,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-26T07:25:16.871Z",
      "deployedAt": "2026-07-26T07:22:43.333Z",
      "headSha": "f67f588c6fe991444a4a72a4ce8459d5e5e38a02",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/242126657554847",
      "shortSha": "f67f588",
      "cleanupDurationMs": 618,
      "deployDurationMs": 7806,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 7499,
      "deployReadinessDurationMs": 264,
      "deployedWorkerName": "dummy-petshop-preview-9",
      "deployedWorkerVersion": "364edc42-be8a-44fb-b615-3a4cecf254c2",
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `f67f588` | [https://auth.iterate-preview-9.com](https://auth.iterate-preview-9.com) | 812.9 KiB | 22.5s |  |  | 2.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/242126657554847) | 2026-07-26T07:25:18.887Z | Preview app released. |
| Dummy Petshop | released | `f67f588` | [https://dummy-petshop.iterate-preview-9.com](https://dummy-petshop.iterate-preview-9.com) | 198.3 KiB | 7.8s |  |  | 618ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/242126657554847) | 2026-07-26T07:25:16.871Z | Preview app released. |
| OS | released | `f67f588` | [https://os.iterate-preview-9.com](https://os.iterate-preview-9.com) | 4.89 MiB (-10.3 KiB vs main) | 67.9s |  |  | 8.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/242126657554847) | 2026-07-26T07:25:24.634Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +18 -1 | +8 -0 🟩⬜⬜⬜⬜ |
| Tests | +87 -0 | +64 -0 🟩🟩🟩⬜⬜ |
| Docs | +136 -0 | +114 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+241 -1** | **+186 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 9df62a1 and f67f588, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes long-running egress hold behavior in `ProjectDurableObject` during human approval waits; bounded backoff and the existing deadline limit blast radius, but incorrect retry classification could prolong holds or mask real failures.
> 
> **Overview**
> Fixes script runs failing with `stream-unavailable` while egress fetches stay parked for human approval when the **stream** Durable Object restarts mid-hold.
> 
> **`#awaitApprovalResolution`** now treats retryable stream availability errors like chunk timeouts: it re-arms `waitForEvent` from the same durable cursor with 200ms→5s backoff (reset after a successful wait), instead of failing the parked fetch and the whole run.
> 
> Adds an e2e that parks a `runScript` fetch on a hold rule, waits until the door’s resolution wait is armed, **`kill()`s** the root stream DO, then grants and expects **200** plus `human-approval-settled`. Documents the incident and fix in a completed task file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f67f588c6fe991444a4a72a4ce8459d5e5e38a02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->