### PR TITLE
Keep project recovery scoped to the config repo

### DIFF
--- a/.agents/skills/recreate-production/SKILL.md
+++ b/.agents/skills/recreate-production/SKILL.md
@@ -36,12 +36,13 @@ doppler run --project os --config prd -- \
 
 `apply` restores Auth users, minimum organization membership, the exact project
 ID, hostnames, inbound-email senders, generic secrets, supported integrations,
-and repositories. It is convergent and proves GitHub/local repository state and
-the served config commit before returning.
+and the config repository. It is convergent and proves its GitHub/local state
+and the served config commit before returning.
 
 GitHub is authoritative. Restore links an existing remote without an initial
-push and imports its current default branch. Local-only repositories come from
-the archived file tree.
+push and imports its current default branch. A local-only config repository
+comes from the archived file tree. Other project repositories are deliberately
+outside the recovery seed.
 
 ## Boundaries
 

--- a/apps/os/docs/project-seeds.md
+++ b/apps/os/docs/project-seeds.md
@@ -39,17 +39,17 @@ doppler run --project os --config prd -- \
 - the exact project ID and slug;
 - direct and Cloudflare-managed hostnames plus inbound-email senders;
 - generic secrets and Slack, GitHub, and Google connections;
-- the config repository and any additional repositories.
+- the config repository.
 
 ## Repositories
 
-GitHub repositories are references: installation ID, owner, and repository
-name. GitHub remains authoritative, so restore refuses to create a missing
-remote, performs no starter push, imports the current default branch, and
-checks that the remote head did not move during the operation.
+GitHub config repositories are references: installation ID, owner, and
+repository name. GitHub remains authoritative, so restore refuses to create a
+missing remote, performs no starter push, imports the current default branch,
+and checks that the remote head did not move during the operation.
 
-A repository without a GitHub link is stored as a base64 file tree in the
-archive. After restoring the config repository, the CLI waits for every
+A config repository without a GitHub link is stored as a base64 file tree in
+the archive. After restoring it, the CLI waits for every
 canonical/custom project route to serve that exact config commit via
 `x-iterate-worker-serve`.
 
@@ -81,6 +81,7 @@ routing lookup.
 ## Limits
 
 The archive intentionally omits ordinary streams, agents, tasks, schedules,
-workspaces, sandboxes, files outside restored repositories, historical
-messages, and derived state. Capture fails rather than silently ignoring a
-connected built-in integration other than Slack, GitHub, or Google.
+workspaces, sandboxes, files outside the config repository, historical
+messages, additional repositories, and derived state. Capture fails rather
+than silently ignoring a connected built-in integration other than Slack,
+GitHub, or Google.

--- a/apps/os/scripts/project-seed.ts
+++ b/apps/os/scripts/project-seed.ts
@@ -647,7 +647,7 @@ async function restoreRepository(input: {
     repo: githubSeed.repo,
   });
   if (link.created) throw new Error(`${githubSeed.owner}/${githubSeed.repo} did not exist.`);
-  const reset = await repository.resetFromGithub({});
+  const reset = await repository.resetFromGithub({ depth: 1 });
   const after = await readGithubHead(github, githubSeed);
   if (
     before.commitOid !== reset.commitOid ||

--- a/apps/os/scripts/project-seed.ts
+++ b/apps/os/scripts/project-seed.ts
@@ -89,7 +89,6 @@ type SeedProject = {
   secrets: SeedSecret[];
   integrations: SeedIntegration[];
   configRepo?: RepositorySeed;
-  repositories: Array<RepositorySeed & { path: string }>;
 };
 
 type ProjectSeedArchive = {
@@ -259,22 +258,7 @@ export async function capture(options: CaptureOptions) {
     ),
   );
 
-  const repositoryPaths = [
-    ...new Set([
-      "/repos/config",
-      ...projectSnapshot.state.repos.map((repository) => repository.path),
-    ]),
-  ].sort();
-  const repositories = await Promise.all(
-    repositoryPaths.map(async (path) => ({
-      path,
-      seed: await captureRepository({ connected, path, project }),
-    })),
-  );
-  const configRepo = repositories.find(({ path }) => path === "/repos/config")!.seed;
-  const additionalRepositories = repositories
-    .filter(({ path }) => path !== "/repos/config")
-    .map(({ path, seed }) => ({ path, ...seed }));
+  const configRepo = await captureConfigRepository({ connected, project });
   const members = [...authSnapshot.members].sort((left, right) =>
     left.user.email.localeCompare(right.user.email),
   );
@@ -314,7 +298,6 @@ export async function capture(options: CaptureOptions) {
         secrets,
         integrations,
         configRepo,
-        repositories: additionalRepositories,
       },
     ],
   };
