### PR TITLE
Scope dynamic loaders to parent isolates

### DIFF
--- a/apps/os/src/domains/workers/worker-loader.serve.test.ts
+++ b/apps/os/src/domains/workers/worker-loader.serve.test.ts
@@ -380,7 +380,7 @@ describe("resolveWorkerSource", () => {
     ]);
   });
 
-  test("keeps using a clone-skew replacement instead of returning to the stale loader", async () => {
+  test("scopes the loader to its parent isolate and keeps a clone-skew replacement", async () => {
     const resolved = sourceFrom(
       await resolveWorkerSource({
         projectId: "prj_replacement",
@@ -406,11 +406,11 @@ describe("resolveWorkerSource", () => {
     load("replacement-1");
     load();
 
-    expect(h.state.loaderCalls.map(({ key }) => key)).toEqual([
-      expect.stringMatching(/:shared$/),
-      expect.stringMatching(/:replacement-1$/),
-      expect.stringMatching(/:replacement-1$/),
-    ]);
+    const [initial, replacement, reusedReplacement] = h.state.loaderCalls.map(({ key }) => key);
+    expect(initial).toMatch(/:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    expect(initial).not.toMatch(/:shared$/);
+    expect(replacement).toMatch(/:replacement-1$/);
+    expect(reusedReplacement).toBe(replacement);
   });
 
   test("does not reuse stream-context-bound workers across script executions", async () => {

--- a/apps/os/src/domains/workers/worker-loader.ts
+++ b/apps/os/src/domains/workers/worker-loader.ts
@@ -37,6 +37,10 @@ export type WorkerBindings = Record<string, unknown>;
 
 const resolvedArtifactMemo = new Map<string, ResolvedWorkerSource>();
 const RESOLVED_ARTIFACT_MEMO_LIMIT = 64;
+// Worker Loader isolates retain the loopback RPC bindings supplied by the
+// parent isolate that created them. This is initialized lazily because Workers
+// forbids random-value generation in module-global execution.
+let parentIsolateLoaderNonce: string | undefined;
 const replacementLoaderNonceMemo = new Map<string, string>();
 const REPLACEMENT_LOADER_NONCE_MEMO_LIMIT = 64;
 
@@ -209,13 +213,14 @@ export function loadResolvedWorker({
   scopePath: string;
   streamContext: StreamContext;
 }): WorkerStub {
-  // Loader isolates capture the parent deployment's loopback RPC bindings.
-  // They must not survive an OS rollout: a hit created by the previous
-  // version can only speak that version of workerd's cloned-data protocol,
-  // and crossing it from the new parent fails with
+  // Loader isolates capture the parent isolate's loopback RPC bindings.
+  // They must not survive that isolate, including a Durable Object eviction
+  // within one deployment: crossing the orphaned bindings from the next
+  // parent fails with
   // "Unable to deserialize cloned data due to invalid or unsupported version".
-  // Build artifacts remain content-addressed and shared; only the cheap
-  // loaded isolate is deployment-scoped.
+  // Build artifacts remain content-addressed and shared; only the cheap loaded
+  // isolate is parent-scoped. The deployment id still keeps identities easy
+  // to attribute and guarantees separation across a rollout.
   const loaderIdentity = [
     "worker-loader",
     env.WORKER_SELF,
@@ -238,7 +243,9 @@ export function loadResolvedWorker({
   }
   const cacheKey = [
     loaderIdentity,
-    freshInstanceNonce || replacementLoaderNonceMemo.get(loaderIdentity) || "shared",
+    freshInstanceNonce ||
+      replacementLoaderNonceMemo.get(loaderIdentity) ||
+      (parentIsolateLoaderNonce ??= crypto.randomUUID()),
   ].join(":");
   return env.LOADER.get(cacheKey, () => ({
     compatibilityDate: resolved.wranglerConfig?.compatibilityDate ?? WORKER_COMPATIBILITY_DATE,


### PR DESCRIPTION
## Summary

- give each parent Worker isolate its own lazy loader nonce
- retain the existing one-shot clone-skew replacement within that isolate
- prevent a newly-woken Durable Object incarnation from reusing a dynamic Worker that captured the previous isolate's loopback RPC bindings

## Production evidence

The deployed version from #2328 still emitted the same clone-version retry every ~20 seconds from the same Stream Durable Object IDs. The replacement memo was module-local, so it disappeared whenever Cloudflare woke the object in a new isolate while the global Worker Loader cache continued returning the old dynamic Worker.

This changes the normal loader key from `shared` to a nonce initialized on first request in the current parent isolate. Build artifacts remain content-addressed; only the cheap loaded isolate is parent-scoped.

## Testing

- `pnpm --dir apps/os exec vitest run src/domains/workers/worker-loader.serve.test.ts src/domains/workers/worker-runner.test.ts`
- `pnpm --dir apps/os typecheck`
- focused oxfmt and oxlint checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Worker Loader caching in the dynamic worker / Stream Durable Object path, which is production-critical runtime infrastructure, but the change is narrowly scoped to isolate binding safety with existing replacement behavior preserved.
> 
> **Overview**
> Fixes **dynamic Worker Loader cache keys** so a newly awakened parent isolate (e.g. after Durable Object eviction) does not reuse a loader isolate that still holds **loopback RPC bindings from the previous parent**, which caused recurring clone-deserialization errors in production.
> 
> In `loadResolvedWorker`, the default loader cache suffix changes from a global `:shared` key to a **lazy per-parent-isolate nonce** (`parentIsolateLoaderNonce`, initialized on first load via `crypto.randomUUID()`). **Build artifacts stay content-addressed and shared**; only the cheap loaded isolate is parent-scoped. Deployment version in `loaderIdentity` still separates rollouts. The existing **clone-skew replacement** path (`freshInstanceNonce` / `replacementLoaderNonceMemo`) is unchanged and still wins over the parent nonce on later loads.
> 
> Tests rename and tighten expectations: the first load key must end with a UUID, not `:shared`, and a successful replacement is reused on the third load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf509f6bc95fb778a565940d46f278ea3b2de084. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +14 -7 | +4 -1 🟩🟩⬜⬜⬜ |
| Tests | +6 -6 | +6 -6 🟩🟩🟩🟥🟥 |
| **Total** | **+20 -13** | **+10 -7** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between a5b85d4 and bf509f6, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T01:31:04.084Z",
      "deployedAt": "2026-07-29T01:25:12.623Z",
      "headSha": "bf509f6bc95fb778a565940d46f278ea3b2de084",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/506155984823076",
      "shortSha": "bf509f6",
      "cleanupDurationMs": 12801,
      "deployDurationMs": 64398,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 62607,
      "deployReadinessDurationMs": 1789,
      "deployedWorkerName": "os-preview-17",
      "deployedWorkerVersion": "007963ad-957d-449b-967b-19b49a6d1908",
      "testDurationMs": 223469,
      "testRetries": null,
      "workerSizeKib": 19900.12,
      "workerGzipKib": 5024.79,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5035.71
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T01:30:54.246Z",
      "deployedAt": "2026-07-29T01:24:29.267Z",
      "headSha": "bf509f6bc95fb778a565940d46f278ea3b2de084",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/506155984823076",
      "shortSha": "bf509f6",
      "cleanupDurationMs": 2960,
      "deployDurationMs": 19534,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 19248,
      "deployReadinessDurationMs": 283,
      "deployedWorkerName": "auth-preview-17",
      "deployedWorkerVersion": "b7d81a18-b10e-44c0-9f49-a23cc8ef63b5",
      "testDurationMs": 10199,
      "testRetries": null,
      "workerSizeKib": 3976.81,
      "workerGzipKib": 814.13,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T01:30:51.887Z",
      "deployedAt": "2026-07-29T01:24:15.953Z",
      "headSha": "bf509f6bc95fb778a565940d46f278ea3b2de084",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/506155984823076",
      "shortSha": "bf509f6",
      "cleanupDurationMs": 600,
      "deployDurationMs": 6134,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 5890,
      "deployReadinessDurationMs": 197,
      "deployedWorkerName": "dummy-petshop-preview-17",
      "deployedWorkerVersion": "27a2dfdd-3d60-4e1c-9bcc-fe92e2df7512",
      "testDurationMs": 34756,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `bf509f6` | [https://auth.iterate-preview-17.com](https://auth.iterate-preview-17.com) | 814.1 KiB | 19.5s | 10.2s |  | 3.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/506155984823076) | 2026-07-29T01:30:54.246Z | Preview app released. |
| Dummy Petshop | released | `bf509f6` | [https://dummy-petshop.iterate-preview-17.com](https://dummy-petshop.iterate-preview-17.com) | 198.3 KiB | 6.1s | 34.8s |  | 600ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/506155984823076) | 2026-07-29T01:30:51.887Z | Preview app released. |
| OS | released | `bf509f6` | [https://os.iterate-preview-17.com](https://os.iterate-preview-17.com) | 4.91 MiB (-10.9 KiB vs main) | 64.4s | 223.5s |  | 12.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/506155984823076) | 2026-07-29T01:31:04.084Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->