### PR TITLE
Fix streamed agent response chunk ordering

### DIFF
--- a/apps/os/src/domains/agents/agent-processor-implementation.ts
+++ b/apps/os/src/domains/agents/agent-processor-implementation.ts
@@ -588,22 +588,21 @@ export class AgentProcessor extends StreamProcessor<AgentProcessorContract, Agen
           // The attempt can never outlive its intent: dial + stream drain
           // self-cap at whatever validity the request has left.
           deadlineMs: Math.max(1, open.expiresAt - this.#now()),
-          onChunk: (chunk) => {
+          onChunk: async (chunk) => {
             if (inFlight.controller.signal.aborted) return;
             inFlight.partialText += extractChunkText(chunk);
             const sequence = chunkSequence;
             chunkSequence += 1;
-            // Ephemeral streaming: best-effort, never awaited, never reduced.
-            void args
-              .append({
-                type: "events.iterate.com/agent/llm-response-chunk",
-                payload: {
-                  chunk: jsonCompatible(chunk),
-                  llmRequestOffset: requestOffset,
-                  sequence,
-                },
-              })
-              .catch(() => undefined);
+            // Each append obtains a fresh Durable Object stub, so await the
+            // commit to preserve provider order across those RPCs.
+            await args.append({
+              type: "events.iterate.com/agent/llm-response-chunk",
+              payload: {
+                chunk: jsonCompatible(chunk),
+                llmRequestOffset: requestOffset,
+                sequence,
+              },
+            });
           },
         });
         // A non-streaming transport reports no chunks, so its text exists
@@ -718,7 +717,7 @@ export class AgentProcessor extends StreamProcessor<AgentProcessorContract, Agen
     messages: WorkersAiMessage[];
     signal: AbortSignal;
     deadlineMs: number;