@@ -466,25 +449,12 @@ export async function apply(options: SeedOptions) {
   const configRepo =
     seed.configRepo === undefined
       ? null
-      : await restoreRepository({
+      : await restoreConfigRepository({
           project,
-          path: "/repos/config",
           seed: seed.configRepo,
           integrations: restoredIntegrations,
           workerUrls,
         });
-  const repositories = [];
-  for (const repository of seed.repositories) {
-    repositories.push(
-      await restoreRepository({
-        project,
-        path: repository.path,
-        seed: repository,
-        integrations: restoredIntegrations,
-      }),
-    );
-  }
-
   return {
     targetEnvironment: archive.targetEnvironment,
     project: identity,
@@ -499,7 +469,6 @@ export async function apply(options: SeedOptions) {
     secrets: seed.secrets.map((secret) => secret.path),
     integrations: restoredIntegrations,
     configRepo,
-    repositories,
   };
 }
 
@@ -528,16 +497,16 @@ async function captureSecret(project: ProjectRpc, projectId: string, path: strin
   };
 }
 
-async function captureRepository(input: {
+async function captureConfigRepository(input: {
   connected: readonly {
     connection: string;
     provider: string;
     status: { externalId: string | null };
   }[];
-  path: string;
   project: ProjectRpc;
 }): Promise<RepositorySeed> {
-  const repository = input.project.repos.get(input.path);
+  const path = "/repos/config";
+  const repository = input.project.repos.get(path);
   const [snapshot, local] = await Promise.all([
     repository.processor.snapshot(),
     repository.listFiles(),
@@ -551,14 +520,14 @@ async function captureRepository(input: {
         entry.status.externalId === github.installationId,
     );
     if (!installation) {
-      throw new Error(`${input.path} has no matching GitHub connection.`);
+      throw new Error(`${path} has no matching GitHub connection.`);
     }
     const remote = await readGithubHead(
       input.project.integrations.github.get(github.connection).octokit,
       github,
     );
     if (remote.commitOid !== local.commitOid) {
-      throw new Error(`${input.path} is not synchronized with GitHub.`);
+      throw new Error(`${path} is not synchronized with GitHub.`);
     }
     return {
       source: "github",
@@ -575,7 +544,7 @@ async function captureRepository(input: {
         encoding: "base64",
         commitOid: local.commitOid,
       });
-      if (file === null) throw new Error(`${input.path}/${path} disappeared during capture.`);
+      if (file === null) throw new Error(`/repos/config/${path} disappeared during capture.`);
       return { path, contentBase64: file.content };
     }),
   );
@@ -586,15 +555,14 @@ async function captureRepository(input: {
   };
 }
 
-async function restoreRepository(input: {
+async function restoreConfigRepository(input: {
   project: ProjectRpc;
-  path: string;
   seed: RepositorySeed;
   integrations: readonly RestoredIntegration[];
   workerUrls?: readonly string[];
 }) {
-  const repository = input.project.repos.get(input.path);
-  if (input.path !== "/repos/config") await repository.create({ type: "empty" });
+  const path = "/repos/config";
+  const repository = input.project.repos.get(path);
   if (input.seed.source === "local") {
     const before = await repository.listFiles();
     const wanted = new Set(input.seed.files.map((file) => file.path));
@@ -617,12 +585,12 @@ async function restoreRepository(input: {
           });
     const after = await repository.listFiles();
     if (!sameStrings(after.paths, [...wanted])) {
-      throw new Error(`${input.path} file-tree proof failed.`);
+      throw new Error(`${path} file-tree proof failed.`);
     }
     const served =
       input.workerUrls === undefined ? null : await proveWorkers(input.workerUrls, after.commitOid);
     return {
-      path: input.path,
+      path,
       source: "local" as const,
       commitOid: after.commitOid,
       changedPaths: "changedPaths" in commit ? commit.changedPaths : [],
@@ -654,12 +622,12 @@ async function restoreRepository(input: {
     after.commitOid !== reset.commitOid ||
     before.branch !== reset.branch
   ) {
-    throw new Error(`${input.path} changed while it was restored from GitHub.`);
+    throw new Error(`${path} changed while it was restored from GitHub.`);
   }
   const served =
     input.workerUrls === undefined ? null : await proveWorkers(input.workerUrls, reset.commitOid);
   return {
-    path: input.path,
+    path,
     source: "github" as const,
     connection,
     owner: githubSeed.owner,
@@ -810,7 +778,6 @@ function validateSelectedProject(archive: ProjectSeedArchive, project: SeedProje
     !Array.isArray(project.cloudflareHostnames) ||
     !Array.isArray(project.secrets) ||
     !Array.isArray(project.integrations) ||
-    !Array.isArray(project.repositories) ||
     !Array.isArray(project.email?.allowedSenders)
   ) {
     throw new Error(`Project ${String(project.slug)} has an invalid seed shape.`);
@@ -882,10 +849,6 @@ function projectSeedPlan(archive: ProjectSeedArchive, project: SeedProject) {
             : integration.googleUserId,
     })),
     configRepo: repositorySummary(project.configRepo),
-    repositories: project.repositories.map((repository) => ({
-      path: repository.path,
-      repository: repositorySummary(repository),
-    })),
   };
 }
 

--- a/apps/os/scripts/project-seed.ts
+++ b/apps/os/scripts/project-seed.ts
@@ -606,34 +606,52 @@ async function restoreConfigRepository(input: {
     throw new Error(`No GitHub connection for installation ${githubSeed.installationId}.`);
   }
   const github = input.project.integrations.github.get(connection).octokit;
-  const before = await readGithubHead(github, githubSeed);
-  const link = await repository.linkGithub({
-    connection,
-    createIfMissing: false,
-    initialPush: false,
-    owner: githubSeed.owner,
-    repo: githubSeed.repo,
-  });
-  if (link.created) throw new Error(`${githubSeed.owner}/${githubSeed.repo} did not exist.`);
-  const reset = await repository.resetFromGithub({ depth: 1 });
+  const [before, local, snapshot] = await Promise.all([
+    readGithubHead(github, githubSeed),
+    repository.listFiles(),
+    repository.processor.snapshot(),
+  ]);
+  const linked = snapshot.state.github;
+  const alreadyCurrent =
+    linked?.connection === connection &&
+    linked.installationId === githubSeed.installationId &&
+    linked.owner === githubSeed.owner &&
+    linked.repo === githubSeed.repo &&
+    local.commitOid === before.commitOid;
+  let restored = before;
+  if (!alreadyCurrent) {
+    const link = await repository.linkGithub({
+      connection,
+      createIfMissing: false,
+      initialPush: false,
+      owner: githubSeed.owner,
+      repo: githubSeed.repo,
+    });
+    if (link.created) throw new Error(`${githubSeed.owner}/${githubSeed.repo} did not exist.`);
+    restored = await repository.resetFromGithub({ depth: 1 });
+  }
   const after = await readGithubHead(github, githubSeed);
   if (
-    before.commitOid !== reset.commitOid ||
-    after.commitOid !== reset.commitOid ||
-    before.branch !== reset.branch
+    before.commitOid !== restored.commitOid ||
+    after.commitOid !== restored.commitOid ||
+    before.branch !== restored.branch ||
+    after.branch !== restored.branch
   ) {
     throw new Error(`${path} changed while it was restored from GitHub.`);
   }
   const served =
-    input.workerUrls === undefined ? null : await proveWorkers(input.workerUrls, reset.commitOid);
+    input.workerUrls === undefined
+      ? null
+      : await proveWorkers(input.workerUrls, restored.commitOid);
   return {
     path,
     source: "github" as const,
     connection,
     owner: githubSeed.owner,
     repo: githubSeed.repo,
-    branch: reset.branch,
-    commitOid: reset.commitOid,
+    branch: restored.branch,
+    commitOid: restored.commitOid,
+    reset: !alreadyCurrent,
     served,
   };
 }


### PR DESCRIPTION
Production apply exposed two unnecessary failure modes in the first semantic-seed implementation:

- a full-history `iterate/config` clone exceeded the Repo Durable Object memory limit;
- after fixing that with `depth: 1`, recovery also tried to clone every secondary project repo, including the 26 MB `iterate/iterate` tree.

This keeps the recovery contract narrow: Auth identity, integrations, secrets, hostnames, email policy, and the authoritative `/repos/config` repository. Arbitrary secondary repos are no longer captured or restored. The config reset remains shallow and GitHub-authoritative.

The failed secondary reset nevertheless completed before its response isolate died; production `/repos/iterate` is linked to `iterate/iterate`, contains 2,005 files, and resolves to current main (`55ce544b661fbdc4b256a6782e200c7f1d017abf`).

Production evidence for the original full-history failure: ITX call `log_51d2b54f702f43f0bd066fa4d014d347`, trace `88e23e43b0fbaeebf2875734a063681a`, `RepoDurableObject` outcome `exceededMemory` after 30.4 seconds.

Validated locally with OS typecheck, focused oxlint, oxfmt, and `git diff --check`.

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| CI & scripts | +49 -68 | +49 -64 🟩🟩🟥🟥🟥 |
| Docs | +11 -10 | +11 -10 🟩⬜⬜⬜⬜ |
| Other | +5 -4 | +5 -4 🟩⬜⬜⬜⬜ |
| **Total** | **+65 -82** | **+65 -78** 🟩🟩🟥🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 55ce544 and d014409, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production disaster-recovery behavior: secondary repos are no longer restored, and GitHub config restore logic is more complex; mis-scoping could leave projects incomplete after apply.
> 
> **Overview**
> Narrows **project-seed** capture/apply so recovery only includes `/repos/config`, not every project repository. That avoids production failures from cloning huge trees (Repo DO memory limits and multi‑MB secondary repos like `iterate/iterate`).
> 
> **Capture** no longer walks all `projectSnapshot.state.repos`; it only calls `captureConfigRepository`. The archive drops the `repositories` array on `SeedProject` and validation/plan output no longer list extra repos.
> 
> **Apply** restores only the config repo via `restoreConfigRepository` (replacing the loop over `seed.repositories`). Non-config paths are no longer created with `repository.create({ type: "empty" }`).
> 
> **GitHub config restore** skips link/reset when the repo is already linked to the seed’s installation and local head matches remote; otherwise it still uses shallow `resetFromGithub({ depth: 1 })` and returns a `reset` flag. Branch stability checks are tightened on the after-head.
> 
> Docs and the recreate-production skill now state that secondary repos are outside the recovery contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d014409b68b785be680d0be0efe192d31532ab35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-28T21:26:25.259Z",
      "deployedAt": "2026-07-28T21:20:44.480Z",
      "headSha": "d014409b68b785be680d0be0efe192d31532ab35",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/228049265739714",
      "shortSha": "d014409",
      "cleanupDurationMs": 10575,
      "deployDurationMs": 71287,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 48826,
      "deployReadinessDurationMs": 22458,
      "deployedWorkerName": "os-preview-1",
      "deployedWorkerVersion": "9d28e42f-4a2c-406d-a514-79c0b9e37fd6",
      "testDurationMs": 191066,
      "testRetries": null,
      "workerSizeKib": 19913.21,
      "workerGzipKib": 5027.48,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5038.44
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-28T21:26:17.766Z",
      "deployedAt": "2026-07-28T21:20:13.381Z",
      "headSha": "d014409b68b785be680d0be0efe192d31532ab35",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/228049265739714",
      "shortSha": "d014409",
      "cleanupDurationMs": 3079,
      "deployDurationMs": 18042,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 17724,
      "deployReadinessDurationMs": 312,
      "deployedWorkerName": "auth-preview-1",
      "deployedWorkerVersion": "4e0da977-f82f-4906-8de6-1f664960d33a",
      "testDurationMs": 11388,
      "testRetries": null,
      "workerSizeKib": 3976.81,
      "workerGzipKib": 814.03,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-28T21:26:15.317Z",
      "deployedAt": "2026-07-28T21:20:04.759Z",
      "headSha": "d014409b68b785be680d0be0efe192d31532ab35",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/228049265739714",
      "shortSha": "d014409",
      "cleanupDurationMs": 627,
      "deployDurationMs": 9345,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 9068,
      "deployReadinessDurationMs": 238,
      "deployedWorkerName": "dummy-petshop-preview-1",
      "deployedWorkerVersion": "23c2c3aa-3705-4d5c-a3d5-2d48106406ac",
      "testDurationMs": 30715,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `d014409` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 814.0 KiB | 18.0s | 11.4s |  | 3.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/228049265739714) | 2026-07-28T21:26:17.766Z | Preview app released. |
| Dummy Petshop | released | `d014409` | [https://dummy-petshop.iterate-preview-1.com](https://dummy-petshop.iterate-preview-1.com) | 198.3 KiB | 9.3s | 30.7s |  | 627ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/228049265739714) | 2026-07-28T21:26:15.317Z | Preview app released. |
| OS | released | `d014409` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 4.91 MiB (-11.0 KiB vs main) | 71.3s | 191.1s |  | 10.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/228049265739714) | 2026-07-28T21:26:25.259Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->