### PR TITLE
Classify hosted callback transport breaks

### DIFF
--- a/apps/os/src/domains/streams/stream-event-sender.test.ts
+++ b/apps/os/src/domains/streams/stream-event-sender.test.ts
@@ -1960,6 +1960,39 @@ describe("StreamConnections hosted delivery watchdog", () => {
     expect(h.durableDeliveryWakes).toHaveBeenCalledOnce();
   });
 
+  it("classifies a broken hosted callback capability as lifecycle unavailability", () => {
+    const h = connectionsHarness();
+    const warnLog = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    let reportBroken: ((error: unknown) => void) | undefined;
+    const processEventBatch = recordingProcessEventBatch([], () => undefined);
+    processEventBatch.onRpcBroken = (handler) => {
+      reportBroken = handler;
+    };
+    h.connections.openHosted({
+      connectionKey: "processor",
+      expectedHostedDelivery: h.expectedDelivery,
+      processEventBatch,
+      replayAfterOffset: 0,
+    });
+
+    reportBroken!(new Error("transport closed"));
+
+    expect(h.connections.has("processor")).toBe(false);
+    expect(h.deliveryFailures).toHaveBeenCalledOnce();
+    expect(warnLog).toHaveBeenCalledWith(
+      "stream durable callback unavailable; backing off before waking it again",
+      {
+        connectionKey: "processor",
+        errorMessage: "transport closed",
+        source: "rpc-broken",
+      },
+    );
+    expect(errorLog).not.toHaveBeenCalled();
+    warnLog.mockRestore();
+    errorLog.mockRestore();
+  });
+
   it("closes and records a session connection whose event condition throws", async () => {
     const appended: unknown[] = [];
     const h = connectionsHarness({

--- a/apps/os/src/domains/streams/stream-event-sender.ts
+++ b/apps/os/src/domains/streams/stream-event-sender.ts
@@ -1640,6 +1640,7 @@ export class StreamConnections {
     connectionKey: string,
     error: unknown,
     expectedDelivery: ExpectedHostedDeliveryState,
+    source: "delivery" | "rpc-broken" = "delivery",
   ): void {
     const connection = this.#connections.get(connectionKey);
     if (
@@ -1650,10 +1651,10 @@ export class StreamConnections {
     ) {
       return;
     }
-    const details = { connectionKey, error };
+    const details = { connectionKey, errorMessage: connectionError(error), source };
     if (error instanceof EventFilterEvaluationError) {
       console.info("stream hosted callback filter condition failed; backing off", details);
-    } else if (isDurableObjectLifecycleError(error)) {
+    } else if (source === "rpc-broken" || isDurableObjectLifecycleError(error)) {
       console.warn(
         "stream durable callback unavailable; backing off before waking it again",
         details,
@@ -1662,7 +1663,10 @@ export class StreamConnections {
       console.error("stream durable callback failed; backing off before waking it again", details);
     }
     this.#hooks.onHostedDeliveryFailure(connectionKey, error);
-    connection.close("delivery-failed", connectionError(error));
+    connection.close(
+      source === "rpc-broken" ? "rpc-broken" : "delivery-failed",
+      connectionError(error),
+    );
   }
 
   samplePingsSoon(): void {
@@ -2100,7 +2104,7 @@ export class StreamConnections {
     this.#hooks.runtimeChanged();
     processEventBatch.onRpcBroken?.((error) => {
       if (kind === "hosted" && args.expectedHostedDelivery !== undefined) {
-        this.onHostedDeliveryError(connectionKey, error, args.expectedHostedDelivery);
+        this.onHostedDeliveryError(connectionKey, error, args.expectedHostedDelivery, "rpc-broken");
       } else {
         connection.close("rpc-broken", connectionError(error));
       }


### PR DESCRIPTION
## What changed

- classify a hosted processor callback capability reporting `onRpcBroken` as lifecycle unavailability, not an application delivery error
- retain the bounded retry/backoff and record the close as `rpc-broken`
- log the error message as a scalar so Workers Observability preserves it

## Why

The production recreation audit found three `stream durable callback failed` errors. Trace evidence showed the callback capabilities ending and being reopened/caught up, including an old-to-new deployment boundary; the generic error classification came from routing `onRpcBroken` through the same branch as a processor-reported failure.

## Proof

- `pnpm --dir apps/os exec vitest run src/domains/streams/stream-event-sender.test.ts` (43/43)
- focused oxlint: zero warnings/errors
- `pnpm --dir apps/os typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to error classification and logging for an existing hosted-callback teardown path; retry/backoff behavior is preserved and covered by tests.
> 
> **Overview**
> When a **hosted processor** callback reports transport breakage via `onRpcBroken`, the stream now treats that as **lifecycle unavailability** (same warn path as Durable Object lifecycle errors), not as an application **delivery failure** that logs `stream durable callback failed`.
> 
> `onHostedDeliveryError` accepts a `source` of `delivery` or `rpc-broken`; the `onRpcBroken` handler passes `rpc-broken`, which drives warn-level logging, records the close as `rpc-broken` instead of `delivery-failed`, and still runs the existing backoff and wake path. Structured log details use a scalar `errorMessage` (and `source`) instead of embedding the raw error object.
> 
> A unit test asserts hosted `onRpcBroken` emits the unavailability warning and does not call `console.error`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81fb0f39e35efe603af382998d1925c7be700784. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +8 -4 | +8 -4 🟩🟥⬜⬜⬜ |
| Tests | +33 -0 | +30 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+41 -4** | **+38 -4** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between e6cfd92 and 81fb0f3, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-28T21:47:16.704Z",
      "deployedAt": "2026-07-28T21:42:16.302Z",
      "headSha": "81fb0f39e35efe603af382998d1925c7be700784",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/300853716870871",
      "shortSha": "81fb0f3",
      "cleanupDurationMs": 12773,
      "deployDurationMs": 97340,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 96033,
      "deployReadinessDurationMs": 1304,
      "deployedWorkerName": "os-preview-2",
      "deployedWorkerVersion": "67359725-3208-42e5-ba12-1d02c223257f",
      "testDurationMs": 221416,
      "testRetries": null,
      "workerSizeKib": 19913.36,
      "workerGzipKib": 5027.51,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5038.4
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-28T21:47:07.528Z",
      "deployedAt": "2026-07-28T21:41:00.817Z",
      "headSha": "81fb0f39e35efe603af382998d1925c7be700784",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/300853716870871",
      "shortSha": "81fb0f3",
      "cleanupDurationMs": 3594,
      "deployDurationMs": 20826,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 20545,
      "deployReadinessDurationMs": 276,
      "deployedWorkerName": "auth-preview-2",
      "deployedWorkerVersion": "c33677df-dd4f-47e7-b3b3-96247a555915",
      "testDurationMs": 10298,
      "testRetries": null,
      "workerSizeKib": 3976.81,
      "workerGzipKib": 814.06,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-28T21:47:11.781Z",
      "deployedAt": "2026-07-28T21:40:54.794Z",
      "headSha": "81fb0f39e35efe603af382998d1925c7be700784",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/300853716870871",
      "shortSha": "81fb0f3",
      "cleanupDurationMs": 7846,
      "deployDurationMs": 59558,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 14521,
      "deployReadinessDurationMs": 45033,
      "deployedWorkerName": "streams-example-app-preview-2",
      "deployedWorkerVersion": "a8599956-0bf5-4970-a9e7-84863313db4a",
      "testDurationMs": 58292,
      "testRetries": null,
      "workerSizeKib": 5235.92,
      "workerGzipKib": 1483.83,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-28T21:47:04.769Z",
      "deployedAt": "2026-07-28T21:40:46.600Z",
      "headSha": "81fb0f39e35efe603af382998d1925c7be700784",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/300853716870871",
      "shortSha": "81fb0f3",
      "cleanupDurationMs": 832,
      "deployDurationMs": 6720,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 6282,
      "deployReadinessDurationMs": 388,
      "deployedWorkerName": "dummy-petshop-preview-2",
      "deployedWorkerVersion": "60e6d227-ffd0-488e-a8d7-2234b0b86ba8",
      "testDurationMs": 5881,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `81fb0f3` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 814.1 KiB | 20.8s | 10.3s |  | 3.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/300853716870871) | 2026-07-28T21:47:07.528Z | Preview app released. |
| Dummy Petshop | released | `81fb0f3` | [https://dummy-petshop.iterate-preview-2.com](https://dummy-petshop.iterate-preview-2.com) | 198.3 KiB | 6.7s | 5.9s |  | 832ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/300853716870871) | 2026-07-28T21:47:04.769Z | Preview app released. |
| OS | released | `81fb0f3` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 4.91 MiB (-10.9 KiB vs main) | 97.3s | 221.4s |  | 12.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/300853716870871) | 2026-07-28T21:47:16.704Z | Preview app released. |
| Streams Example App | released | `81fb0f3` | [https://streams.iterate-preview-2.com](https://streams.iterate-preview-2.com) | 1.45 MiB | 59.6s | 58.3s |  | 7.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/300853716870871) | 2026-07-28T21:47:11.781Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->