### PR TITLE
Pin GitHub rules without parallel clones

### DIFF
--- a/packages/iterate/src/starter-apps/github-ai-linter/rules.test.ts
+++ b/packages/iterate/src/starter-apps/github-ai-linter/rules.test.ts
@@ -4,23 +4,26 @@ import { loadGithubAiLinterRules } from "./rules.ts";
 test("the linter reads only configured rule files", async () => {
   const calls: Array<{ method: string; value: string }> = [];
   const repo = {
-    readFile: async ({ path }: { path: string }) => {
-      calls.push({ method: "readFile", value: path });
+    readFile: async ({ commitOid, path }: { commitOid?: string; path: string }) => {
+      calls.push({ method: "readFile", value: `${commitOid ?? "HEAD"}:${path}` });
+      const id = path.startsWith("rules/structure/")
+        ? "structure/no-lame-helpers"
+        : "typescript/no-inferable-type-annotation";
       return {
         commitOid: "abc123",
         path,
         content: [
           "---",
-          "id: typescript/no-inferable-type-annotation",
+          `id: ${id}`,
           "files:",
           "  [",
           '    "**/*.{ts,tsx,mts,cts}",',
           '    "!**/*.test.ts",',
           "  ]",
           "---",
-          "# Do not annotate inferable types",
+          `# ${id}`,
           "",
-          "Do not declare a type annotation that TypeScript can infer from the value.",
+          `Apply ${id}.`,
         ].join("\n"),
       };
     },
@@ -28,24 +31,32 @@ test("the linter reads only configured rule files", async () => {
   const itx = { repos: { get: (path: string) => (path === "/repos/iterate" ? repo : null) } };
 
   const rules = await loadGithubAiLinterRules(itx as any, {
-    paths: ["rules/typescript/no-inferable-type-annotation.md"],
+    paths: [
+      "rules/typescript/no-inferable-type-annotation.md",
+      "rules/structure/no-lame-helpers.md",
+    ],
     repoPath: "/repos/iterate",
   });
 
   expect(calls).toEqual([
     {
       method: "readFile",
-      value: "rules/typescript/no-inferable-type-annotation.md",
+      value: "HEAD:rules/structure/no-lame-helpers.md",
+    },
+    {
+      method: "readFile",
+      value: "abc123:rules/typescript/no-inferable-type-annotation.md",
     },
   ]);
   expect(rules).toEqual({
+    "structure/no-lame-helpers": {
+      files: ["**/*.{ts,tsx,mts,cts}", "!**/*.test.ts"],
+      invariant: "# structure/no-lame-helpers\n\nApply structure/no-lame-helpers.",
+    },
     "typescript/no-inferable-type-annotation": {
       files: ["**/*.{ts,tsx,mts,cts}", "!**/*.test.ts"],
-      invariant: [
-        "# Do not annotate inferable types",
-        "",
-        "Do not declare a type annotation that TypeScript can infer from the value.",
-      ].join("\n"),
+      invariant:
+        "# typescript/no-inferable-type-annotation\n\nApply typescript/no-inferable-type-annotation.",
     },
   });
 });

--- a/packages/iterate/src/starter-apps/github-ai-linter/rules.ts
+++ b/packages/iterate/src/starter-apps/github-ai-linter/rules.ts
@@ -21,7 +21,10 @@ const RuleMetadata = z.object({
 type RulesProject = {
   repos: {
     get(path: string): {
-      readFile(input: { path: string }): Promise<{ content: string } | null>;
+      readFile(input: {
+        commitOid?: string;
+        path: string;
+      }): Promise<{ commitOid: string; content: string } | null>;
     };
   };
 };
@@ -36,12 +39,22 @@ export async function loadGithubAiLinterRules(
     throw new Error(`GitHub AI linter has no configured rule paths for ${source.repoPath}`);
   }
 
-  const rules: GithubAiLinterRules = {};
-  for (const path of paths) {
-    const file = await repo.readFile({ path });
+  const firstPath = paths[0]!;
+  const firstFile = await repo.readFile({ path: firstPath });
+  if (firstFile === null) {
+    throw new Error(`GitHub AI linter rule does not exist: ${source.repoPath}:${firstPath}`);
+  }
+  const files = [[firstPath, firstFile] as const];
+  for (const path of paths.slice(1)) {
+    const file = await repo.readFile({ commitOid: firstFile.commitOid, path });
     if (file === null) {
       throw new Error(`GitHub AI linter rule does not exist: ${source.repoPath}:${path}`);
     }
+    files.push([path, file] as const);
+  }
+
+  const rules: GithubAiLinterRules = {};
+  for (const [path, file] of files) {
     const rule = parseGithubAiLinterRule(path, file.content);
     if (Object.hasOwn(rules, rule.id)) {
       throw new Error(`Duplicate GitHub AI linter rule id "${rule.id}" in ${path}`);


### PR DESCRIPTION
Follow-up to #2326 and its final review thread.

The first explicit rule path is read through the lazy HEAD lane and supplies the commit oid. Remaining rule files are then read sequentially at that exact commit. This preserves one coherent policy snapshot without concurrent full-tree materialization.

Production benchmark on the intended small `/repos/config` source:

- six files read sequentially at one commit
- 1,373 ms total
- maximum single pinned read 772 ms

Validation: focused tests (3 passed), packages/iterate typecheck, targeted oxlint and oxfmt.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to rule file loading in the github-ai-linter starter app; no auth or production data paths touched.
> 
> **Overview**
> **Rule loading now pins all configured rule files to a single Git commit** instead of reading each path independently at HEAD.
> 
> `loadGithubAiLinterRules` reads the first sorted rule path via `readFile` without `commitOid` (HEAD lane), uses the returned `commitOid`, then loads every other path sequentially with that oid. The repo `readFile` contract now accepts optional `commitOid` and always returns `commitOid` with content.
> 
> Tests assert the HEAD-first read and pinned follow-up reads, and cover multiple rule paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7a45a905a1bf8184fd9caf2a77e2b6e4dd29f0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +17 -4 | +12 -3 🟩🟩⬜⬜⬜ |
| Tests | +23 -12 | +23 -12 🟩🟩🟩🟥🟥 |
| **Total** | **+40 -16** | **+35 -15** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between ee2ef13 and b7a45a9, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T00:20:30.690Z",
      "deployedAt": "2026-07-29T00:14:09.917Z",
      "headSha": "b7a45a905a1bf8184fd9caf2a77e2b6e4dd29f0d",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/472763641324211",
      "shortSha": "b7a45a9",
      "cleanupDurationMs": 11016,
      "deployDurationMs": 82326,
      "deployConfigDurationMs": 1,
      "deployCommandDurationMs": 81272,
      "deployReadinessDurationMs": 1051,
      "deployedWorkerName": "os-preview-9",
      "deployedWorkerVersion": "3d693d20-1157-4b5b-b0e4-c528ae509a68",
      "testDurationMs": 207492,
      "testRetries": null,
      "workerSizeKib": 19899.49,
      "workerGzipKib": 5024.65,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5035.86
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T00:20:22.820Z",
      "deployedAt": "2026-07-29T00:13:16.086Z",
      "headSha": "b7a45a905a1bf8184fd9caf2a77e2b6e4dd29f0d",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/472763641324211",
      "shortSha": "b7a45a9",
      "cleanupDurationMs": 3143,
      "deployDurationMs": 27738,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 27438,
      "deployReadinessDurationMs": 297,
      "deployedWorkerName": "auth-preview-9",
      "deployedWorkerVersion": "9f4e96aa-0618-4b16-a92c-17eb7535606d",
      "testDurationMs": 11255,
      "testRetries": null,
      "workerSizeKib": 3976.81,
      "workerGzipKib": 814.05,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T00:20:20.920Z",
      "deployedAt": "2026-07-29T00:12:56.115Z",
      "headSha": "b7a45a905a1bf8184fd9caf2a77e2b6e4dd29f0d",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/472763641324211",
      "shortSha": "b7a45a9",
      "cleanupDurationMs": 1241,
      "deployDurationMs": 7677,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 7425,
      "deployReadinessDurationMs": 206,
      "deployedWorkerName": "dummy-petshop-preview-9",
      "deployedWorkerVersion": "8034bf6d-d112-4885-90a5-d21f8c5652b7",
      "testDurationMs": 23198,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `b7a45a9` | [https://auth.iterate-preview-9.com](https://auth.iterate-preview-9.com) | 814.0 KiB | 27.7s | 11.3s |  | 3.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/472763641324211) | 2026-07-29T00:20:22.820Z | Preview app released. |
| Dummy Petshop | released | `b7a45a9` | [https://dummy-petshop.iterate-preview-9.com](https://dummy-petshop.iterate-preview-9.com) | 198.3 KiB | 7.7s | 23.2s |  | 1.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/472763641324211) | 2026-07-29T00:20:20.920Z | Preview app released. |
| OS | released | `b7a45a9` | [https://os.iterate-preview-9.com](https://os.iterate-preview-9.com) | 4.91 MiB (-11.2 KiB vs main) | 82.3s | 207.5s |  | 11.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/472763641324211) | 2026-07-29T00:20:30.690Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->