### PR TITLE
Scope dynamic loaders to runner lifetimes

### DIFF
--- a/apps/os/src/domains/workers/worker-loader.serve.test.ts
+++ b/apps/os/src/domains/workers/worker-loader.serve.test.ts
@@ -336,6 +336,7 @@ describe("resolveWorkerSource", () => {
     loadResolvedWorker({
       bindings: {},
       globalOutbound: {} as Fetcher,
+      loaderInstanceNonce: "runner-1",
       projectId: "prj_wrangler",
       resolved,
       scopePath: "/",
@@ -364,6 +365,7 @@ describe("resolveWorkerSource", () => {
       loadResolvedWorker({
         bindings: {},
         globalOutbound: {} as Fetcher,
+        loaderInstanceNonce: "runner-1",
         projectId: "prj_rollout",
         resolved,
         scopePath: "/",
@@ -380,7 +382,7 @@ describe("resolveWorkerSource", () => {
     ]);
   });
 
-  test("scopes the loader to its parent isolate and keeps a clone-skew replacement", async () => {
+  test("scopes loaded workers to the runner that minted their RPC bindings", async () => {
     const resolved = sourceFrom(
       await resolveWorkerSource({
         projectId: "prj_replacement",
@@ -391,26 +393,28 @@ describe("resolveWorkerSource", () => {
         },
       }),
     );
-    const load = (freshInstanceNonce?: string) =>
+    const load = (loaderInstanceNonce: string) =>
       loadResolvedWorker({
         bindings: {},
-        freshInstanceNonce,
         globalOutbound: {} as Fetcher,
+        loaderInstanceNonce,
         projectId: "prj_replacement",
         resolved,
         scopePath: "/",
         streamContext: { kind: "scope", scopePath: "/" },
       });
 
-    load();
-    load("replacement-1");
-    load();
+    load("runner-1");
+    load("runner-2");
+    load("runner-2");
 
-    const [initial, replacement, reusedReplacement] = h.state.loaderCalls.map(({ key }) => key);
-    expect(initial).toMatch(/:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
-    expect(initial).not.toMatch(/:shared$/);
-    expect(replacement).toMatch(/:replacement-1$/);
-    expect(reusedReplacement).toBe(replacement);
+    const [firstRunner, secondRunner, reusedBySecondRunner] = h.state.loaderCalls.map(
+      ({ key }) => key,
+    );
+    expect(firstRunner).toMatch(/:runner-1$/);
+    expect(secondRunner).toMatch(/:runner-2$/);
+    expect(secondRunner).not.toBe(firstRunner);
+    expect(reusedBySecondRunner).toBe(secondRunner);
   });
 
   test("does not reuse stream-context-bound workers across script executions", async () => {
@@ -428,6 +432,7 @@ describe("resolveWorkerSource", () => {
       loadResolvedWorker({
         bindings: {},
         globalOutbound: {} as Fetcher,
+        loaderInstanceNonce: "runner-1",
         projectId: "prj_context",
         resolved,
         scopePath: "/agents/refund-agent",

--- a/apps/os/src/domains/workers/worker-loader.ts
+++ b/apps/os/src/domains/workers/worker-loader.ts
@@ -37,12 +37,6 @@ export type WorkerBindings = Record<string, unknown>;
 
 const resolvedArtifactMemo = new Map<string, ResolvedWorkerSource>();
 const RESOLVED_ARTIFACT_MEMO_LIMIT = 64;
-// Worker Loader isolates retain the loopback RPC bindings supplied by the
-// parent isolate that created them. This is initialized lazily because Workers
-// forbids random-value generation in module-global execution.
-let parentIsolateLoaderNonce: string | undefined;
-const replacementLoaderNonceMemo = new Map<string, string>();
-const REPLACEMENT_LOADER_NONCE_MEMO_LIMIT = 64;
 
 export async function resolveWorkerSource({
   buildBudgetMs,
@@ -197,29 +191,29 @@ async function resolveFileSource({
 
 export function loadResolvedWorker({
   bindings,
-  freshInstanceNonce,
   globalOutbound,
+  loaderInstanceNonce,
   projectId,
   resolved,
   scopePath,
   streamContext,
 }: {
   bindings: WorkerBindings;
-  /** Force a one-off loader isolate instead of reusing the normal cache hit. */
-  freshInstanceNonce?: string;
   globalOutbound: Fetcher;
+  /** The runner lifetime that minted these loopback RPC bindings. */
+  loaderInstanceNonce: string;
   projectId: string;
   resolved: ResolvedWorkerSource;
   scopePath: string;
   streamContext: StreamContext;
 }): WorkerStub {
-  // Loader isolates capture the parent isolate's loopback RPC bindings.
-  // They must not survive that isolate, including a Durable Object eviction
-  // within one deployment: crossing the orphaned bindings from the next
-  // parent fails with
+  // Loader isolates capture this runner's loopback RPC bindings. They must not
+  // survive the runner that minted them: a stateless ingress runner lives for
+  // one request, while a Durable Object runner lives for one incarnation.
+  // Crossing orphaned bindings from a later runner fails with
   // "Unable to deserialize cloned data due to invalid or unsupported version".
   // Build artifacts remain content-addressed and shared; only the cheap loaded
-  // isolate is parent-scoped. The deployment id still keeps identities easy
+  // isolate is runner-scoped. The deployment id still keeps identities easy
   // to attribute and guarantees separation across a rollout.
   const loaderIdentity = [
     "worker-loader",
@@ -230,23 +224,7 @@ export function loadResolvedWorker({
     JSON.stringify(StreamContext.parse(streamContext)),
     resolved.cacheKey,
   ].join(":");
-  if (freshInstanceNonce) {
-    // Clone-version recovery proved the shared loader for this exact identity
-    // stale. Keep using the successful replacement instead of falling back to
-    // the same broken cache hit on every subsequent event batch.
-    replacementLoaderNonceMemo.delete(loaderIdentity);
-    if (replacementLoaderNonceMemo.size >= REPLACEMENT_LOADER_NONCE_MEMO_LIMIT) {
-      const oldest = replacementLoaderNonceMemo.keys().next().value;
-      if (oldest !== undefined) replacementLoaderNonceMemo.delete(oldest);
-    }
-    replacementLoaderNonceMemo.set(loaderIdentity, freshInstanceNonce);
-  }
-  const cacheKey = [
-    loaderIdentity,
-    freshInstanceNonce ||
-      replacementLoaderNonceMemo.get(loaderIdentity) ||
-      (parentIsolateLoaderNonce ??= crypto.randomUUID()),
-  ].join(":");
+  const cacheKey = [loaderIdentity, loaderInstanceNonce].join(":");
   return env.LOADER.get(cacheKey, () => ({
     compatibilityDate: resolved.wranglerConfig?.compatibilityDate ?? WORKER_COMPATIBILITY_DATE,
     compatibilityFlags: resolved.wranglerConfig?.compatibilityFlags ?? WORKER_COMPATIBILITY_FLAGS,

--- a/apps/os/src/domains/workers/worker-runner.test.ts
+++ b/apps/os/src/domains/workers/worker-runner.test.ts
@@ -116,6 +116,41 @@ it("gives bare fetch and scoped ITX the same host-minted invocation source", () 
   expect(h.projectEgressFetcher).toHaveBeenCalledWith(expect.anything(), "prj_private", source);
 });
 
+it("reuses a loaded worker within one runner but not across runner lifetimes", async () => {
+  h.resolveWorkerSource.mockResolvedValue({
+    ok: true,
+    source: {
+      assetConfig: undefined,
+      assetManifest: {},
+      assets: {},
+      cacheKey: "build-key",
+      commitOid: "commit-1",
+      mainModule: "worker.js",
+      modules: {},
+      wranglerConfig: undefined,
+    },
+  });
+  h.loadResolvedWorker.mockImplementation(() => ({
+    getEntrypoint: () => ({ fetch: () => Promise.resolve(new Response("ok")) }),
+  }));
+  const createRunner = () =>
+    new DynamicWorkerRunner({
+      streamContext: { kind: "scope", scopePath: inlineRef.path },
+      exports: {} as ExecutionContext["exports"],
+      projectId: "prj_private",
+      scopePath: inlineRef.path,
+    });
+  const firstRunner = createRunner();
+
+  await firstRunner.fetch({ ref: inlineRef, request: new Request("https://example.com/1") });
+  await firstRunner.fetch({ ref: inlineRef, request: new Request("https://example.com/2") });
+  await createRunner().fetch({ ref: inlineRef, request: new Request("https://example.com/3") });
+
+  const loaderNonces = h.loadResolvedWorker.mock.calls.map(([input]) => input.loaderInstanceNonce);
+  expect(loaderNonces[0]).toBe(loaderNonces[1]);
+  expect(loaderNonces[2]).not.toBe(loaderNonces[0]);
+});
+
 describe("dynamic worker spans", () => {
   it.each<{
     expectedKind: string;
@@ -276,8 +311,11 @@ it("recovers a safe stateless fetch once with a fresh loader after clone-version
 
   expect(await response.text()).toBe("recovered");
   expect(workerFetch).toHaveBeenCalledTimes(2);
-  expect(h.loadResolvedWorker.mock.calls[0]?.[0].freshInstanceNonce).toBeUndefined();
-  expect(h.loadResolvedWorker.mock.calls[1]?.[0].freshInstanceNonce).toEqual(expect.any(String));
+  const initialLoader = h.loadResolvedWorker.mock.calls[0]?.[0].loaderInstanceNonce;
+  const replacementLoader = h.loadResolvedWorker.mock.calls[1]?.[0].loaderInstanceNonce;
+  expect(initialLoader).toEqual(expect.any(String));
+  expect(replacementLoader).toEqual(expect.any(String));
+  expect(replacementLoader).not.toBe(initialLoader);
   expect(recordedSpans[0]?.attributes).toMatchObject({
     "http.response.status_code": 200,
     "iterate.worker.rpc_clone_version_retry": true,
@@ -321,8 +359,11 @@ it("recovers a stateless event batch once with a fresh loader after clone-versio
   });
 
   expect(processEventBatch).toHaveBeenCalledTimes(2);
-  expect(h.loadResolvedWorker.mock.calls[0]?.[0].freshInstanceNonce).toBeUndefined();
-  expect(h.loadResolvedWorker.mock.calls[1]?.[0].freshInstanceNonce).toEqual(expect.any(String));
+  const initialLoader = h.loadResolvedWorker.mock.calls[0]?.[0].loaderInstanceNonce;
+  const replacementLoader = h.loadResolvedWorker.mock.calls[1]?.[0].loaderInstanceNonce;
+  expect(initialLoader).toEqual(expect.any(String));
+  expect(replacementLoader).toEqual(expect.any(String));
+  expect(replacementLoader).not.toBe(initialLoader);
   expect(recordedSpans[0]?.attributes).toMatchObject({
     "iterate.worker.rpc_clone_version_retry": true,
   });

--- a/apps/os/src/domains/workers/worker-runner.ts
+++ b/apps/os/src/domains/workers/worker-runner.ts
@@ -58,6 +58,7 @@ type StatefulWorkerRpc = {
 export class DynamicWorkerRunner {
   readonly #bindings: WorkerBindings;
   readonly #globalOutbound: Fetcher;
+  #loaderInstanceNonce: string = crypto.randomUUID();
   readonly #projectId: string;
   readonly #scopePath: string;
   readonly #streamContext: StreamContext;
@@ -382,10 +383,13 @@ export class DynamicWorkerRunner {
   }
 
   #loadResolved(resolved: ResolvedWorkerSource, freshInstanceNonce?: string): WorkerStub {
+    if (freshInstanceNonce !== undefined) {
+      this.#loaderInstanceNonce = freshInstanceNonce;
+    }
     return loadResolvedWorker({
       bindings: this.#bindings,
-      freshInstanceNonce,
       globalOutbound: this.#globalOutbound,
+      loaderInstanceNonce: this.#loaderInstanceNonce,
       projectId: this.#projectId,
       resolved,
       scopePath: this.#scopePath,


### PR DESCRIPTION
## Summary

- key loaded dynamic Workers to the `DynamicWorkerRunner` that minted their loopback RPC bindings
- keep reuse within one runner, but prevent reuse across HTTP requests or Durable Object incarnations
- retain the one-shot clone-skew replacement by moving that runner to a fresh key
- delete the module-global isolate/replacement cache machinery

## Production evidence

Production version `87422825-0dda-459a-9408-3eb84a9f4954` (the isolate-scoped fix) continued emitting 11 clone-version retries after a clean baseline. They included repeated alarms from the same two Stream Durable Object IDs and a later `iterate.com` fetch. The loader therefore outlived the runner-owned `ctx.exports` bindings even when it did not outlive the JavaScript isolate.

A stateless ingress runner lives for one request; a Durable Object runner lives for one incarnation. This change makes the Worker Loader key match that binding lifetime exactly while leaving source artifacts content-addressed.

## Testing

- `pnpm --dir apps/os exec vitest run src/domains/workers/worker-loader.serve.test.ts src/domains/workers/worker-runner.test.ts` (26 passed)
- focused `oxfmt --check`
- focused `oxlint` (0 warnings, 0 errors)
- the first full local typecheck found and prompted an explicit field annotation; the corrected rerun remained CPU-bound for more than 15 minutes and was stopped, so the required CI typecheck is the authoritative full pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dynamic worker loader identity and RPC binding lifetime in production execution paths; behavior is well-covered by tests but affects core worker loading infrastructure.
> 
> **Overview**
> **Worker Loader cache keys now follow the `DynamicWorkerRunner` that minted loopback RPC bindings**, instead of a module-global parent-isolate nonce and replacement memo map.
> 
> Each `DynamicWorkerRunner` gets a `#loaderInstanceNonce` (new UUID per runner). `loadResolvedWorker` requires `loaderInstanceNonce` and builds `cacheKey` as `loaderIdentity:nonce`, so loaded isolates are reused within one runner but not across HTTP requests or Durable Object incarnations. Build artifacts stay content-addressed and shared.
> 
> **Clone-version skew recovery** still retries with a fresh loader: the runner updates `#loaderInstanceNonce` when `freshInstanceNonce` is passed from fetch/`processEventBatch` retry paths, so the replacement isolate uses a new key without global replacement caching.
> 
> Removed: `parentIsolateLoaderNonce`, `replacementLoaderNonceMemo`, and the `freshInstanceNonce` parameter on `loadResolvedWorker`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dedf24835571b95d90462307af7d2719b9afba7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +14 -32 | +7 -19 🟩🟥⬜⬜⬜ |
| Tests | +61 -15 | +58 -15 🟩🟩🟩🟩🟥 |
| **Total** | **+75 -47** | **+65 -34** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 8c3a384 and dedf248, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T02:14:45.408Z",
      "deployedAt": "2026-07-29T02:09:25.744Z",
      "headSha": "dedf24835571b95d90462307af7d2719b9afba7a",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/556390625698120",
      "shortSha": "dedf248",
      "cleanupDurationMs": 10186,
      "deployDurationMs": 78887,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 62553,
      "deployReadinessDurationMs": 16332,
      "deployedWorkerName": "os-preview-8",
      "deployedWorkerVersion": "9c7f4070-a27e-4cfb-8787-e9599a122846",
      "testDurationMs": 209342,
      "testRetries": null,
      "workerSizeKib": 19899.64,
      "workerGzipKib": 5024.79,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5036
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T02:14:37.997Z",
      "deployedAt": "2026-07-29T02:08:43.185Z",
      "headSha": "dedf24835571b95d90462307af7d2719b9afba7a",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/556390625698120",
      "shortSha": "dedf248",
      "cleanupDurationMs": 2772,
      "deployDurationMs": 20351,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 19992,
      "deployReadinessDurationMs": 355,
      "deployedWorkerName": "auth-preview-8",
      "deployedWorkerVersion": "72288b24-3922-43d2-92fc-6d641b94ca27",
      "testDurationMs": 10934,
      "testRetries": null,
      "workerSizeKib": 3976.81,
      "workerGzipKib": 814.32,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T02:14:35.863Z",
      "deployedAt": "2026-07-29T02:08:29.198Z",
      "headSha": "dedf24835571b95d90462307af7d2719b9afba7a",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/556390625698120",
      "shortSha": "dedf248",
      "cleanupDurationMs": 636,
      "deployDurationMs": 6309,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 5955,
      "deployReadinessDurationMs": 302,
      "deployedWorkerName": "dummy-petshop-preview-8",
      "deployedWorkerVersion": "be058a7e-c354-4bc2-a2b5-8a8b7790951f",
      "testDurationMs": 22182,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `dedf248` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 814.3 KiB | 20.4s | 10.9s |  | 2.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/556390625698120) | 2026-07-29T02:14:37.997Z | Preview app released. |
| Dummy Petshop | released | `dedf248` | [https://dummy-petshop.iterate-preview-8.com](https://dummy-petshop.iterate-preview-8.com) | 198.3 KiB | 6.3s | 22.2s |  | 636ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/556390625698120) | 2026-07-29T02:14:35.863Z | Preview app released. |
| OS | released | `dedf248` | [https://os.iterate-preview-8.com](https://os.iterate-preview-8.com) | 4.91 MiB (-11.2 KiB vs main) | 78.9s | 209.3s |  | 10.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/556390625698120) | 2026-07-29T02:14:45.408Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->