### PR TITLE
Filter GitHub bursts before opening ITX

### DIFF
--- a/packages/iterate/src/starter-apps/github-ai-linter/github-ai-linter.test.ts
+++ b/packages/iterate/src/starter-apps/github-ai-linter/github-ai-linter.test.ts
@@ -54,7 +54,24 @@ test("the project worker handles verified GitHub webhooks directly", async () =>
     },
   });
 
-  await app.processEvent(event("events.iterate.com/github/webhook-received"));
+  await app.processEvent({
+    ...event("events.iterate.com/github/webhook-received"),
+    payload: {
+      associations: {},
+      body: { action: "completed" },
+      delivery: { name: "check_run" },
+    },
+  });
+  expect(get).toHaveBeenCalledTimes(1);
+
+  await app.processEvent({
+    ...event("events.iterate.com/github/webhook-received"),
+    payload: {
+      associations: {},
+      body: { action: "opened" },
+      delivery: { name: "pull_request" },
+    },
+  });
   expect(get).toHaveBeenCalledTimes(2);
   expect(dispose).toHaveBeenCalledTimes(2);
 });

--- a/packages/iterate/src/starter-apps/github-ai-linter/index.ts
+++ b/packages/iterate/src/starter-apps/github-ai-linter/index.ts
@@ -33,6 +33,12 @@ export const GithubAiLinter = {
           linkedRepos = undefined;
           return;
         }
+        if (
+          event.type === "events.iterate.com/github/webhook-received" &&
+          !mightWakePullRequestAgent(event)
+        ) {
+          return;
+        }
         using itx = await env.ITX.get();
         if (event.type === "events.iterate.com/repo/github-link-configured") {
           linkedRepos = undefined;
@@ -51,6 +57,29 @@ export const GithubAiLinter = {
     };
   },
 };
+
+function mightWakePullRequestAgent(event: StreamEvent): boolean {
+  // The platform created this envelope after signature verification. This
+  // deliberately stays a loose prefilter; the handler below performs the
+  // complete authorization and payload validation after an ITX session opens.
+  const webhook = event.payload as
+    | {
+        associations?: { mentionedUsers?: unknown[] };
+        body?: { action?: unknown };
+        delivery?: { name?: unknown };
+      }
+    | undefined;
+  const name = webhook?.delivery?.name;
+  const action = webhook?.body?.action;
+  return (
+    (name === "pull_request" &&
+      (action === "opened" || action === "ready_for_review" || action === "synchronize")) ||
+    ((name === "issue_comment" ||
+      name === "pull_request_review" ||
+      name === "pull_request_review_comment") &&
+      (webhook?.associations?.mentionedUsers?.length ?? 0) > 0)
+  );
+}
 
 async function retireHostedReviewBot(itx: Project, connection: string): Promise<void> {
   const stream = itx.streams.get(`/integrations/github/${connection}`);


### PR DESCRIPTION
## What

- reject webhook types that cannot create or wake a PR agent before opening an ITX session
- retain the full authorization and payload validation inside the existing handler
- prove an irrelevant check-run opens no project session while a PR-open delivery still does

## Production evidence

The restored `iterate` GitHub connection had 400 queued source events after the first batching fix deployed. Of 365 webhook events, only 16 were PR lifecycle or mention candidates, but the `project-worker` still timed out at 20 seconds because the prefilter ran after `env.ITX.get()`. This moves that same coarse gate across the session boundary; no event is skipped from the durable source cursor.

## Proof

- focused Vitest: 2 passed
- `packages/iterate` typecheck
- targeted oxlint: 0 warnings / 0 errors
- targeted oxfmt check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Early filtering could drop webhooks if the prefilter diverges from handler logic, but scope is limited to the github-ai-linter worker and full validation still runs after ITX opens.
> 
> **Overview**
> Moves a **coarse webhook prefilter** ahead of `env.ITX.get()` in the GitHub AI linter project worker so bursts of irrelevant GitHub deliveries (e.g. `check_run`) no longer open an ITX session or hit the 20s worker timeout.
> 
> The new `mightWakePullRequestAgent` gate only allows webhooks that might create or wake a PR agent: `pull_request` with `opened`, `ready_for_review`, or `synchronize`, or comment/review events with `mentionedUsers`. Full authorization and payload checks still run inside `handleGithubPullRequestWebhook` after a session opens.
> 
> Tests now send explicit `check_run` and `pull_request` payloads and assert `ITX.get` is not invoked for the irrelevant delivery while a PR-open webhook still opens a session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fda14b80c25139af3bc8fc7c9e7e00c4753b9036. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +29 -0 | +20 -0 🟩🟩🟩🟩🟩 |
| Tests | +18 -1 | +17 -1 🟩🟩🟩🟩🟩 |
| **Total** | **+47 -1** | **+37 -1** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between f76b46b and fda14b8, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-28T23:49:50.323Z",
      "deployedAt": "2026-07-28T23:44:02.922Z",
      "headSha": "fda14b80c25139af3bc8fc7c9e7e00c4753b9036",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-19.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/466685901674081",
      "shortSha": "fda14b8",
      "cleanupDurationMs": 15123,
      "deployDurationMs": 63790,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 62400,
      "deployReadinessDurationMs": 1386,
      "deployedWorkerName": "os-preview-19",
      "deployedWorkerVersion": "8b79c14e-7da7-469f-a429-54d2eed3b0d3",
      "testDurationMs": 206710,
      "testRetries": null,
      "workerSizeKib": 19899.32,
      "workerGzipKib": 5024.6,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5035.9
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-28T23:49:38.074Z",
      "deployedAt": "2026-07-28T23:43:23.892Z",
      "headSha": "fda14b80c25139af3bc8fc7c9e7e00c4753b9036",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-19.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/466685901674081",
      "shortSha": "fda14b8",
      "cleanupDurationMs": 2871,
      "deployDurationMs": 23894,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 23367,
      "deployReadinessDurationMs": 523,
      "deployedWorkerName": "auth-preview-19",
      "deployedWorkerVersion": "745d8420-96ce-4609-a46f-337f2a505daa",
      "testDurationMs": 12557,
      "testRetries": null,
      "workerSizeKib": 3976.81,
      "workerGzipKib": 814,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-28T23:49:35.770Z",
      "deployedAt": "2026-07-28T23:43:06.935Z",
      "headSha": "fda14b80c25139af3bc8fc7c9e7e00c4753b9036",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-19.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/466685901674081",
      "shortSha": "fda14b8",
      "cleanupDurationMs": 566,
      "deployDurationMs": 6617,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 6358,
      "deployReadinessDurationMs": 203,
      "deployedWorkerName": "dummy-petshop-preview-19",
      "deployedWorkerVersion": "525b127a-8fd2-4bc2-8580-647c98190197",
      "testDurationMs": 34100,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `fda14b8` | [https://auth.iterate-preview-19.com](https://auth.iterate-preview-19.com) | 814.0 KiB | 23.9s | 12.6s |  | 2.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/466685901674081) | 2026-07-28T23:49:38.074Z | Preview app released. |
| Dummy Petshop | released | `fda14b8` | [https://dummy-petshop.iterate-preview-19.com](https://dummy-petshop.iterate-preview-19.com) | 198.3 KiB | 6.6s | 34.1s |  | 566ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/466685901674081) | 2026-07-28T23:49:35.770Z | Preview app released. |
| OS | released | `fda14b8` | [https://os.iterate-preview-19.com](https://os.iterate-preview-19.com) | 4.91 MiB (-11.3 KiB vs main) | 63.8s | 206.7s |  | 15.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/466685901674081) | 2026-07-28T23:49:50.323Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->