### PR TITLE
Bound direct GitHub webhook routing

### DIFF
--- a/apps/os/src/domains/repos/config-repo-github-reviews.test.ts
+++ b/apps/os/src/domains/repos/config-repo-github-reviews.test.ts
@@ -469,7 +469,8 @@ describe("userspace GitHub pull-request routing", () => {
         name: "issue_comment",
       }),
     );
-    expect(ignored.appendBatches[0]?.events).toHaveLength(1);
+    expect(ignored.repoList).not.toHaveBeenCalled();
+    expect(ignored.appendBatches).toHaveLength(0);
   });
 
   it("takes submitted review text from the committed webhook without rereading its ref", async () => {
@@ -503,7 +504,8 @@ describe("userspace GitHub pull-request routing", () => {
       }),
     );
 
-    expect(test.appendBatches[0]?.events).toHaveLength(1);
+    expect(test.repoList).not.toHaveBeenCalled();
+    expect(test.appendBatches).toHaveLength(0);
   });
 
   it("creates the pull-request agent from a trusted mention", async () => {
@@ -548,15 +550,13 @@ describe("userspace GitHub pull-request routing", () => {
     expect(test.appendBatches[0]?.events).toHaveLength(1);
   });
 
-  it("copies native thread resolution without waking the agent", async () => {
+  it("leaves native thread resolution to the durable agent subscription", async () => {
     const test = harness({ agentExists: true });
     await handleGithubPullRequestWebhook(
       test.itx,
       webhook({ action: "resolved", name: "pull_request_review_thread" }),
     );
-    expect(test.appendBatches[0]?.events).toHaveLength(1);
-    expect(test.appendBatches[0]?.events[0]).toMatchObject({
-      type: "events.iterate.com/agent/binding-set",
-    });
+    expect(test.repoList).not.toHaveBeenCalled();
+    expect(test.appendBatches).toHaveLength(0);
   });
 });

--- a/packages/iterate/src/starter-apps/github-ai-linter/index.ts
+++ b/packages/iterate/src/starter-apps/github-ai-linter/index.ts
@@ -1,5 +1,9 @@
 import type { ItxBinding, Project, StreamEvent } from "../../sdk.ts";
-import { handleGithubPullRequestWebhook } from "./review-bot.ts";
+import {
+  handleGithubPullRequestWebhook,
+  loadLinkedGithubRepos,
+  type LinkedGithubRepo,
+} from "./review-bot.ts";
 import { loadGithubAiLinterRules, type GithubAiLinterRuleSource } from "./rules.ts";
 
 export type GithubAiLinterConfig = {
@@ -9,6 +13,7 @@ export type GithubAiLinterConfig = {
 
 export const GithubAiLinter = {
   create(env: { ITX: ItxBinding }, config: GithubAiLinterConfig) {
+    let linkedRepos: LinkedGithubRepo[] | undefined;
     return {
       async processEvent(event: StreamEvent) {
         if (
@@ -25,6 +30,7 @@ export const GithubAiLinter = {
         }
         using itx = await env.ITX.get();
         if (event.type === "events.iterate.com/repo/github-link-configured") {
+          linkedRepos = undefined;
           const connection = event.payload?.connection;
           if (typeof connection === "string" && connection.length > 0) {
             await retireHostedReviewBot(itx, connection);
@@ -32,6 +38,7 @@ export const GithubAiLinter = {
           return;
         }
         await handleGithubPullRequestWebhook(itx, event, {
+          loadLinkedRepos: async () => (linkedRepos ??= await loadLinkedGithubRepos(itx)),
           loadRules: () => loadGithubAiLinterRules(itx, config.rules),
           policyVersion: config.policyVersion,
         });

--- a/packages/iterate/src/starter-apps/github-ai-linter/index.ts
+++ b/packages/iterate/src/starter-apps/github-ai-linter/index.ts
@@ -18,7 +18,8 @@ export const GithubAiLinter = {
       async processEvent(event: StreamEvent) {
         if (
           event.type !== "events.iterate.com/github/webhook-received" &&
-          event.type !== "events.iterate.com/repo/github-link-configured"
+          event.type !== "events.iterate.com/repo/github-link-configured" &&
+          event.type !== "events.iterate.com/repo/github-unlinked"
         ) {
           return;
         }
@@ -26,6 +27,10 @@ export const GithubAiLinter = {
           event.type === "events.iterate.com/github/webhook-received" &&
           event.source?.copiedFrom !== undefined
         ) {
+          return;
+        }
+        if (event.type === "events.iterate.com/repo/github-unlinked") {
+          linkedRepos = undefined;
           return;
         }
         using itx = await env.ITX.get();

--- a/packages/iterate/src/starter-apps/github-ai-linter/review-bot.ts
+++ b/packages/iterate/src/starter-apps/github-ai-linter/review-bot.ts
@@ -2,7 +2,7 @@
 // worker already receives every verified connection event through its normal
 // stream subscription, so this router turns each relevant webhook directly
 // into durable PR-agent facts. Stable idempotency keys collapse redeliveries.
-import type { Project, StreamEvent, StreamEventInput } from "../../sdk.ts";
+import type { GithubRepoLink, Project, StreamEvent, StreamEventInput } from "../../sdk.ts";
 import type { GithubAiLinterRules } from "./rules.ts";
 
 const pullRequestAgentPolicyVersion = "2";
@@ -23,6 +23,7 @@ export async function handleGithubPullRequestWebhook(
   itx: Project,
   event: StreamEvent,
   githubPullRequests: {
+    loadLinkedRepos?: () => Promise<LinkedGithubRepo[]>;
     loadRules: () => Promise<GithubAiLinterRules>;
     policyVersion: string;
   },
@@ -54,23 +55,6 @@ export async function handleGithubPullRequestWebhook(
     return;
   }
 
-  const repos = await itx.repos.list();
-  const linkedRepos = await Promise.all(
-    repos.map(async ({ path }) => ({
-      path,
-      route: (await itx.repos.get(path).processor.snapshot()).state.github,
-    })),
-  );
-  const linkedRepo = linkedRepos.find(
-    ({ route }) =>
-      route !== null &&
-      event.path === `/integrations/github/${route.connection}` &&
-      webhook.installationId === route.installationId &&
-      repository.id === route.repositoryId,
-  );
-  if (linkedRepo === undefined || linkedRepo.route === null) return;
-  const { path: repoPath, route } = linkedRepo;
-
   const action = webhook.body.action;
   const appSlug = webhook.appSlug;
   const author = webhook.associations.author;
@@ -99,6 +83,27 @@ export async function handleGithubPullRequestWebhook(
     ((webhook.delivery.name === "issue_comment" && action === "created") ||
       (webhook.delivery.name === "pull_request_review" && action === "submitted") ||
       (webhook.delivery.name === "pull_request_review_comment" && action === "created"));
+  const reviewLifecycleEvent =
+    webhook.delivery.name === "pull_request" &&
+    (action === "opened" || action === "ready_for_review" || action === "synchronize");
+
+  // The durable agent subscription copies all later PR history. This router
+  // only needs to act when a delivery can create or wake the agent; skipping
+  // status, edit, and thread bookkeeping here keeps a webhook burst bounded.
+  if (!reviewLifecycleEvent && !mention) return;
+
+  const linkedRepos =
+    (await githubPullRequests.loadLinkedRepos?.()) ?? (await loadLinkedGithubRepos(itx));
+  const linkedRepo = linkedRepos.find(
+    ({ route }) =>
+      route !== null &&
+      event.path === `/integrations/github/${route.connection}` &&
+      webhook.installationId === route.installationId &&
+      repository.id === route.repositoryId,
+  );
+  if (linkedRepo === undefined || linkedRepo.route === null) return;
+  const { path: repoPath, route } = linkedRepo;
+
   const agentPath = `/agents${repoPath}/pr/${number}`;
   const agent = itx.agents.get(agentPath);
   const exists =
@@ -266,3 +271,18 @@ type GithubWebhookPayload = {
   delivery: { id: string; name: string };
   installationId: string;
 };
+
+export type LinkedGithubRepo = {
+  path: string;
+  route: GithubRepoLink | null;
+};
+
+export async function loadLinkedGithubRepos(itx: Project): Promise<LinkedGithubRepo[]> {
+  const repos = await itx.repos.list();
+  return await Promise.all(
+    repos.map(async ({ path }) => ({
+      path,
+      route: (await itx.repos.get(path).processor.snapshot()).state.github,
+    })),
+  );
+}


### PR DESCRIPTION
## What changed
- ignore webhook deliveries that cannot create or wake a PR agent
- cache the linked-repository routing table in the project worker
- invalidate that cache when a GitHub link is configured

## Why
A real production webhook burst left `project-worker` at offset 1363 with repeated `itx expression project-worker timed out after 20000ms`. The batch repeatedly listed and snapshotted every linked repo for status/edit/thread events that the PR agent already receives through its durable subscription. This keeps the direct path bounded without bringing back the hosted review-bot machinery.

## Verification
- config-repo GitHub routing tests: 17 passed
- GithubAiLinter tests: 2 passed
- packages/iterate typecheck
- apps/os typecheck (including config template)
- repository lint and focused format check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which webhook deliveries drive direct agent work versus subscription-only history; incorrect early filtering could skip wakes, though lifecycle and mention gates are explicit and covered by tests.
> 
> **Overview**
> Stops the GitHub PR webhook router from listing and snapshotting every linked repo on deliveries that cannot create or wake a PR agent. **`handleGithubPullRequestWebhook`** now returns early unless the event is a **`pull_request`** lifecycle action (`opened`, `ready_for_review`, `synchronize`) or a trusted app mention with a non-empty body; status, edits, thread resolution, and invalid mentions no longer trigger **`loadLinkedGithubRepos`**.
> 
> The **GithubAiLinter** project worker caches the linked-repository routing table and passes **`loadLinkedRepos`** into the handler; the cache is cleared on **`repo/github-link-configured`** and **`repo/github-unlinked`**. **`loadLinkedGithubRepos`** is exported for that reuse.
> 
> Tests now assert that contributor mentions, absent comment bodies, and **`pull_request_review_thread`** resolution do not call **`repoList`** or append agent events, since the durable PR-agent subscription already copies later webhook history.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99665a85f782f6c0b089fbe25f0b351d552c5e02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-28T23:30:52.182Z",
      "deployedAt": "2026-07-28T23:23:30.098Z",
      "headSha": "99665a85f782f6c0b089fbe25f0b351d552c5e02",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/85247442632924",
      "shortSha": "99665a8",
      "cleanupDurationMs": 10973,
      "deployDurationMs": 49563,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 48451,
      "deployReadinessDurationMs": 1109,
      "deployedWorkerName": "os-preview-5",
      "deployedWorkerVersion": "1d7cedff-8c58-4227-9da1-c2a5de14d887",
      "testDurationMs": 289415,
      "testRetries": "1 retried: the consecutive-failure limit survives stream eviction and halts before mass-skipping (vitest x1) — Timed out waiting for failing event 2 to be retried, confirmed, and skipped",
      "workerSizeKib": 19897.75,
      "workerGzipKib": 5024.12,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5035.22
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-28T23:30:44.145Z",
      "deployedAt": "2026-07-28T23:23:01.696Z",
      "headSha": "99665a85f782f6c0b089fbe25f0b351d552c5e02",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/85247442632924",
      "shortSha": "99665a8",
      "cleanupDurationMs": 2933,
      "deployDurationMs": 20348,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 20046,
      "deployReadinessDurationMs": 297,
      "deployedWorkerName": "auth-preview-5",
      "deployedWorkerVersion": "32df8e3e-94ed-4f11-af26-3fc3621bb6b5",
      "testDurationMs": 10206,
      "testRetries": null,
      "workerSizeKib": 3976.81,
      "workerGzipKib": 814,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-28T23:30:41.805Z",
      "deployedAt": "2026-07-28T23:15:08.134Z",
      "headSha": "99665a85f782f6c0b089fbe25f0b351d552c5e02",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/85247442632924",
      "shortSha": "99665a8",
      "cleanupDurationMs": 591,
      "deployDurationMs": 56,
      "deployConfigDurationMs": 5,
      "deployReuseProofDurationMs": 18,
      "deployedWorkerName": "dummy-petshop-preview-5",
      "deployedWorkerVersion": "e676e6c7-d3a1-4916-bcbc-199ad641a553",
      "testDurationMs": 11115,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `99665a8` | [https://auth.iterate-preview-5.com](https://auth.iterate-preview-5.com) | 814.0 KiB | 20.3s | 10.2s |  | 2.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/85247442632924) | 2026-07-28T23:30:44.145Z | Preview app released. |
| Dummy Petshop | released | `99665a8` | [https://dummy-petshop.iterate-preview-5.com](https://dummy-petshop.iterate-preview-5.com) | 198.3 KiB | 56ms | 11.1s |  | 591ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/85247442632924) | 2026-07-28T23:30:41.805Z | Preview app released. |
| OS | released | `99665a8` | [https://os.iterate-preview-5.com](https://os.iterate-preview-5.com) | 4.91 MiB (-11.1 KiB vs main) | 49.6s | 289.4s | 1 retried: the consecutive-failure limit survives stream eviction and halts before mass-skipping (vitest x1) — Timed out waiting for failing event 2 to be retried, confirmed, and skipped | 11.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/85247442632924) | 2026-07-28T23:30:52.182Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +52 -20 | +37 -18 🟩🟩🟩🟥🟥 |
| Tests | +7 -7 | +7 -7 🟩⬜⬜⬜⬜ |
| **Total** | **+59 -27** | **+44 -25** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between ed3eea2 and 99665a8, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->