### PR TITLE
Dispose one-shot repo worker stubs

### DIFF
--- a/apps/os/src/domains/workers/worker-build-capability.ts
+++ b/apps/os/src/domains/workers/worker-build-capability.ts
@@ -93,15 +93,27 @@ async function resolvedSourceFiles(
   const repo = buildEnv.REPO.getByName(
     DurableObjectNameCodec.stringify({ path: resolved.repoPath, projectId }),
   );
-  const snapshot = await repo.getFilesSnapshot({
-    branch: resolved.branch,
-    commitOid: resolved.commitOid,
-    exclude: resolved.exclude,
-    include: resolved.include,
-  });
   try {
-    return snapshot.files;
+    const snapshot = await repo.getFilesSnapshot({
+      branch: resolved.branch,
+      commitOid: resolved.commitOid,
+      exclude: resolved.exclude,
+      include: resolved.include,
+    });
+    try {
+      return snapshot.files;
+    } finally {
+      disposeIgnoredRpcResult(snapshot);
+    }
   } finally {
-    disposeIgnoredRpcResult(snapshot);
+    try {
+      disposeIgnoredRpcResult(repo);
+    } catch (error) {
+      console.warn("worker build repo Durable Object stub dispose failed", {
+        error,
+        projectId,
+        repoPath: resolved.repoPath,
+      });
+    }
   }
 }

