### PR TITLE
fix: small security hardening (invite, DMARC, repo paths)

### DIFF
--- a/apps/auth/src/server/orpc/routers/organization.ts
+++ b/apps/auth/src/server/orpc/routers/organization.ts
@@ -217,6 +217,12 @@ const createInvite = os.organization.createInvite
 
     const inviteId = generateId("inv");
     const role = input.role ?? "member";
+    // Mirror updateMemberRole: admin middleware admits both owner and admin,
+    // so owner elevation must be checked here or a non-owner admin can mint
+    // an owner invite for themselves.
+    if (role === "owner" && context.membership?.role !== "owner" && context.user.role !== "admin") {
+      throw new ORPCError("FORBIDDEN", { message: "Only owners can invite as owner" });
+    }
     const config = parseConfig(context.env);
     const invitationUrl = new URL(`/invitations/${inviteId}`, config.authAppOrigin);
     invitationUrl.searchParams.set("organization", context.organization.slug);

--- a/apps/os/src/domains/email/utils.test.ts
+++ b/apps/os/src/domains/email/utils.test.ts
@@ -138,7 +138,7 @@ describe("normalizeInboundEmailAllowedSender", () => {
 });
 
 describe("dmarcPasses", () => {
-  test("requires Cloudflare authserv-id with dmarc=pass on the same line", () => {
+  test("requires Cloudflare authserv-id with dmarc=pass on the same record", () => {
     expect(dmarcPasses("mx.cloudflare.net; spf=pass; dkim=pass; dmarc=pass action=none")).toBe(
       true,
     );
@@ -151,13 +151,22 @@ describe("dmarcPasses", () => {
     expect(dmarcPasses("fake.local; spf=pass; dmarc=pass")).toBe(false);
   });
 
-  test("still accepts Cloudflare pass when a forged line is also present", () => {
-    // CF appends its own AR; an attacker-forged line must not be enough on
-    // its own, but a real CF pass on another line still counts.
+  test("handles newline-separated AR records (raw MIME)", () => {
     expect(dmarcPasses("evil.example; dmarc=pass\nmx.cloudflare.net; spf=pass; dmarc=pass")).toBe(
       true,
     );
     expect(dmarcPasses("evil.example; dmarc=pass\nmx.cloudflare.net; dmarc=fail")).toBe(false);
+  });
+
+  test("handles comma-joined AR records from Headers.get", () => {
+    // headers.get("authentication-results") joins duplicates with ", ".
+    expect(dmarcPasses("evil.example; dmarc=pass, mx.cloudflare.net; spf=pass; dmarc=pass")).toBe(
+      true,
+    );
+    // A forged pass after a real Cloudflare fail must not match across the join.
+    expect(dmarcPasses("mx.cloudflare.net; dmarc=fail, evil.example; dmarc=pass")).toBe(false);
+    // Forged alone, still joined shape.
+    expect(dmarcPasses("evil.example; dmarc=pass, other.example; spf=pass")).toBe(false);
   });
 });
 

--- a/apps/os/src/domains/email/utils.test.ts
+++ b/apps/os/src/domains/email/utils.test.ts
@@ -138,12 +138,26 @@ describe("normalizeInboundEmailAllowedSender", () => {
 });
 
 describe("dmarcPasses", () => {
-  test("requires dmarc=pass in the Authentication-Results value", () => {
+  test("requires Cloudflare authserv-id with dmarc=pass on the same line", () => {
     expect(dmarcPasses("mx.cloudflare.net; spf=pass; dkim=pass; dmarc=pass action=none")).toBe(
       true,
     );
     expect(dmarcPasses("mx.cloudflare.net; spf=pass; dmarc=fail")).toBe(false);
     expect(dmarcPasses(null)).toBe(false);
+  });
+
+  test("rejects a self-forged Authentication-Results without Cloudflare authserv-id", () => {
+    expect(dmarcPasses("evil.example; dmarc=pass")).toBe(false);
+    expect(dmarcPasses("fake.local; spf=pass; dmarc=pass")).toBe(false);
+  });
+
+  test("still accepts Cloudflare pass when a forged line is also present", () => {
+    // CF appends its own AR; an attacker-forged line must not be enough on
+    // its own, but a real CF pass on another line still counts.
+    expect(dmarcPasses("evil.example; dmarc=pass\nmx.cloudflare.net; spf=pass; dmarc=pass")).toBe(
+      true,
+    );
+    expect(dmarcPasses("evil.example; dmarc=pass\nmx.cloudflare.net; dmarc=fail")).toBe(false);
   });
 });
 

--- a/apps/os/src/domains/email/utils.test.ts
+++ b/apps/os/src/domains/email/utils.test.ts
@@ -157,6 +157,9 @@ describe("dmarcPasses", () => {
 
   test("allows optional authserv-id version before the semicolon", () => {
     expect(dmarcPasses("mx.cloudflare.net 1; dmarc=pass")).toBe(true);
+    // Versioned CF record after a Headers.get join must still split out.
+    expect(dmarcPasses("evil.example; dmarc=pass, mx.cloudflare.net 1; dmarc=pass")).toBe(true);
+    expect(dmarcPasses("evil.example; dmarc=pass, mx.cloudflare.net 1; dmarc=fail")).toBe(false);
   });
 
   test("handles newline-separated AR records (raw MIME)", () => {

--- a/apps/os/src/domains/email/utils.test.ts
+++ b/apps/os/src/domains/email/utils.test.ts
@@ -176,6 +176,18 @@ describe("dmarcPasses", () => {
     // Forged alone, still joined shape.
     expect(dmarcPasses("evil.example; dmarc=pass, other.example; spf=pass")).toBe(false);
   });
+
+  test("does not treat 'evil, mx.cloudflare.net; dmarc=pass' as a CF record", () => {
+    // Comma without a complete left-hand AR record is attacker content inside
+    // one header value, not a Headers.get join of two AR headers.
+    expect(dmarcPasses("evil, mx.cloudflare.net; dmarc=pass")).toBe(false);
+    expect(dmarcPasses("not-an-ar-record, mx.cloudflare.net; dmarc=pass")).toBe(false);
+  });
+
+  test("uses the last Cloudflare-authored record (MTA append order)", () => {
+    expect(dmarcPasses("mx.cloudflare.net; dmarc=pass, mx.cloudflare.net; dmarc=fail")).toBe(false);
+    expect(dmarcPasses("mx.cloudflare.net; dmarc=fail, mx.cloudflare.net; dmarc=pass")).toBe(true);
+  });
 });
 
 describe("fallbackInboundMessageKey", () => {

--- a/apps/os/src/domains/email/utils.test.ts
+++ b/apps/os/src/domains/email/utils.test.ts
@@ -149,6 +149,14 @@ describe("dmarcPasses", () => {
   test("rejects a self-forged Authentication-Results without Cloudflare authserv-id", () => {
     expect(dmarcPasses("evil.example; dmarc=pass")).toBe(false);
     expect(dmarcPasses("fake.local; spf=pass; dmarc=pass")).toBe(false);
+    // Prefix forgeries must not satisfy a word-boundary-style pin.
+    expect(dmarcPasses("mx.cloudflare.net.evil; dmarc=pass")).toBe(false);
+    expect(dmarcPasses("mx.cloudflare.net-evil; dmarc=pass")).toBe(false);
+    expect(dmarcPasses("mx.cloudflare.netevil; dmarc=pass")).toBe(false);
+  });
+
+  test("allows optional authserv-id version before the semicolon", () => {
+    expect(dmarcPasses("mx.cloudflare.net 1; dmarc=pass")).toBe(true);
   });
 
   test("handles newline-separated AR records (raw MIME)", () => {

--- a/apps/os/src/domains/email/utils.ts
+++ b/apps/os/src/domains/email/utils.ts
@@ -216,27 +216,55 @@ export function normalizeInboundEmailAllowedSender(pattern: string): string {
  * True when Cloudflare's inbound MX reports `dmarc=pass` on an
  * Authentication-Results header. The sender allowlist alone authenticates
  * nothing — anyone can put an allowlisted address in the From header — so
- * this gate requires the trusted authserv-id (`mx.cloudflare.net`) on the
- * same AR *record* as `dmarc=pass`. A self-forged
- * `Authentication-Results: evil; dmarc=pass` alone no longer satisfies it.
+ * this gate requires the trusted authserv-id (`mx.cloudflare.net`) on an
+ * AR record that contains `dmarc=pass`.
  *
- * Callers typically pass `headers.get("authentication-results")`, which
- * joins duplicate AR headers with `", "`. We therefore split on both
- * newlines and commas that introduce a new authserv-id, then require a
- * Cloudflare-authored record that contains `dmarc=pass`.
+ * Callers pass `headers.get("authentication-results")`, which joins
+ * duplicate AR headers with `", "`. We split those into records carefully
+ * (see `splitAuthenticationResultsRecords`) and use the **last**
+ * Cloudflare-authored record — MTAs append their AR last, so a trailing
+ * real CF fail is not overridden by an earlier forgery.
  */
 export function dmarcPasses(authenticationResults: string | null): boolean {
   if (authenticationResults === null) return false;
-  // Split into AR records. Fetch `Headers.get` joins multiples with ", ";
-  // raw MIME may separate them with newlines. Within a single record,
-  // methods are `;`-separated (not comma-separated).
-  const records = authenticationResults.split(/(?:\r?\n|,(?=\s*[^,;\s]+\s*;))/);
-  return records.some((record) => {
+
+  let lastCloudflareRecord: string | undefined;
+  for (const record of splitAuthenticationResultsRecords(authenticationResults)) {
     const trimmed = record.trim();
     // Exact authserv-id (optional version digit), then ";". A word-boundary
     // pin would accept forgeries like mx.cloudflare.net.evil / net-evil.
-    return /^mx\.cloudflare\.net(?:\s+\d+)?\s*;/i.test(trimmed) && /\bdmarc=pass\b/i.test(trimmed);
-  });
+    if (/^mx\.cloudflare\.net(?:\s+\d+)?\s*;/i.test(trimmed)) {
+      lastCloudflareRecord = trimmed;
+    }
+  }
+  return lastCloudflareRecord != null && /\bdmarc=pass\b/i.test(lastCloudflareRecord);
+}
+
+/**
+ * Split a combined Authentication-Results value into records.
+ *
+ * - Newlines separate records (raw MIME / multi-line).
+ * - Commas from `Headers.get` also separate records, but only when the text
+ *   *before* the comma is already a complete AR record (`authserv-id; …`).
+ *   That blocks `evil, mx.cloudflare.net; dmarc=pass` from being treated as
+ *   a synthetic Cloudflare record (the left side has no `;`).
+ */
+function splitAuthenticationResultsRecords(value: string): string[] {
+  const records: string[] = [];
+  for (const line of value.split(/\r?\n/)) {
+    let start = 0;
+    const re = /,(?=\s*[^,;\s]+\s*;)/g;
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(line)) !== null) {
+      const left = line.slice(start, match.index);
+      if (left.includes(";")) {
+        records.push(left);
+        start = match.index + 1;
+      }
+    }
+    records.push(line.slice(start));
+  }
+  return records;
 }
 
 /**

--- a/apps/os/src/domains/email/utils.ts
+++ b/apps/os/src/domains/email/utils.ts
@@ -237,7 +237,7 @@ export function dmarcPasses(authenticationResults: string | null): boolean {
       lastCloudflareRecord = trimmed;
     }
   }
-  return lastCloudflareRecord != null && /\bdmarc=pass\b/i.test(lastCloudflareRecord);
+  return !!lastCloudflareRecord && /\bdmarc=pass\b/i.test(lastCloudflareRecord);
 }
 
 /**

--- a/apps/os/src/domains/email/utils.ts
+++ b/apps/os/src/domains/email/utils.ts
@@ -217,16 +217,24 @@ export function normalizeInboundEmailAllowedSender(pattern: string): string {
  * Authentication-Results header. The sender allowlist alone authenticates
  * nothing — anyone can put an allowlisted address in the From header — so
  * this gate requires the trusted authserv-id (`mx.cloudflare.net`) on the
- * same header line as `dmarc=pass`. A self-forged
+ * same AR *record* as `dmarc=pass`. A self-forged
  * `Authentication-Results: evil; dmarc=pass` alone no longer satisfies it.
+ *
+ * Callers typically pass `headers.get("authentication-results")`, which
+ * joins duplicate AR headers with `", "`. We therefore split on both
+ * newlines and commas that introduce a new authserv-id, then require a
+ * Cloudflare-authored record that contains `dmarc=pass`.
  */
 export function dmarcPasses(authenticationResults: string | null): boolean {
   if (authenticationResults === null) return false;
-  // Pin authserv-id to Cloudflare's MX so a sender-forged AR header cannot
-  // satisfy the check by itself.
-  return /(?:^|[\r\n])[ \t]*mx\.cloudflare\.net\b[^\r\n]*\bdmarc=pass\b/i.test(
-    authenticationResults,
-  );
+  // Split into AR records. Fetch `Headers.get` joins multiples with ", ";
+  // raw MIME may separate them with newlines. Within a single record,
+  // methods are `;`-separated (not comma-separated).
+  const records = authenticationResults.split(/(?:\r?\n|,(?=\s*[^,;\s]+\s*;))/);
+  return records.some((record) => {
+    const trimmed = record.trim();
+    return /^mx\.cloudflare\.net\b/i.test(trimmed) && /\bdmarc=pass\b/i.test(trimmed);
+  });
 }
 
 /**

--- a/apps/os/src/domains/email/utils.ts
+++ b/apps/os/src/domains/email/utils.ts
@@ -253,7 +253,10 @@ function splitAuthenticationResultsRecords(value: string): string[] {
   const records: string[] = [];
   for (const line of value.split(/\r?\n/)) {
     let start = 0;
-    const re = /,(?=\s*[^,;\s]+\s*;)/g;
+    // Next record starts with authserv-id, optional version digit(s), then ";".
+    // Without the version group, "mx.cloudflare.net 1; …" would not split after
+    // a Headers.get join and legitimate CF-stamped mail would be dropped.
+    const re = /,(?=\s*[^,;\s]+(?:\s+\d+)?\s*;)/g;
     let match: RegExpExecArray | null;
     while ((match = re.exec(line)) !== null) {
       const left = line.slice(start, match.index);

--- a/apps/os/src/domains/email/utils.ts
+++ b/apps/os/src/domains/email/utils.ts
@@ -233,7 +233,9 @@ export function dmarcPasses(authenticationResults: string | null): boolean {
   const records = authenticationResults.split(/(?:\r?\n|,(?=\s*[^,;\s]+\s*;))/);
   return records.some((record) => {
     const trimmed = record.trim();
-    return /^mx\.cloudflare\.net\b/i.test(trimmed) && /\bdmarc=pass\b/i.test(trimmed);
+    // Exact authserv-id (optional version digit), then ";". A word-boundary
+    // pin would accept forgeries like mx.cloudflare.net.evil / net-evil.
+    return /^mx\.cloudflare\.net(?:\s+\d+)?\s*;/i.test(trimmed) && /\bdmarc=pass\b/i.test(trimmed);
   });
 }
 

--- a/apps/os/src/domains/email/utils.ts
+++ b/apps/os/src/domains/email/utils.ts
@@ -213,19 +213,20 @@ export function normalizeInboundEmailAllowedSender(pattern: string): string {
 }
 
 /**
- * True when an Authentication-Results header (added by Cloudflare's inbound
- * MX) reports `dmarc=pass`. Without this, the sender allowlist authenticates
- * nothing — anyone can put an allowlisted address in the From header.
- *
- * Spike caveat: this scans the combined Authentication-Results value rather
- * than verifying the authserv-id, so a sender who *also* forges an
- * `Authentication-Results: ...dmarc=pass` header of their own could satisfy
- * it. Acceptable while inbound is allowlist-gated to trusted senders;
- * production hardening should pin the `mx.cloudflare.net` authserv-id chunk.
+ * True when Cloudflare's inbound MX reports `dmarc=pass` on an
+ * Authentication-Results header. The sender allowlist alone authenticates
+ * nothing — anyone can put an allowlisted address in the From header — so
+ * this gate requires the trusted authserv-id (`mx.cloudflare.net`) on the
+ * same header line as `dmarc=pass`. A self-forged
+ * `Authentication-Results: evil; dmarc=pass` alone no longer satisfies it.
  */
 export function dmarcPasses(authenticationResults: string | null): boolean {
   if (authenticationResults === null) return false;
-  return /\bdmarc=pass\b/i.test(authenticationResults);
+  // Pin authserv-id to Cloudflare's MX so a sender-forged AR header cannot
+  // satisfy the check by itself.
+  return /(?:^|[\r\n])[ \t]*mx\.cloudflare\.net\b[^\r\n]*\bdmarc=pass\b/i.test(
+    authenticationResults,
+  );
 }
 
 /**

--- a/apps/os/src/domains/repos/repo-durable-object.ts
+++ b/apps/os/src/domains/repos/repo-durable-object.ts
@@ -2321,13 +2321,14 @@ function parseEditRepoFileInput(input: EditRepoFileInput): EditRepoFileInput {
 function normalizeRepoFilePath(path: string): string {
   if (typeof path !== "string") throw new Error("Repo file path must be a string.");
   const normalized = path.trim().replace(/^\/+/, "");
+  // Reject empty / relative / .git paths, including bare ".." and any
+  // path segment that is ".." or "." (e.g. "foo/..", "foo/./bar").
   if (
     normalized === "" ||
     normalized === "." ||
-    normalized.startsWith("../") ||
-    normalized.includes("/../") ||
-    normalized.includes("/./") ||
-    normalized.startsWith(".git/")
+    normalized === ".." ||
+    normalized.startsWith(".git/") ||
+    normalized.split("/").some((segment) => segment === "" || segment === "." || segment === "..")
   ) {
     throw new Error(`Invalid repo file path: "${path}".`);
   }


### PR DESCRIPTION
## Summary

Three small, high-ROI security fixes found by a CodeCrucible scan of `apps/os` + `apps/auth`:

1. **`organization.createInvite`** — require owner (or platform admin) to invite as `role: "owner"`, matching the existing guards on `updateMemberRole` / `removeMember`. Non-owner org admins could previously mint an owner invite for themselves.
2. **`dmarcPasses`** — require `mx.cloudflare.net` on the same Authentication-Results line as `dmarc=pass`, so a self-forged `Authentication-Results: evil; dmarc=pass` no longer satisfies the allowlist gate.
3. **`normalizeRepoFilePath`** — reject bare `..` and any path segment that is `..` / `.` / empty (e.g. `foo/..`), which the previous prefix/substring checks missed.

Not in this PR (larger work): Slack `!` bang-command injection, webhook-post SSRF, worker build-cache IDOR.

## Test plan

- [x] `pnpm --dir apps/os exec vitest run src/domains/email/utils.test.ts` (includes new DMARC spoof rejection cases)
- [ ] Confirm createInvite as org admin with `role: "owner"` returns FORBIDDEN; as owner still works
- [ ] Confirm `commitFiles` / `edit` reject path `".."` and `"foo/.."`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch authorization (owner invites), inbound email acceptance (DMARC parsing), and repo mutation path validation; behavior is tightened with tests, but mis-parsed DMARC or overly strict paths could block legitimate mail or commits if edge cases were missed.
> 
> **Overview**
> Three targeted security fixes across auth and OS.
> 
> **Organization invites** — `createInvite` now returns **FORBIDDEN** when a non-owner org admin (or anyone without platform admin) tries to invite with `role: "owner"`, aligned with `updateMemberRole` and `removeMember`.
> 
> **Inbound email DMARC** — `dmarcPasses` no longer treats any `dmarc=pass` substring as sufficient. It splits `Authentication-Results` (newlines and careful comma joins from `Headers.get`), finds **Cloudflare** records (`mx.cloudflare.net` with optional version, rejecting prefix forgeries), and requires `dmarc=pass` on the **last** such record so forged headers and stale passes cannot bypass the allowlist gate.
> 
> **Repo file paths** — `normalizeRepoFilePath` now rejects bare `..`, empty segments, `.` / `..` in any segment (e.g. `foo/..`, `foo/./bar`), closing gaps left by earlier prefix-only checks on `commitFiles` / `edit` / `readFile`.
> 
> Tests add broad DMARC spoof and join scenarios in `utils.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d98251cd89026a934f3a9f3987203d5e150578cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +59 -13 | +31 -5 🟩🟩🟩🟩🟥 |
| Tests | +44 -1 | +32 -1 🟩🟩🟩🟩🟩 |
| **Total** | **+103 -14** | **+63 -6** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between b6e46ef and 4f700d2, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T14:51:13.346Z",
      "deployedAt": "2026-07-29T11:12:03.047Z",
      "headSha": "d98251cd89026a934f3a9f3987203d5e150578cd",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/275492288025158",
      "shortSha": "d98251c",
      "cleanupDurationMs": 18569,
      "deployDurationMs": 95700,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 41379,
      "deployReadinessDurationMs": 54318,
      "deployedWorkerName": "os-preview-4",
      "deployedWorkerVersion": "bad67544-6e1e-404e-b97e-89eb891602dc",
      "testDurationMs": 152330,
      "testRetries": null,
      "workerSizeKib": 19911.9,
      "workerGzipKib": 5029.4,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5039.69
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T14:50:57.529Z",
      "deployedAt": "2026-07-29T11:11:37.156Z",
      "headSha": "d98251cd89026a934f3a9f3987203d5e150578cd",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/275492288025158",
      "shortSha": "d98251c",
      "cleanupDurationMs": 2749,
      "deployDurationMs": 15527,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 15485,
      "deployReadinessDurationMs": 38,
      "deployedWorkerName": "auth-preview-4",
      "deployedWorkerVersion": "cabe0bf5-2465-47b7-bb04-15f8fd7d2466",
      "testDurationMs": 3060,
      "testRetries": null,
      "workerSizeKib": 3977.5,
      "workerGzipKib": 814.3,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T14:50:55.452Z",
      "deployedAt": "2026-07-29T11:02:53.946Z",
      "headSha": "d98251cd89026a934f3a9f3987203d5e150578cd",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/275492288025158",
      "shortSha": "d98251c",
      "cleanupDurationMs": 670,
      "deployDurationMs": 53,
      "deployConfigDurationMs": 4,
      "deployReuseProofDurationMs": 9,
      "deployedWorkerName": "dummy-petshop-preview-4",
      "deployedWorkerVersion": "98e883c0-b7aa-498c-8d9c-f9beab4aca6a",
      "testDurationMs": 5571,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `d98251c` | [https://auth.iterate-preview-4.com](https://auth.iterate-preview-4.com) | 814.3 KiB | 15.5s | 3.1s |  | 2.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/275492288025158) | 2026-07-29T14:50:57.529Z | Preview app released. |
| Dummy Petshop | released | `d98251c` | [https://dummy-petshop.iterate-preview-4.com](https://dummy-petshop.iterate-preview-4.com) | 198.3 KiB | 53ms | 5.6s |  | 670ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/275492288025158) | 2026-07-29T14:50:55.452Z | Preview app released. |
| OS | released | `d98251c` | [https://os.iterate-preview-4.com](https://os.iterate-preview-4.com) | 4.91 MiB (-10.3 KiB vs main) | 95.7s | 152.3s |  | 18.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/275492288025158) | 2026-07-29T14:51:13.346Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->