### PR TITLE
Dispose one-shot ITX audit RPC resources

### DIFF
--- a/apps/os/scripts/itx.ts
+++ b/apps/os/scripts/itx.ts
@@ -65,16 +65,17 @@ export async function run(options: RunOptions) {
         initialConnectionRetryOptions(),
       )
     : await connectItxReady(connection, initialConnectionRetryOptions());
-  const result = await script(itx, vars, RpcTarget).catch((error: unknown) => {
+  let result: unknown;
+  try {
+    result = await script(itx, vars, RpcTarget);
+  } catch (error) {
     process.stderr.write(formatScriptError(error));
-    process.exit(1);
-  });
+    process.exitCode = 1;
+    return;
+  }
 
   // Exactly one JSON document on stdout — scripts and the e2e suite parse it.
   process.stdout.write(`${JSON.stringify(result ?? null, null, 2)}\n`);
-
-  // The Cap'n Web WebSocket would otherwise keep the process alive.
-  process.exit(0);
 }
 
 /**

--- a/apps/os/src/domains/streams/stream-processor-rpc-target.test.ts
+++ b/apps/os/src/domains/streams/stream-processor-rpc-target.test.ts
@@ -87,6 +87,7 @@ describe("StreamRpcTarget", () => {
     const waitDispose = vi.fn();
     const processorStateDispose = vi.fn();
     const runtimeStateDispose = vi.fn();
+    const runtimeStateStubDispose = vi.fn();
     Object.defineProperty(appended, Symbol.dispose, { value: appendDispose });
     Object.defineProperty(read, Symbol.dispose, { enumerable: true, value: readDispose });
     Object.defineProperty(page, Symbol.dispose, { value: pageDispose });
@@ -96,14 +97,16 @@ describe("StreamRpcTarget", () => {
 
     class TestStreamRpcTarget extends StreamRpcTarget {
       override get [STREAM_DURABLE_OBJECT_STUB]() {
-        return {
+        const stub = {
           append: async () => appended,
           getEvent: async () => read,
           getEvents: async () => page,
           getProcessorRuntimeState: async () => processorState,
           runtimeState: async () => runtimeState,
           waitForEvent: async () => waited,
-        } as never;
+        };
+        Object.defineProperty(stub, Symbol.dispose, { value: runtimeStateStubDispose });
+        return stub as never;
       }
     }
     const stream = new TestStreamRpcTarget({
@@ -140,6 +143,7 @@ describe("StreamRpcTarget", () => {
     expect(waitDispose).toHaveBeenCalledOnce();
     expect(processorStateDispose).toHaveBeenCalledOnce();
     expect(runtimeStateDispose).toHaveBeenCalledOnce();
+    expect(runtimeStateStubDispose).toHaveBeenCalledOnce();
   });
 
   it("preserves a successful plain-data result when native disposal throws", async () => {

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -859,9 +859,22 @@ export class StreamRpcTarget extends IterateRpcTarget<"Stream"> {
    * sampling); live debug surfaces should subscribe through `liveState`.
    */
   async runtimeState(): Promise<StreamRuntimeDebugState> {
-    const result = await this.#read("runtimeState", () =>
-      Promise.resolve(this[STREAM_DURABLE_OBJECT_STUB].runtimeState()),
-    ).catch(rethrowStreamUnavailable);
+    const result = await this.#read("runtimeState", async () => {
+      const stub = this[STREAM_DURABLE_OBJECT_STUB];
+      try {
+        return await stub.runtimeState();
+      } finally {
+        try {
+          disposeIgnoredRpcResult(stub);
+        } catch (error) {
+          console.warn("stream runtime-state Durable Object stub dispose failed", {
+            error,
+            path: this.props.path,
+            projectId: this.props.projectId,
+          });
+        }
+      }
+    }).catch(rethrowStreamUnavailable);
     return detachPlainRpcResult(result);
   }
 


### PR DESCRIPTION
## What

- let the one-shot ITX CLI unwind its `using itx` scope on both success and formatted failure instead of terminating inside that scope
- release each native Stream Durable Object stub used by `runtimeState()` after its attempt settles
- retain the existing plain-result detachment and add a focused stub-lifecycle assertion

## Why

A production audit of all 91 Iterate streams reliably produced `An RPC stub was not disposed properly`. The request trace showed the warning during the `Stream.runtimeState` fan-out. The CLI also called `process.exit()` before its explicit-resource scope could unwind.

## Verification

