### PR TITLE
Keep clone-skew loader replacements

### DIFF
--- a/apps/os/src/domains/workers/worker-loader.serve.test.ts
+++ b/apps/os/src/domains/workers/worker-loader.serve.test.ts
@@ -380,6 +380,39 @@ describe("resolveWorkerSource", () => {
     ]);
   });
 
+  test("keeps using a clone-skew replacement instead of returning to the stale loader", async () => {
+    const resolved = sourceFrom(
+      await resolveWorkerSource({
+        projectId: "prj_replacement",
+        source: {
+          createWorker: {
+            files: { files: { "main.js": "export default {};" }, type: "inline" },
+          },
+        },
+      }),
+    );
+    const load = (freshInstanceNonce?: string) =>
+      loadResolvedWorker({
+        bindings: {},
+        freshInstanceNonce,
+        globalOutbound: {} as Fetcher,
+        projectId: "prj_replacement",
+        resolved,
+        scopePath: "/",
+        streamContext: { kind: "scope", scopePath: "/" },
+      });
+
+    load();
+    load("replacement-1");
+    load();
+
+    expect(h.state.loaderCalls.map(({ key }) => key)).toEqual([
+      expect.stringMatching(/:shared$/),
+      expect.stringMatching(/:replacement-1$/),
+      expect.stringMatching(/:replacement-1$/),
+    ]);
+  });
+
   test("does not reuse stream-context-bound workers across script executions", async () => {
     const resolved = sourceFrom(
       await resolveWorkerSource({

--- a/apps/os/src/domains/workers/worker-loader.ts
+++ b/apps/os/src/domains/workers/worker-loader.ts
@@ -37,6 +37,8 @@ export type WorkerBindings = Record<string, unknown>;
 
 const resolvedArtifactMemo = new Map<string, ResolvedWorkerSource>();
 const RESOLVED_ARTIFACT_MEMO_LIMIT = 64;
+const replacementLoaderNonceMemo = new Map<string, string>();
+const REPLACEMENT_LOADER_NONCE_MEMO_LIMIT = 64;
 
 export async function resolveWorkerSource({
   buildBudgetMs,
@@ -214,7 +216,7 @@ export function loadResolvedWorker({
   // "Unable to deserialize cloned data due to invalid or unsupported version".
   // Build artifacts remain content-addressed and shared; only the cheap
   // loaded isolate is deployment-scoped.
-  const cacheKey = [
+  const loaderIdentity = [
     "worker-loader",
     env.WORKER_SELF,
     workerVersion(env),
@@ -222,7 +224,21 @@ export function loadResolvedWorker({
     scopePath,
     JSON.stringify(StreamContext.parse(streamContext)),
     resolved.cacheKey,
-    freshInstanceNonce ?? "shared",
+  ].join(":");
+  if (freshInstanceNonce) {
+    // Clone-version recovery proved the shared loader for this exact identity
+    // stale. Keep using the successful replacement instead of falling back to
+    // the same broken cache hit on every subsequent event batch.
+    replacementLoaderNonceMemo.delete(loaderIdentity);
+    if (replacementLoaderNonceMemo.size >= REPLACEMENT_LOADER_NONCE_MEMO_LIMIT) {
+      const oldest = replacementLoaderNonceMemo.keys().next().value;
+      if (oldest !== undefined) replacementLoaderNonceMemo.delete(oldest);
+    }
+    replacementLoaderNonceMemo.set(loaderIdentity, freshInstanceNonce);
+  }
+  const cacheKey = [
+    loaderIdentity,
+    freshInstanceNonce || replacementLoaderNonceMemo.get(loaderIdentity) || "shared",
   ].join(":");
   return env.LOADER.get(cacheKey, () => ({
     compatibilityDate: resolved.wranglerConfig?.compatibilityDate ?? WORKER_COMPATIBILITY_DATE,


### PR DESCRIPTION
## Summary
- remember the fresh Worker Loader identity used after clone-version skew
- reuse that bounded replacement for later calls instead of returning to the known-stale shared loader
- cap replacement identities alongside the existing artifact memo

## Why
Production recovery proved the one-shot retry succeeds, but every subsequent project-config event returned to the stale shared loader and emitted another clone-version warning. This makes recovery durable within the current worker isolate while deployments and source changes still produce distinct loader identities.

## Testing
- `pnpm --dir apps/os exec vitest run src/domains/workers/worker-loader.serve.test.ts src/domains/workers/worker-runner.test.ts`
- `pnpm --dir apps/os typecheck`
- `pnpm exec oxfmt --check apps/os/src/domains/workers/worker-loader.ts apps/os/src/domains/workers/worker-loader.serve.test.ts`
- `pnpm exec oxlint apps/os/src/domains/workers/worker-loader.ts apps/os/src/domains/workers/worker-loader.serve.test.ts --deny-warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes worker loader caching in the OS isolate; bounded memo only affects loader key selection after proven skew, but incorrect memo logic could pin wrong isolates or leak entries until the cap evicts them.
> 
> **Overview**
> After workerd clone-version skew, a one-shot `freshInstanceNonce` retry could succeed, but later `loadResolvedWorker` calls without a nonce went back to the stale **shared** loader and kept failing.
> 
> `loadResolvedWorker` now keeps a bounded in-process memo (`replacementLoaderNonceMemo`) keyed by loader identity (deployment, project, scope, stream context, artifact). When recovery passes a `freshInstanceNonce`, that nonce is stored and reused on subsequent loads until identity changes (rollout, source change, etc.).
> 
> A serve test asserts the third load still uses `:replacement-1` instead of `:shared`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f17256f4fe8ee6056a17192e574110403a9321c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +18 -2 | +15 -2 🟩🟩🟩⬜⬜ |
| Tests | +33 -0 | +30 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+51 -2** | **+45 -2** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 579d406 and 1f17256, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T00:58:14.996Z",
      "deployedAt": "2026-07-29T00:53:11.142Z",
      "headSha": "1f17256f4fe8ee6056a17192e574110403a9321c",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/352654656113179",
      "shortSha": "1f17256",
      "cleanupDurationMs": 11415,
      "deployDurationMs": 70253,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 70212,
      "deployReadinessDurationMs": 39,
      "deployedWorkerName": "os-preview-13",
      "deployedWorkerVersion": "a13f2c91-9a2f-4b88-bff9-9aec8818ffd3",
      "testDurationMs": 216965,
      "testRetries": null,
      "workerSizeKib": 19900.05,
      "workerGzipKib": 5024.64,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5035.89
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T00:58:07.118Z",
      "deployedAt": "2026-07-29T00:52:17.080Z",
      "headSha": "1f17256f4fe8ee6056a17192e574110403a9321c",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/352654656113179",
      "shortSha": "1f17256",
      "cleanupDurationMs": 3534,
      "deployDurationMs": 16481,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 16145,
      "deployReadinessDurationMs": 330,
      "deployedWorkerName": "auth-preview-13",
      "deployedWorkerVersion": "508c43fe-5be8-4b9b-88d7-87dbfeff11da",
      "testDurationMs": 10555,
      "testRetries": null,
      "workerSizeKib": 3976.81,
      "workerGzipKib": 814.1,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T00:58:04.415Z",
      "deployedAt": "2026-07-29T00:46:06.774Z",
      "headSha": "1f17256f4fe8ee6056a17192e574110403a9321c",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/352654656113179",
      "shortSha": "1f17256",
      "cleanupDurationMs": 829,
      "deployDurationMs": 86,
      "deployConfigDurationMs": 7,
      "deployReuseProofDurationMs": 39,
      "deployedWorkerName": "dummy-petshop-preview-13",
      "deployedWorkerVersion": "95e80b88-0bae-45f3-86a0-03ac3d49f882",
      "testDurationMs": 5129,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-29T00:58:04.338Z",
      "deployedAt": "2026-07-29T00:52:16.811Z",
      "headSha": "1f17256f4fe8ee6056a17192e574110403a9321c",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/352654656113179",
      "shortSha": "1f17256",
      "cleanupDurationMs": 749,
      "deployDurationMs": 16051,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 15878,
      "deployReadinessDurationMs": 168,
      "deployedWorkerName": "semaphore-preview-13",
      "deployedWorkerVersion": "09843408-e838-4a8a-a47c-bc2ce1611aef",
      "testDurationMs": 56048,
      "testRetries": null,
      "workerSizeKib": 1915.51,
      "workerGzipKib": 441.11,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-29T00:58:14.788Z",
      "deployedAt": "2026-07-29T00:52:17.065Z",
      "headSha": "1f17256f4fe8ee6056a17192e574110403a9321c",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/352654656113179",
      "shortSha": "1f17256",
      "cleanupDurationMs": 11196,
      "deployDurationMs": 16777,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 16129,
      "deployReadinessDurationMs": 642,
      "deployedWorkerName": "streams-example-app-preview-13",
      "deployedWorkerVersion": "90efa94f-b42a-4452-8af4-a37119028a77",
      "testDurationMs": 84731,
      "testRetries": null,
      "workerSizeKib": 5233.85,
      "workerGzipKib": 1483.41,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `1f17256` | [https://auth.iterate-preview-13.com](https://auth.iterate-preview-13.com) | 814.1 KiB | 16.5s | 10.6s |  | 3.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/352654656113179) | 2026-07-29T00:58:07.118Z | Preview app released. |
| Dummy Petshop | released | `1f17256` | [https://dummy-petshop.iterate-preview-13.com](https://dummy-petshop.iterate-preview-13.com) | 198.3 KiB | 86ms | 5.1s |  | 829ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/352654656113179) | 2026-07-29T00:58:04.415Z | Preview app released. |
| OS | released | `1f17256` | [https://os.iterate-preview-13.com](https://os.iterate-preview-13.com) | 4.91 MiB (-11.3 KiB vs main) | 70.3s | 217.0s |  | 11.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/352654656113179) | 2026-07-29T00:58:14.996Z | Preview app released. |
| Semaphore | released | `1f17256` | [https://semaphore.iterate-preview-13.com](https://semaphore.iterate-preview-13.com) | 441.1 KiB | 16.1s | 56.0s |  | 749ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/352654656113179) | 2026-07-29T00:58:04.338Z | Preview app released. |
| Streams Example App | released | `1f17256` | [https://streams.iterate-preview-13.com](https://streams.iterate-preview-13.com) | 1.45 MiB | 16.8s | 84.7s |  | 11.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/352654656113179) | 2026-07-29T00:58:14.788Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->