--- a/apps/os/src/domains/workers/worker-loader.serve.test.ts
+++ b/apps/os/src/domains/workers/worker-loader.serve.test.ts
@@ -30,6 +30,7 @@ const h = vi.hoisted(() => {
     head: { branch: "main", commitOid: "c1", contentHash: "h1" },
     headDisposals: 0,
     loaderCalls: [] as Array<{ config: Record<string, unknown>; key: string }>,
+    repoDisposals: 0,
     snapshotDisposals: 0,
     snapshotCalls: [] as Array<Record<string, unknown>>,
     wranglerConfig: undefined as
@@ -67,6 +68,9 @@ const h = vi.hoisted(() => {
     },
     REPO: {
       getByName: () => ({
+        [Symbol.dispose]() {
+          state.repoDisposals++;
+        },
         getFilesSnapshot: async (input: Record<string, unknown>) => {
           state.snapshotCalls.push(input);
           return {
@@ -164,6 +168,7 @@ beforeEach(async () => {
   h.state.failRuntime = false;
   h.state.headDisposals = 0;
   h.state.loaderCalls.splice(0);
+  h.state.repoDisposals = 0;
   h.state.snapshotDisposals = 0;
   h.state.snapshotCalls.splice(0);
   h.itxEnv.CF_VERSION_METADATA.id = "version-1";
@@ -185,6 +190,7 @@ describe("resolveWorkerSource", () => {
     expect(h.state.buildCalls).toEqual(["A1"]);
     expect(h.state.artifactDisposals).toBe(1);
     expect(h.state.headDisposals).toBe(1);
+    expect(h.state.repoDisposals).toBe(2);
     expect(h.state.snapshotDisposals).toBe(1);
     expect([...h.kv.data.keys()]).toEqual([expect.stringMatching(artifactKeyPattern)]);
 
@@ -196,6 +202,7 @@ describe("resolveWorkerSource", () => {
     );
     expect(second.cacheKey).toBe(first.cacheKey);
     expect(h.state.buildCalls).toEqual(["A1"]);
+    expect(h.state.repoDisposals).toBe(3);
   });
 
   test("shares deterministic artifacts across projects", async () => {

--- a/apps/os/src/domains/workers/worker-loader.ts
+++ b/apps/os/src/domains/workers/worker-loader.ts
@@ -173,19 +173,31 @@ async function resolveFileSource({
   const repo = env.REPO.getByName(
     DurableObjectNameCodec.stringify({ path: files.repoPath, projectId }),
   );
-  const head = await repo.getHead(files.ref === undefined ? {} : { branch: files.ref.branch });
   try {
-    return {
-      branch: head.branch,
-      commitOid: head.commitOid,
-      contentHash: head.contentHash,
-      exclude: files.exclude,
-      include: files.include,
-      repoPath: files.repoPath,
-      type: "repo",
-    };
+    const head = await repo.getHead(files.ref === undefined ? {} : { branch: files.ref.branch });
+    try {
+      return {
+        branch: head.branch,
+        commitOid: head.commitOid,
+        contentHash: head.contentHash,
+        exclude: files.exclude,
+        include: files.include,
+        repoPath: files.repoPath,
+        type: "repo",
+      };
+    } finally {
+      disposeIgnoredRpcResult(head);
+    }
   } finally {
-    disposeIgnoredRpcResult(head);
+    try {
+      disposeIgnoredRpcResult(repo);
+    } catch (error) {
+      console.warn("worker source repo Durable Object stub dispose failed", {
+        error,
+        projectId,
+        repoPath: files.repoPath,
+      });
+    }
   }
 }
 


### PR DESCRIPTION
## What

- dispose the Repo Durable Object handle after resolving a dynamic worker branch head
- dispose the equivalent handle after reading a pinned build snapshot
- assert both head/snapshot values and their enclosing repo handles are released

## Why

The post-recreation production trace caught a Workers RPC lifecycle warning on RepoDurableObject.getHead while the restored iterate config worker was loading. The returned values were already disposed, but the one-shot Repo handles themselves were not.

## Verification

- pnpm --dir apps/os exec vitest run src/domains/workers/worker-loader.serve.test.ts (11 passed)
- targeted oxfmt and oxlint (clean)
- pnpm --dir apps/os typecheck (clean)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lifecycle cleanup only around existing repo RPC calls; behavior unchanged except fewer RPC warnings and safer stub release on errors.
> 
> **Overview**
> Fixes Workers RPC lifecycle warnings by **disposing Repo Durable Object stubs** after one-shot use, not only the inner `getHead` / `getFilesSnapshot` results.
> 
> In **`resolveFileSource`** (`worker-loader.ts`), the repo handle from `REPO.getByName` is released in an outer `finally` after disposing the head result; dispose failures are logged with `console.warn` and context (`projectId`, `repoPath`). **`resolvedSourceFiles`** (`worker-build-capability.ts`) uses the same pattern around `getFilesSnapshot` and the repo stub.
> 
> Tests mock `[Symbol.dispose]` on repo stubs, track `repoDisposals`, and assert expected counts on the fresh-build / cache-hit path alongside existing head and snapshot disposal checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f676a4a5f7afaed4f3d375c2a2435a3f97c80ee7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +43 -19 | +43 -19 🟩🟩🟩🟥🟥 |
| Tests | +7 -0 | +7 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+50 -19** | **+50 -19** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between e1363d0 and f676a4a, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T04:10:32.624Z",
      "deployedAt": "2026-07-29T04:05:37.788Z",
      "headSha": "f676a4a5f7afaed4f3d375c2a2435a3f97c80ee7",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/264282169617546",
      "shortSha": "f676a4a",
      "cleanupDurationMs": 9968,
      "deployDurationMs": 64584,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 63546,
      "deployReadinessDurationMs": 1035,
      "deployedWorkerName": "os-preview-6",
      "deployedWorkerVersion": "c7546218-d259-4b6d-ae38-c881dce6ceb5",
      "testDurationMs": 210612,
      "testRetries": null,
      "workerSizeKib": 19901.35,
      "workerGzipKib": 5025.8,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5036.18
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T04:10:25.368Z",
      "deployedAt": "2026-07-29T04:04:52.693Z",
      "headSha": "f676a4a5f7afaed4f3d375c2a2435a3f97c80ee7",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/264282169617546",
      "shortSha": "f676a4a",
      "cleanupDurationMs": 2709,
      "deployDurationMs": 18907,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 18449,
      "deployReadinessDurationMs": 454,
      "deployedWorkerName": "auth-preview-6",
      "deployedWorkerVersion": "50569ecf-446b-46d8-9c11-66ccaa8be432",
      "testDurationMs": 9417,
      "testRetries": null,
      "workerSizeKib": 3976.81,
      "workerGzipKib": 814.05,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T04:10:23.214Z",
      "deployedAt": "2026-07-29T04:04:39.728Z",
      "headSha": "f676a4a5f7afaed4f3d375c2a2435a3f97c80ee7",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/264282169617546",
      "shortSha": "f676a4a",
      "cleanupDurationMs": 554,
      "deployDurationMs": 5661,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 5437,
      "deployReadinessDurationMs": 174,
      "deployedWorkerName": "dummy-petshop-preview-6",
      "deployedWorkerVersion": "9b85a972-5207-421a-af57-e128043ae569",
      "testDurationMs": 34502,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `f676a4a` | [https://auth.iterate-preview-6.com](https://auth.iterate-preview-6.com) | 814.0 KiB | 18.9s | 9.4s |  | 2.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/264282169617546) | 2026-07-29T04:10:25.368Z | Preview app released. |
| Dummy Petshop | released | `f676a4a` | [https://dummy-petshop.iterate-preview-6.com](https://dummy-petshop.iterate-preview-6.com) | 198.3 KiB | 5.7s | 34.5s |  | 554ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/264282169617546) | 2026-07-29T04:10:23.214Z | Preview app released. |
| OS | released | `f676a4a` | [https://os.iterate-preview-6.com](https://os.iterate-preview-6.com) | 4.91 MiB (-10.4 KiB vs main) | 64.6s | 210.6s |  | 10.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/264282169617546) | 2026-07-29T04:10:32.624Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->