### PR TITLE
Recover transient project worker clone skew

### DIFF
--- a/apps/os/src/domains/workers/worker-loader.ts
+++ b/apps/os/src/domains/workers/worker-loader.ts
@@ -191,6 +191,7 @@ async function resolveFileSource({
 
 export function loadResolvedWorker({
   bindings,
+  freshInstanceNonce,
   globalOutbound,
   projectId,
   resolved,
@@ -198,6 +199,8 @@ export function loadResolvedWorker({
   streamContext,
 }: {
   bindings: WorkerBindings;
+  /** Force a one-off loader isolate instead of reusing the normal cache hit. */
+  freshInstanceNonce?: string;
   globalOutbound: Fetcher;
   projectId: string;
   resolved: ResolvedWorkerSource;
@@ -219,6 +222,7 @@ export function loadResolvedWorker({
     scopePath,
     JSON.stringify(StreamContext.parse(streamContext)),
     resolved.cacheKey,
+    freshInstanceNonce ?? "shared",
   ].join(":");
   return env.LOADER.get(cacheKey, () => ({
     compatibilityDate: resolved.wranglerConfig?.compatibilityDate ?? WORKER_COMPATIBILITY_DATE,

--- a/apps/os/src/domains/workers/worker-runner.test.ts
+++ b/apps/os/src/domains/workers/worker-runner.test.ts
@@ -284,6 +284,50 @@ it("recovers a safe stateless fetch once with a fresh loader after clone-version
   });
 });
 
+it("recovers a stateless event batch once with a fresh loader after clone-version skew", async () => {
+  const processEventBatch = vi
+    .fn()
+    .mockRejectedValueOnce(
+      new Error("Unable to deserialize cloned data due to invalid or unsupported version."),
+    )
+    .mockResolvedValueOnce(undefined);
+  h.resolveWorkerSource.mockResolvedValue({
+    ok: true,
+    source: {
+      assetConfig: undefined,
+      assetManifest: {},
+      assets: {},
+      cacheKey: "build-key",
+      commitOid: "commit-1",
+      mainModule: "worker.js",
+      modules: {},
+      wranglerConfig: undefined,
+    },
+  });
+  h.loadResolvedWorker.mockImplementation(() => ({
+    getEntrypoint: () => ({ processEventBatch }),
+  }));
+  const runner = new DynamicWorkerRunner({
+    streamContext: { kind: "scope", scopePath: inlineRef.path },
+    exports: {} as ExecutionContext["exports"],
+    projectId: "prj_private",
+    scopePath: inlineRef.path,
+  });
+
+  await runner.invokeCapability({
+    args: [{ events: [] }],
+    path: ["processEventBatch"],
+    ref: inlineRef,
+  });
+
+  expect(processEventBatch).toHaveBeenCalledTimes(2);
+  expect(h.loadResolvedWorker.mock.calls[0]?.[0].freshInstanceNonce).toBeUndefined();
+  expect(h.loadResolvedWorker.mock.calls[1]?.[0].freshInstanceNonce).toEqual(expect.any(String));
+  expect(recordedSpans[0]?.attributes).toMatchObject({
+    "iterate.worker.rpc_clone_version_retry": true,
+  });
+});
+
 it("turns a stateful source-build result into a local terminal delivery error", async () => {
   h.statefulInvokeCapability.mockImplementation(
     async ({ buildFailureNonce }: { buildFailureNonce: string }) => [

--- a/apps/os/src/domains/workers/worker-runner.test.ts
+++ b/apps/os/src/domains/workers/worker-runner.test.ts
@@ -239,6 +239,51 @@ describe("createApp asset dispatch", () => {
   });
 });
 
+it("recovers a safe stateless fetch once with a fresh loader after clone-version skew", async () => {
+  const workerFetch = vi
+    .fn()
+    .mockRejectedValueOnce(
+      new Error("Unable to deserialize cloned data due to invalid or unsupported version."),
+    )
+    .mockResolvedValueOnce(new Response("recovered"));
+  h.resolveWorkerSource.mockResolvedValue({
+    ok: true,
+    source: {
+      assetConfig: undefined,
+      assetManifest: {},
+      assets: {},
+      cacheKey: "build-key",
+      commitOid: "commit-1",
+      mainModule: "worker.js",
+      modules: {},
+      wranglerConfig: undefined,
+    },
+  });
+  h.loadResolvedWorker.mockImplementation(() => ({
+    getEntrypoint: () => ({ fetch: workerFetch }),
+  }));
+  const runner = new DynamicWorkerRunner({
+    streamContext: { kind: "scope", scopePath: inlineRef.path },
+    exports: {} as ExecutionContext["exports"],
+    projectId: "prj_private",
+    scopePath: inlineRef.path,
+  });
+
+  const response = await runner.fetch({
+    ref: inlineRef,
+    request: new Request("https://example.com/"),
+  });
+
+  expect(await response.text()).toBe("recovered");
+  expect(workerFetch).toHaveBeenCalledTimes(2);
+  expect(h.loadResolvedWorker.mock.calls[0]?.[0].freshInstanceNonce).toBeUndefined();
+  expect(h.loadResolvedWorker.mock.calls[1]?.[0].freshInstanceNonce).toEqual(expect.any(String));
+  expect(recordedSpans[0]?.attributes).toMatchObject({
+    "http.response.status_code": 200,
+    "iterate.worker.rpc_clone_version_retry": true,
+  });
+});
+
 it("turns a stateful source-build result into a local terminal delivery error", async () => {
   h.statefulInvokeCapability.mockImplementation(
     async ({ buildFailureNonce }: { buildFailureNonce: string }) => [

--- a/apps/os/src/domains/workers/worker-runner.ts
+++ b/apps/os/src/domains/workers/worker-runner.ts
@@ -219,17 +219,20 @@ export class DynamicWorkerRunner {
         return withWorkerCommit(await entrypoint.fetch(currentRequest), resolved.commitOid);
       };
 
-      const retryable =
+      const retryRequest =
         ref.type === "stateless" &&
         !isWebSocketUpgradeRequest(request) &&
-        (request.method === "GET" || request.method === "HEAD");
-      const retryRequest = retryable ? (request.clone() as Request) : undefined;
+        (request.method === "GET" || request.method === "HEAD")
+          ? // Cloudflare's clone() widens the Request metadata generics even
+            // though the runtime value remains the same Fetch API request.
+            (request.clone() as typeof request)
+          : undefined;
       let response: Response;
       try {
         response = await dispatch(request);
       } catch (error) {
         if (
-          !retryable ||
+          retryRequest === undefined ||
           !(error instanceof Error) ||
           !error.message.includes(WORKERS_RPC_CLONE_VERSION_ERROR)
         ) {
@@ -241,7 +244,7 @@ export class DynamicWorkerRunner {
           rayId: request.headers.get("cf-ray") ?? undefined,
           traceRole,
         });
-        response = await dispatch(retryRequest!, crypto.randomUUID());
+        response = await dispatch(retryRequest, crypto.randomUUID());
       }
       span.setAttribute("http.response.status_code", response.status);
       return response;

--- a/apps/os/src/domains/workers/worker-runner.ts
+++ b/apps/os/src/domains/workers/worker-runner.ts
@@ -97,8 +97,9 @@ export class DynamicWorkerRunner {
   async #getStatelessEntrypoint<T = unknown>(
     ref: StatelessDynamicWorkerRef,
     buildBudgetMs?: number,
+    freshInstanceNonce?: string,
   ): Promise<{ ok: true; target: T } | { failure: WorkerBuildFailure; ok: false }> {
-    const loaded = await this.#load(ref, buildBudgetMs);
+    const loaded = await this.#load(ref, buildBudgetMs, freshInstanceNonce);
     if (!loaded.ok) return loaded;
     return {
       ok: true,
@@ -284,7 +285,7 @@ export class DynamicWorkerRunner {
       );
     }
 
-    return this.#trace(ref, "call", traceRole, async () => {
+    return this.#trace(ref, "call", traceRole, async (span) => {
       if (ref.type === "stateful") {
         // Method replay must happen inside StatefulWorkerDurableObject. Returning
         // a dynamic facet stub through one DO and then invoking it from another RPC
@@ -316,11 +317,31 @@ export class DynamicWorkerRunner {
         return result;
       }
 
-      const loaded = await this.#getStatelessEntrypoint(ref, buildBudgetMs);
-      if (!loaded.ok) throw new WorkerBuildFailedError(loaded.failure);
-      return flattenNestedPath
-        ? await invokePreferringFlattenedPath({ args, path, target: loaded.target })
-        : await replayPath({ args, path, target: loaded.target });
+      const dispatch = async (freshInstanceNonce?: string) => {
+        const loaded = await this.#getStatelessEntrypoint(ref, buildBudgetMs, freshInstanceNonce);
+        if (!loaded.ok) throw new WorkerBuildFailedError(loaded.failure);
+        return flattenNestedPath
+          ? await invokePreferringFlattenedPath({ args, path, target: loaded.target })
+          : await replayPath({ args, path, target: loaded.target });
+      };
+      try {
+        return await dispatch();
+      } catch (error) {
+        if (
+          path.length !== 1 ||
+          path[0] !== "processEventBatch" ||
+          !(error instanceof Error) ||
+          !error.message.includes(WORKERS_RPC_CLONE_VERSION_ERROR)
+        ) {
+          throw error;
+        }
+        span.setAttribute("iterate.worker.rpc_clone_version_retry", true);
+        console.warn("Workers RPC clone-version skew; retrying stateless event batch once", {
+          projectId: this.#projectId,
+          traceRole,
+        });
+        return await dispatch(crypto.randomUUID());
+      }
     });
   }
 
@@ -342,6 +363,7 @@ export class DynamicWorkerRunner {
   async #load(
     ref: DynamicWorkerRef,
     buildBudgetMs?: number,
+    freshInstanceNonce?: string,
   ): Promise<
     | { ok: true; resolved: ResolvedWorkerSource; worker: WorkerStub }
     | { failure: WorkerBuildFailure; ok: false }
@@ -355,7 +377,7 @@ export class DynamicWorkerRunner {
     return {
       ok: true,
       resolved: result.source,
-      worker: this.#loadResolved(result.source),
+      worker: this.#loadResolved(result.source, freshInstanceNonce),
     };
   }
 

--- a/apps/os/src/domains/workers/worker-runner.ts
+++ b/apps/os/src/domains/workers/worker-runner.ts
@@ -26,6 +26,9 @@ import {
 
 export type DynamicWorkerTraceRole = "project_config" | "run_script" | "scheduler_action";
 
+const WORKERS_RPC_CLONE_VERSION_ERROR =
+  "Unable to deserialize cloned data due to invalid or unsupported version.";
+
 // Structural shadow of StatefulWorkerDurableObject.invokeCapability instead
 // of the DO's own type: the DO imports this module (cycle), and a typed
 // DurableObjectStub of it deep-instantiates the stub's self-referential type
@@ -159,42 +162,43 @@ export class DynamicWorkerRunner {
     traceRole?: DynamicWorkerTraceRole;
   }): Promise<Response> {
     return this.#trace(ref, "fetch", traceRole, async (span) => {
-      let resolved: ResolvedWorkerSource | undefined;
-      if (
-        "createApp" in ref.source &&
-        !isWebSocketUpgradeRequest(request) &&
-        (request.method === "GET" || request.method === "HEAD")
-      ) {
-        const result = await resolveWorkerSource({
-          buildBudgetMs,
-          projectId: this.#projectId,
-          source: ref.source,
-        });
-        if (!result.ok) throw new WorkerBuildFailedError(result.failure);
-        resolved = result.source;
-        const asset = await env.WORKER_BUNDLER.handleAssetRequest(
-          request,
-          resolved.assetManifest,
-          resolved.assets,
-          resolved.assetConfig,
-        );
-        if (asset !== null) {
-          const response = withWorkerCommit(asset, resolved.commitOid);
-          span.setAttribute("http.response.status_code", response.status);
-          return response;
+      const dispatch = async (
+        currentRequest: Request,
+        freshInstanceNonce?: string,
+      ): Promise<Response> => {
+        let resolved: ResolvedWorkerSource | undefined;
+        if (
+          "createApp" in ref.source &&
+          !isWebSocketUpgradeRequest(currentRequest) &&
+          (currentRequest.method === "GET" || currentRequest.method === "HEAD")
+        ) {
+          const result = await resolveWorkerSource({
+            buildBudgetMs,
+            projectId: this.#projectId,
+            source: ref.source,
+          });
+          if (!result.ok) throw new WorkerBuildFailedError(result.failure);
+          resolved = result.source;
+          const asset = await env.WORKER_BUNDLER.handleAssetRequest(
+            currentRequest,
+            resolved.assetManifest,
+            resolved.assets,
+            resolved.assetConfig,
+          );
+          if (asset !== null) {
+            return withWorkerCommit(asset, resolved.commitOid);
+          }
         }
-      }
 
-      let response: Response;
-      if (ref.type === "stateful") {
-        // The hosting DO resolves the facet and stamps its trusted build
-        // header after the user response returns.
-        response = await (
-          env.WORKER.getByName(
-            statefulWorkerDurableObjectName(this.#projectId, ref),
-          ) as unknown as Fetcher
-        ).fetch(withWorkerFetchDispatchHeader(request, { buildBudgetMs, ref }));
-      } else {
+        if (ref.type === "stateful") {
+          // The hosting DO resolves the facet and stamps its trusted build
+          // header after the user response returns.
+          return await (
+            env.WORKER.getByName(
+              statefulWorkerDurableObjectName(this.#projectId, ref),
+            ) as unknown as Fetcher
+          ).fetch(withWorkerFetchDispatchHeader(currentRequest, { buildBudgetMs, ref }));
+        }
         if (resolved === undefined) {
           const result = await resolveWorkerSource({
             buildBudgetMs,
@@ -206,10 +210,38 @@ export class DynamicWorkerRunner {
         }
         // The serve header is trusted platform output on the fetch lane —
         // stamped (and any user-set value dropped) at this authority boundary.
-        const entrypoint = this.#loadResolved(resolved).getEntrypoint(ref.entrypoint, {
-          props: ref.props ?? {},
-        }) as Fetcher;
-        response = withWorkerCommit(await entrypoint.fetch(request), resolved.commitOid);
+        const entrypoint = this.#loadResolved(resolved, freshInstanceNonce).getEntrypoint(
+          ref.entrypoint,
+          {
+            props: ref.props ?? {},
+          },
+        ) as Fetcher;
+        return withWorkerCommit(await entrypoint.fetch(currentRequest), resolved.commitOid);
+      };
+
+      const retryable =
+        ref.type === "stateless" &&
+        !isWebSocketUpgradeRequest(request) &&
+        (request.method === "GET" || request.method === "HEAD");
+      const retryRequest = retryable ? (request.clone() as Request) : undefined;
+      let response: Response;
+      try {
+        response = await dispatch(request);
+      } catch (error) {
+        if (
+          !retryable ||
+          !(error instanceof Error) ||
+          !error.message.includes(WORKERS_RPC_CLONE_VERSION_ERROR)
+        ) {
+          throw error;
+        }
+        span.setAttribute("iterate.worker.rpc_clone_version_retry", true);
+        console.warn("Workers RPC clone-version skew; retrying stateless fetch once", {
+          projectId: this.#projectId,
+          rayId: request.headers.get("cf-ray") ?? undefined,
+          traceRole,
+        });
+        response = await dispatch(retryRequest!, crypto.randomUUID());
       }
       span.setAttribute("http.response.status_code", response.status);
       return response;
@@ -324,9 +356,10 @@ export class DynamicWorkerRunner {
     };
   }
 
-  #loadResolved(resolved: ResolvedWorkerSource): WorkerStub {
+  #loadResolved(resolved: ResolvedWorkerSource, freshInstanceNonce?: string): WorkerStub {
     return loadResolvedWorker({
       bindings: this.#bindings,
+      freshInstanceNonce,
       globalOutbound: this.#globalOutbound,
       projectId: this.#projectId,
       resolved,


### PR DESCRIPTION
## What

- retry exactly one Cloudflare Workers RPC clone-version failure for safe stateless `GET`/`HEAD` fetches
- force the retry through a fresh Worker Loader isolate
- mark recovered traces and log the classified retry; persistent failures still surface normally

## Why

A production proof request to `www.iterate.com` resolved the correct KV route and ran the current config worker, then the outer serve lane returned 500. Cloudflare Ray `a2277abb7b56ef42` and PostHog issue `019f84a2-8daf-77d0-8dc3-9d9c7c803292` identify the swallowed exception as:

`Unable to deserialize cloned data due to invalid or unsupported version.`

The next request succeeded. This bounds recovery to the known cross-runtime skew and avoids retrying stateful calls, writes, WebSockets, or unrelated errors.

## Proof

- `pnpm --dir apps/os exec vitest run src/domains/workers/worker-runner.test.ts`
- `pnpm --dir apps/os typecheck`
- targeted oxlint: 0 warnings / 0 errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the dynamic worker fetch and event-batch dispatch paths with a one-shot retry, but scope is limited to a known RPC error and safe read-only/stateless operations—not auth or broad capability replay.
> 
> **Overview**
> After an OS rollout, a cached **Worker Loader** isolate from the previous deployment can still be reused and fail Workers RPC with *Unable to deserialize cloned data due to invalid or unsupported version.* This adds a **single automatic recovery** for narrowly safe stateless paths.
> 
> `loadResolvedWorker` now accepts an optional `freshInstanceNonce` so a retry can bypass the normal loader cache and spin a one-off isolate while build artifacts stay shared.
> 
> `DynamicWorkerRunner` catches that error and retries **once** with a fresh nonce for **stateless `GET`/`HEAD` fetches** (cloned request; no WebSockets or stateful DO lane) and for **stateless `processEventBatch`** capability calls. Retries are traced via `iterate.worker.rpc_clone_version_retry` and a warning log; other errors and paths still fail normally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb3823d1f823ed9f3dbb174ee5927fa0811a93ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +109 -47 | +101 -44 🟩🟩🟩🟥🟥 |
| Tests | +89 -0 | +83 -0 🟩🟩🟩⬜⬜ |
| **Total** | **+198 -47** | **+184 -44** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between ed3eea2 and 1367862, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-28T23:36:24.489Z",
      "deployedAt": "2026-07-28T23:31:30.596Z",
      "headSha": "bb3823d1f823ed9f3dbb174ee5927fa0811a93ca",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-14.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/61333134860123",
      "shortSha": "bb3823d",
      "cleanupDurationMs": 12137,
      "deployDurationMs": 47984,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 46154,
      "deployReadinessDurationMs": 1827,
      "deployedWorkerName": "os-preview-14",
      "deployedWorkerVersion": "3885145b-ab03-4359-9ff7-a17622f0d15e",
      "testDurationMs": 199293,
      "testRetries": null,
      "workerSizeKib": 19899.32,
      "workerGzipKib": 5024.6,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5035.22
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-28T23:36:14.987Z",
      "deployedAt": "2026-07-28T23:31:02.674Z",
      "headSha": "bb3823d1f823ed9f3dbb174ee5927fa0811a93ca",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-14.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/61333134860123",
      "shortSha": "bb3823d",
      "cleanupDurationMs": 2633,
      "deployDurationMs": 18642,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 18229,
      "deployReadinessDurationMs": 409,
      "deployedWorkerName": "auth-preview-14",
      "deployedWorkerVersion": "9da2c392-23c6-478d-ab9e-249e6441aba1",
      "testDurationMs": 10154,
      "testRetries": null,
      "workerSizeKib": 3976.81,
      "workerGzipKib": 813.99,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-28T23:36:12.781Z",
      "deployedAt": "2026-07-28T23:08:10.957Z",
      "headSha": "bb3823d1f823ed9f3dbb174ee5927fa0811a93ca",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-14.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/61333134860123",
      "shortSha": "bb3823d",
      "cleanupDurationMs": 425,
      "deployDurationMs": 52,
      "deployConfigDurationMs": 5,
      "deployReuseProofDurationMs": 18,
      "deployedWorkerName": "dummy-petshop-preview-14",
      "deployedWorkerVersion": "aae0c698-eefd-44f4-9e6b-e7e85ea4d5dc",
      "testDurationMs": 5471,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `bb3823d` | [https://auth.iterate-preview-14.com](https://auth.iterate-preview-14.com) | 814.0 KiB | 18.6s | 10.2s |  | 2.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/61333134860123) | 2026-07-28T23:36:14.987Z | Preview app released. |
| Dummy Petshop | released | `bb3823d` | [https://dummy-petshop.iterate-preview-14.com](https://dummy-petshop.iterate-preview-14.com) | 198.3 KiB | 52ms | 5.5s |  | 425ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/61333134860123) | 2026-07-28T23:36:12.781Z | Preview app released. |
| OS | released | `bb3823d` | [https://os.iterate-preview-14.com](https://os.iterate-preview-14.com) | 4.91 MiB (-10.6 KiB vs main) | 48.0s | 199.3s |  | 12.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/61333134860123) | 2026-07-28T23:36:24.489Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->