- `pnpm --dir apps/os exec vitest run src/domains/streams/stream-processor-rpc-target.test.ts` (32 passed)
- focused oxfmt and oxlint
- `pnpm --dir apps/os typecheck`
- the modified CLI exits naturally after a production 91-stream run; final warning proof follows after this server-side change deploys

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lifecycle and RPC cleanup changes with no auth or data-model changes; behavior for successful calls stays the same aside from eliminating dispose warnings.
> 
> **Overview**
> Fixes **“RPC stub was not disposed properly”** warnings from production stream audits by releasing Cap'n Web resources in two places that previously skipped explicit disposal.
> 
> **ITX CLI (`itx run`)** no longer calls `process.exit()` inside the `using itx` scope. Script failures set `process.exitCode = 1` and return so the connection unwinds; success paths also exit naturally instead of forcing exit before disposal.
> 
> **`StreamRpcTarget.runtimeState()`** now disposes the **Stream Durable Object stub** in a `finally` after `stub.runtimeState()` completes (with warn-only handling if dispose throws), in addition to detaching the plain-data result. A test asserts the stub’s `Symbol.dispose` runs once per fan-out call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7bd5cc01c57b664bd2e0406c3818fd43f2f4daf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +16 -3 | +16 -3 🟩🟩🟩🟩🟥 |
| Tests | +6 -2 | +6 -2 🟩🟩⬜⬜⬜ |
| CI & scripts | +7 -6 | +7 -4 🟩🟩🟥⬜⬜ |
| **Total** | **+29 -11** | **+29 -9** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 639ba05 and d7bd5cc, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T03:44:42.132Z",
      "deployedAt": "2026-07-29T03:39:24.944Z",
      "headSha": "d7bd5cc01c57b664bd2e0406c3818fd43f2f4daf",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/535254541727755",
      "shortSha": "d7bd5cc",
      "cleanupDurationMs": 11246,
      "deployDurationMs": 74015,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 73039,
      "deployReadinessDurationMs": 972,
      "deployedWorkerName": "os-preview-2",
      "deployedWorkerVersion": "91ee704e-c9c9-4a11-8e2d-d72f994a443f",
      "testDurationMs": 215109,
      "testRetries": "1 retried: agent runs an itx script that appends a proof event, then replies (vitest x1) — expected [ 'stream/created', …(31) ] to include 'capability-host/script-run-settled'",
      "workerSizeKib": 19900.85,
      "workerGzipKib": 5025.37,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5036.28
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T03:44:34.573Z",
      "deployedAt": "2026-07-29T03:38:30.718Z",
      "headSha": "d7bd5cc01c57b664bd2e0406c3818fd43f2f4daf",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/535254541727755",
      "shortSha": "d7bd5cc",
      "cleanupDurationMs": 3683,
      "deployDurationMs": 19170,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 18811,
      "deployReadinessDurationMs": 355,
      "deployedWorkerName": "auth-preview-2",
      "deployedWorkerVersion": "24be127f-7d22-47cd-836e-70ca0bfc903d",
      "testDurationMs": 9750,
      "testRetries": null,
      "workerSizeKib": 3976.81,
      "workerGzipKib": 814.11,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-29T03:44:38.511Z",
      "deployedAt": "2026-07-29T03:38:25.195Z",
      "headSha": "d7bd5cc01c57b664bd2e0406c3818fd43f2f4daf",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/535254541727755",
      "shortSha": "d7bd5cc",
      "cleanupDurationMs": 7619,
      "deployDurationMs": 14303,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 13286,
      "deployReadinessDurationMs": 1012,
      "deployedWorkerName": "streams-example-app-preview-2",
      "deployedWorkerVersion": "f61ce177-6be5-4004-b9f7-2d841f650629",
      "testDurationMs": 79079,
      "testRetries": null,
      "workerSizeKib": 5234.61,
      "workerGzipKib": 1483.59,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T03:44:31.476Z",
      "deployedAt": "2026-07-29T03:38:17.972Z",
      "headSha": "d7bd5cc01c57b664bd2e0406c3818fd43f2f4daf",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/535254541727755",
      "shortSha": "d7bd5cc",
      "cleanupDurationMs": 575,
      "deployDurationMs": 6255,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 6022,
      "deployReadinessDurationMs": 185,
      "deployedWorkerName": "dummy-petshop-preview-2",
      "deployedWorkerVersion": "b65c37cd-fc9d-4215-b48c-4498457de315",
      "testDurationMs": 26539,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `d7bd5cc` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 814.1 KiB | 19.2s | 9.8s |  | 3.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/535254541727755) | 2026-07-29T03:44:34.573Z | Preview app released. |
| Dummy Petshop | released | `d7bd5cc` | [https://dummy-petshop.iterate-preview-2.com](https://dummy-petshop.iterate-preview-2.com) | 198.3 KiB | 6.3s | 26.5s |  | 575ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/535254541727755) | 2026-07-29T03:44:31.476Z | Preview app released. |
| OS | released | `d7bd5cc` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 4.91 MiB (-10.9 KiB vs main) | 74.0s | 215.1s | 1 retried: agent runs an itx script that appends a proof event, then replies (vitest x1) — expected [ 'stream/created', …(31) ] to include 'capability-host/script-run-settled' | 11.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/535254541727755) | 2026-07-29T03:44:42.132Z | Preview app released. |
| Streams Example App | released | `d7bd5cc` | [https://streams.iterate-preview-2.com](https://streams.iterate-preview-2.com) | 1.45 MiB | 14.3s | 79.1s |  | 7.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/535254541727755) | 2026-07-29T03:44:38.511Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->