### PR TITLE
Retry safe stateful worker fetches after deploy resets

### DIFF
--- a/apps/os/src/domains/workers/worker-runner.test.ts
+++ b/apps/os/src/domains/workers/worker-runner.test.ts
@@ -322,6 +322,42 @@ it("recovers a safe stateless fetch once with a fresh loader after clone-version
   });
 });
 
+it("replays one safe stateful fetch after its hosting Durable Object resets", async () => {
+  const reset = Object.assign(new Error("Durable Object reset because its code was updated."), {
+    durableObjectReset: true,
+  });
+  h.statefulFetch.mockRejectedValueOnce(reset).mockResolvedValueOnce(new Response("recovered"));
+  const info = vi.spyOn(console, "info").mockImplementation(() => undefined);
+  const runner = new DynamicWorkerRunner({
+    streamContext: { kind: "scope", scopePath: statefulRef.path },
+    exports: {} as ExecutionContext["exports"],
+    projectId: "prj_private",
+    scopePath: statefulRef.path,
+  });
+
+  const response = await runner.fetch({
+    ref: statefulRef,
+    request: new Request("https://example.com/"),
+  });
+
+  expect(await response.text()).toBe("recovered");
+  expect(h.statefulFetch).toHaveBeenCalledTimes(2);
+  expect(info).toHaveBeenCalledWith(
+    "Stateful worker fetch retrying after Durable Object unavailability",
+    {
+      error: reset,
+      projectId: "prj_private",
+      rayId: undefined,
+      traceRole: undefined,
+    },
+  );
+  expect(recordedSpans[0]?.attributes).toMatchObject({
+    "http.response.status_code": 200,
+    "iterate.worker.durable_object_availability_retry": true,
+  });
+  info.mockRestore();
+});
+
 it("recovers a stateless event batch once with a fresh loader after clone-version skew", async () => {
   const processEventBatch = vi
     .fn()

--- a/apps/os/src/domains/workers/worker-runner.ts
+++ b/apps/os/src/domains/workers/worker-runner.ts
@@ -4,6 +4,7 @@ import { itxEntrypointBinding, itxEntrypointProps } from "../itx/utils.ts";
 import type { StreamContext } from "../projects/stream-context.ts";
 import { projectEgressFetcher } from "../projects/utils.ts";
 import { DurableObjectNameCodec } from "../durable-object-names.ts";
+import { isDurableObjectLifecycleError } from "../streams/stream-unavailable.ts";
 import { invokePreferringFlattenedPath, replayPath } from "../capability-host/live-capability.ts";
 import { WorkerBuildFailedError, type WorkerBuildFailure } from "./artifact-store.ts";
 import type {
@@ -222,7 +223,6 @@ export class DynamicWorkerRunner {
       };
 
       const retryRequest =
-        ref.type === "stateless" &&
         !isWebSocketUpgradeRequest(request) &&
         (request.method === "GET" || request.method === "HEAD")
           ? // Cloudflare's clone() widens the Request metadata generics even
@@ -233,20 +233,35 @@ export class DynamicWorkerRunner {
       try {
         response = await dispatch(request);
       } catch (error) {
-        if (
-          retryRequest === undefined ||
-          !(error instanceof Error) ||
-          !error.message.includes(WORKERS_RPC_CLONE_VERSION_ERROR)
+        if (retryRequest && ref.type === "stateful" && isDurableObjectLifecycleError(error)) {
+          span.setAttribute("iterate.worker.durable_object_availability_retry", true);
+          console.info("Stateful worker fetch retrying after Durable Object unavailability", {
+            error,
+            projectId: this.#projectId,
+            rayId: request.headers.get("cf-ray") ?? undefined,
+            traceRole,
+          });
+          // GET/HEAD are safe to replay. A deploy, eviction, or temporary
+          // platform fault may retire the hosting DO between dispatch and
+          // response; the second lookup reaches a fresh incarnation, and a
+          // second failure remains terminal.
+          response = await dispatch(retryRequest);
+        } else if (
+          retryRequest &&
+          ref.type === "stateless" &&
+          error instanceof Error &&
+          error.message.includes(WORKERS_RPC_CLONE_VERSION_ERROR)
         ) {
+          span.setAttribute("iterate.worker.rpc_clone_version_retry", true);
+          console.warn("Workers RPC clone-version skew; retrying stateless fetch once", {
+            projectId: this.#projectId,
+            rayId: request.headers.get("cf-ray") ?? undefined,
+            traceRole,
+          });
+          response = await dispatch(retryRequest, crypto.randomUUID());
+        } else {
           throw error;
         }
-        span.setAttribute("iterate.worker.rpc_clone_version_retry", true);
-        console.warn("Workers RPC clone-version skew; retrying stateless fetch once", {
-          projectId: this.#projectId,
-          rayId: request.headers.get("cf-ray") ?? undefined,
-          traceRole,
-        });
-        response = await dispatch(retryRequest, crypto.randomUUID());
       }
       span.setAttribute("http.response.status_code", response.status);
       return response;


### PR DESCRIPTION
A production GET to guestbook.iterate.com crossed a StatefulWorkerDurableObject code-update reset and fell through to the generic project serve error page.

This replays exactly one GET/HEAD fetch when workerd explicitly flags a Durable Object lifecycle failure. POSTs, WebSockets, application failures, and a second lifecycle failure remain terminal.

Validation:
- focused worker-runner test: 16/16
- oxfmt
- oxlint
- apps/os typecheck (including config template)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request routing and retry behavior on the worker fetch path for stateful DOs; scope is limited to one safe GET/HEAD replay and reuses established lifecycle error detection.
> 
> **Overview**
> **Stateful dynamic worker `fetch`** now replays **one** cloned **GET/HEAD** when dispatch fails with a **Durable Object lifecycle** error (e.g. code-update reset during deploy), using the existing `isDurableObjectLifecycleError` helper. That addresses production cases where a safe read crossed a hosting DO reset and surfaced as a generic serve error.
> 
> **POST**, **WebSocket upgrades**, and a **second** lifecycle failure stay **terminal**. Observability adds an info log and span attribute `iterate.worker.durable_object_availability_retry`.
> 
> The existing **stateless** Workers RPC clone-version fetch retry is unchanged in behavior but folded into the same retry branch structure (still one retry with a fresh loader nonce for stateless only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8523ebf87c9efbdbc04416918e198f6be647be5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +27 -12 | +23 -12 🟩🟩🟩🟥🟥 |
| Tests | +36 -0 | +33 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+63 -12** | **+56 -12** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between ab639d8 and c8523eb, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T03:29:34.822Z",
      "deployedAt": "2026-07-29T03:24:39.659Z",
      "headSha": "c8523ebf87c9efbdbc04416918e198f6be647be5",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/454391648970527",
      "shortSha": "c8523eb",
      "cleanupDurationMs": 11270,
      "deployDurationMs": 60939,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 59794,
      "deployReadinessDurationMs": 1142,
      "deployedWorkerName": "os-preview-1",
      "deployedWorkerVersion": "65739ebe-d7c3-4a40-a3eb-825b1197ed08",
      "testDurationMs": 207536,
      "testRetries": "1 retried: agent runs an itx script that appends a proof event, then replies (vitest x1) — expected [ 'stream/created', …(31) ] to include 'capability-host/script-run-settled'",
      "workerSizeKib": 19900.55,
      "workerGzipKib": 5025.46,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5035.9
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T03:29:27.492Z",
      "deployedAt": "2026-07-29T03:23:55.039Z",
      "headSha": "c8523ebf87c9efbdbc04416918e198f6be647be5",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/454391648970527",
      "shortSha": "c8523eb",
      "cleanupDurationMs": 3937,
      "deployDurationMs": 15485,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 15169,
      "deployReadinessDurationMs": 309,
      "deployedWorkerName": "auth-preview-1",
      "deployedWorkerVersion": "442696fc-8ac9-4155-839a-c4bee609334f",
      "testDurationMs": 2903,
      "testRetries": null,
      "workerSizeKib": 3976.81,
      "workerGzipKib": 814.05,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T03:29:24.502Z",
      "deployedAt": "2026-07-29T03:15:19.601Z",
      "headSha": "c8523ebf87c9efbdbc04416918e198f6be647be5",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/454391648970527",
      "shortSha": "c8523eb",
      "cleanupDurationMs": 946,
      "deployDurationMs": 90,
      "deployConfigDurationMs": 7,
      "deployReuseProofDurationMs": 45,
      "deployedWorkerName": "dummy-petshop-preview-1",
      "deployedWorkerVersion": "7010062e-1fd6-4733-b656-3d160dd19327",
      "testDurationMs": 5393,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-29T03:29:24.529Z",
      "deployedAt": "2026-07-29T03:23:52.434Z",
      "headSha": "c8523ebf87c9efbdbc04416918e198f6be647be5",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/454391648970527",
      "shortSha": "c8523eb",
      "cleanupDurationMs": 971,
      "deployDurationMs": 12755,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 12565,
      "deployReadinessDurationMs": 185,
      "deployedWorkerName": "semaphore-preview-1",
      "deployedWorkerVersion": "1e3d12eb-81c3-49e4-86c1-067eda6bccee",
      "testDurationMs": 54578,
      "testRetries": null,
      "workerSizeKib": 1915.51,
      "workerGzipKib": 441.11,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-29T03:29:30.847Z",
      "deployedAt": "2026-07-29T03:23:51.910Z",
      "headSha": "c8523ebf87c9efbdbc04416918e198f6be647be5",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/454391648970527",
      "shortSha": "c8523eb",
      "cleanupDurationMs": 7286,
      "deployDurationMs": 17333,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 12039,
      "deployReadinessDurationMs": 5288,
      "deployedWorkerName": "streams-example-app-preview-1",
      "deployedWorkerVersion": "e9888552-0400-41f8-9f0f-b06a6ee1edae",
      "testDurationMs": 92731,
      "testRetries": null,
      "workerSizeKib": 5234.31,
      "workerGzipKib": 1483.53,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `c8523eb` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 814.0 KiB | 15.5s | 2.9s |  | 3.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/454391648970527) | 2026-07-29T03:29:27.492Z | Preview app released. |
| Dummy Petshop | released | `c8523eb` | [https://dummy-petshop.iterate-preview-1.com](https://dummy-petshop.iterate-preview-1.com) | 198.3 KiB | 90ms | 5.4s |  | 946ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/454391648970527) | 2026-07-29T03:29:24.502Z | Preview app released. |
| OS | released | `c8523eb` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 4.91 MiB (-10.4 KiB vs main) | 60.9s | 207.5s | 1 retried: agent runs an itx script that appends a proof event, then replies (vitest x1) — expected [ 'stream/created', …(31) ] to include 'capability-host/script-run-settled' | 11.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/454391648970527) | 2026-07-29T03:29:34.822Z | Preview app released. |
| Semaphore | released | `c8523eb` | [https://semaphore.iterate-preview-1.com](https://semaphore.iterate-preview-1.com) | 441.1 KiB | 12.8s | 54.6s |  | 971ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/454391648970527) | 2026-07-29T03:29:24.529Z | Preview app released. |
| Streams Example App | released | `c8523eb` | [https://streams.iterate-preview-1.com](https://streams.iterate-preview-1.com) | 1.45 MiB | 17.3s | 92.7s |  | 7.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/454391648970527) | 2026-07-29T03:29:30.847Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->