### PR TITLE
Dispose project processor-state RPC resources

### DIFF
--- a/apps/os/src/project-processor-state-rpc-lifecycle.test.ts
+++ b/apps/os/src/project-processor-state-rpc-lifecycle.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+
+const getProject = vi.hoisted(() => vi.fn());
+
+vi.mock("./env.ts", () => ({
+  itxEnv: {
+    PROJECT: {
+      getByName: getProject,
+    },
+  },
+  workerVersion: () => "test-version",
+}));
+
+const { ProjectRpcTarget } = await import("./rpc-targets.ts");
+
+describe("project processor-state reads", () => {
+  it("releases the snapshot, processor facade, and Project Durable Object stub", async () => {
+    const streams = [{ createdAt: "2026-07-29T00:00:00.000Z", path: "/" }];
+    const snapshot = { state: { streams } };
+    const snapshotDispose = vi.fn();
+    const processorDispose = vi.fn();
+    const projectDispose = vi.fn();
+    Object.defineProperty(snapshot, Symbol.dispose, { value: snapshotDispose });
+    const processor = { snapshot: vi.fn(async () => snapshot) };
+    Object.defineProperty(processor, Symbol.dispose, { value: processorDispose });
+    const project = { processor: Promise.resolve(processor) };
+    Object.defineProperty(project, Symbol.dispose, { value: projectDispose });
+    getProject.mockReturnValue(project);
+
+    const target = new ProjectRpcTarget({
+      auth: { assertCanAccessProject: vi.fn() },
+      capabilityHost: { path: "/" },
+      ctx: {},
+      streamContext: { kind: "scope", scopePath: "/" },
+      projectId: "prj_preview",
+    } as never);
+
+    await expect(target.streams.list()).resolves.toEqual(streams);
+    expect(snapshotDispose).toHaveBeenCalledOnce();
+    expect(processorDispose).toHaveBeenCalledOnce();
+    expect(projectDispose).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -6404,9 +6404,32 @@ export function deploymentItxForInternal(props: { auth: ItxAuth; ctx: CfExecutio
 
 async function projectProcessorState(projectId: string) {
   const project = env.PROJECT.getByName(DurableObjectNameCodec.stringify({ path: "/", projectId }));
-  const processor = await project.processor;
-  const { state } = await processor.snapshot();
-  return state;
+  try {
+    const processor = await project.processor;
+    try {
+      return detachPlainRpcResult(await processor.snapshot()).state;
+    } finally {
+      disposeProjectProcessorStateResource(processor, "processor", projectId);
+    }
+  } finally {
+    disposeProjectProcessorStateResource(project, "project", projectId);
+  }
+}
+
+function disposeProjectProcessorStateResource(
+  resource: unknown,
+  resourceType: "processor" | "project",
+  projectId: string,
+): void {
+  try {
+    disposeIgnoredRpcResult(resource);
+  } catch (error) {
+    console.warn("project processor-state RPC resource dispose failed", {
+      error,
+      projectId,
+      resourceType,
+    });
+  }
 }
 
 /**

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -6420,7 +6420,7 @@ function disposeProjectProcessorStateResource(
   resource: unknown,
   resourceType: "processor" | "project",
   projectId: string,
-): void {
+) {
   try {
     disposeIgnoredRpcResult(resource);
   } catch (error) {


### PR DESCRIPTION
## What

- release the Project Durable Object stub, its transient processor facade, and the snapshot result used by shared project-state reads
- preserve the plain reduced state before cleanup
- add one focused lifecycle regression test through `itx.streams.list()`

## Why

A post-restore production audit on worker `c016524d-f9ac-425e-9da2-a95f0d556493` emitted `An RPC stub was not disposed properly` in request `a2294b5c4dd6d98f`. That request began with `ProjectStreamCollection.list()` and then performed the sequential stream runtime-state audit. The shared `projectProcessorState()` helper acquired three native RPC resources and released none of them. It backs stream/repo/secret/workspace listings, so the fix belongs at that shared boundary.

## Verification

- `pnpm --dir apps/os exec vitest run src/project-processor-state-rpc-lifecycle.test.ts --reporter=default`
- focused `oxfmt` and `oxlint`
- `pnpm --dir apps/os run typecheck`

Production warning-free proof will follow after merge and deployment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped cleanup at an existing read boundary with no auth or data-model changes; behavior for callers remains the same plain state, only resource lifetime is fixed.
> 
> **Overview**
> Fixes **RPC stub leaks** in the shared `projectProcessorState()` helper used by stream/repo/secret/workspace listings (e.g. `ProjectStreamCollection.list()`).
> 
> The helper now **detaches** plain state from the processor snapshot via `detachPlainRpcResult`, then **disposes** the snapshot, processor facade, and Project Durable Object stub in nested `try/finally` blocks. Failed disposes are logged with `console.warn` instead of failing the read.
> 
> Adds a **lifecycle regression test** that asserts all three `Symbol.dispose` hooks run when calling `itx.streams.list()` through `ProjectRpcTarget`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a44ae10a792b35058c2ef764ff78c93477d0138. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +26 -3 | +24 -3 🟩🟩🟩🟩⬜ |
| Tests | +43 -0 | +37 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+69 -3** | **+61 -3** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between feaa008 and 7a44ae1, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T04:34:24.575Z",
      "deployedAt": "2026-07-29T04:29:19.776Z",
      "headSha": "7a44ae10a792b35058c2ef764ff78c93477d0138",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-18.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/272881628985643",
      "shortSha": "7a44ae1",
      "cleanupDurationMs": 10815,
      "deployDurationMs": 52322,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 43857,
      "deployReadinessDurationMs": 8462,
      "deployedWorkerName": "os-preview-18",
      "deployedWorkerVersion": "3a4463e3-3e36-4adf-b550-6ad0bdb6f6d9",
      "testDurationMs": 196270,
      "testRetries": null,
      "workerSizeKib": 19901.87,
      "workerGzipKib": 5025.82,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5036.58
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T04:34:16.486Z",
      "deployedAt": "2026-07-29T04:28:52.454Z",
      "headSha": "7a44ae10a792b35058c2ef764ff78c93477d0138",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-18.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/272881628985643",
      "shortSha": "7a44ae1",
      "cleanupDurationMs": 2722,
      "deployDurationMs": 16567,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 16533,
      "deployReadinessDurationMs": 30,
      "deployedWorkerName": "auth-preview-18",
      "deployedWorkerVersion": "79840525-3c89-4061-af94-012542617304",
      "testDurationMs": 10169,
      "testRetries": null,
      "workerSizeKib": 3976.81,
      "workerGzipKib": 813.98,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T04:34:14.437Z",
      "deployedAt": "2026-07-29T04:23:17.769Z",
      "headSha": "7a44ae10a792b35058c2ef764ff78c93477d0138",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-18.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/272881628985643",
      "shortSha": "7a44ae1",
      "cleanupDurationMs": 672,
      "deployDurationMs": 58,
      "deployConfigDurationMs": 5,
      "deployReuseProofDurationMs": 17,
      "deployedWorkerName": "dummy-petshop-preview-18",
      "deployedWorkerVersion": "8efb93f6-78a5-4321-b6ca-ad896c3cb4f3",
      "testDurationMs": 5499,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `7a44ae1` | [https://auth.iterate-preview-18.com](https://auth.iterate-preview-18.com) | 814.0 KiB | 16.6s | 10.2s |  | 2.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/272881628985643) | 2026-07-29T04:34:16.486Z | Preview app released. |
| Dummy Petshop | released | `7a44ae1` | [https://dummy-petshop.iterate-preview-18.com](https://dummy-petshop.iterate-preview-18.com) | 198.3 KiB | 58ms | 5.5s |  | 672ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/272881628985643) | 2026-07-29T04:34:14.437Z | Preview app released. |
| OS | released | `7a44ae1` | [https://os.iterate-preview-18.com](https://os.iterate-preview-18.com) | 4.91 MiB (-10.8 KiB vs main) | 52.3s | 196.3s |  | 10.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/272881628985643) | 2026-07-29T04:34:24.575Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->