### PR TITLE
Dispose internal stream RPC results

### DIFF
--- a/apps/os/src/domains/streams/stream-durable-object.ts
+++ b/apps/os/src/domains/streams/stream-durable-object.ts
@@ -241,6 +241,19 @@ function rethrowItxDeliveryError(error: unknown): never {
   throw error;
 }
 
+function disposeAcknowledgedRpcResult(result: unknown, operation: string): void {
+  try {
+    disposeIgnoredRpcResult(result);
+  } catch (error) {
+    // The remote call already committed. Cleanup must stay visible without
+    // turning its acknowledgement into a retry of the same durable work.
+    console.warn("stream internal RPC result dispose failed after acknowledgement", {
+      operation,
+      error,
+    });
+  }
+}
+
 /** Build the four concrete calls used by the receiver union. */
 function createSubscriptionReceiverCalls(deps: {
   projectId: string | null;
@@ -296,7 +309,10 @@ function createSubscriptionReceiverCalls(deps: {
     },
 
     async copyToStream(path: string, batch: StreamDeliveryBatch) {
-      return deps.copyToStream(path, batch);
+      const result = await deps.copyToStream(path, batch);
+      const receipt = { acknowledged: result.acknowledged };
+      disposeAcknowledgedRpcResult(result, "copy-to-stream");
+      return receipt;
     },
 
     async deliverToWebhook(url: string, delivery: StreamWebhookDelivery) {
@@ -1115,8 +1131,9 @@ export class StreamDurableObject extends DurableObject<Env> {
     return receipt;
   }
 
-  #appendCoreEventToStreamPath(path: string, event: StreamEventInput) {
-    return this.#streamStub(path).appendCoreEvent(event);
+  async #appendCoreEventToStreamPath(path: string, event: StreamEventInput): Promise<void> {
+    const result = await this.#streamStub(path).appendCoreEvent(event);
+    disposeAcknowledgedRpcResult(result, "ancestor-core-event");
   }
 
   #runInBackground(work: () => Promise<unknown>): void {

--- a/apps/os/src/domains/streams/stream-durable-object.ts
+++ b/apps/os/src/domains/streams/stream-durable-object.ts
@@ -241,7 +241,7 @@ function rethrowItxDeliveryError(error: unknown): never {
   throw error;
 }
 
-function disposeAcknowledgedRpcResult(result: unknown, operation: string): void {
+function disposeAcknowledgedRpcResult(result: unknown, operation: string) {
   try {
     disposeIgnoredRpcResult(result);
   } catch (error) {
@@ -1131,7 +1131,7 @@ export class StreamDurableObject extends DurableObject<Env> {
     return receipt;
   }
 
-  async #appendCoreEventToStreamPath(path: string, event: StreamEventInput): Promise<void> {
+  async #appendCoreEventToStreamPath(path: string, event: StreamEventInput) {
     const result = await this.#streamStub(path).appendCoreEvent(event);
     disposeAcknowledgedRpcResult(result, "ancestor-core-event");
   }


### PR DESCRIPTION
## Summary

- dispose copy-delivery RPC results after detaching their acknowledgement
- dispose ancestor-stream append results after the durable call commits
- keep cleanup failures observable without retrying already-committed stream work

## Why

Production telemetry on OS version 850c4906-fcda-4447-a13e-46984035f657 showed retained Cap n Web stubs in StreamDurableObject.receiveCopiedEvents and appendCoreEvent during normal restored-project GitHub and Slack traffic. These were the two ignored native Durable Object RPC results.

## Verification

- pnpm exec oxfmt --check apps/os/src/domains/streams/stream-durable-object.ts
- pnpm exec oxlint apps/os/src/domains/streams/stream-durable-object.ts --threads 1 --deny-warnings
- pnpm --dir apps/os exec vitest run src/domains/streams/stream-durable-object-background-work.test.ts src/domains/streams/stream-durable-object-copy-recovery.test.ts src/domains/streams/stream-event-sender.test.ts (66 passed)
- pnpm --dir apps/os typecheck

After merge I will deploy the exact merge commit and repeat the production GitHub, Slack, copied-stream, ancestor-announcement, telemetry, and stream-state proofs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal stream DO RPC lifecycle only; committed work is explicitly not retried on dispose failure, which reduces leak risk without changing delivery semantics.
> 
> **Overview**
> Fixes **retained Cap'n Web RPC stubs** on internal stream Durable Object calls by disposing ignored RPC results once the remote side has already committed.
> 
> Adds **`disposeAcknowledgedRpcResult`**, which calls `disposeIgnoredRpcResult` but only **logs a warning** if cleanup fails so a dispose error cannot be treated as a failed delivery and **retry already-committed** copy or ancestor work.
> 
> **Copy-to-stream** delivery now strips the native RPC return to `{ acknowledged }` and disposes the full result after the copy commits. **Ancestor announcements** (`#appendCoreEventToStreamPath`) dispose the `appendCoreEvent` RPC result the same way after the append succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef788ee86b10957b2e6a60b6cd5286158e01241b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +20 -3 | +17 -3 🟩🟩🟩🟩🟥 |
| **Total** | **+20 -3** | **+17 -3** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between c905c6a and ef788ee, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T02:45:13.631Z",
      "deployedAt": "2026-07-29T02:40:22.181Z",
      "headSha": "ef788ee86b10957b2e6a60b6cd5286158e01241b",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-16.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/281077592286330",
      "shortSha": "ef788ee",
      "cleanupDurationMs": 11950,
      "deployDurationMs": 51383,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 50381,
      "deployReadinessDurationMs": 999,
      "deployedWorkerName": "os-preview-16",
      "deployedWorkerVersion": "60f359ff-72ec-4012-9d85-24f698c98633",
      "testDurationMs": 199272,
      "testRetries": null,
      "workerSizeKib": 19900.08,
      "workerGzipKib": 5024.88,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5035.85
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T02:45:04.775Z",
      "deployedAt": "2026-07-29T02:39:47.133Z",
      "headSha": "ef788ee86b10957b2e6a60b6cd5286158e01241b",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-16.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/281077592286330",
      "shortSha": "ef788ee",
      "cleanupDurationMs": 3091,
      "deployDurationMs": 15830,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 15330,
      "deployReadinessDurationMs": 494,
      "deployedWorkerName": "auth-preview-16",
      "deployedWorkerVersion": "e19560b0-d4fe-4784-84fc-0eee7f3922e2",
      "testDurationMs": 9816,
      "testRetries": null,
      "workerSizeKib": 3976.81,
      "workerGzipKib": 813.88,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-29T02:45:09.569Z",
      "deployedAt": "2026-07-29T02:39:44.084Z",
      "headSha": "ef788ee86b10957b2e6a60b6cd5286158e01241b",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-16.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/281077592286330",
      "shortSha": "ef788ee",
      "cleanupDurationMs": 7884,
      "deployDurationMs": 18525,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 12280,
      "deployReadinessDurationMs": 6240,
      "deployedWorkerName": "streams-example-app-preview-16",
      "deployedWorkerVersion": "3ce6b07c-eacf-4756-9fcf-34cb3e00f785",
      "testDurationMs": 105925,
      "testRetries": null,
      "workerSizeKib": 5233.88,
      "workerGzipKib": 1483.42,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T02:45:02.322Z",
      "deployedAt": "2026-07-29T02:34:26.029Z",
      "headSha": "ef788ee86b10957b2e6a60b6cd5286158e01241b",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-16.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/281077592286330",
      "shortSha": "ef788ee",
      "cleanupDurationMs": 634,
      "deployDurationMs": 56,
      "deployConfigDurationMs": 7,
      "deployReuseProofDurationMs": 11,
      "deployedWorkerName": "dummy-petshop-preview-16",
      "deployedWorkerVersion": "52d62695-44a6-44d3-a56b-2e52d56a0da3",
      "testDurationMs": 5330,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `ef788ee` | [https://auth.iterate-preview-16.com](https://auth.iterate-preview-16.com) | 813.9 KiB | 15.8s | 9.8s |  | 3.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/281077592286330) | 2026-07-29T02:45:04.775Z | Preview app released. |
| Dummy Petshop | released | `ef788ee` | [https://dummy-petshop.iterate-preview-16.com](https://dummy-petshop.iterate-preview-16.com) | 198.3 KiB | 56ms | 5.3s |  | 634ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/281077592286330) | 2026-07-29T02:45:02.322Z | Preview app released. |
| OS | released | `ef788ee` | [https://os.iterate-preview-16.com](https://os.iterate-preview-16.com) | 4.91 MiB (-11.0 KiB vs main) | 51.4s | 199.3s |  | 11.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/281077592286330) | 2026-07-29T02:45:13.631Z | Preview app released. |
| Streams Example App | released | `ef788ee` | [https://streams.iterate-preview-16.com](https://streams.iterate-preview-16.com) | 1.45 MiB | 18.5s | 105.9s |  | 7.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/281077592286330) | 2026-07-29T02:45:09.569Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->