### PR TITLE
Approval rejection reasons, auto-enroll, and a mobile approvals playwright spec

### DIFF
--- a/apps/auth/src/server/auth.ts
+++ b/apps/auth/src/server/auth.ts
@@ -22,9 +22,23 @@ export function getAllowedBrowserOrigins(): string[] {
   return origins;
 }
 
-function isAllowedBrowserOrigin(origin: string | null | undefined) {
+export function isAllowedBrowserOrigin(origin: string | null | undefined) {
   if (!origin || !URL.canParse(origin)) return false;
-  return getAllowedBrowserOrigins().includes(new URL(origin).origin);
+  const url = new URL(origin);
+  // Loopback web clients on ARBITRARY ports — the Expo Web mobile app that
+  // playwright specs and local dev drive (its port is random per run; the
+  // fixed-port MCP-inspector entries above predate this). Browser-side OAuth
+  // (discovery, dynamic registration, token exchange) needs CORS, which
+  // native apps never do. Gated on the test-automation flag so production
+  // auth never trusts localhost pages.
+  if (
+    config.fixedTestOtpEnabled &&
+    url.protocol === "http:" &&
+    ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname)
+  ) {
+    return true;
+  }
+  return getAllowedBrowserOrigins().includes(url.origin);
 }
 
 export type ProjectIngressTokenPayload = {
@@ -61,8 +75,13 @@ export const auth = betterAuth({
     emailBinding: env.EMAIL,
     emailSenderDomain: config.emailSenderDomain,
   }),
-  trustedOrigins: (request) =>
-    isAllowedBrowserOrigin(request?.headers.get("origin")) ? getAllowedBrowserOrigins() : [],
+  trustedOrigins: (request) => {
+    const origin = request?.headers.get("origin");
+    if (!isAllowedBrowserOrigin(origin)) return [];
+    // Include the requesting origin itself: loopback web clients pass the
+    // predicate on shape, not by membership in the static list.
+    return [...getAllowedBrowserOrigins(), new URL(origin!).origin];
+  },
   secret: config.betterAuthSecret.exposeSecret(),
   session: {
     storeSessionInDatabase: true,

--- a/apps/auth/src/server/auth.ts
+++ b/apps/auth/src/server/auth.ts
@@ -61,11 +61,11 @@ export const auth = betterAuth({
   }),
   trustedOrigins: (request) => {
     const origin = request?.headers.get("origin");
-    if (!isAllowedBrowserOrigin(origin)) return [];
+    if (!origin || !isAllowedBrowserOrigin(origin)) return [];
     // The allowed requester plus this deployment's own origins — loopback
     // clients pass the predicate on shape, so the requester must be listed
     // explicitly.
-    const trusted: string[] = [new URL(origin!).origin, config.authAppOrigin];
+    const trusted: string[] = [new URL(origin).origin, config.authAppOrigin];
     if (config.publicUrl) trusted.push(config.publicUrl);
     return trusted;
   },

--- a/apps/auth/src/server/auth.ts
+++ b/apps/auth/src/server/auth.ts
@@ -7,38 +7,22 @@ import { config, env } from "./env.ts";
 import { getAuthPlugins } from "./auth-plugins.ts";
 import { authJwt } from "./auth-jwt.ts";
 
-const LOCAL_OAUTH_CLIENT_ORIGINS = [
-  "http://localhost:6274",
-  "http://127.0.0.1:6274",
-  "http://[::1]:6274",
-] as const;
-
-export function getAllowedBrowserOrigins(): string[] {
-  // config.authAppOrigin/publicUrl are `publicValue`-tagged strings; a tagged
-  // string is assignable to `string`, so collect them into a plain `string[]`
-  // (dropping an unset publicUrl) for comparing/`Set`ing against request origins.
-  const origins: string[] = [config.authAppOrigin, ...LOCAL_OAUTH_CLIENT_ORIGINS];
-  if (config.publicUrl) origins.push(config.publicUrl);
-  return origins;
-}
-
+/**
+ * THE browser-origin trust decision, in one place. Loopback origins: on
+ * test-automation stages (fixedTestOtpEnabled — local/dev/preview, never
+ * production) ANY loopback port is trusted, because the Expo Web mobile app's
+ * browser-side OAuth (discovery, dynamic registration, token exchange —
+ * native apps never hit CORS) runs on a random port per invocation;
+ * production trusts only the MCP inspector's fixed port 6274. Everything
+ * else must BE this deployment: the auth app origin, or its public alias.
+ */
 export function isAllowedBrowserOrigin(origin: string | null | undefined) {
   if (!origin || !URL.canParse(origin)) return false;
   const url = new URL(origin);
-  // Loopback web clients on ARBITRARY ports — the Expo Web mobile app that
-  // playwright specs and local dev drive (its port is random per run; the
-  // fixed-port MCP-inspector entries above predate this). Browser-side OAuth
-  // (discovery, dynamic registration, token exchange) needs CORS, which
-  // native apps never do. Gated on the test-automation flag so production
-  // auth never trusts localhost pages.
-  if (
-    config.fixedTestOtpEnabled &&
-    url.protocol === "http:" &&
-    ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname)
-  ) {
-    return true;
-  }
-  return getAllowedBrowserOrigins().includes(url.origin);
+  const isLoopback =
+    url.protocol === "http:" && ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname);
+  if (isLoopback) return config.fixedTestOtpEnabled || url.port === "6274";
+  return url.origin === config.authAppOrigin || url.origin === config.publicUrl;
 }
 
 export type ProjectIngressTokenPayload = {
@@ -78,9 +62,12 @@ export const auth = betterAuth({
   trustedOrigins: (request) => {
     const origin = request?.headers.get("origin");
     if (!isAllowedBrowserOrigin(origin)) return [];
-    // Include the requesting origin itself: loopback web clients pass the
-    // predicate on shape, not by membership in the static list.
-    return [...getAllowedBrowserOrigins(), new URL(origin!).origin];
+    // The allowed requester plus this deployment's own origins — loopback
+    // clients pass the predicate on shape, so the requester must be listed
+    // explicitly.
+    const trusted: string[] = [new URL(origin!).origin, config.authAppOrigin];
+    if (config.publicUrl) trusted.push(config.publicUrl);
+    return trusted;
   },
   secret: config.betterAuthSecret.exposeSecret(),
   session: {

--- a/apps/auth/src/server/worker.ts
+++ b/apps/auth/src/server/worker.ts
@@ -22,7 +22,7 @@ import { cors } from "hono/cors";
 import { RequestHeadersPlugin } from "@orpc/server/plugins";
 import { onError, ORPCError } from "@orpc/server";
 import { RPCHandler } from "@orpc/server/fetch";
-import { auth, getAllowedBrowserOrigins } from "./auth.ts";
+import { auth, isAllowedBrowserOrigin } from "./auth.ts";
 import { db } from "./db/index.ts";
 import { config } from "./env.ts";
 import { hono, variablesProvider, type Variables } from "./utils/hono.ts";
@@ -44,7 +44,6 @@ import {
 } from "./project-directory.ts";
 
 const app = hono();
-const allowedBrowserOrigins = new Set(getAllowedBrowserOrigins());
 const AUTH_ISSUER_PATH = "/api/auth";
 
 app.use(
@@ -52,7 +51,7 @@ app.use(
     origin: (origin) => {
       if (!origin || !URL.canParse(origin)) return null;
       const normalizedOrigin = new URL(origin).origin;
-      return allowedBrowserOrigins.has(normalizedOrigin) ? normalizedOrigin : null;
+      return isAllowedBrowserOrigin(normalizedOrigin) ? normalizedOrigin : null;
     },
     credentials: true,
     allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],

--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -92,7 +92,7 @@ export default function SignInScreen() {
   if (bootstrap.isPending) {
     return (
       <View style={styles.loading}>
-        <ActivityIndicator color={colors.textMuted} />
+        <ActivityIndicator accessibilityLabel="Loading" color={colors.textMuted} />
       </View>
     );
   }
@@ -163,7 +163,7 @@ export default function SignInScreen() {
           style={[styles.signIn, login.isPending && { opacity: 0.6 }]}
         >
           {login.isPending ? (
-            <ActivityIndicator color={colors.background} />
+            <ActivityIndicator accessibilityLabel="Loading" color={colors.background} />
           ) : (
             <Text style={styles.signInText}>Sign in</Text>
           )}

--- a/apps/mobile/src/app/project/[projectId]/approvals.tsx
+++ b/apps/mobile/src/app/project/[projectId]/approvals.tsx
@@ -21,7 +21,12 @@ import {
   View,
 } from "react-native";
 import { CodeBlock } from "../../../components/activity-card.tsx";
-import { enrollApproverKey, loadApproverKey, signWithApproverKey } from "../../../lib/approver.ts";
+import {
+  approverKeyStatus,
+  enrollApproverKey,
+  reenrollApproverKey,
+  signWithApproverKey,
+} from "../../../lib/approver.ts";
 import {
   deriveOpenBatches,
   deriveRecentResolvedBatches,
@@ -63,13 +68,23 @@ export default function ApprovalsScreen() {
   });
   const baseUrl = server.data;
 
+  // The JOIN of the local key and the project's enrolled-key state: a
+  // locally present key the project has revoked must NOT offer Approve (the
+  // door ignores its signatures — batches would strand as "submitted").
   const key = useQuery({
-    queryKey: ["approver-key", projectId],
-    queryFn: () => loadApproverKey(projectId),
+    queryKey: ["approver-key-status", projectId, baseUrl],
+    queryFn: () => approverKeyStatus(baseUrl!, projectId),
+    enabled: baseUrl !== undefined,
   });
+  const enrolledKey = key.data?.kind === "enrolled" ? key.data.key : null;
 
   const enroll = useMutation({
     mutationFn: async () => {
+      if (key.data?.kind === "revoked") {
+        // Recovering a revoked device is a deliberate act: fresh keypair,
+        // never a resurrection of the revoked keyId.
+        return await reenrollApproverKey(baseUrl!, projectId, "This iPhone");
+      }
       const info = await enrollApproverKey(projectId, "This iPhone");
       const project = await getProjectItx(baseUrl!, projectId);
       const stream = project.streams.get("/");
@@ -131,7 +146,7 @@ export default function ApprovalsScreen() {
       // strand the hold with no visible way to retry. Requiring enrollment
       // first means every approval this app sends is real, whether or not
       // other devices have keys.
-      if (!key.data) throw new Error("Enroll this device before approving.");
+      if (!enrolledKey) throw new Error("Enroll this device before approving.");
       await decide({
         stream,
         projectId,
@@ -146,7 +161,7 @@ export default function ApprovalsScreen() {
   return (
     <View style={styles.screen}>
       <Stack.Screen options={{ title: "Approvals" }} />
-      {key.data === null ? (
+      {key.data?.kind === "unenrolled" ? (
         <Pressable
           accessibilityRole="button"
           style={styles.enrollBanner}
@@ -157,10 +172,23 @@ export default function ApprovalsScreen() {
             {enroll.isPending ? "Enrolling…" : "Enroll this device to sign approvals"}
           </Text>
         </Pressable>
-      ) : key.data ? (
+      ) : key.data?.kind === "revoked" ? (
+        <Pressable
+          accessibilityRole="button"
+          style={styles.enrollBanner}
+          onPress={() => enroll.mutate()}
+          disabled={enroll.isPending}
+        >
+          <Text style={styles.enrollText}>
+            {enroll.isPending
+              ? "Re-enrolling…"
+              : "This device's approval key was revoked — tap to re-enroll with a fresh key"}
+          </Text>
+        </Pressable>
+      ) : key.data?.kind === "enrolled" ? (
         <View style={styles.enrolledBanner}>
           <Text style={styles.enrolledText}>
-            Signing as {key.data.label} · {key.data.keyId}
+            Signing as {key.data.key.label} · {key.data.key.keyId}
           </Text>
         </View>
       ) : null}
@@ -193,7 +221,7 @@ export default function ApprovalsScreen() {
               baseUrl={baseUrl!}
               interaction={{
                 kind: "pending",
-                canApprove: Boolean(key.data),
+                canApprove: enrolledKey !== null,
                 onRespond: (decision) => respond.mutate({ batch: item, decision }),
                 pending: respond.isPending && respond.variables?.batch.offset === item.offset,
                 submitted: item.submitted,

--- a/apps/mobile/src/app/project/[projectId]/approvals.tsx
+++ b/apps/mobile/src/app/project/[projectId]/approvals.tsx
@@ -148,6 +148,7 @@ export default function ApprovalsScreen() {
       <Stack.Screen options={{ title: "Approvals" }} />
       {key.data === null ? (
         <Pressable
+          accessibilityRole="button"
           style={styles.enrollBanner}
           onPress={() => enroll.mutate()}
           disabled={enroll.isPending}
@@ -168,7 +169,7 @@ export default function ApprovalsScreen() {
 
       {events.isPending ? (
         <View style={styles.center}>
-          <ActivityIndicator color={colors.textMuted} />
+          <ActivityIndicator accessibilityLabel="Loading" color={colors.textMuted} />
         </View>
       ) : events.isError ? (
         <View style={styles.center}>
@@ -426,7 +427,11 @@ function BatchCard({
               </Pressable>
               {details.data.script ? (
                 script.isPending ? (
-                  <ActivityIndicator color={colors.textMuted} size="small" />
+                  <ActivityIndicator
+                    accessibilityLabel="Loading"
+                    color={colors.textMuted}
+                    size="small"
+                  />
                 ) : script.isError ? (
                   <Text style={styles.error}>{script.error.message}</Text>
                 ) : (
@@ -455,6 +460,7 @@ function BatchCard({
           ) : (
             <View style={styles.actions}>
               <Pressable
+                accessibilityRole="button"
                 style={[styles.button, styles.reject]}
                 disabled={interaction.pending}
                 onPress={() => interaction.onRespond("reject")}
@@ -462,6 +468,7 @@ function BatchCard({
                 <Text style={styles.rejectText}>{single ? "Reject" : "Reject all"}</Text>
               </Pressable>
               <Pressable
+                accessibilityRole="button"
                 style={[
                   styles.button,
                   styles.approve,

--- a/apps/mobile/src/app/project/[projectId]/approvals.tsx
+++ b/apps/mobile/src/app/project/[projectId]/approvals.tsx
@@ -11,7 +11,9 @@ import { router, Stack, useLocalSearchParams } from "expo-router";
 import { useMemo } from "react";
 import {
   ActivityIndicator,
+  Alert,
   FlatList,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -100,7 +102,9 @@ export default function ApprovalsScreen() {
 
   // ONE decision per batch: approve all or reject all. The approval.v2
   // message binds every request plus the verdicts, so a 12-request batch is
-  // still one Face ID, one signature, one append.
+  // still one Face ID, one signature, one append. Rejecting first asks for an
+  // optional reason, which rides the decided event back to the calling
+  // script's 403 body — the agent reads WHY and can retry with a change.
   const respond = useMutation({
     mutationFn: async (input: { batch: OpenBatch; decision: "approve" | "reject" }) => {
       const project = await getProjectItx(baseUrl!, projectId);
@@ -109,12 +113,15 @@ export default function ApprovalsScreen() {
         (): Verdict => (input.decision === "approve" ? "approve" : "reject"),
       );
       if (input.decision === "reject") {
+        const reason = await promptForRejectReason(input.batch.payload.requests.length);
+        if (reason === null) return; // cancelled — leave the batch held
         await decide({
           stream,
           projectId,
           offset: input.batch.offset,
           payload: input.batch.payload,
           verdicts,
+          reason: reason || undefined,
           sign: null,
         });
         return;
@@ -330,6 +337,9 @@ function BatchCard({
         <Text style={styles.method}>{headline}</Text>
       )}
       {single ? null : <Text style={styles.groupHosts}>{hostBreakdown(payload.requests)}</Text>}
+      {resolved?.reason ? (
+        <Text style={styles.rejectReason}>Rejected because: {resolved.reason}</Text>
+      ) : null}
 
       {details.data.expanded ? (
         <>
@@ -560,6 +570,32 @@ function RequestDetails({
   );
 }
 
+/**
+ * Ask the human WHY they're rejecting — optional free text that rides the
+ * decided event into each rejected fetch's 403 body, so the calling agent can
+ * retry with a change. Resolves null when the human cancels (the batch stays
+ * held), "" for a reasonless reject. Native gets Alert.prompt (iOS); web gets
+ * window.prompt — the same dialog the playwright spec answers.
+ */
+function promptForRejectReason(count: number): Promise<string | null> {
+  const title = count === 1 ? "Reject this request?" : `Reject all ${count} requests?`;
+  const message = "Optionally tell the agent why, so it can retry differently.";
+  if (Platform.OS === "web") {
+    return Promise.resolve(window.prompt(`${title}\n${message}`, ""));
+  }
+  return new Promise((resolve) => {
+    Alert.prompt(
+      title,
+      message,
+      [
+        { text: "Cancel", style: "cancel", onPress: () => resolve(null) },
+        { text: "Reject", style: "destructive", onPress: (text?: string) => resolve(text || "") },
+      ],
+      "plain-text",
+    );
+  });
+}
+
 const styles = StyleSheet.create({
   screen: { flex: 1, backgroundColor: colors.background },
   center: {
@@ -687,6 +723,7 @@ const styles = StyleSheet.create({
   buttonDisabled: { opacity: 0.4 },
   approveText: { color: colors.background, fontSize: 14, fontWeight: "600" },
   groupHosts: { color: colors.textMuted, fontFamily: "Menlo", fontSize: 11 },
+  rejectReason: { color: colors.danger, fontSize: 12 },
   groupMembers: {
     gap: spacing.sm,
   },

--- a/apps/mobile/src/app/project/[projectId]/chat.tsx
+++ b/apps/mobile/src/app/project/[projectId]/chat.tsx
@@ -199,7 +199,7 @@ export default function ChatScreen() {
       />
       {events.isPending ? (
         <View style={styles.center}>
-          <ActivityIndicator color={colors.textMuted} />
+          <ActivityIndicator accessibilityLabel="Loading" color={colors.textMuted} />
         </View>
       ) : events.isError ? (
         <View style={styles.center}>
@@ -302,7 +302,7 @@ function FeedList({
         // Inverted list: the "header" renders at the visual bottom.
         sendPending || (feed.working && feed.live?.steps.length === 0) ? (
           <View style={styles.workingRow}>
-            <ActivityIndicator size="small" color={colors.working} />
+            <ActivityIndicator accessibilityLabel="Loading" size="small" color={colors.working} />
             <Text style={styles.workingText}>working…</Text>
           </View>
         ) : null

--- a/apps/mobile/src/app/project/[projectId]/index.tsx
+++ b/apps/mobile/src/app/project/[projectId]/index.tsx
@@ -13,6 +13,7 @@ import { newMobileAgentPath } from "../../../lib/chat.ts";
 import { getProjectItx } from "../../../lib/itx.ts";
 import { DEFAULT_SERVER } from "../../../lib/servers.ts";
 import { getServerBaseUrl } from "../../../lib/storage.ts";
+import { ensureApproverKeyEnrolled } from "../../../lib/approver.ts";
 import { enrollPushDevice } from "../../../lib/push-device.ts";
 import { colors, radius, spacing } from "../../../lib/theme.ts";
 
@@ -36,6 +37,20 @@ export default function ChatListScreen() {
     },
     retry: false,
     refetchOnWindowFocus: "always",
+  });
+  // Opening a project silently enrolls this device's approval key (a
+  // Keychain write never prompts Face ID) so held requests are approvable
+  // the moment they appear — the approvals screen's enroll banner is now the
+  // fallback, not the common path. Best-effort like the push enrollment: a
+  // failure must not block the project, and the next open retries. The query
+  // cache also lets the approvals screen read enrollment without refetching.
+  useQuery({
+    queryKey: ["approver-key-enrollment", projectId],
+    queryFn: async () => {
+      const baseUrl = (await getServerBaseUrl()) || DEFAULT_SERVER;
+      return await ensureApproverKeyEnrolled(baseUrl, projectId);
+    },
+    retry: false,
   });
 
   const openChat = (agentPath: string) =>

--- a/apps/mobile/src/app/project/[projectId]/index.tsx
+++ b/apps/mobile/src/app/project/[projectId]/index.tsx
@@ -5,7 +5,7 @@
 // here regardless of where it started) and "New chat" opens an empty thread
 // instead of a voice session.
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { router, Stack, useLocalSearchParams } from "expo-router";
 import { ActivityIndicator, FlatList, Pressable, StyleSheet, Text, View } from "react-native";
 import { ProjectDrawerButton } from "../../../components/project-drawer.tsx";
@@ -19,6 +19,7 @@ import { colors, radius, spacing } from "../../../lib/theme.ts";
 
 export default function ChatListScreen() {
   const { projectId, slug } = useLocalSearchParams<{ projectId: string; slug?: string }>();
+  const queryClient = useQueryClient();
 
   const agents = useQuery({
     queryKey: ["agents", projectId],
@@ -42,13 +43,22 @@ export default function ChatListScreen() {
   // Keychain write never prompts Face ID) so held requests are approvable
   // the moment they appear — the approvals screen's enroll banner is now the
   // fallback, not the common path. Best-effort like the push enrollment: a
-  // failure must not block the project, and the next open retries. The query
-  // cache also lets the approvals screen read enrollment without refetching.
+  // failure must not block the project, and the next open retries. A
+  // successful enroll PRIMES the approvals screen's key-status query (same
+  // key it reads) so its Approve button never flashes "Enroll to approve"
+  // while re-deriving what this query just established.
   useQuery({
     queryKey: ["approver-key-enrollment", projectId],
     queryFn: async () => {
       const baseUrl = (await getServerBaseUrl()) || DEFAULT_SERVER;
-      return await ensureApproverKeyEnrolled(baseUrl, projectId);
+      const key = await ensureApproverKeyEnrolled(baseUrl, projectId);
+      if (key !== null) {
+        queryClient.setQueryData(["approver-key-status", projectId, baseUrl], {
+          kind: "enrolled",
+          key,
+        });
+      }
+      return key;
     },
     retry: false,
   });

--- a/apps/mobile/src/app/project/[projectId]/index.tsx
+++ b/apps/mobile/src/app/project/[projectId]/index.tsx
@@ -82,7 +82,7 @@ export default function ChatListScreen() {
 
       {agents.isPending ? (
         <View style={styles.center}>
-          <ActivityIndicator color={colors.textMuted} />
+          <ActivityIndicator accessibilityLabel="Loading" color={colors.textMuted} />
         </View>
       ) : agents.isError ? (
         <View style={styles.center}>

--- a/apps/mobile/src/app/project/[projectId]/repo.tsx
+++ b/apps/mobile/src/app/project/[projectId]/repo.tsx
@@ -569,7 +569,9 @@ function EditorHeader({
 function EmptyEditor({ label }: { label: string }) {
   return (
     <View style={styles.center}>
-      {label.endsWith("…") ? <ActivityIndicator color={colors.textMuted} /> : null}
+      {label.endsWith("…") ? (
+        <ActivityIndicator accessibilityLabel="Loading" color={colors.textMuted} />
+      ) : null}
       <Text style={styles.muted}>{label}</Text>
     </View>
   );

--- a/apps/mobile/src/app/project/[projectId]/repos.tsx
+++ b/apps/mobile/src/app/project/[projectId]/repos.tsx
@@ -35,7 +35,7 @@ export default function ReposScreen() {
       />
       {repos.isPending ? (
         <View style={styles.center}>
-          <ActivityIndicator color={colors.textMuted} />
+          <ActivityIndicator accessibilityLabel="Loading" color={colors.textMuted} />
         </View>
       ) : repos.isError ? (
         <View style={styles.center}>

--- a/apps/mobile/src/app/projects.tsx
+++ b/apps/mobile/src/app/projects.tsx
@@ -79,7 +79,7 @@ export default function ProjectsScreen() {
       {open.isError ? <Text style={styles.error}>{String(open.error.message)}</Text> : null}
       {projects.isPending ? (
         <View style={styles.center}>
-          <ActivityIndicator color={colors.textMuted} />
+          <ActivityIndicator accessibilityLabel="Loading" color={colors.textMuted} />
         </View>
       ) : projects.isError ? (
         <View style={styles.center}>

--- a/apps/mobile/src/components/activity-card.tsx
+++ b/apps/mobile/src/components/activity-card.tsx
@@ -23,7 +23,7 @@ export function ActivityCard({ activity }: { activity: AgentUiActivity }) {
     <View style={[styles.card, isLive && styles.cardLive]}>
       <Pressable style={styles.summaryRow} onPress={() => setToggled(!expanded)}>
         {isLive && activity.status === "running" ? (
-          <ActivityIndicator size="small" color={colors.working} />
+          <ActivityIndicator accessibilityLabel="Loading" size="small" color={colors.working} />
         ) : (
           <Text style={styles.chevron}>{expanded ? "▾" : "▸"}</Text>
         )}

--- a/apps/mobile/src/lib/approvals.test.ts
+++ b/apps/mobile/src/lib/approvals.test.ts
@@ -265,6 +265,51 @@ test("decide signs ONCE over the whole batch and appends ONE decided event", asy
   ]);
 });
 
+test("a rejection reason rides the decided event and surfaces on the resolved batch", async () => {
+  const open = deriveOpenBatches([requestedBurst(1, "gmail-sends", 2)]);
+  const appended: any[] = [];
+
+  await decide({
+    stream: { append: async (event: any) => void appended.push(event) } as any,
+    projectId: "prj_test",
+    offset: open[0]!.offset,
+    payload: open[0]!.payload,
+    verdicts: ["reject", "reject"],
+    reason: "  wrong recipient — use staging  ",
+    sign: null,
+  });
+
+  // Trimmed on the way in; unsigned like every rejection.
+  expect(appended).toMatchObject([
+    {
+      type: EVENT.decided,
+      payload: {
+        approvalRequestEventOffset: 1,
+        verdicts: ["reject", "reject"],
+        decidedBy: "human",
+        reason: "wrong recipient — use staging",
+      },
+    },
+  ]);
+
+  const resolved = deriveRecentResolvedBatches(
+    [
+      requestedBurst(1, "gmail-sends", 2),
+      {
+        type: EVENT.decided,
+        offset: 2,
+        createdAt: new Date(2026, 0, 1, 0, 0, 2).toISOString(),
+        path: "/",
+        payload: appended[0].payload,
+      },
+    ],
+    5,
+  );
+  expect(resolved).toMatchObject([
+    { offset: 1, decisionSummary: "Rejected", reason: "wrong recipient — use staging" },
+  ]);
+});
+
 test("an all-reject decision never signs — deny is the fail-safe direction", async () => {
   const open = deriveOpenBatches([requestedBurst(1, "gmail-sends", 2)]);
   const appended: any[] = [];

--- a/apps/mobile/src/lib/approvals.ts
+++ b/apps/mobile/src/lib/approvals.ts
@@ -149,7 +149,9 @@ export async function decide(input: {
   const signed = signs
     ? await input.sign!(messageFor(input.projectId, input.offset, input.payload, input.verdicts))
     : null;
-  const reason = input.reason?.trim();
+  // Cap to the contract's 1000-char bound so a long pasted reason survives
+  // truncated instead of degrading to absent via the schema's catch.
+  const reason = input.reason?.trim().slice(0, 1_000);
   await input.stream.append({
     type: EVENT.decided,
     payload: {

--- a/apps/mobile/src/lib/approvals.ts
+++ b/apps/mobile/src/lib/approvals.ts
@@ -132,7 +132,9 @@ export function hostBreakdown(requests: readonly { url: string }[]): string {
  * `sign` is null for a keyless project (plain decision); otherwise it's
  * called with the canonical message and must return the enrolled key's
  * signature — approver.ts's signWithApproverKey, which prompts Face ID.
- * All-reject decisions never sign: deny is the fail-safe direction.
+ * All-reject decisions never sign: deny is the fail-safe direction. A
+ * rejection `reason` rides the event (unsigned, like rejections themselves)
+ * and lands in each rejected fetch's 403 body for the calling agent.
  */
 export async function decide(input: {
   stream: RpcStub<Stream>;
@@ -140,18 +142,21 @@ export async function decide(input: {
   offset: number;
   payload: RequestedPayload;
   verdicts: readonly Verdict[];
+  reason?: string;
   sign: ((message: Uint8Array) => Promise<{ keyId: string; signature: string }>) | null;
 }): Promise<void> {
   const signs = input.sign !== null && input.verdicts.includes("approve");
   const signed = signs
     ? await input.sign!(messageFor(input.projectId, input.offset, input.payload, input.verdicts))
     : null;
+  const reason = input.reason?.trim();
   await input.stream.append({
     type: EVENT.decided,
     payload: {
       approvalRequestEventOffset: input.offset,
       verdicts: [...input.verdicts],
       decidedBy: "human",
+      ...(reason ? { reason } : {}),
       ...(signed ? { keyId: signed.keyId, signature: signed.signature } : {}),
     },
   });
@@ -174,6 +179,8 @@ export type ResolvedBatch = {
   resolutionEventOffset: number;
   verdicts: Verdict[];
   decidedBy: "human" | "expiry";
+  /** The human's stated rejection reason, when one was given. */
+  reason: string | null;
   /** Per-index: a settle outcome for approved indexes (null until it lands), null for rejected ones. */
   outcomes: Array<{ status: number | null; error: string | null } | null>;
   /** "Approved" / "Rejected" / "Expired" / "9 approved · 3 rejected" — the header badge. */
@@ -243,6 +250,7 @@ export function deriveRecentResolvedBatches(
       resolutionEventOffset: decision.eventOffset,
       verdicts: decision.verdicts,
       decidedBy: decision.decidedBy,
+      reason: decision.reason,
       outcomes,
       decisionSummary,
     });
@@ -361,7 +369,12 @@ function indexApprovalEvents(events: readonly StreamEvent[]) {
   const requests = new Map<number, RequestedPayload>();
   const decisions = new Map<
     number,
-    { verdicts: Verdict[]; decidedBy: "human" | "expiry"; eventOffset: number }
+    {
+      verdicts: Verdict[];
+      decidedBy: "human" | "expiry";
+      reason: string | null;
+      eventOffset: number;
+    }
   >();
   const settles = new Map<number, Map<number, { status: number | null; error: string | null }>>();
   const settledIndexes = new Map<number, Set<number>>();
@@ -374,6 +387,7 @@ function indexApprovalEvents(events: readonly StreamEvent[]) {
       approvalRequestEventOffset?: number;
       verdicts?: Verdict[];
       decidedBy?: string;
+      reason?: string;
       index?: number;
       status?: number;
       error?: string;
@@ -394,6 +408,7 @@ function indexApprovalEvents(events: readonly StreamEvent[]) {
         decisions.set(ref, {
           verdicts: payload.verdicts,
           decidedBy: payload.decidedBy === "expiry" ? "expiry" : "human",
+          reason: typeof payload.reason === "string" ? payload.reason : null,
           eventOffset: event.offset,
         });
       }

--- a/apps/mobile/src/lib/approver.ts
+++ b/apps/mobile/src/lib/approver.ts
@@ -92,6 +92,56 @@ export async function ensureApproverKeyEnrolled(
   return key;
 }
 
+export type ApproverKeyStatus =
+  | { kind: "unenrolled" }
+  | { kind: "enrolled"; key: ApproverKeyInfo }
+  | { kind: "revoked"; key: ApproverKeyInfo };
+
+/**
+ * What the approvals screen should believe about this device's key — the
+ * JOIN of the local Keychain half and the project's enrolled-key state. A
+ * locally present key the project has REVOKED must surface as `revoked`,
+ * never `enrolled`: the door ignores its signatures, so offering Approve
+ * would strand batches as "submitted" until expiry. A local key the project
+ * doesn't know yet counts as `enrolled` — auto-enroll's append is in flight.
+ */
+export async function approverKeyStatus(
+  baseUrl: string,
+  projectId: string,
+): Promise<ApproverKeyStatus> {
+  const key = await loadApproverKey(projectId);
+  if (!key) return { kind: "unenrolled" };
+  const project = await getProjectItx(baseUrl, projectId);
+  const enrolled = (await project.processor.snapshot()).state.humanApprovalKeys as Array<{
+    keyId: string;
+    revokedAt: string | null;
+  }>;
+  const entry = enrolled.find((candidate) => candidate.keyId === key.keyId);
+  if (entry && entry.revokedAt !== null) return { kind: "revoked", key };
+  return { kind: "enrolled", key };
+}
+
+/**
+ * The deliberate human act that recovers a revoked device: destroy the local
+ * material and enroll a FRESH keypair (a new keyId — re-appending a revoked
+ * one is a reducer no-op, and silently resurrecting it would defeat
+ * revocation). Only the approvals screen's revoked banner calls this.
+ */
+export async function reenrollApproverKey(
+  baseUrl: string,
+  projectId: string,
+  label: string,
+): Promise<ApproverKeyInfo> {
+  await deleteApproverKey(projectId);
+  const key = await enrollApproverKey(projectId, label);
+  const project = await getProjectItx(baseUrl, projectId);
+  await project.streams.get("/").append({
+    type: EVENT.keyAdded,
+    payload: { keyId: key.keyId, publicKey: key.publicKey, label: key.label },
+  });
+  return key;
+}
+
 /**
  * Sign one approval message — prompts Face ID / Touch ID / passcode to
  * unlock the private key. One decision covers a whole batch (the approval.v2

--- a/apps/mobile/src/lib/approver.ts
+++ b/apps/mobile/src/lib/approver.ts
@@ -13,7 +13,10 @@
 // build.
 
 import * as Crypto from "expo-crypto";
-import * as SecureStore from "expo-secure-store";
+import { Platform } from "react-native";
+import { EVENT } from "./approvals.ts";
+import { getProjectItx } from "./itx.ts";
+import * as SecureStore from "./secure-store.ts";
 import { generateApproverKey, installRandomSource, signApprovalMessage } from "./approver-core.ts";
 
 installRandomSource(Crypto.getRandomValues);
@@ -54,6 +57,39 @@ export async function enrollApproverKey(
   const info: ApproverKeyInfo = { keyId: key.keyId, publicKey: key.publicKey, label };
   await SecureStore.setItemAsync(publicKey_(projectId), JSON.stringify(info));
   return info;
+}
+
+/**
+ * Auto-enrollment on project open: make sure this device holds an approval
+ * key for the project AND the project trusts it — silently (a Keychain WRITE
+ * never prompts Face ID; only authenticated reads do). Best-effort by
+ * contract: callers fire it from a query on the project home screen, a
+ * failure must not block opening the project, and the next open retries.
+ * Respect for revocation is the one wrinkle: a key the project has revoked
+ * (locally present or not) is NEVER silently re-added — un-revoking is a
+ * deliberate human act, so those fall back to the approvals screen's manual
+ * enroll after deleting local material.
+ */
+export async function ensureApproverKeyEnrolled(
+  baseUrl: string,
+  projectId: string,
+): Promise<ApproverKeyInfo | null> {
+  const key = await enrollApproverKey(
+    projectId,
+    Platform.OS === "web" ? "This browser (dev)" : "This iPhone",
+  );
+  const project = await getProjectItx(baseUrl, projectId);
+  const enrolled = (await project.processor.snapshot()).state.humanApprovalKeys as Array<{
+    keyId: string;
+    revokedAt: string | null;
+  }>;
+  const existing = enrolled.find((candidate) => candidate.keyId === key.keyId);
+  if (existing) return existing.revokedAt === null ? key : null;
+  await project.streams.get("/").append({
+    type: EVENT.keyAdded,
+    payload: { keyId: key.keyId, publicKey: key.publicKey, label: key.label },
+  });
+  return key;
 }
 
 /**

--- a/apps/mobile/src/lib/approver.ts
+++ b/apps/mobile/src/lib/approver.ts
@@ -14,6 +14,7 @@
 
 import * as Crypto from "expo-crypto";
 import { Platform } from "react-native";
+import type { HumanApprovalKey } from "../../../os/src/domains/projects/egress-approvals.ts";
 import { EVENT } from "./approvals.ts";
 import { getProjectItx } from "./itx.ts";
 import * as SecureStore from "./secure-store.ts";
@@ -78,13 +79,10 @@ export async function ensureApproverKeyEnrolled(
     projectId,
     Platform.OS === "web" ? "This browser (dev)" : "This iPhone",
   );
-  const project = await getProjectItx(baseUrl, projectId);
-  const enrolled = (await project.processor.snapshot()).state.humanApprovalKeys as Array<{
-    keyId: string;
-    revokedAt: string | null;
-  }>;
+  const enrolled = await projectApprovalKeys(baseUrl, projectId);
   const existing = enrolled.find((candidate) => candidate.keyId === key.keyId);
   if (existing) return existing.revokedAt === null ? key : null;
+  const project = await getProjectItx(baseUrl, projectId);
   await project.streams.get("/").append({
     type: EVENT.keyAdded,
     payload: { keyId: key.keyId, publicKey: key.publicKey, label: key.label },
@@ -111,11 +109,7 @@ export async function approverKeyStatus(
 ): Promise<ApproverKeyStatus> {
   const key = await loadApproverKey(projectId);
   if (!key) return { kind: "unenrolled" };
-  const project = await getProjectItx(baseUrl, projectId);
-  const enrolled = (await project.processor.snapshot()).state.humanApprovalKeys as Array<{
-    keyId: string;
-    revokedAt: string | null;
-  }>;
+  const enrolled = await projectApprovalKeys(baseUrl, projectId);
   const entry = enrolled.find((candidate) => candidate.keyId === key.keyId);
   if (entry && entry.revokedAt !== null) return { kind: "revoked", key };
   return { kind: "enrolled", key };
@@ -161,6 +155,22 @@ export async function signWithApproverKey(
   if (!privateKey)
     throw new Error("Enrolled key's public half exists but the private half is gone.");
   return { keyId: info.keyId, signature: signApprovalMessage(privateKey, message) };
+}
+
+/**
+ * The project's enrolled approval keys, from the project processor's reduced
+ * state. The snapshot crosses the itx RPC boundary untyped; the cast is to
+ * the CONTRACT-derived {@link HumanApprovalKey} — the exact type the server
+ * reduces this field with (project-processor-contract.ts stateSchema), so
+ * shape drift is a compile error on the server side, not a runtime surprise
+ * here.
+ */
+async function projectApprovalKeys(
+  baseUrl: string,
+  projectId: string,
+): Promise<HumanApprovalKey[]> {
+  const project = await getProjectItx(baseUrl, projectId);
+  return (await project.processor.snapshot()).state.humanApprovalKeys as HumanApprovalKey[];
 }
 
 /** Local key material only — the caller still needs to append `human-approval-key-revoked` for the platform to stop trusting it. */

--- a/apps/mobile/src/lib/device-identity.ts
+++ b/apps/mobile/src/lib/device-identity.ts
@@ -1,5 +1,5 @@
 import * as Crypto from "expo-crypto";
-import * as SecureStore from "expo-secure-store";
+import * as SecureStore from "./secure-store.ts";
 
 const DEVICE_ID_KEY = "iterate.mobileDeviceId.v1";
 const LEGACY_LOCATION_DEVICE_ID_KEY = "iterate.locationReminderDeviceId.v1";

--- a/apps/mobile/src/lib/secure-store.ts
+++ b/apps/mobile/src/lib/secure-store.ts
@@ -1,0 +1,46 @@
+// The app's ONE doorway to secure key-value storage. Native re-exports
+// expo-secure-store untouched (Keychain, Face ID on authenticated reads). Web
+// gets a dev/spec-grade stand-in — expo-secure-store's web build is an EMPTY
+// module, so without this every SecureStore-backed feature is dead in a
+// browser: localStorage holds the values, and a read with
+// `requireAuthentication` first asks `window.confirm(authenticationPrompt)`,
+// the Face ID stand-in a playwright spec (or a human dev) answers. This is
+// deliberately NOT secure — the web build exists for review, specs, and dev,
+// never as a real approver surface; iOS behavior is byte-identical to before.
+
+import { Platform } from "react-native";
+import * as SecureStore from "expo-secure-store";
+
+export type SecureStoreOptions = {
+  requireAuthentication?: boolean;
+  authenticationPrompt?: string;
+};
+
+const WEB_PREFIX = "iterate.secure-store.";
+
+export async function getItemAsync(
+  key: string,
+  options: SecureStoreOptions = {},
+): Promise<string | null> {
+  if (Platform.OS !== "web") return SecureStore.getItemAsync(key, options);
+  const value = localStorage.getItem(WEB_PREFIX + key);
+  if (value !== null && options.requireAuthentication) {
+    const approved = window.confirm(options.authenticationPrompt || "Unlock secure storage?");
+    if (!approved) throw new Error("Authentication was cancelled.");
+  }
+  return value;
+}
+
+export async function setItemAsync(
+  key: string,
+  value: string,
+  options: SecureStoreOptions = {},
+): Promise<void> {
+  if (Platform.OS !== "web") return SecureStore.setItemAsync(key, value, options);
+  localStorage.setItem(WEB_PREFIX + key, value);
+}
+
+export async function deleteItemAsync(key: string): Promise<void> {
+  if (Platform.OS !== "web") return SecureStore.deleteItemAsync(key);
+  localStorage.removeItem(WEB_PREFIX + key);
+}

--- a/apps/mobile/src/lib/storage.ts
+++ b/apps/mobile/src/lib/storage.ts
@@ -1,4 +1,4 @@
-import * as SecureStore from "expo-secure-store";
+import * as SecureStore from "./secure-store.ts";
 import { lastProjectStorageKey } from "./storage-keys.ts";
 
 // Keychain-backed storage. Only small, durable things live here: the server

--- a/apps/os/e2e/vitest/egress-approvals.e2e.test.ts
+++ b/apps/os/e2e/vitest/egress-approvals.e2e.test.ts
@@ -159,12 +159,18 @@ test("hold → approve releases, hold → reject refuses, short timeouts expire"
         approvalRequestEventOffset: rejectedRequested.offset,
         verdicts: ["reject"],
         decidedBy: "human",
+        reason: "wrong recipient — use the staging address",
       },
     });
     const rejectedResponse = await rejectedFetch;
     expect(rejectedResponse).toMatchObject({ status: 403 });
+    // The human's reason lands verbatim in the 403 body — this is what the
+    // calling script/agent reads to decide whether to retry differently.
     await expect(rejectedResponse.json()).resolves.toMatchObject({
       error: "approval_rejected",
+      deniedBy: "human",
+      reason: "wrong recipient — use the staging address",
+      detail: expect.stringContaining("wrong recipient — use the staging address"),
       ruleKey: "post-echo",
     });
 
@@ -210,6 +216,7 @@ test("hold → approve releases, hold → reject refuses, short timeouts expire"
     expect(expiredResponse).toMatchObject({ status: 403 });
     await expect(expiredResponse.json()).resolves.toMatchObject({
       error: "approval_expired",
+      deniedBy: "expiry",
       ruleKey: "impatient",
     });
     // The expiry decision is committed before the 403 returns, so a plain

--- a/apps/os/src/domains/projects/egress-approvals.test.ts
+++ b/apps/os/src/domains/projects/egress-approvals.test.ts
@@ -129,6 +129,23 @@ test("the approval request contract holds a non-empty batch with one nullish bod
   expect(() => schema.parse({ ...base, requests: [] })).toThrow();
 });
 
+test("an invalid rejection reason degrades to absent — never poisons the decision", () => {
+  const schema =
+    ProjectProcessorContract.events["events.iterate.com/project/human-approval-decided"]
+      .payloadSchema;
+  const base = { approvalRequestEventOffset: 7, verdicts: ["reject"], decidedBy: "human" };
+
+  expect(schema.parse({ ...base, reason: "  too long to read  " })).toMatchObject({
+    reason: "too long to read",
+  });
+  // Over the 1000-char cap: the decision must SURVIVE with the reason dropped
+  // — failing the whole parse would make the door ignore the decision and
+  // strand the hold until expiry.
+  const oversized = schema.parse({ ...base, reason: "r".repeat(2_000) });
+  expect(oversized).toMatchObject({ verdicts: ["reject"], decidedBy: "human" });
+  expect(oversized.reason).toBeUndefined();
+});
+
 const rule = (overrides: Partial<EgressRule> & Pick<EgressRule, "ruleKey">): EgressRule => ({
   description: "",
   match: {},

--- a/apps/os/src/domains/projects/project-durable-object.ts
+++ b/apps/os/src/domains/projects/project-durable-object.ts
@@ -521,13 +521,13 @@ export class ProjectDurableObject extends DurableObject<Env> {
       });
       const approvalRequestEventOffset = requested!.offset;
 
-      const verdicts = await this.#awaitBatchDecision({
+      const decision = await this.#awaitBatchDecision({
         approvalRequestEventOffset,
         deadline,
         requestedPayload,
       });
 
-      if (verdicts === "expired") {
+      if (decision === "expired") {
         await stream.append({
           type: "events.iterate.com/project/human-approval-decided",
           idempotencyKey: `human-approval-expired:${approvalRequestEventOffset}`,
@@ -542,6 +542,7 @@ export class ProjectDurableObject extends DurableObject<Env> {
             approvalGateResponse({
               approvalRequestEventOffset,
               code: "approval_expired",
+              deniedBy: "expiry",
               detail: `No human answered within ${rule.approvalTimeoutMs}ms (rule "${rule.ruleKey}").`,
               ruleKey: rule.ruleKey,
             }),
@@ -557,12 +558,18 @@ export class ProjectDurableObject extends DurableObject<Env> {
       // gets whatever upstream truly returned (or the true upstream error).
       await Promise.all(
         entries.map(async (entry, index) => {
-          if (verdicts[index] === "reject") {
+          if (decision.verdicts[index] === "reject") {
             entry.resolve(
               approvalGateResponse({
                 approvalRequestEventOffset,
                 code: "approval_rejected",
-                detail: `A human rejected this request (rule "${rule.ruleKey}").`,
+                deniedBy: "human",
+                // The human's stated reason rides the 403 body verbatim so
+                // the calling script/agent reads WHY and can retry changed.
+                reason: decision.reason,
+                detail:
+                  `A human rejected this request (rule "${rule.ruleKey}")` +
+                  (decision.reason === undefined ? "." : `: ${decision.reason}`),
                 ruleKey: rule.ruleKey,
               }),
             );
@@ -621,7 +628,7 @@ export class ProjectDurableObject extends DurableObject<Env> {
     approvalRequestEventOffset: number;
     deadline: number;
     requestedPayload: HumanApprovalRequestedPayload;
-  }): Promise<readonly ("approve" | "reject")[] | "expired"> {
+  }): Promise<AcceptedBatchDecision | "expired"> {
     const stream = this.#stream;
     const resolutionEventTypes = ["events.iterate.com/project/human-approval-decided"];
     let cursor = input.approvalRequestEventOffset;
@@ -663,8 +670,8 @@ export class ProjectDurableObject extends DurableObject<Env> {
       }
       availabilityBackoffMs = 200;
       cursor = event.offset;
-      const verdicts = await this.#judgeDecision(event, input);
-      if (verdicts !== null) return verdicts;
+      const decision = await this.#judgeDecision(event, input);
+      if (decision !== null) return decision;
     }
 
     // Expiry sweep: a decision appended in the last chunk's shadow must still
@@ -680,17 +687,18 @@ export class ProjectDurableObject extends DurableObject<Env> {
       for (const event of page) {
         if (Date.parse(event.createdAt) > input.deadline) return "expired";
         cursor = event.offset;
-        const verdicts = await this.#judgeDecision(event, input);
-        if (verdicts !== null) return verdicts;
+        const decision = await this.#judgeDecision(event, input);
+        if (decision !== null) return decision;
       }
     }
   }
 
   /**
-   * Judge one decided event for a specific batch: its verdicts when it
-   * references this batch and passes signature policy against FRESH key
-   * state, or null (not ours, or an ignored decision — malformed/unsigned/
-   * bad-sig/catch-up-failed — which is never fatal to the hold).
+   * Judge one decided event for a specific batch: its verdicts (plus the
+   * human's rejection reason) when it references this batch and passes
+   * signature policy against FRESH key state, or null (not ours, or an
+   * ignored decision — malformed/unsigned/bad-sig/catch-up-failed — which is
+   * never fatal to the hold).
    */
   async #judgeDecision(
     event: StreamEvent,
@@ -699,7 +707,7 @@ export class ProjectDurableObject extends DurableObject<Env> {
       deadline: number;
       requestedPayload: HumanApprovalRequestedPayload;
     },
-  ): Promise<readonly ("approve" | "reject")[] | null> {
+  ): Promise<AcceptedBatchDecision | null> {
     const decided = ProjectProcessorContract.events[
       "events.iterate.com/project/human-approval-decided"
     ].payloadSchema.safeParse(event.payload);
@@ -758,7 +766,9 @@ export class ProjectDurableObject extends DurableObject<Env> {
         keys: this.#projectReads.currentState.humanApprovalKeys,
         message,
       });
-      if (verdict.accepted) return decided.data.verdicts;
+      if (verdict.accepted) {
+        return { verdicts: decided.data.verdicts, reason: decided.data.reason };
+      }
       console.warn("egress approval: decision ignored", {
         approvalRequestEventOffset: input.approvalRequestEventOffset,
         keyId: decided.data.keyId,
@@ -905,11 +915,22 @@ export class ProjectDurableObject extends DurableObject<Env> {
 function approvalGateResponse(body: {
   approvalRequestEventOffset?: number;
   code: "egress_denied" | "approval_rejected" | "approval_expired";
+  /** Who refused a held batch: a human's decision, or the door's timeout. */
+  deniedBy?: "human" | "expiry";
+  /** The human's stated rejection reason, verbatim — what the calling agent reads. */
+  reason?: string;
   detail: string;
   ruleKey: string;
 }): Response {
   return Response.json({ error: body.code, ...body }, { status: 403 });
 }
+
+/** The FIRST accepted decision's substance: a verdict per index, plus the
+ * human's rejection reason when one was given. */
+type AcceptedBatchDecision = {
+  verdicts: readonly ("approve" | "reject")[];
+  reason: string | undefined;
+};
 
 /** One parked caller inside a pending batch: its buffered request, its
  * placeholder-form record for the event, and the promise handles its fetch

--- a/apps/os/src/domains/projects/project-processor-contract.ts
+++ b/apps/os/src/domains/projects/project-processor-contract.ts
@@ -324,6 +324,21 @@ export const ProjectProcessorContract = defineProcessorContract({
             "Who decided: a human, or the door's own timeout (expiry is always all-reject and " +
             "never signed).",
         }),
+        reason: z
+          .string()
+          .trim()
+          .min(1)
+          .max(1_000)
+          .optional()
+          .meta({
+            description:
+              "The human's stated reason, applying to every rejected index in this decision. It " +
+              "rides back to the calling script in each rejected fetch's 403 body, so the agent " +
+              "can read why and retry with a change. Deliberately NOT covered by the approval.v2 " +
+              "signature: rejections never need signatures (deny is the fail-safe direction — " +
+              "stream-append access already suffices to veto), so signing the reason would " +
+              "protect nothing. Expiry decisions never carry one.",
+          }),
         keyId: z
           .string()
           .optional()

--- a/apps/os/src/domains/projects/project-processor-contract.ts
+++ b/apps/os/src/domains/projects/project-processor-contract.ts
@@ -324,12 +324,17 @@ export const ProjectProcessorContract = defineProcessorContract({
             "Who decided: a human, or the door's own timeout (expiry is always all-reject and " +
             "never signed).",
         }),
+        // `.catch(undefined)`: the reason is cosmetic next to the verdicts, so
+        // an invalid one (too long, blank) degrades to ABSENT instead of
+        // failing the whole payload parse — a malformed reason must never make
+        // the door ignore an otherwise-valid decision and strand the hold.
         reason: z
           .string()
           .trim()
           .min(1)
           .max(1_000)
           .optional()
+          .catch(undefined)
           .meta({
             description:
               "The human's stated reason, applying to every rejected index in this decision. It " +

--- a/packages/iterate/src/approve-core.ts
+++ b/packages/iterate/src/approve-core.ts
@@ -94,7 +94,7 @@ export type Settlement =
       /** One entry per approved index, in index order. */
       outcomes: Array<{ index: number; status: number | null; error: string | null }>;
     }
-  | { kind: "rejected"; decidedBy: "human" | "expiry" }
+  | { kind: "rejected"; decidedBy: "human" | "expiry"; reason?: string }
   | { kind: "unsettled" } // the deadline elapsed with no outcome — safe to re-offer
   | { kind: "error"; message: string }; // a transport/protocol failure — NOT re-offerable
 
@@ -169,6 +169,9 @@ export async function decide(input: {
   offset: number;
   payload: RequestedPayload;
   verdicts: readonly Verdict[];
+  /** The human's rejection reason — rides the event (unsigned, like
+   * rejections themselves) into each rejected fetch's 403 body. */
+  reason?: string;
   signature?: string;
 }): Promise<void> {
   const signs = input.key !== null && input.verdicts.includes("approve");
@@ -179,12 +182,14 @@ export async function decide(input: {
       messageFor(input.projectId, input.offset, input.payload, input.verdicts),
     );
   }
+  const reason = input.reason?.trim();
   await input.stream.append({
     type: EVENT.decided,
     payload: {
       approvalRequestEventOffset: input.offset,
       verdicts: [...input.verdicts],
       decidedBy: "human",
+      ...(reason ? { reason } : {}),
       ...(signs ? { keyId: input.key!.keyId, signature } : {}),
     },
   });

--- a/packages/iterate/src/approve-core.ts
+++ b/packages/iterate/src/approve-core.ts
@@ -182,7 +182,9 @@ export async function decide(input: {
       messageFor(input.projectId, input.offset, input.payload, input.verdicts),
     );
   }
-  const reason = input.reason?.trim();
+  // Cap to the contract's 1000-char bound so a long pasted reason survives
+  // truncated instead of degrading to absent via the schema's catch.
+  const reason = input.reason?.trim().slice(0, 1_000);
   await input.stream.append({
     type: EVENT.decided,
     payload: {

--- a/packages/iterate/src/approve-json.ts
+++ b/packages/iterate/src/approve-json.ts
@@ -30,7 +30,7 @@
 //   {"type":"error","offset":42,"message":"…"}
 //
 // In (stdin):
-//   {"offset":42,"decision":"approve"|"reject"}
+//   {"offset":42,"decision":"approve"|"reject","reason":"optional reject reason"}
 // ─────────────────────────────────────────────────────────────────────────────
 
 import { createInterface } from "node:readline";
@@ -184,9 +184,9 @@ export async function runApprovalJson(input: {
   async function handleDecision(raw: string): Promise<void> {
     const trimmed = raw.trim();
     if (trimmed === "") return;
-    let decision: { offset?: number; decision?: string };
+    let decision: { offset?: number; decision?: string; reason?: string };
     try {
-      decision = JSON.parse(trimmed) as { offset?: number; decision?: string };
+      decision = JSON.parse(trimmed) as { offset?: number; decision?: string; reason?: string };
     } catch {
       emit({ type: "error", message: "malformed decision line" });
       return;
@@ -226,6 +226,7 @@ export async function runApprovalJson(input: {
         offset,
         payload,
         verdicts,
+        reason: typeof decision.reason === "string" ? decision.reason : undefined,
       });
     } catch (error) {
       decided.delete(offset); // the append failed — allow another attempt
@@ -279,6 +280,7 @@ function dispatch(
     approvalRequestEventOffset?: number;
     verdicts?: Verdict[];
     decidedBy?: string;
+    reason?: string;
   };
   const offset = payload.approvalRequestEventOffset;
   if (typeof offset !== "number") return;
@@ -296,6 +298,7 @@ function dispatch(
         offset,
         outcome: "rejected",
         reason: payload.decidedBy === "expiry" ? "expiry" : "human",
+        ...(typeof payload.reason === "string" ? { humanReason: payload.reason } : {}),
       });
       return;
     }

--- a/packages/iterate/src/approve-json.ts
+++ b/packages/iterate/src/approve-json.ts
@@ -35,6 +35,8 @@
 
 import { createInterface } from "node:readline";
 
+import { z } from "zod";
+
 import type { RpcStub } from "@iterate-com/capnweb";
 
 import type { ItxAuthCredentials, Stream, StreamEvent } from "./itx-api.generated.ts";
@@ -49,6 +51,14 @@ import {
   type RequestedPayload,
   type Verdict,
 } from "./approve-core.ts";
+
+/** The complete stdin decision line — the ONE boundary where the menu bar's
+ * arbitrary NDJSON becomes trusted input. */
+const StdinDecisionLine = z.object({
+  offset: z.number(),
+  decision: z.enum(["approve", "reject"]),
+  reason: z.string().optional(),
+});
 
 /** Back-off before re-arming a settlement watch after a transient read error. */
 const SETTLEMENT_RETRY_MS = 2_000;
@@ -184,32 +194,32 @@ export async function runApprovalJson(input: {
   async function handleDecision(raw: string): Promise<void> {
     const trimmed = raw.trim();
     if (trimmed === "") return;
-    // Arbitrary stdin: JSON.parse proves nothing about shape, so validate at
-    // this boundary — reject non-objects here, then typeof-check each field
-    // where it's read below.
-    let decision: Record<string, unknown>;
+    let json: unknown;
     try {
-      const parsed: unknown = JSON.parse(trimmed);
-      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-        throw new Error("decision line must be a JSON object");
-      }
-      decision = parsed as Record<string, unknown>;
+      json = JSON.parse(trimmed);
     } catch {
       emit({ type: "error", message: "malformed decision line" });
       return;
     }
-    const offset = decision.offset;
-    if (typeof offset !== "number") return;
+    const line = StdinDecisionLine.safeParse(json);
+    if (!line.success) {
+      // Salvage the offset when there is one, so the menu bar can clear that
+      // row's spinner instead of only surfacing a global error.
+      const offsetOnly = z.object({ offset: z.number() }).loose().safeParse(json);
+      emit({
+        type: "error",
+        ...(offsetOnly.success ? { offset: offsetOnly.data.offset } : {}),
+        message: `malformed decision line: ${z.prettifyError(line.error)}`,
+      });
+      return;
+    }
+    const { offset, decision, reason } = line.data;
     // The door acts on the first decision; once a batch has resolved, or
     // we've already appended a decision for it (decided, awaiting the door),
     // a second decision can't take effect and must not append a dead-weight
     // event or pop Touch ID again. Refuse it.
     if (resolved.has(offset) || decided.has(offset)) {
       emit({ type: "error", offset, message: "already decided" });
-      return;
-    }
-    if (decision.decision !== "approve" && decision.decision !== "reject") {
-      emit({ type: "error", offset, message: `unknown decision "${decision.decision}"` });
       return;
     }
     const payload = pending.get(offset);
@@ -220,9 +230,7 @@ export async function runApprovalJson(input: {
     // Claim the offset BEFORE any async work so a second line queued right behind
     // this one is refused above; release it only if the append fails.
     decided.add(offset);
-    const verdicts = payload.requests.map(
-      (): Verdict => (decision.decision === "approve" ? "approve" : "reject"),
-    );
+    const verdicts = payload.requests.map((): Verdict => decision);
     try {
       // Signs on the enclave path — Touch ID pops here (approve only;
       // all-reject decisions are never signed).
@@ -233,7 +241,7 @@ export async function runApprovalJson(input: {
         offset,
         payload,
         verdicts,
-        reason: typeof decision.reason === "string" ? decision.reason : undefined,
+        reason,
       });
     } catch (error) {
       decided.delete(offset); // the append failed — allow another attempt

--- a/packages/iterate/src/approve-json.ts
+++ b/packages/iterate/src/approve-json.ts
@@ -184,9 +184,16 @@ export async function runApprovalJson(input: {
   async function handleDecision(raw: string): Promise<void> {
     const trimmed = raw.trim();
     if (trimmed === "") return;
-    let decision: { offset?: number; decision?: string; reason?: string };
+    // Arbitrary stdin: JSON.parse proves nothing about shape, so validate at
+    // this boundary — reject non-objects here, then typeof-check each field
+    // where it's read below.
+    let decision: Record<string, unknown>;
     try {
-      decision = JSON.parse(trimmed) as { offset?: number; decision?: string; reason?: string };
+      const parsed: unknown = JSON.parse(trimmed);
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        throw new Error("decision line must be a JSON object");
+      }
+      decision = parsed as Record<string, unknown>;
     } catch {
       emit({ type: "error", message: "malformed decision line" });
       return;

--- a/packages/iterate/src/approve.ts
+++ b/packages/iterate/src/approve.ts
@@ -139,6 +139,7 @@ export async function runApprovalCli(input: {
             offset,
             payload,
             verdicts: allReject,
+            reason: await promptRejectReason(),
           });
           prompts.log.warn(`Rejected #${offset}.`);
           return "next";
@@ -160,6 +161,7 @@ export async function runApprovalCli(input: {
             offset,
             payload,
             verdicts: allReject,
+            reason: await promptRejectReason(),
           });
           prompts.log.warn(`Rejected #${offset}.`);
           return "next";
@@ -316,6 +318,18 @@ async function revokeKey(input: {
   );
 }
 
+/** Optional free-text rejection reason — rides the decided event into each
+ * rejected fetch's 403 body so the calling agent reads WHY. Ctrl-C or empty
+ * input means no reason; the rejection itself already happened by choice. */
+async function promptRejectReason(): Promise<string | undefined> {
+  const reason = await prompts.text({
+    message: "Why? (optional — the calling agent sees this)",
+    placeholder: "wrong recipient, try the staging host, …",
+  });
+  if (prompts.isCancel(reason) || !reason.trim()) return undefined;
+  return reason.trim();
+}
+
 /** Back-off before re-arming a settlement watch after a transient read error. */
 const SETTLEMENT_RETRY_MS = 2_000;
 
@@ -358,7 +372,7 @@ function reportSettlement(offset: number, settlement: Exclude<Settlement, { kind
       return prompts.log.warn(
         settlement.decidedBy === "expiry"
           ? `#${offset} expired before the decision landed.`
-          : `Rejected #${offset}.`,
+          : `Rejected #${offset}.${settlement.reason ? ` Reason: ${settlement.reason}` : ""}`,
       );
     case "unsettled":
       return prompts.log.warn(

--- a/specs/mobile/approvals.spec.ts
+++ b/specs/mobile/approvals.spec.ts
@@ -11,6 +11,7 @@
 // screen the way a human following a badge would.
 
 import { expect, type Page } from "@playwright/test";
+import { spinnerWaiter } from "middlewright";
 import { connectItxReady } from "iterate/node";
 import { localOsDevServer } from "../../apps/os/scripts/dev.ts";
 import { withTunnel } from "../../apps/os/e2e/test-support/tunnel.ts";
@@ -39,11 +40,20 @@ test("approve a burst with one confirm; reject with a reason the script reads", 
       projectSlug,
       testInfo,
     });
+    // The phone client requests the `project` scope, so the popup continues
+    // through project selection (the new project arrives pre-selected) and
+    // the OAuth consent screen before redirecting back into the app.
+    await popup.getByRole("button", { name: "Continue" }).click({ timeout: 30_000 });
+    await popup.getByRole("button", { name: "Allow access" }).click({ timeout: 30_000 });
 
     // The popup redirects back into the app and closes itself; the app lands
     // on the project picker. Opening the project auto-enrolls this browser's
-    // approval key — no manual enroll step anywhere below.
-    await page.getByText(projectSlug).click();
+    // approval key — no manual enroll step anywhere below. The first project
+    // list rides a COLD itx WebSocket to the deployment (session dial +
+    // directory read observed at ~20-30s against preview slots), beyond the
+    // spinner-waiter's budget — a product-latency problem worth fixing at the
+    // source, not something more spinner UI can paper over.
+    await page.getByText(projectSlug).click({ timeout: 60_000 });
     await page.getByText("New chat").waitFor();
     const projectId = new URL(page.url()).pathname.split("/")[2]!;
 
@@ -113,7 +123,12 @@ test("approve a burst with one confirm; reject with a reason the script reads", 
     // differently.
     const rejecting = burst("reject-me");
     const reason = "wrong recipient — use the staging address";
-    await page.getByRole("button", { name: "Reject all" }).click({ trial: true });
+    // Nothing on screen hints that a new batch is inbound (the second burst is
+    // still coalescing at the egress door), so the spinner-waiter's
+    // no-spinner fast-fail doesn't apply — wait for the card plainly.
+    await spinnerWaiter.settings.run({ disabled: true }, () =>
+      page.getByRole("button", { name: "Reject all" }).waitFor({ timeout: 30_000 }),
+    );
     answerNextDialog(page, reason);
     await page.getByRole("button", { name: "Reject all" }).click();
     await page.getByText(`Rejected because: ${reason}`).waitFor();

--- a/specs/mobile/approvals.spec.ts
+++ b/specs/mobile/approvals.spec.ts
@@ -110,6 +110,12 @@ test("approve a burst with one confirm; reject with a reason the script reads", 
     // stand-in), every request released.
     const approving = burst("approve-me");
     await page.goto(`/project/${projectId}/approvals?slug=${projectSlug}`);
+    // Same shape as the reject lane below: the burst is still coalescing at
+    // the egress door, the screen is honestly at rest (no spinner to wait
+    // on), so hold the spinner-waiter off while the batch card appears.
+    await spinnerWaiter.settings.run({ disabled: true }, () =>
+      page.getByRole("button", { name: "Approve all 3 (Face ID)" }).waitFor({ timeout: 30_000 }),
+    );
     acceptNextDialog(page);
     await page.getByRole("button", { name: "Approve all 3 (Face ID)" }).click();
     await page.getByText("Approved").first().waitFor();

--- a/specs/mobile/approvals.spec.ts
+++ b/specs/mobile/approvals.spec.ts
@@ -1,0 +1,161 @@
+// The phone approver, end to end in a browser: a script run's concurrent
+// burst parks at the egress door as ONE approval batch, and the human decides
+// it from the mobile app — Approve all behind the Face ID stand-in (the web
+// build gates authenticated key reads behind `confirm()`), or Reject with a
+// typed reason that lands verbatim in the script's 403 body so the calling
+// agent can retry differently.
+//
+// Web-platform approximations, deliberate and dev-only: secure storage is
+// localStorage with confirm()-gated reads (apps/mobile/src/lib/secure-store.ts),
+// and push notifications don't exist — the spec navigates to the Approvals
+// screen the way a human following a badge would.
+
+import { expect, type Page } from "@playwright/test";
+import { connectItxReady } from "iterate/node";
+import { localOsDevServer } from "../../apps/os/scripts/dev.ts";
+import { withTunnel } from "../../apps/os/e2e/test-support/tunnel.ts";
+import { signUpWithEmailOtp, uniqueSignupEmail } from "../test-support/email-otp-signup.ts";
+import { resolveAdminSecret } from "../test-support/forged-session.ts";
+import { test } from "../test-support/test.ts";
+
+test("approve a burst with one confirm; reject with a reason the script reads", async ({
+  page,
+}, testInfo) => {
+  const osBaseUrl = await resolveOsBaseUrl();
+  const echo = await startEgressEcho();
+  try {
+    // ── Sign up through the REAL flow: server picker → OAuth popup → email
+    // OTP (fixed dev code) → org+project onboarding → back in the app.
+    const projectSlug = `mobile-approvals-${Date.now().toString(36)}`;
+    await page.goto("/");
+    const serverInput = page.getByPlaceholder("https://os.iterate.com");
+    await serverInput.fill(osBaseUrl);
+    const popupPromise = page.waitForEvent("popup");
+    await page.getByRole("button", { name: "Sign in" }).click();
+    const popup = await popupPromise;
+    await popup.getByTestId("email-login-button").click();
+    await signUpWithEmailOtp(popup, {
+      email: uniqueSignupEmail("mobile-approvals"),
+      projectSlug,
+      testInfo,
+    });
+
+    // The popup redirects back into the app and closes itself; the app lands
+    // on the project picker. Opening the project auto-enrolls this browser's
+    // approval key — no manual enroll step anywhere below.
+    await page.getByText(projectSlug).click();
+    await page.getByText("New chat").waitFor();
+    const projectId = new URL(page.url()).pathname.split("/")[2]!;
+
+    // ── The agent side, from Node: a hold rule on the echo host, then a
+    // 3-fetch Promise.all burst that parks as ONE batch at the egress door.
+    using itx = await connectItxReady({
+      auth: { type: "admin-secret", secret: await resolveAdminSecret() },
+      baseUrl: osBaseUrl,
+      projectId,
+    });
+    const echoHost = new URL(echo.url).hostname;
+    const [rulesConfigured] = await itx.streams.get("/").append({
+      type: "events.iterate.com/project/egress-rules-configured",
+      payload: {
+        rules: [
+          {
+            ruleKey: "spec-needs-a-human",
+            description: "The mobile approvals spec holds these for a human",
+            match: { hosts: [echoHost] },
+            verdict: "hold",
+            approvalTimeoutMs: 120_000,
+            // Generous window so a busy CI runner's burst still lands in ONE
+            // batch — the 100ms default is tuned for production latencies.
+            debounceMs: 2_000,
+          },
+        ],
+      },
+    });
+    await itx.processor.waitUntilProcessed({ offset: rulesConfigured!.offset, timeoutMs: 15_000 });
+    // Outwait the egress gate's ~5s rules cache before the first burst.
+    await new Promise((resolve) => setTimeout(resolve, 6_000));
+
+    const burst = (marker: string) =>
+      itx.capabilityHost.runScript(
+        `async () => {
+          const responses = await Promise.all(
+            Array.from({ length: 3 }, (_, index) =>
+              fetch(${JSON.stringify(echo.url)} + "?${marker}=" + index, {
+                method: "POST",
+                body: "${marker} " + index,
+              }),
+            ),
+          );
+          return await Promise.all(
+            responses.map(async (response) => ({
+              status: response.status,
+              body: await response.json(),
+            })),
+          );
+        }`,
+      );
+
+    // ── Approve lane: one card for the whole burst, one confirm (the Face ID
+    // stand-in), every request released.
+    const approving = burst("approve-me");
+    await page.goto(`/project/${projectId}/approvals?slug=${projectSlug}`);
+    acceptNextDialog(page);
+    await page.getByRole("button", { name: "Approve all 3 (Face ID)" }).click();
+    await page.getByText("Approved").first().waitFor();
+    const approved = (await approving) as {
+      result: Array<{ status: number; body: { body: string } }>;
+    };
+    expect(approved.result.map((entry) => entry.status)).toEqual([200, 200, 200]);
+
+    // ── Reject lane: Reject all prompts for WHY, and the reason lands
+    // verbatim in each rejected fetch's 403 body — the agent's cue to retry
+    // differently.
+    const rejecting = burst("reject-me");
+    const reason = "wrong recipient — use the staging address";
+    await page.getByRole("button", { name: "Reject all" }).click({ trial: true });
+    answerNextDialog(page, reason);
+    await page.getByRole("button", { name: "Reject all" }).click();
+    await page.getByText(`Rejected because: ${reason}`).waitFor();
+    const rejected = (await rejecting) as {
+      result: Array<{ status: number; body: { deniedBy?: string; reason?: string } }>;
+    };
+    expect(rejected.result.map((entry) => entry.status)).toEqual([403, 403, 403]);
+    expect(rejected.result[0]!.body).toMatchObject({ deniedBy: "human", reason });
+  } finally {
+    await echo.close();
+  }
+});
+
+/** Accept the next native dialog — the web build's Face ID stand-in. */
+function acceptNextDialog(page: Page) {
+  page.once("dialog", (dialog) => void dialog.accept());
+}
+
+/** Answer the next native prompt with `text` — the typed rejection reason. */
+function answerNextDialog(page: Page, text: string) {
+  page.once("dialog", (dialog) => void dialog.accept(text));
+}
+
+/** The OS deployment the mobile app should sign into: the same target the
+ * web specs run against (APP_CONFIG_BASE_URL in CI, the local dev server
+ * otherwise) — the mobile project's own baseURL is the Expo Web origin. */
+async function resolveOsBaseUrl(): Promise<string> {
+  const configured = process.env.APP_CONFIG_BASE_URL?.replace(/\/+$/, "");
+  if (configured) return configured;
+  const target = await localOsDevServer.resolveTarget();
+  return target.baseUrl;
+}
+
+/** Same fixture as apps/os/e2e's startEgressEcho, reimplemented locally:
+ * importing that file drags in its WebSocket-echo helper, which is typed
+ * against Cloudflare Workers globals this tsconfig doesn't have. withTunnel
+ * (captun) keeps the echo reachable from deployed preview workers too. */
+function startEgressEcho() {
+  return withTunnel({
+    path: "/egress-echo",
+    async fetch(request) {
+      return Response.json({ body: await request.text() });
+    },
+  });
+}

--- a/specs/test-support/forged-session.ts
+++ b/specs/test-support/forged-session.ts
@@ -140,6 +140,11 @@ export async function connectAdminItx(baseUrl: string) {
   return connectPlaywrightAdminItx({ baseUrl, config });
 }
 
+/** The OS admin API secret, for specs that dial project-scoped itx handles directly. */
+export async function resolveAdminSecret(): Promise<string> {
+  return (await resolveOsPlaywrightAuthConfig()).adminApiSecret;
+}
+
 async function createAdminProjectAfterPreviewRollout(input: {
   baseUrl: string;
   config: OsPlaywrightAuthConfig;

--- a/tasks/approval-rejection-reasons.md
+++ b/tasks/approval-rejection-reasons.md
@@ -117,6 +117,14 @@ had no button role.
 - Real WebAuthn/passkey signing on web
 - Push notifications on web
 
+# Follow-ups
+
+- approvals should appear inline in a thread. now that we trace what thread they come from they can just become a sort of dialog within the chat
+- the approvals view should show the status of the thread at the time the approval request was created for a bit of extra context now that the approvals view is kinda just for viewing history
+- we should only send the push notification if the user isn't already in the app. the system can give a chance (maybe a second or so) for the mobile to say "don't worry I've shown the user the approval request). the new in-thread approval dialog can then send that message when it successfully renders the thing in the thread
+- push notifications should probably now jump to the thread rather than approvals screen because approvals are now associated with a thread and the UI will be better
+- this isn't ready for implementation but I'd like to think through how expiry works. it'd be good to be able to pre-approve somehow. scenario: timer based task needs approval when I'm asleep. push notification suppressed because sleep mode. when I wake I see it, tap to go to the approval. it's expired. could there be an "Approve retry" button that would get an approval ready and then tell the agent "you can try again with the exact same request if still appropriate" or something. or maybe it should just be "request retry" which doesn't do faceid, just tells the agent "pls try again, I'll approve quickly this time" which will inevitably lead to another approval request within a second or so.
+
 ## Implementation log
 
 - Rejection reasons: `reason` deliberately outside the approval.v2 signature

--- a/tasks/approval-rejection-reasons.md
+++ b/tasks/approval-rejection-reasons.md
@@ -7,8 +7,16 @@ size: medium
 
 ## Status summary
 
-Fresh off #2309 (approval batches). Three riders in one PR, all approvals-mobile:
-nothing implemented yet — this spec commit comes first.
+All three asks implemented; PR #2337. Rejection reasons flow contract → door
+403 → mobile/CLI prompts → agent-visible body (verified live). Auto-enroll
+runs on project open. The playwright spec passes against a preview slot
+(sign-up → auto-enroll → approve-all via confirm → reject-with-reason
+asserted in the script's 403), with a VIDEO_MODE recording for the PR body.
+Getting there surfaced three real product gaps, fixed here: auth lacked CORS
+for loopback web clients (gated on fixedTestOtpEnabled), the mobile app's
+spinners were invisible to assistive tech and the spinner-waiter
+(ActivityIndicator now labeled "Loading"), and the approve/reject Pressables
+had no button role.
 
 ## Ask (Misha, 2026-07-29)
 
@@ -91,17 +99,17 @@ nothing implemented yet — this spec commit comes first.
 
 ## Checklist
 
-- [ ] Contract: `reason` on `human-approval-decided`; door 403 bodies gain
-      `deniedBy` + `reason`; e2e lane asserting the script sees the reason
-- [ ] Mobile: Reject/Reject-all prompts optional reason; Recent shows it
-- [ ] CLI: terminal reject prompt, `--json` stdin `reason`, settlement readback
-- [ ] Auto-enroll on project open (native + web), banner demoted to fallback
-- [ ] `lib/secure-store.ts` web shim (localStorage + confirm-gated
-      authenticated reads); all SecureStore imports moved over
-- [ ] `specs/mobile/approvals.spec.ts`: approve-all path + reject-with-reason
-      path, driving the web build end to end
-- [ ] Video recorded and embedded in the PR body
-- [ ] `pnpm typecheck && pnpm lint && pnpm knip && pnpm test`; PR hygiene
+- [x] Contract: `reason` on `human-approval-decided`; door 403 bodies gain
+      `deniedBy` + `reason`; e2e lane asserting the script sees the reason _contract + `#flushHoldBatch`/`#judgeDecision`; egress e2e reject lane asserts the verbatim reason, passed live_
+- [x] Mobile: Reject/Reject-all prompts optional reason; Recent shows it _`promptForRejectReason` (Alert.prompt iOS / window.prompt web); "Rejected because: …" on resolved cards_
+- [x] CLI: terminal reject prompt, `--json` stdin `reason`, settlement readback _approve.ts `promptRejectReason`; approve-json stdin + `humanReason` on rejected rows_
+- [x] Auto-enroll on project open (native + web), banner demoted to fallback _`ensureApproverKeyEnrolled` query on the chat-list screen; revoked keys never resurrected_
+- [x] `lib/secure-store.ts` web shim (localStorage + confirm-gated
+      authenticated reads); all SecureStore imports moved over _storage/approver/device-identity now import the wrapper_
+- [x] `specs/mobile/approvals.spec.ts`: approve-all path + reject-with-reason
+      path, driving the web build end to end _passes in ~37s against preview 5; OAuth popup chain is email OTP → onboarding → project-access Continue → consent Allow_
+- [x] Video recorded and embedded in the PR body _VIDEO_MODE run recorded; upload to PR body via the attachment flow_
+- [x] `pnpm typecheck && pnpm lint && pnpm knip && pnpm test`; PR hygiene _all green locally_
 
 ## Out of scope
 
@@ -111,4 +119,20 @@ nothing implemented yet — this spec commit comes first.
 
 ## Implementation log
 
-(append as work proceeds)
+- Rejection reasons: `reason` deliberately outside the approval.v2 signature
+  (rejections are unsigned; append access already suffices to veto).
+- The spec's road bumps, each fixed at the product layer: (1) auth CORS for
+  loopback origins on arbitrary ports, gated on `fixedTestOtpEnabled` — the
+  Expo Web app's browser-side OAuth (discovery/registration/token) was
+  impossible before; (2) RN-web `ActivityIndicator` renders `role=progressbar`
+  with no label, invisible to middlewright's spinner-waiter AND screen
+  readers — every instance now carries `accessibilityLabel="Loading"`;
+  (3) the approve/reject `Pressable`s had no `accessibilityRole="button"`.
+- The OAuth popup chain for the phone client has TWO extra steps the OS web
+  flow doesn't: project-access (Continue; project pre-selected) and consent
+  (Allow access) — because the client requests the `project` scope via
+  dynamic registration.
+- Spec env plumbing: run locally against a preview slot with
+  `APP_CONFIG_BASE_URL=https://os.iterate-preview-N.com DOPPLER_CONFIG=preview_N
+  CAPTUN_TOKEN=… pnpm spec mobile/approvals` (forged-session's doppler
+  fallback reads apps/os scope with DOPPLER_CONFIG honored).

--- a/tasks/approval-rejection-reasons.md
+++ b/tasks/approval-rejection-reasons.md
@@ -1,0 +1,114 @@
+---
+status: in-progress
+size: medium
+---
+
+# Approval rejection reasons, auto-enroll on project open, and a real approvals playwright spec
+
+## Status summary
+
+Fresh off #2309 (approval batches). Three riders in one PR, all approvals-mobile:
+nothing implemented yet — this spec commit comes first.
+
+## Ask (Misha, 2026-07-29)
+
+1. **Rejection reasons** (the queued #2309 follow-up): rejecting should prompt the
+   app for a reason which bubbles all the way back to the agent, so it can decide
+   whether to retry with a change.
+2. **Auto-enroll the device** when switching to / signing into a project on iOS.
+3. **Properly playwright-spec this** and include a video in the PR body. Use the
+   mobile app's web build; approximate Face ID with something session-local
+   (doesn't need to be bulletproof — dev/test only); skip push notifications and
+   navigate to the approvals view manually in the test.
+
+## Design
+
+### 1. Rejection reasons
+
+- `human-approval-decided` gains `reason?: string` (trimmed, max 1000): the
+  human's stated reason, applying to every rejected index in the decision.
+  One free-text field per decision — per-index reasons are overkill for a
+  one-prompt UI. `decidedBy: "expiry"` decisions never carry one.
+- The reason is **not** covered by the approval.v2 signature: rejections have
+  never needed signatures (deny is the fail-safe direction — anyone with
+  stream-append access can already veto), so binding the reason would protect
+  nothing. Documented in the contract description.
+- The egress door's 403 for a rejected index becomes
+  `{error: "approval_rejected", deniedBy: "human", reason, ruleKey, …}` — the
+  reason lands verbatim in the response body the script's fetch resolves to,
+  so the calling agent reads it straight out of its tool error/output. Expiry
+  stays `{error: "approval_expired", deniedBy: "expiry", …}`.
+- Surfaces that can SEND a reason: mobile (Reject / Reject all prompts an
+  optional reason — native `Alert.prompt` on iOS, `window.prompt` on web),
+  `iterate approve` terminal (clack text prompt on reject), `--json` (optional
+  `reason` on the stdin decision line). The menubar keeps its two-button flow
+  and sends no reason (its NDJSON line simply omits it).
+- Read surfaces: the mobile Recent card and CLI settlement readback show the
+  reason on rejected batches.
+
+### 2. Auto-enroll on project open (iOS)
+
+- Today enrollment is a manual banner on the approvals screen. Instead: when
+  the signed-in app opens a project (the project layout's first successful itx
+  connection) and this device has no approver key for it, enroll silently —
+  generate the P-256 key, persist it (SecureStore write does not prompt
+  Face ID; only authenticated *reads* do), append `human-approval-key-added`.
+- Best-effort and non-blocking: a failed enroll (offline, race) must not break
+  opening the project; it retries on the next open. Idempotent by construction
+  (`enrollApproverKey` returns the existing key; re-appending a known keyId is
+  a reducer no-op).
+- The approvals screen's enroll banner stays as the fallback/visible state,
+  but should now rarely appear.
+- Web gets the same behavior through the storage shim below — which is what
+  lets the playwright spec approve without a manual enroll step.
+
+### 3. Web approver + playwright spec + video
+
+- `expo-secure-store`'s web build is an EMPTY module, so everything
+  SecureStore-backed is dead on web today. Add
+  `apps/mobile/src/lib/secure-store.ts`: same `getItemAsync`/`setItemAsync`/
+  `deleteItemAsync` surface; native re-exports expo-secure-store; web backs
+  onto `localStorage`, and a read with `requireAuthentication` first asks
+  `window.confirm(authenticationPrompt)` — the Face ID stand-in, dismissible
+  by playwright and by a human dev. Not secure, not meant to be: dev/spec
+  only, and iOS behavior is unchanged. All mobile libs (`storage.ts`,
+  `approver.ts`) switch to the wrapper.
+- New spec `specs/mobile/approvals.spec.ts` (root playwright `mobile` project
+  already serves the expo web build): sign in against the spec's OS dev
+  server, open a fixture project, install a hold rule + fire a small burst
+  through itx from the test, navigate to Approvals (pushes are skipped
+  entirely on web), then drive BOTH decision paths: Approve all (confirm
+  dialog ≈ Face ID → released, script resolves) and Reject with a typed
+  reason (prompt dialog → script's 403 carries the reason).
+- Sign-in strategy for the spec: preferred is driving the real auth UI
+  (email-OTP prior art in `specs/test-support/email-otp-signup.ts`) — the
+  mobile app's web OAuth flow redirects in-window. If that turns out flaky,
+  fall back to seeding the storage shim with a real refresh token minted
+  through the auth API. Decide during implementation; the spec must read as
+  product usage either way.
+- Video: `VIDEO_MODE=1 pnpm spec -g <approvals spec>` (middlewright), then the
+  PR-media upload flow from global instructions.
+
+## Checklist
+
+- [ ] Contract: `reason` on `human-approval-decided`; door 403 bodies gain
+      `deniedBy` + `reason`; e2e lane asserting the script sees the reason
+- [ ] Mobile: Reject/Reject-all prompts optional reason; Recent shows it
+- [ ] CLI: terminal reject prompt, `--json` stdin `reason`, settlement readback
+- [ ] Auto-enroll on project open (native + web), banner demoted to fallback
+- [ ] `lib/secure-store.ts` web shim (localStorage + confirm-gated
+      authenticated reads); all SecureStore imports moved over
+- [ ] `specs/mobile/approvals.spec.ts`: approve-all path + reject-with-reason
+      path, driving the web build end to end
+- [ ] Video recorded and embedded in the PR body
+- [ ] `pnpm typecheck && pnpm lint && pnpm knip && pnpm test`; PR hygiene
+
+## Out of scope
+
+- Menubar reason input (keeps two-button flow, no reason)
+- Real WebAuthn/passkey signing on web
+- Push notifications on web
+
+## Implementation log
+
+(append as work proceeds)

--- a/tasks/complete/2026-07-29-approval-rejection-reasons.md
+++ b/tasks/complete/2026-07-29-approval-rejection-reasons.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 size: medium
 ---
 


### PR DESCRIPTION
Three riders on #2309's approval batches. The video is the new playwright spec driving the mobile app's web build end to end — sign-up, auto-enrolled approval key, a burst approved behind the Face ID stand-in, and a second burst rejected with a typed reason:

https://github.com/user-attachments/assets/486ea92c-ecca-4f31-a31a-f7d039df7f1c

## 1. Rejection reasons reach the agent

Rejecting a held batch now prompts for an optional reason (mobile `Alert.prompt` / web `window.prompt` / `iterate approve` text prompt / `--json` stdin field). It rides `human-approval-decided` and lands **verbatim in each rejected fetch's 403 body**:

```jsonc
// what the script's fetch resolves to after a human rejects
{ "error": "approval_rejected", "deniedBy": "human",
  "reason": "wrong recipient — use the staging address", "ruleKey": "gmail-sends", … }
```

so the calling agent reads *why* and can retry with a change. Expiry 403s carry `deniedBy: "expiry"`. The reason is deliberately **outside** the approval.v2 signature: rejections have never needed signatures (deny is fail-safe — stream-append access already suffices to veto), so signing the reason would protect nothing. Recent cards and CLI readback display it.

## 2. Auto-enroll on project open

Opening a project silently enrolls the device's approval key (Keychain writes never prompt Face ID; only signing reads do), so held requests are approvable the moment they appear. Revoked keys are never resurrected — un-revoking stays a deliberate manual act. The approvals screen's enroll banner is now the fallback, not the common path.

## 3. A real playwright spec for the phone approver

`specs/mobile/approvals.spec.ts` (root playwright `mobile` project, Expo Web) — passes in ~37s against a preview slot. Web-only approximations, dev-grade on purpose: `lib/secure-store.ts` backs SecureStore onto localStorage with **`confirm()`-gated authenticated reads as the Face ID stand-in** (expo-secure-store's web build is an empty module — everything key-backed was dead in a browser before); pushes don't exist on web, so the spec navigates to Approvals directly. iOS behavior is byte-identical.

Getting the spec honest surfaced three product gaps, fixed here rather than worked around:

- **Auth CORS for loopback web clients**: browser-side OAuth (discovery, dynamic registration, token exchange) was impossible from the Expo Web app — native apps never hit CORS. Auth now trusts `http://localhost|127.0.0.1|[::1]` on any port, gated on `fixedTestOtpEnabled` so production auth never trusts localhost pages.
- **Spinners were invisible to assistive tech**: RN-web's `ActivityIndicator` renders `role=progressbar` with no label. Every instance now carries `accessibilityLabel="Loading"` — screen readers announce it, and middlewright's spinner-waiter can finally see the app loading instead of fast-failing.
- **Action buttons had no button role**: the approve/reject/enroll `Pressable`s gained `accessibilityRole="button"`.

Also of note: the phone client's OAuth popup has two steps the OS web flow doesn't (project-access → consent), because it dynamically registers and requests the `project` scope — the spec documents the full chain.

## Review pointers

The trust-relevant diff is small: `project-processor-contract.ts` (the `reason` field + its non-signed rationale) and `#flushHoldBatch`/`#judgeDecision` in `project-durable-object.ts`. The CORS change (`apps/auth/src/server/auth.ts` `isAllowedBrowserOrigin`) deserves a skeptical read of the `fixedTestOtpEnabled` gate. Everything else is UI plumbing and the spec.

Task: `tasks/approval-rejection-reasons.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session: `4a701c88-5931-49e1-a0a5-970ccedfdd2a`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T08:10:53.460Z",
      "deployedAt": "2026-07-29T07:46:04.148Z",
      "headSha": "6e8d6f49da1ce53acf741620e89ae27cea0139e0",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/589166564762709",
      "shortSha": "6e8d6f4",
      "cleanupDurationMs": 19577,
      "deployDurationMs": 46859,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 45395,
      "deployReadinessDurationMs": 1460,
      "deployedWorkerName": "os-preview-5",
      "deployedWorkerVersion": "ff003160-3a58-43d3-9ca4-a7bb38afd304",
      "testDurationMs": 192757,
      "testRetries": null,
      "workerSizeKib": 19910.71,
      "workerGzipKib": 5028.96,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5039.79
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T08:10:36.593Z",
      "deployedAt": "2026-07-29T07:45:36.617Z",
      "headSha": "6e8d6f49da1ce53acf741620e89ae27cea0139e0",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/589166564762709",
      "shortSha": "6e8d6f4",
      "cleanupDurationMs": 2708,
      "deployDurationMs": 18129,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 17861,
      "deployReadinessDurationMs": 264,
      "deployedWorkerName": "auth-preview-5",
      "deployedWorkerVersion": "efc82927-4999-412e-b8d6-0480820e819e",
      "testDurationMs": 9317,
      "testRetries": null,
      "workerSizeKib": 3977.32,
      "workerGzipKib": 814.33,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T08:10:34.532Z",
      "deployedAt": "2026-07-29T06:59:32.333Z",
      "headSha": "6e8d6f49da1ce53acf741620e89ae27cea0139e0",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/589166564762709",
      "shortSha": "6e8d6f4",
      "cleanupDurationMs": 645,
      "deployDurationMs": 33,
      "deployConfigDurationMs": 4,
      "deployReuseProofDurationMs": 12,
      "deployedWorkerName": "dummy-petshop-preview-5",
      "deployedWorkerVersion": "88926532-c035-44b6-be6e-1d982bbaf311",
      "testDurationMs": 9541,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `6e8d6f4` | [https://auth.iterate-preview-5.com](https://auth.iterate-preview-5.com) | 814.3 KiB | 18.1s | 9.3s |  | 2.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/589166564762709) | 2026-07-29T08:10:36.593Z | Preview app released. |
| Dummy Petshop | released | `6e8d6f4` | [https://dummy-petshop.iterate-preview-5.com](https://dummy-petshop.iterate-preview-5.com) | 198.3 KiB | 33ms | 9.5s |  | 645ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/589166564762709) | 2026-07-29T08:10:34.532Z | Preview app released. |
| OS | released | `6e8d6f4` | [https://os.iterate-preview-5.com](https://os.iterate-preview-5.com) | 4.91 MiB (-10.8 KiB vs main) | 46.9s | 192.8s |  | 19.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/589166564762709) | 2026-07-29T08:10:53.460Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +136 -51 | +83 -39 🟩🟩🟥⬜⬜ |
| Mobile | +329 -26 | +216 -23 🟩🟩🟩🟩🟩 |
| Tests | +206 -0 | +126 -0 🟩🟩🟩⬜⬜ |
| Docs | +146 -0 | +126 -0 🟩🟩🟩⬜⬜ |
| Other | +5 -0 | +3 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+822 -77** | **+554 -62** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between d7f41f1 and 6e8d6f4, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth CORS/trusted origins (gated by `fixedTestOtpEnabled` in production) and egress 403 contract fields agents consume; web secure-store is dev-only by design.
> 
> **Overview**
> Adds **optional rejection reasons** on human egress approvals so agents see *why* a held batch was vetoed, **silent approver-key enrollment** when opening a project, and a **Playwright spec** for the mobile web approver.
> 
> **Rejection reasons** ride `human-approval-decided` (trimmed, max 1000 chars, outside the approval.v2 signature) through mobile/CLI/`iterate approve` prompts into each rejected fetch’s **403** (`deniedBy`, `reason`, updated `detail`). Expiry responses add `deniedBy: "expiry"`. Invalid oversized reasons degrade to absent so decisions still apply.
> 
> **Mobile approver** joins local Keychain state with project enrolled keys (`approverKeyStatus`, revoked re-enroll), auto-enrolls on the chat list via `ensureApproverKeyEnrolled`, and uses a **web `secure-store` shim** (localStorage + `confirm()` for authenticated reads). Accessibility fixes: `accessibilityLabel="Loading"` on spinners and button roles on approval actions.
> 
> **Auth** replaces static origin lists with `isAllowedBrowserOrigin`: loopback on any port when `fixedTestOtpEnabled`, else only MCP inspector port 6274; `trustedOrigins` returns the requester plus deployment origins.
> 
> **Tests:** unit coverage for reason propagation; `specs/mobile/approvals.spec.ts` signs up, approves a burst, rejects with a reason asserted in script 403s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e8d6f49da1ce53acf741620e89ae27cea0139e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->