### PR TITLE
Dispose project stream RPC results

### DIFF
--- a/apps/os/src/domains/streams/itx-project-stream-sdk.test.ts
+++ b/apps/os/src/domains/streams/itx-project-stream-sdk.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { itxProjectStream, type StreamEvent } from "iterate/sdk";
+
+describe("itxProjectStream", () => {
+  it("detaches and disposes an appendIfStreamId result obtained through the project stub", async () => {
+    const event = {
+      createdAt: new Date(0).toISOString(),
+      offset: 1,
+      path: "/events",
+      type: "events.iterate.com/test/sdk-rpc-result",
+    } satisfies StreamEvent;
+    const result = [{ ...event }];
+    const disposeResult = vi.fn();
+    const disposeProject = vi.fn();
+    Object.defineProperty(result, Symbol.dispose, { value: disposeResult });
+    const project = {
+      streams: {
+        get: () => ({
+          appendIfStreamId: async () => result,
+        }),
+      },
+      [Symbol.dispose]: disposeProject,
+    };
+    const stream = itxProjectStream(
+      {
+        ITERATE_WORKER_VERSION: "test",
+        ITX: {
+          fetch: vi.fn(),
+          get: async () => project,
+        },
+      } as never,
+      "/events",
+    );
+
+    const committed = await stream.appendIfStreamId({
+      streamId: "760f1ba4-3429-47ce-bfa9-eb52214fb699",
+      events: [event],
+    });
+
+    expect(committed).toEqual([event]);
+    expect(committed).not.toBe(result);
+    expect(Reflect.has(committed, Symbol.dispose)).toBe(false);
+    expect(disposeResult).toHaveBeenCalledOnce();
+    expect(disposeProject).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/iterate/src/sdk.ts
+++ b/packages/iterate/src/sdk.ts
@@ -216,6 +216,32 @@ async function withProject<T>(env: IterateEnv, fn: (project: Project) => Promise
 }
 
 /**
+ * Detach plain data returned by Workers RPC before releasing the per-call
+ * result capability. Disposing the project root does not release values
+ * obtained through it; each stream call owns its own result reference.
+ */
+function detachPlainRpcResult<T>(result: T): T {
+  if (result === null || (typeof result !== "object" && typeof result !== "function")) {
+    return result;
+  }
+  // ProcessorStream returns JSON-shaped data only. Workers RPC adds a hidden
+  // disposer that is absent from the generated data types; a shallow spread
+  // preserves that data and drops the capability, but TypeScript cannot prove
+  // that the generic spread still has T's exact shape.
+  const detached = Array.isArray(result) ? [...result] : { ...result };
+  Reflect.deleteProperty(detached, Symbol.dispose);
+  try {
+    const dispose = Reflect.get(result, Symbol.dispose);
+    if (typeof dispose === "function") Reflect.apply(dispose, result, []);
+  } catch (error) {
+    // The plain data is already detached and the remote operation succeeded.
+    // Keep cleanup failure visible without rewriting that outcome as failure.
+    console.warn("project stream RPC result dispose failed after detaching plain data", { error });
+  }
+  return detached as T;
+}
+
+/**
  * A view of `target` with `overrides` in front and everything else passed
  * through. Proxies (not spreads or Object.create) because DurableObjectState
  * and DurableObjectStorage are host objects: their methods must be invoked
@@ -244,7 +270,7 @@ function overlay<T extends object>(target: T, overrides: Record<PropertyKey, unk
  */
 export function itxProjectStream(env: IterateEnv, path: string): ProcessorStream {
   const withStream = <T>(fn: (streams: Project["streams"]) => Promise<T>): Promise<T> =>
-    withProject(env, (project) => fn(project.streams));
+    withProject(env, (project) => fn(project.streams)).then(detachPlainRpcResult);
   return {
     append: (...events) => withStream((streams) => streams.get(path).append(...events)),
     appendIfStreamId: (args) => withStream((streams) => streams.get(path).appendIfStreamId(args)),
@@ -262,7 +288,7 @@ export function itxProjectStream(env: IterateEnv, path: string): ProcessorStream
             project,
           }));
           const { pager } = await opened;
-          return await pager.next();
+          return detachPlainRpcResult(await pager.next());
         },
         [Symbol.dispose]() {
           closed = true;


### PR DESCRIPTION
## Summary
- detach plain stream results returned through userspace `env.ITX` before releasing their per-call Workers RPC capability
- cover the restored-project `appendIfStreamId` path with one focused regression test
- apply the same ownership rule to paged stream reads

## Production evidence
After restoring production, Cloudflare logged an undisposed RPC stub for Misha project `prj_83f23927d3b043dda5591dcf706ea6b9` on `StreamDurableObject.appendIfStreamId` (request `523R9ZKE5HFKR3HO`). The server-side DO result was already detached, but the SDK adapter disposed only the project root; Workers RPC values obtained through that root own separate references.

## Verification
- `pnpm --dir apps/os exec vitest run src/domains/streams/itx-project-stream-sdk.test.ts --reporter=default`
- `pnpm exec oxfmt --check packages/iterate/src/sdk.ts apps/os/src/domains/streams/itx-project-stream-sdk.test.ts`
- `pnpm exec oxlint packages/iterate/src/sdk.ts apps/os/src/domains/streams/itx-project-stream-sdk.test.ts`
- `pnpm --dir packages/iterate run typecheck`
- `pnpm --dir apps/os run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes RPC lifecycle for all ITX stream reads/writes in dynamic workers; behavior should match data but incorrect dispose handling could affect resource cleanup under load.
> 
> **Overview**
> Fixes undisposed Workers RPC stubs when stream operations return data through `env.ITX` by **detaching** plain JSON-shaped results before releasing each call’s hidden `Symbol.dispose` capability.
> 
> Adds `detachPlainRpcResult` in `packages/iterate/src/sdk.ts`: shallow copy of arrays/objects, strip the RPC disposer from the copy, invoke dispose on the original stub, and return detached data. **`itxProjectStream`** now runs this on every `withStream` return and on each **`readEvents` pager `next()`** batch, not only when disposing the project root.
> 
> Adds a regression test in `apps/os` for **`appendIfStreamId`** through a mocked project stub, asserting callers get detached data, per-result dispose runs, and the project stub is still disposed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4672242c7b1a0944c75a4168c84020f782c5c961. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +28 -2 | +16 -2 🟩🟩⬜⬜⬜ |
| Tests | +46 -0 | +43 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+74 -2** | **+59 -2** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between b0d7d1f and 4672242, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T03:09:56.246Z",
      "deployedAt": "2026-07-29T03:04:45.839Z",
      "headSha": "4672242c7b1a0944c75a4168c84020f782c5c961",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/345304690963990",
      "shortSha": "4672242",
      "cleanupDurationMs": 11956,
      "deployDurationMs": 137552,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 76358,
      "deployReadinessDurationMs": 61192,
      "deployedWorkerName": "os-preview-3",
      "deployedWorkerVersion": "b129b8a1-6a68-444d-abc3-c3b45961c96b",
      "testDurationMs": 147898,
      "testRetries": null,
      "workerSizeKib": 19900.08,
      "workerGzipKib": 5024.88,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5035.99
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T03:09:48.223Z",
      "deployedAt": "2026-07-29T03:03:44.987Z",
      "headSha": "4672242c7b1a0944c75a4168c84020f782c5c961",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/345304690963990",
      "shortSha": "4672242",
      "cleanupDurationMs": 3931,
      "deployDurationMs": 15558,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 15501,
      "deployReadinessDurationMs": 52,
      "deployedWorkerName": "auth-preview-3",
      "deployedWorkerVersion": "d4806e0e-1596-4d25-9b9f-f0e6257d7f70",
      "testDurationMs": 9623,
      "testRetries": null,
      "workerSizeKib": 3976.81,
      "workerGzipKib": 814.23,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-29T03:09:52.702Z",
      "deployedAt": "2026-07-29T03:03:43.078Z",
      "headSha": "4672242c7b1a0944c75a4168c84020f782c5c961",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/345304690963990",
      "shortSha": "4672242",
      "cleanupDurationMs": 8408,
      "deployDurationMs": 20357,
      "deployConfigDurationMs": 7,
      "deployCommandDurationMs": 13590,
      "deployReadinessDurationMs": 6759,
      "deployedWorkerName": "streams-example-app-preview-3",
      "deployedWorkerVersion": "46ead729-93f6-4eb5-adbc-56ab85707d3c",
      "testDurationMs": 53301,
      "testRetries": null,
      "workerSizeKib": 5233.88,
      "workerGzipKib": 1483.42,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T03:09:45.243Z",
      "deployedAt": "2026-07-29T03:03:43.104Z",
      "headSha": "4672242c7b1a0944c75a4168c84020f782c5c961",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/345304690963990",
      "shortSha": "4672242",
      "cleanupDurationMs": 948,
      "deployDurationMs": 13647,
      "deployConfigDurationMs": 8,
      "deployCommandDurationMs": 13584,
      "deployReadinessDurationMs": 24,
      "deployedWorkerName": "dummy-petshop-preview-3",
      "deployedWorkerVersion": "badb00f9-ac3d-4e17-a0e7-9597c306525f",
      "testDurationMs": 9360,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-29T03:09:45.324Z",
      "deployedAt": "2026-07-29T03:03:48.249Z",
      "headSha": "4672242c7b1a0944c75a4168c84020f782c5c961",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/345304690963990",
      "shortSha": "4672242",
      "cleanupDurationMs": 1026,
      "deployDurationMs": 18814,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 18764,
      "deployReadinessDurationMs": 45,
      "deployedWorkerName": "semaphore-preview-3",
      "deployedWorkerVersion": "4a51f3f4-7415-4ee3-a38b-0331f4f64955",
      "testDurationMs": 17674,
      "testRetries": null,
      "workerSizeKib": 1915.51,
      "workerGzipKib": 441.11,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `4672242` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 814.2 KiB | 15.6s | 9.6s |  | 3.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/345304690963990) | 2026-07-29T03:09:48.223Z | Preview app released. |
| Dummy Petshop | released | `4672242` | [https://dummy-petshop.iterate-preview-3.com](https://dummy-petshop.iterate-preview-3.com) | 198.3 KiB | 13.6s | 9.4s |  | 948ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/345304690963990) | 2026-07-29T03:09:45.243Z | Preview app released. |
| OS | released | `4672242` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 4.91 MiB (-11.1 KiB vs main) | 137.6s | 147.9s |  | 12.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/345304690963990) | 2026-07-29T03:09:56.246Z | Preview app released. |
| Semaphore | released | `4672242` | [https://semaphore.iterate-preview-3.com](https://semaphore.iterate-preview-3.com) | 441.1 KiB | 18.8s | 17.7s |  | 1.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/345304690963990) | 2026-07-29T03:09:45.324Z | Preview app released. |
| Streams Example App | released | `4672242` | [https://streams.iterate-preview-3.com](https://streams.iterate-preview-3.com) | 1.45 MiB | 20.4s | 53.3s |  | 8.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/345304690963990) | 2026-07-29T03:09:52.702Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->