-    onChunk: (chunk: unknown) => void;
+    onChunk: (chunk: unknown) => Promise<void>;
   }): Promise<{
     text: string;
     usage?: {
@@ -809,7 +808,7 @@ export class AgentProcessor extends StreamProcessor<AgentProcessorContract, Agen
         ),
         signal: new AbortController().signal,
         deadlineMs,
-        onChunk: () => {},
+        onChunk: async () => {},
       });
 
       await this.append({
@@ -990,7 +989,8 @@ export type AgentLlmTransport = (args: {
   model: string;
   messages: WorkersAiMessage[];
   signal: AbortSignal;
-  onChunk?: (text: string) => void;
+  /** The transport awaits each result before delivering the next chunk. */
+  onChunk?: (text: string) => Promise<void>;
 }) => Promise<{
   text: string;
   usage?: {

--- a/apps/os/src/domains/agents/agent-processor.test.ts
+++ b/apps/os/src/domains/agents/agent-processor.test.ts
@@ -100,7 +100,7 @@ function makeScriptedLlm() {
   const calls: {
     model: string;
     messages: WorkersAiMessage[];
-    onChunk?: (text: string) => void;
+    onChunk?: (text: string) => Promise<void>;
     signal: AbortSignal;
     resolve: (result: {
       text: string;
@@ -120,7 +120,7 @@ function makeScriptedLlm() {
       model: string;
       messages: WorkersAiMessage[];
       signal: AbortSignal;
-      onChunk?: (text: string) => void;
+      onChunk?: (text: string) => Promise<void>;
     }) =>
       new Promise<{ text: string; usage?: { inputTokens: number; outputTokens: number } }>(
         (resolve, reject) => {
@@ -146,6 +146,7 @@ function makeAgentHarness(substrate?: HarnessSubstrate, extraDeps?: Partial<Agen
 const REQUESTED = "events.iterate.com/agent/llm-request-requested";
 const SETTLED = "events.iterate.com/agent/llm-request-settled";
 const CONTEXT_ADDED = "events.iterate.com/agents/context-added";
+const RESPONSE_CHUNK = "events.iterate.com/agent/llm-response-chunk";
 
 // =============================================================================
 // The turn lifecycle
@@ -207,6 +208,39 @@ describe("AgentProcessor turn lifecycle", () => {
     expect(h.state().tokenUsage).toMatchObject({ totalInputTokens: 10, totalOutputTokens: 2 });
   });
 
+  it("backpressures streamed response chunks so append order stays provider order", async () => {
+    const h = makeAgentHarness();
+    await h.play(
+      ["append", ...NEW_AGENT_EVENTS, userMessage("Stream some code")],
+      ["advanceTime", 10_000],
+    );
+
+    const realAppend = h.stream.append.bind(h.stream);
+    let releaseFirstChunk = () => {};
+    const firstChunkHeld = new Promise<void>((resolve) => {
+      releaseFirstChunk = resolve;
+    });
+    h.stream.append = async (...inputs) => {
+      const chunk = inputs.find((input) => input.type === RESPONSE_CHUNK);
+      if (chunk?.payload?.sequence === 0) await firstChunkHeld;
+      return realAppend(...inputs);
+    };
+
+    const streaming = (async () => {
+      await h.llm.calls[0]!.onChunk?.("const answer = ");
+      await h.llm.calls[0]!.onChunk?.("42;");
+    })();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // The transport must not deliver chunk 2 while chunk 1 is still appending.
+    expect(h.events(RESPONSE_CHUNK)).toEqual([]);
+
+    releaseFirstChunk();
+    await streaming;
+    await h.settle();
+    expect(h.events(RESPONSE_CHUNK).map((event) => event.payload.sequence)).toEqual([0, 1]);
+  });
+
   it("debounce coalesces a burst: two inputs, ONE open request covering both", async () => {
     const h = makeAgentHarness();
     await h.play(
@@ -262,9 +296,9 @@ describe("AgentProcessor turn lifecycle", () => {
     await h.play(
       ["append", ...NEW_AGENT_EVENTS, userMessage("Hello")],
       ["advanceTime", 10_000],
-      () => {
-        h.llm.calls[0]!.onChunk?.("Hel");
-        h.llm.calls[0]!.onChunk?.("lo");
+      async () => {
+        await h.llm.calls[0]!.onChunk?.("Hel");
+        await h.llm.calls[0]!.onChunk?.("lo");
       },
       ["append", userMessage("actually stop", { behaviour: "interrupt-current-request" })],
     );

--- a/apps/os/src/domains/agents/workers-ai-transport.test.ts
+++ b/apps/os/src/domains/agents/workers-ai-transport.test.ts
@@ -83,6 +83,31 @@ describe("runWorkersAiAttempt", () => {
     expect(chunks).toEqual([{ response: "hel" }]);
   });
 
+  it("applies the attempt deadline while a chunk callback is in flight", async () => {
+    const encoder = new TextEncoder();
+    let cancelled = false;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('data: {"response":"hel"}\n\n'));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+
+    await expect(
+      runWorkersAiAttempt({
+        ai: { run: async () => body },
+        deadlineMs: 50,
+        messages: [{ role: "user", content: "hi" }],
+        model: "test-model",
+        onChunk: () => new Promise(() => {}),
+      }),
+    ).rejects.toThrow(/timed out/);
+
+    expect(cancelled).toBe(true);
+  });
+
   it("caps the dial itself, not just the drain", async () => {
     await expect(
       runWorkersAiAttempt({

--- a/apps/os/src/domains/agents/workers-ai-transport.ts
+++ b/apps/os/src/domains/agents/workers-ai-transport.ts
@@ -307,7 +307,7 @@ async function drainSseResponse(input: {
   const handleChunk = async (chunk: unknown) => {
     text += extractChunkText(chunk);
     usage = extractUsage(chunk) ?? usage;
-    await input.onChunk(chunk, chunkCount);
+    await input.deadline.race(input.onChunk(chunk, chunkCount));
     chunkCount += 1;
   };
 


### PR DESCRIPTION
## Summary

- await each ephemeral response-chunk append before draining the next provider chunk
- propagate the async callback contract and keep the new wait inside the existing attempt deadline
- add regressions for slow-first-append overtaking and a wedged callback

## Root cause

The July 20 clean-room processor rewrite changed the previous awaited chunk append to fire-and-forget. Each append obtains a fresh native Durable Object stub, and Cloudflare does not guarantee ordering between different stubs. A later append could therefore receive the earlier stream offset, which made the live UI concatenate chunks in the wrong order.

## Verification

- `pnpm install`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm test`
- local Worker/browser stress: 1,952 streamed chunk events; all 300 ordered literals rendered and executed without mismatch

Screenshots: not applicable; this changes the processor/RPC ordering boundary with no visual design change.

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +16 -16 | +11 -13 🟩🟥⬜⬜⬜ |
| Tests | +64 -5 | +53 -3 🟩🟩🟩🟩🟩 |
| **Total** | **+80 -21** | **+64 -16** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 02c089e and a18038a, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hot-path streaming and timeout behavior for agent LLM turns; correctness fix with new regressions, but any await/backpressure could affect latency under slow stream commits.
> 
> **Overview**
> Fixes **live UI chunk concatenation** when streamed agent responses arrived out of provider order.
> 
> Previously each `llm-response-chunk` append was fire-and-forget. Each append uses a **fresh Durable Object stub**, and ordering across those RPCs is not guaranteed—so a later chunk could commit before an earlier one.
> 
> The processor now **awaits each chunk append** before the transport delivers the next delta. `onChunk` is **`async` end-to-end** (`AgentLlmTransport`, `#attemptLlm`, compaction’s no-op handler).
> 
> In **`workers-ai-transport`**, each `onChunk` is raced against the **attempt deadline** so a stuck callback cannot block timeout/cancel (the stream reader still gets cancelled on deadline).
> 
> **Tests** cover slow-first-append backpressure and deadline firing while a chunk callback is wedged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a18038ae32ba4cc03305ace18060437483a2588e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-28T13:06:06.143Z",
      "deployedAt": "2026-07-28T12:38:36.569Z",
      "headSha": "a18038ae32ba4cc03305ace18060437483a2588e",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/176349239648197",
      "shortSha": "a18038a",
      "cleanupDurationMs": 12887,
      "deployDurationMs": 91885,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 69304,
      "deployReadinessDurationMs": 22577,
      "deployedWorkerName": "os-preview-13",
      "deployedWorkerVersion": "7c35e6c5-ac39-4de7-abf1-86d64a51a02f",
      "testDurationMs": 169163,
      "testRetries": "1 retried: append after idle teardown re-wakes configured subscriber from its checkpoint (vitest x1) — Timed out waiting for configured processor connections to become live",
      "workerSizeKib": 19787.98,
      "workerGzipKib": 5004.59,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5014.95
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-28T13:05:56.331Z",
      "deployedAt": "2026-07-28T12:37:48.254Z",
      "headSha": "a18038ae32ba4cc03305ace18060437483a2588e",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/176349239648197",
      "shortSha": "a18038a",
      "cleanupDurationMs": 3072,
      "deployDurationMs": 21350,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 20988,
      "deployReadinessDurationMs": 359,
      "deployedWorkerName": "auth-preview-13",
      "deployedWorkerVersion": "4aee96ae-dacb-4712-852f-a186ae91fda1",
      "testDurationMs": 10536,
      "testRetries": null,
      "workerSizeKib": 3971.06,
      "workerGzipKib": 812.86,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-28T13:05:54.598Z",
      "deployedAt": "2026-07-28T12:37:33.990Z",
      "headSha": "a18038ae32ba4cc03305ace18060437483a2588e",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/176349239648197",
      "shortSha": "a18038a",
      "cleanupDurationMs": 1337,
      "deployDurationMs": 6943,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 6698,
      "deployReadinessDurationMs": 216,
      "deployedWorkerName": "dummy-petshop-preview-13",
      "deployedWorkerVersion": "fe1d0ac3-75cc-4f1c-a2f3-0dd5babd749b",
      "testDurationMs": 8335,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `a18038a` | [https://auth.iterate-preview-13.com](https://auth.iterate-preview-13.com) | 812.9 KiB | 21.4s | 10.5s |  | 3.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/176349239648197) | 2026-07-28T13:05:56.331Z | Preview app released. |
| Dummy Petshop | released | `a18038a` | [https://dummy-petshop.iterate-preview-13.com](https://dummy-petshop.iterate-preview-13.com) | 198.3 KiB | 6.9s | 8.3s |  | 1.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/176349239648197) | 2026-07-28T13:05:54.598Z | Preview app released. |
| OS | released | `a18038a` | [https://os.iterate-preview-13.com](https://os.iterate-preview-13.com) | 4.89 MiB (-10.4 KiB vs main) | 91.9s | 169.2s | 1 retried: append after idle teardown re-wakes configured subscriber from its checkpoint (vitest x1) — Timed out waiting for configured processor connections to become live | 12.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/176349239648197) | 2026-07-28T13:06:06.143Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->