### PR TITLE
Annotate the rendered preview: select-to-comment, painted threads, W3C anchors

### DIFF
--- a/apps/tasks/README.md
+++ b/apps/tasks/README.md
@@ -60,6 +60,15 @@ mutates threads, and every mutation is an ordinary whole-file transform
 through the live-editor/write lane — so comments commit, diff, and merge
 like any other task edit.
 
+The Preview tab is the annotation surface: the body renders through
+`iterate/annotated-markdown/react` (a source-stamped mdast renderer),
+anchored threads paint as CSS Custom Highlights in their author's color,
+and selecting text opens a comment bubble whose thread lands in the file
+with a W3C-style anchor (quote + context + position; no inline marker).
+Clicking a highlight selects its thread in the Comments strip and vice
+versa; drifted anchors surface as `needs_review`/`orphaned` badges rather
+than painting the wrong text.
+
 ## Using it
 
 Install `@iterate-com/tasks`, configure its project-side connector, and route

--- a/apps/tasks/src/components/task-comments.tsx
+++ b/apps/tasks/src/components/task-comments.tsx
@@ -11,15 +11,15 @@ import {
   editComment,
   formatUtcTimestamp,
   parseAnnotatedMarkdown,
+  resolveThreadAnchor,
   setThreadStatus,
 } from "iterate/annotated-markdown";
-import type { StructuredDocument, Thread, ThreadComment } from "iterate/annotated-markdown";
+import type { AnchorResolution, Thread, ThreadComment } from "iterate/annotated-markdown";
 import { authorColor } from "../lib/collab-redline.ts";
+import { useDiscussionApply } from "../lib/use-discussion-apply.ts";
+import type { DiscussionOp } from "../lib/use-discussion-apply.ts";
 
 export type CommentIdentity = { author: string; authorDisplay?: string };
-
-/** An edit against the parsed document; returns the next raw source. */
-type DiscussionOp = (doc: StructuredDocument) => { raw: string };
 
 /**
  * Linear-style discussion for one task file, backed by the annotated-markdown
@@ -32,6 +32,8 @@ export function TaskComments({
   identity,
   busy,
   onTransform,
+  selectedThreadId = null,
+  onSelectThread,
 }: {
   source: string;
   identity: CommentIdentity | null;
@@ -42,48 +44,38 @@ export function TaskComments({
   /** Route a whole-file transform to the live editor or the write lane;
    * resolves whether it landed (the write lane can roll back). */
   onTransform: (transform: (source: string) => string) => Promise<boolean>;
+  /** Two-way selection sync with the preview's highlights. */
+  selectedThreadId?: string | null;
+  onSelectThread?: (threadId: string | null) => void;
 }) {
   const parsed = useMemo(() => parseAnnotatedMarkdown(source), [source]);
   const [open, setOpen] = useState(true);
   const [showResolved, setShowResolved] = useState(false);
-  const [opError, setOpError] = useState<string | null>(null);
+  const { apply, opError } = useDiscussionApply({ busy, onTransform });
 
-  // The transform re-parses at apply time: the live document may have moved
-  // since this render, so ops must re-find their targets by id — and back off
-  // to a no-op (surfacing the reason) instead of corrupting the file.
-  // Resolution waits for the WRITE, not just the transform: the fallback
-  // write lane is optimistic and rolls back on RPC failure, and callers
-  // (composers clearing drafts) must not celebrate a change that vanished.
-  const apply = async (op: DiscussionOp): Promise<boolean> => {
-    if (busy) {
-      setOpError("Comment change failed: the editor is still connecting — retry in a moment");
-      return false;
+  const threads = useMemo(
+    () => (parsed.kind === "structured" ? (parsed.discussion?.threads ?? []) : []),
+    [parsed],
+  );
+  const body = parsed.kind === "structured" ? parsed.body : "";
+  // Anchored threads sort by where their text sits in the document, like the
+  // margin of a review; document-level threads keep append order below them.
+  const resolutions = useMemo(() => {
+    const map = new Map<string, AnchorResolution>();
+    for (const thread of threads) {
+      if (thread.anchor === null) continue;
+      map.set(thread.id, resolveThreadAnchor(body, thread.id, thread.anchor.selector));
     }
-    let ok = false;
-    let failure = "the file changed mid-edit";
-    const landed = await onTransform((current) => {
-      const doc = parseAnnotatedMarkdown(current);
-      if (doc.kind !== "structured") {
-        failure = doc.diagnostics[0]?.message ?? "the file failed to parse";
-        return current;
-      }
-      try {
-        const result = op(doc);
-        ok = true;
-        return result.raw;
-      } catch (error) {
-        failure = error instanceof Error ? error.message : String(error);
-        return current;
-      }
-    });
-    if (ok && !landed) failure = "the write did not reach the workspace — retry";
-    ok = ok && landed;
-    setOpError(ok ? null : `Comment change failed: ${failure}`);
-    return ok;
-  };
-
-  const threads = parsed.kind === "structured" ? (parsed.discussion?.threads ?? []) : [];
-  const openThreads = threads.filter((thread) => thread.status === "open");
+    return map;
+  }, [body, threads]);
+  const threadKind = (thread: Thread): number => (thread.anchor !== null ? 0 : 1);
+  const positionOf = (thread: Thread): number =>
+    resolutions.get(thread.id)?.range?.start ?? Number.MAX_SAFE_INTEGER;
+  const byPosition = (a: Thread, b: Thread): number =>
+    threadKind(a) !== threadKind(b)
+      ? threadKind(a) - threadKind(b)
+      : positionOf(a) - positionOf(b);
+  const openThreads = threads.filter((thread) => thread.status === "open").sort(byPosition);
   const resolvedThreads = threads.filter((thread) => thread.status === "resolved");
   const commentTotal = threads.reduce(
     (total, thread) => total + thread.comments.filter((comment) => !comment.deleted).length,
@@ -117,7 +109,15 @@ export function TaskComments({
               <p className="pb-2 text-xs text-muted-foreground">No comments yet.</p>
             ) : null}
             {openThreads.map((thread) => (
-              <ThreadBlock key={thread.id} thread={thread} identity={identity} apply={apply} />
+              <ThreadBlock
+                key={thread.id}
+                thread={thread}
+                identity={identity}
+                apply={apply}
+                resolution={resolutions.get(thread.id) ?? null}
+                selected={thread.id === selectedThreadId}
+                onSelect={onSelectThread}
+              />
             ))}
             {resolvedThreads.length > 0 ? (
               <button
@@ -130,7 +130,15 @@ export function TaskComments({
             ) : null}
             {showResolved
               ? resolvedThreads.map((thread) => (
-                  <ThreadBlock key={thread.id} thread={thread} identity={identity} apply={apply} />
+                  <ThreadBlock
+                    key={thread.id}
+                    thread={thread}
+                    identity={identity}
+                    apply={apply}
+                    resolution={resolutions.get(thread.id) ?? null}
+                    selected={thread.id === selectedThreadId}
+                    onSelect={onSelectThread}
+                  />
                 ))
               : null}
           </div>
@@ -158,19 +166,54 @@ function ThreadBlock({
   thread,
   identity,
   apply,
+  resolution,
+  selected,
+  onSelect,
 }: {
   thread: Thread;
   identity: CommentIdentity | null;
   apply: (op: DiscussionOp) => Promise<boolean>;
+  /** Null for document-level threads (no anchor). */
+  resolution: AnchorResolution | null;
+  selected: boolean;
+  onSelect?: (threadId: string | null) => void;
 }) {
   const [replyOpen, setReplyOpen] = useState(false);
+  const blockRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (selected) blockRef.current?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+  }, [selected]);
   const resolved = thread.status === "resolved";
+  const quote = thread.anchor?.selector.quote.exact ?? null;
   return (
-    <div className={cn("border-b border-border/50 py-2 last:border-b-0", resolved && "opacity-70")}>
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events -- selection sync only; every action inside is a real button
+    <div
+      ref={blockRef}
+      onClick={onSelect === undefined ? undefined : () => onSelect(thread.id)}
+      className={cn(
+        "-mx-2 border-b border-border/50 px-2 py-2 last:border-b-0",
+        resolved && "opacity-70",
+        selected && "rounded-md bg-primary/5 ring-1 ring-primary/30",
+      )}
+    >
       {thread.label !== null && (
         <p className="pb-1 font-mono text-[10px] text-muted-foreground">
           {thread.label}
           {resolved ? " · resolved" : ""}
+        </p>
+      )}
+      {quote !== null && (
+        <p
+          className="mb-1.5 truncate border-l-2 pl-2 text-xs text-muted-foreground italic"
+          style={{ borderColor: authorColor(thread.comments[0]?.author ?? "someone", 0.8) }}
+          title={quote}
+        >
+          {quote}
+        </p>
+      )}
+      {resolution !== null && resolution.state !== "attached" && (
+        <p className="mb-1 text-[10px] font-medium tracking-wide text-amber-700 uppercase">
+          {resolution.state === "needs_review" ? "anchor needs review" : "anchor lost"}
         </p>
       )}
       {thread.comments.map((comment) => (
@@ -263,6 +306,14 @@ function CommentRow({
           >
             {relativeTime(comment.createdAt)}
           </time>
+          {comment.modifiedAt !== null && !comment.deleted ? (
+            <span
+              className="text-[10px] text-muted-foreground/70"
+              title={`edited ${formatUtcTimestamp(comment.modifiedAt)}`}
+            >
+              (edited)
+            </span>
+          ) : null}
           {comment.deleted || !mine ? null : (
             <span className="ml-auto hidden shrink-0 items-center gap-1 group-hover:flex">
               <button
@@ -294,7 +345,7 @@ function CommentRow({
             focusOnMount
             onCancel={() => setEditing(null)}
             onSubmit={(body) =>
-              apply((doc) => editComment(doc, comment.id, body)).then((ok) => {
+              apply((doc) => editComment(doc, comment.id, body, { modifiedAt: nowIso() })).then((ok) => {
                 if (ok) setEditing(null);
                 return ok;
               })
@@ -314,7 +365,7 @@ function CommentRow({
   );
 }
 
-function CommentComposer({
+export function CommentComposer({
   placeholder,
   submitLabel,
   initialValue,

--- a/apps/tasks/src/components/task-comments.tsx
+++ b/apps/tasks/src/components/task-comments.tsx
@@ -68,13 +68,14 @@ export function TaskComments({
     }
     return map;
   }, [body, threads]);
-  const threadKind = (thread: Thread): number => (thread.anchor !== null ? 0 : 1);
-  const positionOf = (thread: Thread): number =>
-    resolutions.get(thread.id)?.range?.start ?? Number.MAX_SAFE_INTEGER;
-  const byPosition = (a: Thread, b: Thread): number =>
-    threadKind(a) !== threadKind(b)
-      ? threadKind(a) - threadKind(b)
-      : positionOf(a) - positionOf(b);
+  const byPosition = (a: Thread, b: Thread) => {
+    const kindA = a.anchor !== null ? 0 : 1;
+    const kindB = b.anchor !== null ? 0 : 1;
+    if (kindA !== kindB) return kindA - kindB;
+    const positionA = resolutions.get(a.id)?.range?.start ?? Number.MAX_SAFE_INTEGER;
+    const positionB = resolutions.get(b.id)?.range?.start ?? Number.MAX_SAFE_INTEGER;
+    return positionA - positionB;
+  };
   const openThreads = threads.filter((thread) => thread.status === "open").sort(byPosition);
   const resolvedThreads = threads.filter((thread) => thread.status === "resolved");
   const commentTotal = threads.reduce(

--- a/apps/tasks/src/components/workspace-task-preview.tsx
+++ b/apps/tasks/src/components/workspace-task-preview.tsx
@@ -136,6 +136,8 @@ function FrontmatterTable({ metadata }: { metadata: { key: string; value: string
 
 interface PendingSelection {
   range: { start: number; end: number };
+  /** The body the range was computed against — live edits must remap. */
+  sourceBody: string;
   /** Bubble position, relative to the positioned content wrapper. */
   top: number;
   left: number;
@@ -234,6 +236,23 @@ function AnnotatedPreview({
     setComposerOpen(false);
   }, []);
 
+  // Live edits move the body under a pending selection: re-find the selected
+  // text so the pending paint stays on the right passage, and drop the
+  // selection when it can't be re-found unambiguously (the submit path would
+  // refuse it anyway).
+  useEffect(() => {
+    setPending((current) => {
+      if (current === null || current.sourceBody === body) return current;
+      const exact = current.sourceBody.slice(current.range.start, current.range.end);
+      const first = body.indexOf(exact);
+      if (first === -1 || body.indexOf(exact, first + 1) !== -1) {
+        setComposerOpen(false);
+        return null;
+      }
+      return { ...current, range: { start: first, end: first + exact.length }, sourceBody: body };
+    });
+  }, [body]);
+
   const onMouseUp = useCallback(() => {
     if (identity === null || composerOpen) return;
     const root = markdownRef.current;
@@ -250,11 +269,12 @@ function AnnotatedPreview({
     const wrapperRect = wrapper.getBoundingClientRect();
     setPending({
       range,
+      sourceBody: body,
       top: rect.bottom - wrapperRect.top + 8,
       left: Math.max(0, rect.left - wrapperRect.left),
     });
     setComposerOpen(false);
-  }, [identity, composerOpen]);
+  }, [identity, composerOpen, body]);
 
   const onClick = useCallback(
     (event: React.MouseEvent) => {
@@ -272,7 +292,7 @@ function AnnotatedPreview({
       let best: { threadId: string; width: number } | null = null;
       for (const { thread, resolution } of resolved) {
         const range = resolution.range;
-        if (range === null || offset < range.start || offset >= range.end) continue;
+        if (range === null || offset < range.start || offset > range.end) continue;
         const width = range.end - range.start;
         if (best === null || width < best.width) best = { threadId: thread.id, width };
       }

--- a/apps/tasks/src/components/workspace-task-preview.tsx
+++ b/apps/tasks/src/components/workspace-task-preview.tsx
@@ -214,8 +214,13 @@ function AnnotatedPreview({
     return () => clearHighlights("amv");
   }, [body, resolved, selectedThreadId, pending]);
 
-  // Selected-from-panel: bring the thread's text into view.
+  // Selected-from-panel: bring the thread's text into view — once per
+  // selection. `resolved` recomputes on every live edit, and re-scrolling
+  // then would yank the viewport away from wherever the user is reading.
+  const scrolledThreadRef = useRef<string | null>(null);
   useEffect(() => {
+    if (selectedThreadId === scrolledThreadRef.current) return;
+    scrolledThreadRef.current = selectedThreadId;
     if (selectedThreadId === null) return;
     const projection = projectionRef.current;
     const entry = resolved.find(({ thread }) => thread.id === selectedThreadId);

--- a/apps/tasks/src/components/workspace-task-preview.tsx
+++ b/apps/tasks/src/components/workspace-task-preview.tsx
@@ -1,44 +1,102 @@
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { MessageResponse } from "@iterate-com/ui/components/ai-elements/message";
+import { Button } from "@iterate-com/ui/components/button";
 import { Table, TableBody, TableCell, TableRow } from "@iterate-com/ui/components/table";
-import { parseAnnotatedMarkdown } from "iterate/annotated-markdown";
+import { MessageSquarePlusIcon } from "lucide-react";
+import {
+  addThread,
+  createAnchorSelector,
+  parseAnnotatedMarkdown,
+  resolveThreadAnchor,
+} from "iterate/annotated-markdown";
+import type { AnchorResolution, Thread } from "iterate/annotated-markdown";
+import {
+  AnnotatedMarkdownView,
+  buildProjection,
+  clearHighlights,
+  paintHighlights,
+  sourceOffsetAtPoint,
+} from "iterate/annotated-markdown/react";
+import type { SourceProjection } from "iterate/annotated-markdown/react";
+import { authorColor } from "../lib/collab-redline.ts";
+import { useDiscussionApply } from "../lib/use-discussion-apply.ts";
+import type { CommentIdentity } from "./task-comments.tsx";
+import { CommentComposer } from "./task-comments.tsx";
 import { projectMarkdownPreview } from "~/components/repo-ide/markdown-frontmatter.ts";
 
-/**
- * The Preview tab: the SAME rendering path as the apps/os repo IDE —
- * projectMarkdownPreview for the frontmatter table, MessageResponse
- * (streamdown, GitHub-sanitized by its default rehype pipeline) for the
- * body. Local and instant; no server round trip. SECURITY INVARIANT (from
- * the os pane): don't pass `rehypePlugins` without re-checking sanitization.
- */
-export function WorkspaceTaskPreview({ source }: { source: string }) {
-  // The EOF discussion store renders in the Comments section, not here.
-  const parsed = parseAnnotatedMarkdown(source);
-  const withoutDiscussion =
-    parsed.kind === "structured" && parsed.discussion !== null
-      ? source.slice(0, parsed.discussion.range.start)
-      : source;
-  const preview = projectMarkdownPreview(withoutDiscussion);
+// The Preview tab, now the annotation surface: the body renders through the
+// source-stamped viewer, anchored threads paint as CSS highlights in their
+// author's color, and selecting text grows a comment bubble whose thread is
+// an ordinary whole-file edit through the same landed-outcome lane as the
+// comments strip. Fail-open files keep the old read-only streamdown path —
+// when the codec refuses a file, nothing may interpret it.
+
+const BODY_STYLES = [
+  "text-[15px] leading-relaxed text-foreground",
+  "[&_h1]:mt-6 [&_h1]:mb-3 [&_h1]:text-2xl [&_h1]:font-semibold [&_h1]:tracking-tight [&_h1:first-child]:mt-0",
+  "[&_h2]:mt-6 [&_h2]:mb-2 [&_h2]:text-xl [&_h2]:font-semibold [&_h2:first-child]:mt-0",
+  "[&_h3]:mt-5 [&_h3]:mb-1.5 [&_h3]:text-base [&_h3]:font-semibold",
+  "[&_h4]:mt-4 [&_h4]:mb-1 [&_h4]:text-sm [&_h4]:font-semibold",
+  "[&_p]:my-2.5",
+  "[&_a]:text-primary [&_a]:underline [&_a]:underline-offset-2",
+  "[&_ul]:my-2 [&_ul]:list-disc [&_ul]:pl-6 [&_ol]:my-2 [&_ol]:list-decimal [&_ol]:pl-6",
+  "[&_li]:my-0.5 [&_li[data-task]]:list-none [&_li[data-task]]:-ml-5",
+  "[&_li[data-task]_input]:mr-1.5 [&_li[data-task]_input]:align-middle",
+  "[&_blockquote]:my-3 [&_blockquote]:border-l-2 [&_blockquote]:border-border [&_blockquote]:pl-4 [&_blockquote]:text-muted-foreground",
+  "[&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre]:rounded-md [&_pre]:bg-muted/50 [&_pre]:p-3 [&_pre]:font-mono [&_pre]:text-[13px]",
+  "[&_:not(pre)>code]:rounded [&_:not(pre)>code]:bg-muted/60 [&_:not(pre)>code]:px-1 [&_:not(pre)>code]:py-0.5 [&_:not(pre)>code]:font-mono [&_:not(pre)>code]:text-[13px]",
+  "[&_hr]:my-6 [&_hr]:border-border",
+  "[&_table]:my-3 [&_table]:w-full [&_table]:border-collapse [&_table]:text-sm",
+  "[&_th]:border [&_th]:border-border [&_th]:bg-muted/40 [&_th]:px-2.5 [&_th]:py-1.5 [&_th]:text-left [&_th]:font-medium",
+  "[&_td]:border [&_td]:border-border [&_td]:px-2.5 [&_td]:py-1.5",
+  "[&_img]:my-2 [&_img]:max-w-full [&_img]:rounded-md",
+  "[&_code[data-raw-html]]:block [&_code[data-raw-html]]:whitespace-pre-wrap [&_code[data-raw-html]]:text-muted-foreground",
+].join(" ");
+
+const slugForAuthor = (author: string): string =>
+  author.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "someone";
+
+export function WorkspaceTaskPreview({
+  source,
+  identity,
+  busy,
+  onTransform,
+  selectedThreadId,
+  onSelectThread,
+}: {
+  source: string;
+  /** Null → read-only preview (no select-to-comment). */
+  identity: CommentIdentity | null;
+  busy: boolean;
+  onTransform: (transform: (source: string) => string) => Promise<boolean>;
+  selectedThreadId: string | null;
+  onSelectThread: (threadId: string | null) => void;
+}) {
+  const parsed = useMemo(() => parseAnnotatedMarkdown(source), [source]);
+  if (parsed.kind !== "structured") {
+    return <PlainPreview source={source} />;
+  }
+  return (
+    <AnnotatedPreview
+      body={parsed.body}
+      threads={parsed.discussion?.threads ?? []}
+      source={source}
+      identity={identity}
+      busy={busy}
+      onTransform={onTransform}
+      selectedThreadId={selectedThreadId}
+      onSelectThread={onSelectThread}
+    />
+  );
+}
+
+/** The pre-annotation rendering path, kept verbatim for fail-open files. */
+function PlainPreview({ source }: { source: string }) {
+  const preview = projectMarkdownPreview(source);
   return (
     <div className="min-h-0 flex-1 overflow-y-auto">
       <div className="mx-auto w-full max-w-3xl px-8 py-6 text-sm">
-        {preview.metadata.length > 0 && (
-          <div className="mb-6 overflow-hidden rounded-lg border bg-muted/20">
-            <Table className="text-xs">
-              <TableBody>
-                {preview.metadata.map((property) => (
-                  <TableRow key={property.key} className="hover:bg-transparent">
-                    <TableCell className="w-36 py-1.5 font-medium text-muted-foreground">
-                      {property.key}
-                    </TableCell>
-                    <TableCell className="py-1.5 font-mono whitespace-normal">
-                      {property.value}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
-        )}
+        <FrontmatterTable metadata={preview.metadata} />
         {/* A settled document, not a stream — skip streamdown's unpaired-
             marker balancing (it appends a phantom `*` to text like "17 * 23"). */}
         <MessageResponse
@@ -51,6 +109,263 @@ export function WorkspaceTaskPreview({ source }: { source: string }) {
         >
           {preview.body}
         </MessageResponse>
+      </div>
+    </div>
+  );
+}
+
+function FrontmatterTable({ metadata }: { metadata: { key: string; value: string }[] }) {
+  if (metadata.length === 0) return null;
+  return (
+    <div className="mb-6 overflow-hidden rounded-lg border bg-muted/20">
+      <Table className="text-xs">
+        <TableBody>
+          {metadata.map((property) => (
+            <TableRow key={property.key} className="hover:bg-transparent">
+              <TableCell className="w-36 py-1.5 font-medium text-muted-foreground">
+                {property.key}
+              </TableCell>
+              <TableCell className="py-1.5 font-mono whitespace-normal">{property.value}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+interface PendingSelection {
+  range: { start: number; end: number };
+  /** Bubble position, relative to the positioned content wrapper. */
+  top: number;
+  left: number;
+}
+
+function AnnotatedPreview({
+  body,
+  threads,
+  source,
+  identity,
+  busy,
+  onTransform,
+  selectedThreadId,
+  onSelectThread,
+}: {
+  body: string;
+  threads: Thread[];
+  source: string;
+  identity: CommentIdentity | null;
+  busy: boolean;
+  onTransform: (transform: (source: string) => string) => Promise<boolean>;
+  selectedThreadId: string | null;
+  onSelectThread: (threadId: string | null) => void;
+}) {
+  const metadata = useMemo(() => projectMarkdownPreview(source).metadata, [source]);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const markdownRef = useRef<HTMLDivElement | null>(null);
+  const projectionRef = useRef<SourceProjection | null>(null);
+  const [pending, setPending] = useState<PendingSelection | null>(null);
+  const [composerOpen, setComposerOpen] = useState(false);
+  const { apply, opError } = useDiscussionApply({ busy, onTransform });
+
+  /** Open threads with a live resolution, the paint + hit-test working set. */
+  const resolved = useMemo(() => {
+    const entries: { thread: Thread; resolution: AnchorResolution }[] = [];
+    for (const thread of threads) {
+      if (thread.status !== "open") continue;
+      const resolution = resolveThreadAnchor(body, thread.id, thread.anchor?.selector ?? null);
+      if (resolution.range !== null) entries.push({ thread, resolution });
+    }
+    return entries;
+  }, [body, threads]);
+
+  const authorOf = (thread: Thread): string => thread.comments[0]?.author ?? "someone";
+
+  // Projection + paint after every body/thread render. Highlights are a
+  // registry beside the DOM (CSS Custom Highlight API): repainting is
+  // re-registering fresh Ranges against the freshly rendered nodes.
+  useLayoutEffect(() => {
+    const root = markdownRef.current;
+    if (root === null) return;
+    const projection = buildProjection(root);
+    projectionRef.current = projection;
+    const groups = new Map<string, Range[]>();
+    const push = (key: string, ranges: Range[]) => {
+      if (ranges.length === 0) return;
+      groups.set(key, [...(groups.get(key) ?? []), ...ranges]);
+    };
+    for (const { thread, resolution } of resolved) {
+      if (resolution.range === null) continue;
+      const ranges = projection.sourceRangeToDomRanges(resolution.range);
+      if (resolution.state === "needs_review") push("review", ranges);
+      else push(`a-${slugForAuthor(authorOf(thread))}`, ranges);
+      if (thread.id === selectedThreadId) push("selected", ranges);
+    }
+    if (pending !== null) push("pending", projection.sourceRangeToDomRanges(pending.range));
+    // Registration order is paint order: selected and pending go last so
+    // they win where highlights overlap.
+    const ordered = [...groups.entries()].sort(
+      ([a], [b]) => Number(a === "selected" || a === "pending") - Number(b === "selected" || b === "pending"),
+    );
+    paintHighlights(
+      "amv",
+      ordered.map(([key, ranges]) => ({ key, ranges })),
+    );
+    return () => clearHighlights("amv");
+  }, [body, resolved, selectedThreadId, pending]);
+
+  // Selected-from-panel: bring the thread's text into view.
+  useEffect(() => {
+    if (selectedThreadId === null) return;
+    const projection = projectionRef.current;
+    const entry = resolved.find(({ thread }) => thread.id === selectedThreadId);
+    if (projection === null || entry === undefined || entry.resolution.range === null) return;
+    const first = projection.sourceRangeToDomRanges(entry.resolution.range)[0];
+    first?.startContainer.parentElement?.scrollIntoView({ block: "center", behavior: "smooth" });
+  }, [selectedThreadId, resolved]);
+
+  const cancelPending = useCallback(() => {
+    setPending(null);
+    setComposerOpen(false);
+  }, []);
+
+  const onMouseUp = useCallback(() => {
+    if (identity === null || composerOpen) return;
+    const root = markdownRef.current;
+    const wrapper = wrapperRef.current;
+    const projection = projectionRef.current;
+    if (root === null || wrapper === null || projection === null) return;
+    const selection = root.ownerDocument.getSelection();
+    if (selection === null || selection.isCollapsed || selection.rangeCount === 0) return;
+    const domRange = selection.getRangeAt(0);
+    if (!root.contains(domRange.startContainer) || !root.contains(domRange.endContainer)) return;
+    const range = projection.domRangeToSource(domRange);
+    if (range === null) return;
+    const rect = domRange.getBoundingClientRect();
+    const wrapperRect = wrapper.getBoundingClientRect();
+    setPending({
+      range,
+      top: rect.bottom - wrapperRect.top + 8,
+      left: Math.max(0, rect.left - wrapperRect.left),
+    });
+    setComposerOpen(false);
+  }, [identity, composerOpen]);
+
+  const onClick = useCallback(
+    (event: React.MouseEvent) => {
+      if (composerOpen) return;
+      const projection = projectionRef.current;
+      const root = markdownRef.current;
+      if (projection === null || root === null) return;
+      const selection = root.ownerDocument.getSelection();
+      if (selection !== null && !selection.isCollapsed) return; // a drag, not a click
+      const offset = sourceOffsetAtPoint(projection, root.ownerDocument, event.clientX, event.clientY);
+      if (offset === null) {
+        onSelectThread(null);
+        return;
+      }
+      let best: { threadId: string; width: number } | null = null;
+      for (const { thread, resolution } of resolved) {
+        const range = resolution.range;
+        if (range === null || offset < range.start || offset >= range.end) continue;
+        const width = range.end - range.start;
+        if (best === null || width < best.width) best = { threadId: thread.id, width };
+      }
+      onSelectThread(best?.threadId ?? null);
+      if (best === null) cancelPending();
+    },
+    [composerOpen, resolved, onSelectThread, cancelPending],
+  );
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") cancelPending();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [cancelPending]);
+
+  const submitThread = (commentBody: string): Promise<boolean> => {
+    const selection = pending;
+    if (selection === null || identity === null) return Promise.resolve(false);
+    const renderBody = body;
+    return apply((doc) => {
+      // The document may have moved since the selection was made: keep the
+      // offsets only while the body is byte-identical, otherwise re-find the
+      // selected text and refuse ambiguity rather than anchor wrongly.
+      let range = selection.range;
+      if (doc.body !== renderBody) {
+        const exact = renderBody.slice(selection.range.start, selection.range.end);
+        const first = doc.body.indexOf(exact);
+        if (first === -1 || doc.body.indexOf(exact, first + 1) !== -1) {
+          throw new Error("the document changed under the selection — reselect and retry");
+        }
+        range = { start: first, end: first + exact.length };
+      }
+      const anchor = createAnchorSelector(doc.body, range.start, range.end);
+      return addThread(doc, {
+        body: commentBody,
+        createdAt: new Date().toISOString(),
+        anchor,
+        // Highlights carry the location in this surface; a visible marker
+        // would drop markdown syntax into the middle of the selected prose.
+        insertMarker: false,
+        ...identity,
+      });
+    }).then((ok) => {
+      if (ok) cancelPending();
+      return ok;
+    });
+  };
+
+  const highlightCss = useMemo(() => {
+    const authors = [...new Set(resolved.map(({ thread }) => authorOf(thread)))];
+    const rules = authors.map(
+      (author) =>
+        `::highlight(amv-a-${slugForAuthor(author)}) { background-color: ${authorColor(author, 0.28)}; }`,
+    );
+    rules.push(
+      "::highlight(amv-review) { background-color: color-mix(in srgb, var(--color-amber-500, #f59e0b) 25%, transparent); text-decoration: underline dotted; }",
+      "::highlight(amv-selected) { background-color: color-mix(in srgb, var(--color-primary, #6366f1) 30%, transparent); }",
+      "::highlight(amv-pending) { background-color: color-mix(in srgb, var(--color-primary, #6366f1) 22%, transparent); }",
+    );
+    return rules.join("\n");
+  }, [resolved]);
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <style>{highlightCss}</style>
+      <div ref={wrapperRef} className="relative mx-auto w-full max-w-3xl px-8 py-6">
+        <FrontmatterTable metadata={metadata} />
+        {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events -- selection/hit-test layer over rendered text; the threads themselves are reachable through the comments panel */}
+        <div ref={markdownRef} onMouseUp={onMouseUp} onClick={onClick} className="cursor-text">
+          <AnnotatedMarkdownView source={body} className={BODY_STYLES} />
+        </div>
+        {pending !== null && !composerOpen && (
+          <div
+            className="absolute z-10"
+            style={{ top: pending.top, left: Math.min(pending.left, 560) }}
+          >
+            <Button size="sm" variant="secondary" className="shadow-md" onClick={() => setComposerOpen(true)}>
+              <MessageSquarePlusIcon aria-hidden className="size-3.5" /> Comment
+            </Button>
+          </div>
+        )}
+        {pending !== null && composerOpen && (
+          <div
+            className="absolute z-10 w-80 rounded-lg border bg-popover p-2 shadow-lg"
+            style={{ top: pending.top, left: Math.min(pending.left, 420) }}
+          >
+            <CommentComposer
+              placeholder="Comment on the selection…"
+              submitLabel="Comment"
+              focusOnMount
+              onSubmit={submitThread}
+              onCancel={cancelPending}
+            />
+            {opError !== null && <p className="pt-1 text-xs text-red-700">{opError}</p>}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/tasks/src/components/workspace-task-preview.tsx
+++ b/apps/tasks/src/components/workspace-task-preview.tsx
@@ -53,7 +53,7 @@ const BODY_STYLES = [
   "[&_code[data-raw-html]]:block [&_code[data-raw-html]]:whitespace-pre-wrap [&_code[data-raw-html]]:text-muted-foreground",
 ].join(" ");
 
-const slugForAuthor = (author: string): string =>
+const slugForAuthor = (author: string) =>
   author.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "someone";
 
 export function WorkspaceTaskPreview({
@@ -181,7 +181,7 @@ function AnnotatedPreview({
     return entries;
   }, [body, threads]);
 
-  const authorOf = (thread: Thread): string => thread.comments[0]?.author ?? "someone";
+  const authorOf = (thread: Thread) => thread.comments[0]?.author ?? "someone";
 
   // Projection + paint after every body/thread render. Highlights are a
   // registry beside the DOM (CSS Custom Highlight API): repainting is
@@ -310,7 +310,7 @@ function AnnotatedPreview({
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [cancelPending]);
 
-  const submitThread = (commentBody: string): Promise<boolean> => {
+  const submitThread = (commentBody: string) => {
     const selection = pending;
     if (selection === null || identity === null) return Promise.resolve(false);
     const renderBody = body;

--- a/apps/tasks/src/components/workspace-task-preview.tsx
+++ b/apps/tasks/src/components/workspace-task-preview.tsx
@@ -237,9 +237,10 @@ function AnnotatedPreview({
   }, []);
 
   // Live edits move the body under a pending selection: re-find the selected
-  // text so the pending paint stays on the right passage, and drop the
-  // selection when it can't be re-found unambiguously (the submit path would
-  // refuse it anyway).
+  // text so the pending paint stays on the right passage (and the bubble
+  // follows it — this runs AFTER the layout effect rebuilt the projection
+  // for the new body), dropping the selection when it can't be re-found
+  // unambiguously (the submit path would refuse it anyway).
   useEffect(() => {
     setPending((current) => {
       if (current === null || current.sourceBody === body) return current;
@@ -249,7 +250,21 @@ function AnnotatedPreview({
         setComposerOpen(false);
         return null;
       }
-      return { ...current, range: { start: first, end: first + exact.length }, sourceBody: body };
+      const range = { start: first, end: first + exact.length };
+      const projection = projectionRef.current;
+      const wrapper = wrapperRef.current;
+      const rect = projection?.sourceRangeToDomRanges(range)[0]?.getBoundingClientRect();
+      const wrapperRect = wrapper?.getBoundingClientRect();
+      if (rect === undefined || wrapperRect === undefined) {
+        setComposerOpen(false);
+        return null;
+      }
+      return {
+        range,
+        sourceBody: body,
+        top: rect.bottom - wrapperRect.top + 8,
+        left: Math.max(0, rect.left - wrapperRect.left),
+      };
     });
   }, [body]);
 
@@ -313,14 +328,15 @@ function AnnotatedPreview({
   const submitThread = (commentBody: string) => {
     const selection = pending;
     if (selection === null || identity === null) return Promise.resolve(false);
-    const renderBody = body;
     return apply((doc) => {
-      // The document may have moved since the selection was made: keep the
-      // offsets only while the body is byte-identical, otherwise re-find the
-      // selected text and refuse ambiguity rather than anchor wrongly.
+      // The document may have moved since the selection was made: the range
+      // is only valid against the body it was computed on (the remap effect
+      // keeps that current, but the apply-time doc can be newer still) —
+      // otherwise re-find the selected text and refuse ambiguity rather
+      // than anchor wrongly.
       let range = selection.range;
-      if (doc.body !== renderBody) {
-        const exact = renderBody.slice(selection.range.start, selection.range.end);
+      if (doc.body !== selection.sourceBody) {
+        const exact = selection.sourceBody.slice(selection.range.start, selection.range.end);
         const first = doc.body.indexOf(exact);
         if (first === -1 || doc.body.indexOf(exact, first + 1) !== -1) {
           throw new Error("the document changed under the selection — reselect and retry");

--- a/apps/tasks/src/components/workspace-task-sheet.tsx
+++ b/apps/tasks/src/components/workspace-task-sheet.tsx
@@ -190,6 +190,8 @@ function SheetBody({
   onRequestClose: () => void;
 }) {
   const [status, setStatus] = useState("connecting…");
+  // One selection shared by the preview's highlights and the comments strip.
+  const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
   // The path is editable in place; SheetBody is keyed by task.path, so a
   // successful rename remounts with the fresh path and clean state.
   const [pathDraft, setPathDraft] = useState(task.path);
@@ -337,7 +339,14 @@ function SheetBody({
       </div>
         <TabsContent value="preview" className="flex min-h-0 flex-1 flex-col">
           <Suspense fallback={<p className="p-4 text-sm text-muted-foreground">Rendering…</p>}>
-            <WorkspaceTaskPreview source={liveSource?.() ?? task.source} />
+            <WorkspaceTaskPreview
+              source={liveSource?.() ?? task.source}
+              identity={commentIdentity}
+              busy={status === "connecting…"}
+              onTransform={onApplyTransform}
+              selectedThreadId={selectedThreadId}
+              onSelectThread={setSelectedThreadId}
+            />
           </Suspense>
         </TabsContent>
         <TabsContent value="editor" keepMounted className="flex min-h-0 flex-1 flex-col data-[hidden]:hidden">
@@ -369,6 +378,8 @@ function SheetBody({
             // overwrites with its older snapshot, dropping the comment.
             busy={status === "connecting…"}
             onTransform={onApplyTransform}
+            selectedThreadId={selectedThreadId}
+            onSelectThread={setSelectedThreadId}
           />
         </Suspense>
       </div>

--- a/apps/tasks/src/lib/use-discussion-apply.ts
+++ b/apps/tasks/src/lib/use-discussion-apply.ts
@@ -1,0 +1,56 @@
+import { useState } from "react";
+import { parseAnnotatedMarkdown } from "iterate/annotated-markdown";
+import type { StructuredDocument } from "iterate/annotated-markdown";
+
+/** An edit against the parsed document; returns the next raw source. */
+export type DiscussionOp = (doc: StructuredDocument) => { raw: string };
+
+/**
+ * The one lane every discussion mutation takes (comments strip AND the
+ * preview's select-to-comment): re-parse at apply time so ops re-find their
+ * targets by id, refuse to run while the editor is attaching (the raw-write
+ * fallback would race the arriving session), and only report success once
+ * the write actually LANDED — the write lane is optimistic and rolls back.
+ */
+export function useDiscussionApply({
+  busy,
+  onTransform,
+}: {
+  /** True while the file's live editor is still attaching. */
+  busy: boolean;
+  /** Route a whole-file transform to the live editor or the write lane;
+   * resolves whether it landed (the write lane can roll back). */
+  onTransform: (transform: (source: string) => string) => Promise<boolean>;
+}) {
+  const [opError, setOpError] = useState<string | null>(null);
+
+  const apply = async (op: DiscussionOp): Promise<boolean> => {
+    if (busy) {
+      setOpError("Comment change failed: the editor is still connecting — retry in a moment");
+      return false;
+    }
+    let ok = false;
+    let failure = "the file changed mid-edit";
+    const landed = await onTransform((current) => {
+      const doc = parseAnnotatedMarkdown(current);
+      if (doc.kind !== "structured") {
+        failure = doc.diagnostics[0]?.message ?? "the file failed to parse";
+        return current;
+      }
+      try {
+        const result = op(doc);
+        ok = true;
+        return result.raw;
+      } catch (error) {
+        failure = error instanceof Error ? error.message : String(error);
+        return current;
+      }
+    });
+    if (ok && !landed) failure = "the write did not reach the workspace — retry";
+    ok = ok && landed;
+    setOpError(ok ? null : `Comment change failed: ${failure}`);
+    return ok;
+  };
+
+  return { apply, opError };
+}

--- a/apps/tasks/src/lib/use-discussion-apply.ts
+++ b/apps/tasks/src/lib/use-discussion-apply.ts
@@ -24,7 +24,7 @@ export function useDiscussionApply({
 }) {
   const [opError, setOpError] = useState<string | null>(null);
 
-  const apply = async (op: DiscussionOp): Promise<boolean> => {
+  const apply = async (op: DiscussionOp) => {
     if (busy) {
       setOpError("Comment change failed: the editor is still connecting — retry in a moment");
       return false;

--- a/packages/iterate/package.json
+++ b/packages/iterate/package.json
@@ -27,6 +27,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./annotated-markdown": "./src/annotated-markdown/index.ts",
+    "./annotated-markdown/react": "./src/annotated-markdown/react/index.ts",
     "./client": "./src/client.ts",
     "./node": "./src/node.ts",
     "./starter-apps/github-ai-linter": "./src/starter-apps/github-ai-linter/index.ts",
@@ -56,6 +57,11 @@
         "types": "./dist/annotated-markdown/index.d.ts",
         "import": "./dist/annotated-markdown.mjs",
         "default": "./dist/annotated-markdown.mjs"
+      },
+      "./annotated-markdown/react": {
+        "types": "./dist/annotated-markdown/react/index.d.ts",
+        "import": "./dist/annotated-markdown-react.mjs",
+        "default": "./dist/annotated-markdown-react.mjs"
       },
       "./client": {
         "types": "./dist/client.d.ts",
@@ -157,6 +163,10 @@
     "@orpc/client": "1.13.14",
     "@orpc/server": "1.13.14",
     "@tanstack/react-query": "^5.101.2",
+    "approx-string-match": "^2.0.0",
+    "mdast-util-from-markdown": "^2.0.3",
+    "mdast-util-gfm": "^3.1.0",
+    "micromark-extension-gfm": "^3.0.0",
     "react": "^19.2.7",
     "sqlfu": "0.1.1",
     "trpc-cli": "0.15.1",
@@ -180,6 +190,7 @@
   },
   "devDependencies": {
     "@iterate-com/ui": "workspace:*",
+    "@types/mdast": "^4.0.4",
     "@types/node": "^22.0.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/packages/iterate/src/annotated-markdown/README.md
+++ b/packages/iterate/src/annotated-markdown/README.md
@@ -29,7 +29,7 @@ Publishing must durably enqueue invalidation before returning. [T1](#thread-th_0
 
 ### T1 · Open
 
-<!-- task-anchor:v1 {"quote":{"exact":"durably enqueue","prefix":"must ","suffix":" invalidation"},"position":{"start":58,"end":73}} -->
+<!-- task-anchor:v1 {"selector":[{"type":"TextQuoteSelector","exact":"durably enqueue","prefix":"must ","suffix":" invalidation"},{"type":"TextPositionSelector","start":58,"end":73}]} -->
 
 <!-- task-comment:v1 begin id=cm_01K… author=lee created=2026-07-28T08:30:00Z -->
 
@@ -64,12 +64,16 @@ closes is fatal.
   `<!-- task-thread:v1 end id=<id> -->` — a thread block. Only legal at store
   level; ids on both boundaries must match.
 - `<!-- task-comment:v1 begin id=<id> author=<token> created=<iso-utc>
-[in-reply-to=<id>] [deleted=true] -->` …
+[modified=<iso-utc>] [in-reply-to=<id>] [deleted=true] -->` …
   `<!-- task-comment:v1 end id=<id> -->` — a comment block inside a thread.
+  `modified` is the last-edit instant; `editComment` stamps it when asked.
 - `<!-- task-anchor:v1 <json> -->` — at most one per thread, before the first
-  comment: a W3C-style selector
-  `{"quote":{"exact","prefix","suffix"},"position?":{"start","end"}}` with
-  body-relative offsets.
+  comment: a W3C Web Annotation selector list
+  `{"selector":[{"type":"TextQuoteSelector","exact","prefix?","suffix?"},
+{"type":"TextPositionSelector","start","end"}?]}` — exactly one
+  TextQuoteSelector, at most one TextPositionSelector, body-relative offsets.
+  The pre-W3C spelling `{"quote":{…},"position?":{…}}` is still read (files
+  written before the rename); the writer emits W3C only.
 
 Attributes are single-space-separated `key=value` tokens; unknown or duplicate
 attributes are fatal. Ids are opaque `[A-Za-z0-9._-]` tokens (this codec
@@ -140,6 +144,12 @@ Comment text may not contain a line starting with `<!-- task-` at column 0
 (indent or fence such lines to quote them).
 
 ## Divergences from the task-spec sketch
+
+- Offsets everywhere (positions, ranges, splices) are UTF-16 code units — the
+  native JavaScript string index — while the W3C model counts Unicode code
+  points. The two diverge only after astral characters (emoji); a third-party
+  reader counting code points still recovers through the quote selector, which
+  is exactly what the reconciliation ladder is for.
 
 - The spec sketch carries `format: task/v1` in front matter; existing iterate
   task files predate that key, so this codec neither requires nor interprets

--- a/packages/iterate/src/annotated-markdown/anchors.ts
+++ b/packages/iterate/src/annotated-markdown/anchors.ts
@@ -1,3 +1,4 @@
+import approxSearch from "approx-string-match";
 import type { AnchorSelector, SourceRange } from "./types.ts";
 
 // Anchor reconciliation. Anchor drift is nonfatal by design: a thread whose
@@ -23,6 +24,7 @@ const MAX_FUZZY_BODY_LENGTH = 256 * 1024;
 const FUZZY_ATTACH_THRESHOLD = 0.8;
 const FUZZY_REVIEW_THRESHOLD = 0.6;
 const FUZZY_AMBIGUITY_MARGIN = 0.05;
+const MIN_APPROX_QUOTE_LENGTH = 8;
 
 export function createAnchorSelector(
   body: string,
@@ -201,37 +203,64 @@ function fuzzyResolve(body: string, selector: AnchorSelector): AnchorResolution 
     }
   }
 
-  // Sliding-window bigram similarity (Dice coefficient) as the last resort.
-  const window = exact.length;
-  const step = Math.max(1, Math.floor(window / 8));
-  const target = bigramCounts(exact);
-  let bestStart = -1;
-  let bestScore = 0;
-  let runnerUpScore = 0;
-  for (let start = 0; start + window <= body.length; start += step) {
-    const score = diceSimilarity(target, bigramCounts(body.slice(start, start + window)));
-    if (bestStart !== -1 && Math.abs(start - bestStart) < window) {
-      // Same region as the current best: keep the max, don't count it as an
-      // independent runner-up.
-      if (score > bestScore) bestScore = score;
-      continue;
-    }
-    if (score > bestScore) {
-      runnerUpScore = bestScore;
-      bestScore = score;
-      bestStart = start;
-    } else if (score > runnerUpScore) {
-      runnerUpScore = score;
-    }
-  }
-  if (bestStart === -1 || bestScore < FUZZY_REVIEW_THRESHOLD) {
+  // Approximate search (bitap over edit distance — the engine Hypothesis
+  // settled on) as the last resort. Candidates are RANKED by a weighted
+  // fusion of quote similarity, surviving context, and distance from the
+  // recorded position; the reported confidence stays the quote similarity
+  // alone so thresholds keep their meaning.
+  if (exact.length < MIN_APPROX_QUOTE_LENGTH) {
+    // One-or-two-word quotes produce spurious approximate matches; they only
+    // attach via the exact rungs above.
     return { state: "orphaned", method: null, range: null, confidence: 0 };
   }
-  const range: SourceRange = { start: bestStart, end: Math.min(body.length, bestStart + window) };
-  if (bestScore >= FUZZY_ATTACH_THRESHOLD && bestScore - runnerUpScore >= FUZZY_AMBIGUITY_MARGIN) {
-    return { state: "attached", method: "fuzzy", range, confidence: bestScore };
+  const maxErrors = Math.floor(exact.length * (1 - FUZZY_REVIEW_THRESHOLD));
+  const matches = approxSearch(body, exact, maxErrors);
+  interface Candidate {
+    range: SourceRange;
+    similarity: number;
+    rank: number;
   }
-  return { state: "needs_review", method: "fuzzy", range, confidence: bestScore };
+  let best: Candidate | null = null;
+  let runnerUp: Candidate | null = null;
+  for (const match of matches) {
+    const similarity = 1 - match.errors / exact.length;
+    const context =
+      contextScore(body, match.start, match.end - match.start, selector) /
+      Math.max(1, selector.quote.prefix.length + selector.quote.suffix.length);
+    const positionCloseness =
+      selector.position === undefined
+        ? 0
+        : 1 -
+          Math.min(1, Math.abs(match.start - selector.position.start) / Math.max(1, body.length));
+    const rank = similarity + 0.25 * context + 0.1 * positionCloseness;
+    const candidate: Candidate = {
+      range: { start: match.start, end: match.end },
+      similarity,
+      rank,
+    };
+    if (best !== null && Math.abs(candidate.range.start - best.range.start) < exact.length) {
+      // Same region as the current best: keep the better, don't count it as
+      // an independent runner-up.
+      if (candidate.rank > best.rank) best = candidate;
+      continue;
+    }
+    if (best === null || candidate.rank > best.rank) {
+      runnerUp = best;
+      best = candidate;
+    } else if (runnerUp === null || candidate.rank > runnerUp.rank) {
+      runnerUp = candidate;
+    }
+  }
+  if (best === null || best.similarity < FUZZY_REVIEW_THRESHOLD) {
+    return { state: "orphaned", method: null, range: null, confidence: 0 };
+  }
+  if (
+    best.similarity >= FUZZY_ATTACH_THRESHOLD &&
+    (runnerUp === null || best.rank - runnerUp.rank >= FUZZY_AMBIGUITY_MARGIN)
+  ) {
+    return { state: "attached", method: "fuzzy", range: best.range, confidence: best.similarity };
+  }
+  return { state: "needs_review", method: "fuzzy", range: best.range, confidence: best.similarity };
 }
 
 function normalizeWithMap(text: string): { text: string; map: number[] } {
@@ -254,27 +283,4 @@ function normalizeWithMap(text: string): { text: string; map: number[] } {
     map.push(i);
   }
   return { text: out, map };
-}
-
-function bigramCounts(text: string): Map<string, number> {
-  const counts = new Map<string, number>();
-  for (let i = 0; i + 1 < text.length; i++) {
-    const bigram = text.slice(i, i + 2);
-    counts.set(bigram, (counts.get(bigram) ?? 0) + 1);
-  }
-  return counts;
-}
-
-function diceSimilarity(a: Map<string, number>, b: Map<string, number>): number {
-  let aTotal = 0;
-  for (const count of a.values()) aTotal += count;
-  let bTotal = 0;
-  for (const count of b.values()) bTotal += count;
-  if (aTotal === 0 || bTotal === 0) return 0;
-  let overlap = 0;
-  for (const [bigram, count] of a) {
-    const other = b.get(bigram);
-    if (other !== undefined) overlap += Math.min(count, other);
-  }
-  return (2 * overlap) / (aTotal + bTotal);
 }

--- a/packages/iterate/src/annotated-markdown/edits.test.ts
+++ b/packages/iterate/src/annotated-markdown/edits.test.ts
@@ -150,7 +150,7 @@ describe("addThread", () => {
         '<a id="thread-th_1"></a>',
         "### T1 · Open",
         "",
-        '<!-- task-anchor:v1 {"quote":{"exact":"beta","prefix":"Alpha ","suffix":" gamma.\\n"},"position":{"start":6,"end":10}} -->',
+        '<!-- task-anchor:v1 {"selector":[{"type":"TextQuoteSelector","exact":"beta","prefix":"Alpha ","suffix":" gamma.\\n"},{"type":"TextPositionSelector","start":6,"end":10}]} -->',
         "",
         "<!-- task-comment:v1 begin id=cm_1 author=jonas created=2026-07-28T10:00:00Z -->",
         "#### Jonas · 2026-07-28 10:00 UTC",
@@ -187,7 +187,7 @@ describe("addThread", () => {
         '<a id="thread-th_1"></a>',
         "### T1 · Open",
         "",
-        '<!-- task-anchor:v1 {"quote":{"exact":"beta","prefix":"Alpha ","suffix":""},"position":{"start":6,"end":10}} -->',
+        '<!-- task-anchor:v1 {"selector":[{"type":"TextQuoteSelector","exact":"beta","prefix":"Alpha ","suffix":""},{"type":"TextPositionSelector","start":6,"end":10}]} -->',
         "",
         "<!-- task-comment:v1 begin id=cm_1 author=jonas created=2026-07-28T10:00:00Z -->",
         "#### Jonas · 2026-07-28 10:00 UTC",
@@ -396,6 +396,45 @@ describe("editComment", () => {
     const result = editComment(structured(content), "cm_a", "Now with text.");
     expect(result.doc.discussion?.threads[0]?.comments[0]?.body).toBe("Now with text.");
     expectMinimalDiff(content, result);
+  });
+
+  test("modifiedAt stamps the begin sentinel and re-stamps in place", () => {
+    const base = addThread(structured(BARE), {
+      ...WHO,
+      body: "First.",
+      threadId: "th_1",
+      commentId: "cm_1",
+    });
+    const stamped = editComment(base.doc, "cm_1", "Second.", {
+      modifiedAt: "2026-07-29T09:00:00Z",
+    });
+    expect(stamped.raw).toContain(
+      "<!-- task-comment:v1 begin id=cm_1 author=jonas created=2026-07-28T10:00:00Z modified=2026-07-29T09:00:00Z -->",
+    );
+    expect(stamped.doc.discussion?.threads[0]?.comments[0]?.modifiedAt).toBe(
+      "2026-07-29T09:00:00Z",
+    );
+    expectMinimalDiff(base.raw, stamped);
+
+    // A later edit replaces the value, never accumulates attributes.
+    const again = editComment(stamped.doc, "cm_1", "Third.", {
+      modifiedAt: "2026-07-29T10:30:00Z",
+    });
+    expect(again.raw).toContain("modified=2026-07-29T10:30:00Z");
+    expect(again.raw).not.toContain("2026-07-29T09:00:00Z");
+    expectMinimalDiff(stamped.raw, again);
+  });
+
+  test("an invalid modifiedAt is rejected", () => {
+    const base = addThread(structured(BARE), {
+      ...WHO,
+      body: "First.",
+      threadId: "th_1",
+      commentId: "cm_1",
+    });
+    expect(() => editComment(base.doc, "cm_1", "X.", { modifiedAt: "yesterday" })).toThrowError(
+      /modifiedAt/,
+    );
   });
 });
 

--- a/packages/iterate/src/annotated-markdown/edits.ts
+++ b/packages/iterate/src/annotated-markdown/edits.ts
@@ -375,7 +375,12 @@ export function setThreadStatus(
   return finish(doc, splices);
 }
 
-export function editComment(doc: StructuredDocument, commentId: string, body: string): EditResult {
+export function editComment(
+  doc: StructuredDocument,
+  commentId: string,
+  body: string,
+  options: { modifiedAt?: string } = {},
+): EditResult {
   const { comment } = requireComment(doc, commentId);
   if (comment.deleted) return fail("comment-deleted", `comment ${commentId} is deleted`);
   const eol = dominantEol(doc.raw);
@@ -384,7 +389,30 @@ export function editComment(doc: StructuredDocument, commentId: string, body: st
     comment.bodyRange.start === comment.bodyRange.end
       ? bodyLines.join(eol) + eol
       : bodyLines.join(eol);
-  return finish(doc, [{ range: comment.bodyRange, insert }]);
+  const splices: Splice[] = [];
+  if (options.modifiedAt !== undefined) {
+    if (!isValidCreatedAt(options.modifiedAt)) {
+      return fail(
+        "invalid-created",
+        "modifiedAt must be an ISO-8601 UTC instant like 2026-07-28T08:30:00Z",
+      );
+    }
+    const beginLine = lineAt(doc.raw, comment.range.start);
+    const parsed = parseSentinelLine(beginLine.content, comment.range.start);
+    if (!parsed.ok || parsed.token.kind !== "comment-begin") {
+      throw new Error("unreachable: structured comment has an unparsable begin sentinel");
+    }
+    splices.push(
+      parsed.token.modifiedValueRange !== null
+        ? { range: parsed.token.modifiedValueRange, insert: options.modifiedAt }
+        : {
+            range: { start: parsed.token.attrsEnd, end: parsed.token.attrsEnd },
+            insert: ` modified=${options.modifiedAt}`,
+          },
+    );
+  }
+  splices.push({ range: comment.bodyRange, insert });
+  return finish(doc, splices);
 }
 
 export function deleteComment(doc: StructuredDocument, commentId: string): EditResult {

--- a/packages/iterate/src/annotated-markdown/parse.test.ts
+++ b/packages/iterate/src/annotated-markdown/parse.test.ts
@@ -824,3 +824,110 @@ describe("whole-file plain fallback", () => {
     expect(result.diagnostics[0]?.code).toBe("frontmatter-yaml-error");
   });
 });
+
+describe("anchor selector spellings", () => {
+  const store = (anchorLine: string): string =>
+    md(
+      "Alpha beta gamma.",
+      "",
+      "<!-- task-discussions:v1 -->",
+      "",
+      "<!-- task-thread:v1 begin id=th_a status=open -->",
+      anchorLine,
+      "<!-- task-comment:v1 begin id=cm_a author=lee created=2026-07-28T08:30:00Z -->",
+      "Body.",
+      "<!-- task-comment:v1 end id=cm_a -->",
+      "<!-- task-thread:v1 end id=th_a -->",
+      "",
+    );
+
+  test("the W3C spelling parses to the same selector as the legacy spelling", () => {
+    const w3c = expectStructured(
+      store(
+        '<!-- task-anchor:v1 {"selector":[{"type":"TextQuoteSelector","exact":"beta","prefix":"Alpha ","suffix":" gamma."},{"type":"TextPositionSelector","start":6,"end":10}]} -->',
+      ),
+    );
+    const legacy = expectStructured(
+      store(
+        '<!-- task-anchor:v1 {"quote":{"exact":"beta","prefix":"Alpha ","suffix":" gamma."},"position":{"start":6,"end":10}} -->',
+      ),
+    );
+    const expected = {
+      quote: { exact: "beta", prefix: "Alpha ", suffix: " gamma." },
+      position: { start: 6, end: 10 },
+    };
+    expect(w3c.discussion?.threads[0]?.anchor?.selector).toEqual(expected);
+    expect(legacy.discussion?.threads[0]?.anchor?.selector).toEqual(expected);
+  });
+
+  test("W3C prefix and suffix are optional and default to empty", () => {
+    const result = expectStructured(
+      store('<!-- task-anchor:v1 {"selector":[{"type":"TextQuoteSelector","exact":"beta"}]} -->'),
+    );
+    expect(result.discussion?.threads[0]?.anchor?.selector).toEqual({
+      quote: { exact: "beta", prefix: "", suffix: "" },
+    });
+  });
+
+  test.for([
+    {
+      name: "unknown selector type",
+      json: '{"selector":[{"type":"CssSelector","value":"p"}]}',
+    },
+    {
+      name: "two quote selectors",
+      json: '{"selector":[{"type":"TextQuoteSelector","exact":"a"},{"type":"TextQuoteSelector","exact":"b"}]}',
+    },
+    {
+      name: "position without a quote",
+      json: '{"selector":[{"type":"TextPositionSelector","start":0,"end":4}]}',
+    },
+    {
+      name: "unknown key inside a selector entry",
+      json: '{"selector":[{"type":"TextQuoteSelector","exact":"a","refinedBy":{}}]}',
+    },
+    {
+      name: "selector key mixed with the legacy quote key",
+      json: '{"selector":[{"type":"TextQuoteSelector","exact":"a"}],"quote":{"exact":"a"}}',
+    },
+    {
+      name: "empty selector list",
+      json: '{"selector":[]}',
+    },
+  ] as const)("rejected W3C shape: $name", ({ json }) => {
+    const result = expectPlain(store(`<!-- task-anchor:v1 ${json} -->`));
+    expect(result.diagnostics[0]?.code).toBe("anchor-invalid");
+  });
+});
+
+describe("comment modified attribute", () => {
+  test("modified parses onto the comment and survives round-trip", () => {
+    const content = md(
+      "Body.",
+      "",
+      "<!-- task-discussions:v1 -->",
+      "",
+      "<!-- task-thread:v1 begin id=th_a status=open -->",
+      "<!-- task-comment:v1 begin id=cm_a author=lee created=2026-07-28T08:30:00Z modified=2026-07-29T09:00:00Z -->",
+      "Edited body.",
+      "<!-- task-comment:v1 end id=cm_a -->",
+      "<!-- task-thread:v1 end id=th_a -->",
+      "",
+    );
+    const result = expectStructured(content);
+    expect(result.discussion?.threads[0]?.comments[0]?.modifiedAt).toBe("2026-07-29T09:00:00Z");
+  });
+
+  test("an invalid modified value is a fatal sentinel diagnostic", () => {
+    const content = md(
+      "<!-- task-discussions:v1 -->",
+      "<!-- task-thread:v1 begin id=th_a status=open -->",
+      "<!-- task-comment:v1 begin id=cm_a author=lee created=2026-07-28T08:30:00Z modified=yesterday -->",
+      "<!-- task-comment:v1 end id=cm_a -->",
+      "<!-- task-thread:v1 end id=th_a -->",
+      "",
+    );
+    const result = expectPlain(content);
+    expect(result.diagnostics[0]?.code).toBe("sentinel-malformed");
+  });
+});

--- a/packages/iterate/src/annotated-markdown/parse.ts
+++ b/packages/iterate/src/annotated-markdown/parse.ts
@@ -150,6 +150,7 @@ export function parseAnnotatedMarkdown(raw: string): ParseResult {
     id: string;
     author: string;
     createdAt: string;
+    modifiedAt: string | null;
     inReplyTo: string | null;
     deleted: boolean;
     beginLine: Line;
@@ -202,6 +203,7 @@ export function parseAnnotatedMarkdown(raw: string): ParseResult {
       id: comment.id,
       author: comment.author,
       createdAt: comment.createdAt,
+      modifiedAt: comment.modifiedAt,
       inReplyTo: comment.inReplyTo,
       deleted: comment.deleted,
       displayName,
@@ -300,6 +302,7 @@ export function parseAnnotatedMarkdown(raw: string): ParseResult {
           id: token.id,
           author: token.author,
           createdAt: token.createdAt,
+          modifiedAt: token.modifiedAt,
           inReplyTo: token.inReplyTo,
           deleted: token.deleted,
           beginLine: line,

--- a/packages/iterate/src/annotated-markdown/react/highlights.ts
+++ b/packages/iterate/src/annotated-markdown/react/highlights.ts
@@ -15,6 +15,10 @@ interface HighlightApi {
 }
 
 function highlightApi(): HighlightApi | null {
+  // CSS.highlights and the Highlight constructor are Baseline browser APIs
+  // that TypeScript's DOM lib doesn't model yet (and jsdom lacks). The casts
+  // only add them as OPTIONAL members — presence is probed at runtime below,
+  // so an environment without them returns null instead of crashing.
   const cssGlobal = globalThis.CSS as (typeof CSS & { highlights?: HighlightRegistry }) | undefined;
   const highlightCtor = (globalThis as { Highlight?: HighlightApi["Highlight"] }).Highlight;
   if (cssGlobal?.highlights === undefined || highlightCtor === undefined) return null;

--- a/packages/iterate/src/annotated-markdown/react/highlights.ts
+++ b/packages/iterate/src/annotated-markdown/react/highlights.ts
@@ -1,0 +1,54 @@
+// Highlight painting via the CSS Custom Highlight API: ranges live in a
+// registry BESIDE the DOM, so painting never mutates nodes React owns and
+// re-painting after a render is just re-registering fresh ranges. Styling is
+// the host's `::highlight(<name>)` rules; names are `<prefix>-<key>`.
+
+interface HighlightRegistry {
+  set(name: string, highlight: unknown): void;
+  delete(name: string): boolean;
+  keys(): IterableIterator<string>;
+}
+
+interface HighlightApi {
+  registry: HighlightRegistry;
+  Highlight: new (...ranges: Range[]) => unknown;
+}
+
+function highlightApi(): HighlightApi | null {
+  const cssGlobal = globalThis.CSS as (typeof CSS & { highlights?: HighlightRegistry }) | undefined;
+  const highlightCtor = (globalThis as { Highlight?: HighlightApi["Highlight"] }).Highlight;
+  if (cssGlobal?.highlights === undefined || highlightCtor === undefined) return null;
+  return { registry: cssGlobal.highlights, Highlight: highlightCtor };
+}
+
+/** True when the runtime can paint (Baseline browsers; not jsdom). */
+export function canPaintHighlights(): boolean {
+  return highlightApi() !== null;
+}
+
+/**
+ * Replace every highlight under `prefix` with the given groups. A group's
+ * `key` becomes the registered name `<prefix>-<key>` — style it with
+ * `::highlight(<prefix>-<key>)`.
+ */
+export function paintHighlights(
+  prefix: string,
+  groups: { key: string; ranges: Range[] }[],
+): boolean {
+  const api = highlightApi();
+  if (api === null) return false;
+  clearHighlights(prefix);
+  for (const group of groups) {
+    if (group.ranges.length === 0) continue;
+    api.registry.set(`${prefix}-${group.key}`, new api.Highlight(...group.ranges));
+  }
+  return true;
+}
+
+export function clearHighlights(prefix: string): void {
+  const api = highlightApi();
+  if (api === null) return;
+  for (const name of [...api.registry.keys()]) {
+    if (name.startsWith(`${prefix}-`)) api.registry.delete(name);
+  }
+}

--- a/packages/iterate/src/annotated-markdown/react/index.ts
+++ b/packages/iterate/src/annotated-markdown/react/index.ts
@@ -1,0 +1,9 @@
+// React viewer for annotated-markdown bodies: a source-stamped renderer, the
+// DOM↔source projection built from its stamps, and CSS-Highlight painting.
+// The codec itself (parse/edits/anchors) is the sibling `annotated-markdown`
+// entry; this entry adds only presentation machinery.
+
+export { AnnotatedMarkdownView } from "./render.tsx";
+export { buildProjection, sourceOffsetAtPoint } from "./projection.ts";
+export type { SourceProjection } from "./projection.ts";
+export { canPaintHighlights, clearHighlights, paintHighlights } from "./highlights.ts";

--- a/packages/iterate/src/annotated-markdown/react/projection.test.tsx
+++ b/packages/iterate/src/annotated-markdown/react/projection.test.tsx
@@ -127,6 +127,23 @@ describe("selection → source", () => {
     expect(body.slice(range!.start, range!.end)).toBe("const x");
   });
 
+  test("multiline blockquote lines map exactly through the > prefixes", () => {
+    const body = "> first quoted line\n> second quoted line\n> third here.\n";
+    const { root } = mount(body);
+    const projection = buildProjection(root);
+    const point = domPointAt(root, "second quoted");
+    const range = projection.domRangeToSource({
+      startContainer: point.node,
+      startOffset: point.offset,
+      endContainer: point.node,
+      endOffset: point.offset + "second quoted".length,
+    });
+    expect(body.slice(range!.start, range!.end)).toBe("second quoted");
+    // And source → DOM picks exactly the same words back out.
+    const painted = projection.sourceRangeToDomRanges(range!);
+    expect(painted.map((r) => r.toString()).join("")).toBe("second quoted");
+  });
+
   test("entity-decoded text snaps atomically to its source unit", () => {
     const body = "Fish &amp; chips forever.\n";
     const { root } = mount(body);

--- a/packages/iterate/src/annotated-markdown/react/projection.test.tsx
+++ b/packages/iterate/src/annotated-markdown/react/projection.test.tsx
@@ -1,0 +1,200 @@
+// @vitest-environment jsdom
+/** @jsxImportSource react */
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+import { buildProjection } from "./projection.ts";
+import { AnnotatedMarkdownView } from "./render.tsx";
+
+// The projection contract: DOM selection → source → DOM must round-trip
+// without wrong attachment across markdown constructs. Rendering here goes
+// through static markup + innerHTML — the projection only reads data stamps
+// off the live DOM, so the render path is irrelevant to what's under test.
+
+function mount(source: string): { root: HTMLElement; body: string } {
+  const html = renderToStaticMarkup(<AnnotatedMarkdownView source={source} />);
+  const host = document.createElement("div");
+  host.innerHTML = html;
+  const root = host.firstElementChild as HTMLElement;
+  return { root, body: source };
+}
+
+/** The DOM point at the nth occurrence of `needle` in rendered text. */
+function domPointAt(
+  root: HTMLElement,
+  needle: string,
+  occurrence = 0,
+): { node: Text; offset: number } {
+  const walker = root.ownerDocument.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  let seen = 0;
+  for (let node = walker.nextNode(); node !== null; node = walker.nextNode()) {
+    const text = node as Text;
+    let index = text.data.indexOf(needle);
+    while (index !== -1) {
+      if (seen === occurrence) return { node: text, offset: index };
+      seen++;
+      index = text.data.indexOf(needle, index + 1);
+    }
+  }
+  throw new Error(`rendered text does not contain ${JSON.stringify(needle)}`);
+}
+
+describe("selection → source", () => {
+  test("plain prose maps exactly", () => {
+    const body = "Alpha beta gamma delta.\n";
+    const { root } = mount(body);
+    const projection = buildProjection(root);
+    const start = domPointAt(root, "beta");
+    const end = domPointAt(root, "gamma");
+    const range = projection.domRangeToSource({
+      startContainer: start.node,
+      startOffset: start.offset,
+      endContainer: end.node,
+      endOffset: end.offset + "gamma".length,
+    });
+    expect(range).toEqual({ start: body.indexOf("beta"), end: body.indexOf("gamma") + 5 });
+    expect(body.slice(range!.start, range!.end)).toBe("beta gamma");
+  });
+
+  test("a selection crossing emphasis spans the markup in source", () => {
+    const body = "Plain **bold middle** after.\n";
+    const { root } = mount(body);
+    const projection = buildProjection(root);
+    const start = domPointAt(root, "Plain");
+    const end = domPointAt(root, "middle");
+    const range = projection.domRangeToSource({
+      startContainer: start.node,
+      startOffset: 0,
+      endContainer: end.node,
+      endOffset: end.offset + "middle".length,
+    });
+    expect(body.slice(range!.start, range!.end)).toBe("Plain **bold middle");
+  });
+
+  test("inline code maps through its backticks", () => {
+    const body = "Run `pnpm test` now.\n";
+    const { root } = mount(body);
+    const projection = buildProjection(root);
+    const point = domPointAt(root, "pnpm test");
+    const range = projection.domRangeToSource({
+      startContainer: point.node,
+      startOffset: point.offset,
+      endContainer: point.node,
+      endOffset: point.offset + "pnpm test".length,
+    });
+    expect(body.slice(range!.start, range!.end)).toBe("pnpm test");
+  });
+
+  test("fenced code content maps to the inside of the fence", () => {
+    const body = "Before.\n\n```ts\nconst x = 1;\n```\n\nAfter.\n";
+    const { root } = mount(body);
+    const projection = buildProjection(root);
+    const point = domPointAt(root, "const x");
+    const range = projection.domRangeToSource({
+      startContainer: point.node,
+      startOffset: point.offset,
+      endContainer: point.node,
+      endOffset: point.offset + "const x".length,
+    });
+    expect(body.slice(range!.start, range!.end)).toBe("const x");
+  });
+
+  test("entity-decoded text snaps atomically to its source unit", () => {
+    const body = "Fish &amp; chips forever.\n";
+    const { root } = mount(body);
+    const projection = buildProjection(root);
+    // Rendered text is "Fish & chips forever." — the "&" leaf is atomic.
+    const amp = domPointAt(root, "&");
+    const start = projection.domPointToSource(amp.node, amp.offset, "start");
+    const source = body.slice(start!, start! + "&amp;".length);
+    expect(source).toBe("&amp;");
+  });
+
+  test("selection inside a GFM table cell maps exactly", () => {
+    const body = "| Col A | Col B |\n| --- | --- |\n| left cell | right cell |\n";
+    const { root } = mount(body);
+    const projection = buildProjection(root);
+    const point = domPointAt(root, "right cell");
+    const range = projection.domRangeToSource({
+      startContainer: point.node,
+      startOffset: point.offset,
+      endContainer: point.node,
+      endOffset: point.offset + "right cell".length,
+    });
+    expect(body.slice(range!.start, range!.end)).toBe("right cell");
+  });
+
+  test("unicode text (emoji) keeps UTF-16 offsets aligned", () => {
+    const body = "Ship 🚀 tomorrow, not today.\n";
+    const { root } = mount(body);
+    const projection = buildProjection(root);
+    const point = domPointAt(root, "tomorrow");
+    const range = projection.domRangeToSource({
+      startContainer: point.node,
+      startOffset: point.offset,
+      endContainer: point.node,
+      endOffset: point.offset + "tomorrow".length,
+    });
+    expect(body.slice(range!.start, range!.end)).toBe("tomorrow");
+  });
+
+  test("raw HTML renders as literal text and maps identically", () => {
+    const body = 'Before.\n\n<div class="x">raw</div>\n\nAfter.\n';
+    const { root } = mount(body);
+    // Never parsed into elements:
+    expect(root.querySelector("div.x")).toBeNull();
+    const projection = buildProjection(root);
+    const point = domPointAt(root, '<div class="x">');
+    const start = projection.domPointToSource(point.node, point.offset, "start");
+    expect(body.slice(start!, start! + 4)).toBe("<div");
+  });
+});
+
+describe("source → DOM", () => {
+  test("a mid-paragraph source range paints exactly its text", () => {
+    const body = "One two three four five.\n";
+    const { root } = mount(body);
+    const projection = buildProjection(root);
+    const start = body.indexOf("two");
+    const end = body.indexOf("four") + 4;
+    const ranges = projection.sourceRangeToDomRanges({ start, end });
+    const painted = ranges.map((r) => r.toString()).join("");
+    expect(painted).toBe("two three four");
+  });
+
+  test("a range crossing bold produces per-leaf ranges that concatenate to the visible text", () => {
+    const body = "alpha **bravo** charlie\n";
+    const { root } = mount(body);
+    const projection = buildProjection(root);
+    const start = body.indexOf("alpha");
+    const end = body.indexOf("charlie") + "charlie".length;
+    const ranges = projection.sourceRangeToDomRanges({ start, end });
+    expect(ranges.map((r) => r.toString()).join("")).toBe("alpha bravo charlie");
+  });
+
+  test("round-trip: selection → source → DOM re-selects the same text", () => {
+    const body = "# Title\n\nSome *emphasised words* in a sentence with `code` too.\n";
+    const { root } = mount(body);
+    const projection = buildProjection(root);
+    const start = domPointAt(root, "emphasised");
+    const end = domPointAt(root, "code");
+    const source = projection.domRangeToSource({
+      startContainer: start.node,
+      startOffset: start.offset,
+      endContainer: end.node,
+      endOffset: end.offset + "code".length,
+    });
+    const ranges = projection.sourceRangeToDomRanges(source!);
+    expect(ranges.map((r) => r.toString()).join("")).toBe(
+      "emphasised words in a sentence with code",
+    );
+  });
+
+  test("block ranges resolve from any descendant", () => {
+    const body = "First paragraph.\n\nSecond paragraph here.\n";
+    const { root } = mount(body);
+    const projection = buildProjection(root);
+    const point = domPointAt(root, "Second");
+    const block = projection.blockRangeOf(point.node);
+    expect(body.slice(block!.start, block!.end)).toBe("Second paragraph here.");
+  });
+});

--- a/packages/iterate/src/annotated-markdown/react/projection.test.tsx
+++ b/packages/iterate/src/annotated-markdown/react/projection.test.tsx
@@ -84,6 +84,35 @@ describe("selection → source", () => {
     expect(body.slice(range!.start, range!.end)).toBe("pnpm test");
   });
 
+  test("a fence body echoing its info string maps to the body, not the fence", () => {
+    const body = "Use this:\n\n```python\npython\n```\n\nDone.\n";
+    const { root } = mount(body);
+    const projection = buildProjection(root);
+    const point = domPointAt(root, "python");
+    const range = projection.domRangeToSource({
+      startContainer: point.node,
+      startOffset: point.offset,
+      endContainer: point.node,
+      endOffset: point.offset + "python".length,
+    });
+    // The BODY "python" sits on the line after the opening fence.
+    expect(range).toEqual({
+      start: body.indexOf("python\n```"),
+      end: body.indexOf("python\n```") + "python".length,
+    });
+  });
+
+  test("single-line indented code still maps its content", () => {
+    const body = "Steps:\n\n    make deploy\n\nDone.\n";
+    const { root } = mount(body);
+    const projection = buildProjection(root);
+    const point = domPointAt(root, "make deploy");
+    const start = projection.domPointToSource(point.node, point.offset, "start");
+    // Indented code has no fence line; the mapping may be exact or snap to
+    // the block atomically, but it must land on the code, never elsewhere.
+    expect(body.slice(start!, start! + 4)).toBe("make");
+  });
+
   test("fenced code content maps to the inside of the fence", () => {
     const body = "Before.\n\n```ts\nconst x = 1;\n```\n\nAfter.\n";
     const { root } = mount(body);

--- a/packages/iterate/src/annotated-markdown/react/projection.ts
+++ b/packages/iterate/src/annotated-markdown/react/projection.ts
@@ -1,0 +1,206 @@
+import {
+  BLOCK_END_ATTR,
+  BLOCK_START_ATTR,
+  SEGMENT_ATOMIC_ATTR,
+  SEGMENT_END_ATTR,
+  SEGMENT_START_ATTR,
+} from "./render.tsx";
+
+// The rendered-DOM ↔ source bridge. Built by walking the stamps the renderer
+// left on the live DOM — never by diffing textContent against the source.
+// Identity segments map character-for-character; atomic segments (decoded
+// entities, escapes, non-contiguous code) map as indivisible units whose
+// interior snaps to their edges.
+
+export interface SourceProjection {
+  /** Map a DOM point to a body-relative source offset (null: outside). */
+  domPointToSource(node: Node, offset: number, affinity: "start" | "end"): number | null;
+  /** Map a body-relative source range to paintable DOM ranges. */
+  sourceRangeToDomRanges(range: { start: number; end: number }): Range[];
+  /** Map a DOM selection to its body-relative source range (null: outside). */
+  domRangeToSource(range: {
+    startContainer: Node;
+    startOffset: number;
+    endContainer: Node;
+    endOffset: number;
+  }): { start: number; end: number } | null;
+  /** The nearest enclosing block's source range for a DOM node. */
+  blockRangeOf(node: Node): { start: number; end: number } | null;
+}
+
+interface Segment {
+  text: Text;
+  sourceStart: number;
+  sourceEnd: number;
+  atomic: boolean;
+}
+
+export function buildProjection(root: HTMLElement): SourceProjection {
+  const segments: Segment[] = [];
+  for (const span of root.querySelectorAll<HTMLElement>(`[${SEGMENT_START_ATTR}]`)) {
+    const start = Number(span.getAttribute(SEGMENT_START_ATTR));
+    const end = Number(span.getAttribute(SEGMENT_END_ATTR));
+    if (!Number.isInteger(start) || !Number.isInteger(end)) continue;
+    const atomic = span.hasAttribute(SEGMENT_ATOMIC_ATTR);
+    // The renderer emits exactly one text node per segment span; a re-render
+    // may split it (React text updates), so walk all of them in order.
+    let sourceCursor = start;
+    const walker = span.ownerDocument.createTreeWalker(span, NodeFilter.SHOW_TEXT);
+    for (let node = walker.nextNode(); node !== null; node = walker.nextNode()) {
+      const text = node as Text;
+      const length = text.data.length;
+      if (atomic) {
+        segments.push({ text, sourceStart: start, sourceEnd: end, atomic: true });
+      } else {
+        segments.push({
+          text,
+          sourceStart: sourceCursor,
+          sourceEnd: Math.min(end, sourceCursor + length),
+          atomic: false,
+        });
+        sourceCursor += length;
+      }
+    }
+  }
+
+  const segmentOf = (node: Node): Segment | undefined =>
+    segments.find((segment) => segment.text === node);
+
+  const pointToSource = (node: Node, offset: number, affinity: "start" | "end"): number | null => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const segment = segmentOf(node);
+      if (segment !== undefined) {
+        if (segment.atomic) {
+          // Interior offsets have no honest mapping; snap to the unit's edge.
+          if (offset <= 0) return segment.sourceStart;
+          if (offset >= segment.text.data.length) return segment.sourceEnd;
+          return affinity === "start" ? segment.sourceStart : segment.sourceEnd;
+        }
+        return segment.sourceStart + Math.min(offset, segment.sourceEnd - segment.sourceStart);
+      }
+      // Un-stamped text (list bullets never produce these, but be safe):
+      // resolve through its parent element below.
+      return elementPointToSource(node.parentNode, affinity);
+    }
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      // The point sits between child nodes: resolve to the nearest stamped
+      // neighbour in the chosen direction.
+      const children = Array.from(node.childNodes);
+      if (affinity === "start") {
+        for (let i = offset; i < children.length; i++) {
+          const child = children[i];
+          if (child === undefined) break;
+          const first = firstSegmentWithin(child);
+          if (first !== null) return first.sourceStart;
+        }
+        return elementPointToSource(node, "start");
+      }
+      for (let i = offset - 1; i >= 0; i--) {
+        const child = children[i];
+        if (child === undefined) break;
+        const last = lastSegmentWithin(child);
+        if (last !== null) return last.sourceEnd;
+      }
+      return elementPointToSource(node, "end");
+    }
+    return null;
+  };
+
+  const firstSegmentWithin = (node: Node): Segment | null => {
+    if (node.nodeType === Node.TEXT_NODE) return segmentOf(node) ?? null;
+    if (node.nodeType !== Node.ELEMENT_NODE) return null;
+    for (const segment of segments) {
+      if (node.contains(segment.text)) return segment;
+    }
+    return null;
+  };
+  const lastSegmentWithin = (node: Node): Segment | null => {
+    if (node.nodeType === Node.TEXT_NODE) return segmentOf(node) ?? null;
+    if (node.nodeType !== Node.ELEMENT_NODE) return null;
+    for (let i = segments.length - 1; i >= 0; i--) {
+      const segment = segments[i];
+      if (segment !== undefined && node.contains(segment.text)) return segment;
+    }
+    return null;
+  };
+
+  const elementPointToSource = (node: Node | null, affinity: "start" | "end"): number | null => {
+    if (node === null || !(node instanceof Element)) return null;
+    const scope =
+      node.closest(`[${BLOCK_START_ATTR}]`) ?? node.closest("[data-annotated-markdown-root]");
+    if (scope === null) return null;
+    const segment = affinity === "start" ? firstSegmentWithin(scope) : lastSegmentWithin(scope);
+    if (segment === null) return null;
+    return affinity === "start" ? segment.sourceStart : segment.sourceEnd;
+  };
+
+  return {
+    domPointToSource: pointToSource,
+
+    domRangeToSource(range) {
+      const start = pointToSource(range.startContainer, range.startOffset, "start");
+      const end = pointToSource(range.endContainer, range.endOffset, "end");
+      if (start === null || end === null || end <= start) return null;
+      return { start, end };
+    },
+
+    sourceRangeToDomRanges(range) {
+      const doc = root.ownerDocument;
+      const ranges: Range[] = [];
+      for (const segment of segments) {
+        const overlapStart = Math.max(range.start, segment.sourceStart);
+        const overlapEnd = Math.min(range.end, segment.sourceEnd);
+        if (overlapEnd <= overlapStart) continue;
+        const domRange = doc.createRange();
+        if (segment.atomic) {
+          domRange.selectNodeContents(segment.text);
+        } else {
+          domRange.setStart(segment.text, overlapStart - segment.sourceStart);
+          domRange.setEnd(segment.text, overlapEnd - segment.sourceStart);
+        }
+        ranges.push(domRange);
+      }
+      return ranges;
+    },
+
+    blockRangeOf(node) {
+      const element = node instanceof Element ? node : node.parentElement;
+      const block = element?.closest(`[${BLOCK_START_ATTR}]`);
+      if (block == null) return null;
+      const start = Number(block.getAttribute(BLOCK_START_ATTR));
+      const end = Number(block.getAttribute(BLOCK_END_ATTR));
+      if (!Number.isInteger(start) || !Number.isInteger(end)) return null;
+      return { start, end };
+    },
+  };
+}
+
+interface CaretPositionLike {
+  offsetNode: Node;
+  offset: number;
+}
+
+/**
+ * Source offset under a pointer event, for highlight hit-testing (CSS
+ * highlights are paint, not elements — clicks resolve through the caret).
+ */
+export function sourceOffsetAtPoint(
+  projection: SourceProjection,
+  documentRef: Document,
+  x: number,
+  y: number,
+): number | null {
+  const caretDocument = documentRef as Document & {
+    caretPositionFromPoint?: (x: number, y: number) => CaretPositionLike | null;
+    caretRangeFromPoint?: (x: number, y: number) => Range | null;
+  };
+  const position = caretDocument.caretPositionFromPoint?.(x, y);
+  if (position != null) {
+    return projection.domPointToSource(position.offsetNode, position.offset, "start");
+  }
+  const range = caretDocument.caretRangeFromPoint?.(x, y);
+  if (range != null) {
+    return projection.domPointToSource(range.startContainer, range.startOffset, "start");
+  }
+  return null;
+}

--- a/packages/iterate/src/annotated-markdown/react/projection.ts
+++ b/packages/iterate/src/annotated-markdown/react/projection.ts
@@ -47,6 +47,8 @@ export function buildProjection(root: HTMLElement): SourceProjection {
     let sourceCursor = start;
     const walker = span.ownerDocument.createTreeWalker(span, NodeFilter.SHOW_TEXT);
     for (let node = walker.nextNode(); node !== null; node = walker.nextNode()) {
+      // SHOW_TEXT guarantees every visited node is a Text node; the walker's
+      // return type is just the general Node.
       const text = node as Text;
       const length = text.data.length;
       if (atomic) {
@@ -190,6 +192,9 @@ export function sourceOffsetAtPoint(
   x: number,
   y: number,
 ): number | null {
+  // caretPositionFromPoint (standard) and caretRangeFromPoint (WebKit) are
+  // divergent vendor APIs missing from TypeScript's DOM lib; the cast adds
+  // them as OPTIONAL members and both calls are runtime-probed with ?. below.
   const caretDocument = documentRef as Document & {
     caretPositionFromPoint?: (x: number, y: number) => CaretPositionLike | null;
     caretRangeFromPoint?: (x: number, y: number) => Range | null;

--- a/packages/iterate/src/annotated-markdown/react/render.tsx
+++ b/packages/iterate/src/annotated-markdown/react/render.tsx
@@ -138,7 +138,7 @@ function textSegment(ctx: RenderContext, node: Nodes & { value: string }): React
  * sit BETWEEN lines); returns null when it doesn't so the caller falls back
  * to prefix/suffix splitting.
  */
-function alignLines(value: string, slice: string, sliceStart: number): ReactNode[] | null {
+function alignLines(value: string, slice: string, sliceStart: number) {
   const lines = value.split("\n");
   const segments: ReactNode[] = [];
   let cursor = 0;

--- a/packages/iterate/src/annotated-markdown/react/render.tsx
+++ b/packages/iterate/src/annotated-markdown/react/render.tsx
@@ -1,0 +1,314 @@
+/** @jsxImportSource react */
+import { fromMarkdown } from "mdast-util-from-markdown";
+import { gfmFromMarkdown } from "mdast-util-gfm";
+import { gfm } from "micromark-extension-gfm";
+import type { Nodes, Parents, RootContent } from "mdast";
+import type { ReactNode } from "react";
+
+// A markdown renderer whose one job beyond looking clean is SOURCE FIDELITY:
+// every rendered text run is wrapped in a span stamped with the body-relative
+// source offsets it came from, and every block element carries its block's
+// range. The projection module reads those stamps back off the live DOM to
+// map selections to source and source ranges to paintable DOM ranges — the
+// renderer never guesses by comparing text after the fact.
+//
+// Sanitization is by construction: markdown is rendered from the mdast tree
+// to React elements only. Raw HTML in the source is shown as literal code
+// text, never parsed into the DOM; only http(s)/mailto/# links and http(s)
+// images survive as active references.
+
+/** data attribute names shared with projection.ts. */
+export const SEGMENT_START_ATTR = "data-ams";
+export const SEGMENT_END_ATTR = "data-ame";
+export const SEGMENT_ATOMIC_ATTR = "data-amx";
+export const BLOCK_START_ATTR = "data-amb";
+export const BLOCK_END_ATTR = "data-ambe";
+
+interface RenderContext {
+  /** The body markdown exactly as parsed. */
+  source: string;
+}
+
+const offsetsOf = (node: Nodes): { start: number; end: number } | null => {
+  const start = node.position?.start.offset;
+  const end = node.position?.end.offset;
+  if (typeof start !== "number" || typeof end !== "number") return null;
+  return { start, end };
+};
+
+/**
+ * A stamped text run. `atomic` marks runs whose rendered characters do NOT
+ * map 1:1 onto the source slice (entity/escape decoding, fence trimming) —
+ * the projection then treats the run as a single indivisible unit and snaps
+ * selection boundaries to its edges instead of inventing offsets.
+ */
+function Segment({
+  value,
+  start,
+  end,
+  atomic,
+}: {
+  value: string;
+  start: number;
+  end: number;
+  atomic: boolean;
+}) {
+  const attrs: Record<string, string | number> = {
+    [SEGMENT_START_ATTR]: start,
+    [SEGMENT_END_ATTR]: end,
+  };
+  if (atomic) attrs[SEGMENT_ATOMIC_ATTR] = "";
+  return <span {...attrs}>{value}</span>;
+}
+
+function textSegment(ctx: RenderContext, node: Nodes & { value: string }): ReactNode {
+  const offsets = offsetsOf(node);
+  if (offsets === null) return node.value;
+  const slice = ctx.source.slice(offsets.start, offsets.end);
+  if (slice === node.value) {
+    return <Segment value={node.value} start={offsets.start} end={offsets.end} atomic={false} />;
+  }
+  // Decoded text (an entity, an escape): keep the identical prefix and
+  // suffix as exact segments so only the decoded core snaps atomically —
+  // one `&amp;` must not make a whole paragraph indivisible.
+  const value = node.value;
+  let prefix = 0;
+  const maxShared = Math.min(slice.length, value.length);
+  while (prefix < maxShared && slice[prefix] === value[prefix]) prefix++;
+  let suffix = 0;
+  while (
+    suffix < maxShared - prefix &&
+    slice[slice.length - 1 - suffix] === value[value.length - 1 - suffix]
+  ) {
+    suffix++;
+  }
+  // Greedy ends can meet in the middle (`&` matching into `&amp;`); shrink
+  // until both cores are non-empty so the atomic unit exists.
+  while (
+    prefix + suffix > 0 &&
+    (value.length - prefix - suffix <= 0 || slice.length - prefix - suffix <= 0)
+  ) {
+    if (suffix > 0) suffix--;
+    else prefix--;
+  }
+  const coreValue = value.slice(prefix, value.length - suffix);
+  const coreSlice = slice.slice(prefix, slice.length - suffix);
+  if (coreValue.length === 0 || coreSlice.length === 0) {
+    return <Segment value={value} start={offsets.start} end={offsets.end} atomic={true} />;
+  }
+  return (
+    <>
+      {prefix > 0 ? (
+        <Segment
+          value={value.slice(0, prefix)}
+          start={offsets.start}
+          end={offsets.start + prefix}
+          atomic={false}
+        />
+      ) : null}
+      <Segment
+        value={coreValue}
+        start={offsets.start + prefix}
+        end={offsets.end - suffix}
+        atomic={true}
+      />
+      {suffix > 0 ? (
+        <Segment
+          value={value.slice(value.length - suffix)}
+          start={offsets.end - suffix}
+          end={offsets.end}
+          atomic={false}
+        />
+      ) : null}
+    </>
+  );
+}
+
+/**
+ * Inline code / fenced code carry their content INSIDE delimiters; locate the
+ * verbatim content within the node's slice so the segment maps exactly, and
+ * fall back to an atomic whole-node segment when it isn't contiguous
+ * (indented code blocks, exotic escapes).
+ */
+function innerSegment(ctx: RenderContext, node: Nodes & { value: string }): { segment: ReactNode } {
+  const offsets = offsetsOf(node);
+  if (offsets === null) return { segment: node.value };
+  const slice = ctx.source.slice(offsets.start, offsets.end);
+  const inner = node.value.length === 0 ? -1 : slice.indexOf(node.value);
+  if (inner === -1) {
+    return {
+      segment: <Segment value={node.value} start={offsets.start} end={offsets.end} atomic={true} />,
+    };
+  }
+  return {
+    segment: (
+      <Segment
+        value={node.value}
+        start={offsets.start + inner}
+        end={offsets.start + inner + node.value.length}
+        atomic={false}
+      />
+    ),
+  };
+}
+
+const SAFE_LINK = /^(https?:\/\/|mailto:|#)/i;
+const SAFE_IMAGE = /^https?:\/\//i;
+
+function renderChildren(ctx: RenderContext, node: Parents): ReactNode[] {
+  return node.children.map((child, index) => <RenderNode key={index} ctx={ctx} node={child} />);
+}
+
+function blockAttrs(node: Nodes): Record<string, number> {
+  const offsets = offsetsOf(node);
+  if (offsets === null) return {};
+  return { [BLOCK_START_ATTR]: offsets.start, [BLOCK_END_ATTR]: offsets.end };
+}
+
+function RenderNode({ ctx, node }: { ctx: RenderContext; node: RootContent }): ReactNode {
+  switch (node.type) {
+    case "text":
+      return textSegment(ctx, node);
+    case "paragraph":
+      return <p {...blockAttrs(node)}>{renderChildren(ctx, node)}</p>;
+    case "heading": {
+      const Tag = `h${node.depth}` as "h1";
+      return <Tag {...blockAttrs(node)}>{renderChildren(ctx, node)}</Tag>;
+    }
+    case "emphasis":
+      return <em>{renderChildren(ctx, node)}</em>;
+    case "strong":
+      return <strong>{renderChildren(ctx, node)}</strong>;
+    case "delete":
+      return <del>{renderChildren(ctx, node)}</del>;
+    case "inlineCode":
+      return <code>{innerSegment(ctx, node).segment}</code>;
+    case "code": {
+      const { segment } = innerSegment(ctx, node);
+      return (
+        <pre {...blockAttrs(node)} data-language={node.lang ?? undefined}>
+          <code>{segment}</code>
+        </pre>
+      );
+    }
+    case "blockquote":
+      return <blockquote {...blockAttrs(node)}>{renderChildren(ctx, node)}</blockquote>;
+    case "list": {
+      const Tag = node.ordered === true ? "ol" : "ul";
+      return (
+        <Tag {...blockAttrs(node)} start={node.ordered === true ? (node.start ?? 1) : undefined}>
+          {renderChildren(ctx, node)}
+        </Tag>
+      );
+    }
+    case "listItem": {
+      const checkbox =
+        node.checked === true || node.checked === false ? (
+          <input type="checkbox" checked={node.checked} readOnly disabled aria-hidden />
+        ) : null;
+      return (
+        <li {...blockAttrs(node)} data-task={checkbox === null ? undefined : ""}>
+          {checkbox}
+          {renderChildren(ctx, node)}
+        </li>
+      );
+    }
+    case "link": {
+      const safe = SAFE_LINK.test(node.url);
+      if (!safe) return <span>{renderChildren(ctx, node)}</span>;
+      const external = /^https?:\/\//i.test(node.url);
+      return (
+        <a
+          href={node.url}
+          title={node.title ?? undefined}
+          target={external ? "_blank" : undefined}
+          rel={external ? "noreferrer" : undefined}
+        >
+          {renderChildren(ctx, node)}
+        </a>
+      );
+    }
+    case "image": {
+      if (!SAFE_IMAGE.test(node.url)) {
+        return <span>{node.alt ?? node.url}</span>;
+      }
+      return <img src={node.url} alt={node.alt ?? ""} title={node.title ?? undefined} />;
+    }
+    case "break":
+      return <br />;
+    case "thematicBreak":
+      return <hr {...blockAttrs(node)} />;
+    case "table": {
+      const [head, ...rows] = node.children;
+      return (
+        <table {...blockAttrs(node)}>
+          {head !== undefined ? (
+            <thead>
+              <tr>
+                {head.children.map((cell, index) => (
+                  <th key={index} align={node.align?.[index] ?? undefined}>
+                    {renderChildren(ctx, cell)}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+          ) : null}
+          <tbody>
+            {rows.map((row, rowIndex) => (
+              <tr key={rowIndex}>
+                {row.children.map((cell, cellIndex) => (
+                  <td key={cellIndex} align={node.align?.[cellIndex] ?? undefined}>
+                    {renderChildren(ctx, cell)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      );
+    }
+    case "html":
+      // Never parsed into the DOM — shown as what it is: source text.
+      return <code data-raw-html="">{textSegment(ctx, node)}</code>;
+    case "footnoteReference":
+    case "footnoteDefinition":
+    case "definition":
+    case "imageReference":
+    case "linkReference":
+      // Reference-style constructs are rare in task files; render their
+      // readable children (or nothing for pure definitions).
+      return "children" in node ? <span>{renderChildren(ctx, node)}</span> : null;
+    case "tableRow":
+    case "tableCell":
+      // Handled inside `table`; unreachable as direct children.
+      return null;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Render annotated-markdown BODY text (front matter and discussion store
+ * already sliced off by the codec) as clean, source-stamped HTML. Styling is
+ * the host's: the wrapper is plain semantic HTML under `className`.
+ */
+export function AnnotatedMarkdownView({
+  source,
+  className,
+}: {
+  source: string;
+  className?: string;
+}) {
+  const tree = fromMarkdown(source, {
+    extensions: [gfm()],
+    mdastExtensions: [gfmFromMarkdown()],
+  });
+  const ctx: RenderContext = { source };
+  return (
+    <div className={className} data-annotated-markdown-root="">
+      {tree.children.map((child, index) => (
+        <RenderNode key={index} ctx={ctx} node={child} />
+      ))}
+    </div>
+  );
+}

--- a/packages/iterate/src/annotated-markdown/react/render.tsx
+++ b/packages/iterate/src/annotated-markdown/react/render.tsx
@@ -68,6 +68,14 @@ function textSegment(ctx: RenderContext, node: Nodes & { value: string }): React
   if (slice === node.value) {
     return <Segment value={node.value} start={offsets.start} end={offsets.end} atomic={false} />;
   }
+  // Multiline mismatch: blockquote `> ` continuations (and list lazy
+  // indents) live in the SOURCE between the value's lines. Align line by
+  // line — each rendered line maps exactly, and each newline becomes an
+  // atomic unit covering the newline plus the structural prefix.
+  if (node.value.includes("\n")) {
+    const lineSegments = alignLines(node.value, slice, offsets.start);
+    if (lineSegments !== null) return <>{lineSegments}</>;
+  }
   // Decoded text (an entity, an escape): keep the identical prefix and
   // suffix as exact segments so only the decoded core snaps atomically —
   // one `&amp;` must not make a whole paragraph indivisible.
@@ -122,6 +130,53 @@ function textSegment(ctx: RenderContext, node: Nodes & { value: string }): React
       ) : null}
     </>
   );
+}
+
+/**
+ * Map a multiline text value onto its source slice line by line. Every value
+ * line must appear in order in the slice (blockquote/list prefixes only ever
+ * sit BETWEEN lines); returns null when it doesn't so the caller falls back
+ * to prefix/suffix splitting.
+ */
+function alignLines(value: string, slice: string, sliceStart: number): ReactNode[] | null {
+  const lines = value.split("\n");
+  const segments: ReactNode[] = [];
+  let cursor = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    const at = line === "" ? cursor : slice.indexOf(line, cursor);
+    if (at === -1) return null;
+    if (line !== "") {
+      segments.push(
+        <Segment
+          key={segments.length}
+          value={line}
+          start={sliceStart + at}
+          end={sliceStart + at + line.length}
+          atomic={false}
+        />,
+      );
+      cursor = at + line.length;
+    }
+    if (i < lines.length - 1) {
+      const gapEnd = slice.indexOf("\n", cursor);
+      if (gapEnd === -1) return null;
+      const nextLine = lines[i + 1] ?? "";
+      const nextAt = nextLine === "" ? gapEnd + 1 : slice.indexOf(nextLine, gapEnd + 1);
+      if (nextAt === -1) return null;
+      segments.push(
+        <Segment
+          key={segments.length}
+          value={"\n"}
+          start={sliceStart + cursor}
+          end={sliceStart + nextAt}
+          atomic={true}
+        />,
+      );
+      cursor = nextAt;
+    }
+  }
+  return segments;
 }
 
 /**

--- a/packages/iterate/src/annotated-markdown/react/render.tsx
+++ b/packages/iterate/src/annotated-markdown/react/render.tsx
@@ -184,6 +184,9 @@ function RenderNode({ ctx, node }: { ctx: RenderContext; node: RootContent }): R
     case "paragraph":
       return <p {...blockAttrs(node)}>{renderChildren(ctx, node)}</p>;
     case "heading": {
+      // mdast constrains depth to 1..6, so the template yields h1–h6; they
+      // share h1's prop type, and the single-literal cast keeps JSX typing
+      // without enumerating six branches.
       const Tag = `h${node.depth}` as "h1";
       return <Tag {...blockAttrs(node)}>{renderChildren(ctx, node)}</Tag>;
     }

--- a/packages/iterate/src/annotated-markdown/react/render.tsx
+++ b/packages/iterate/src/annotated-markdown/react/render.tsx
@@ -128,13 +128,25 @@ function textSegment(ctx: RenderContext, node: Nodes & { value: string }): React
  * Inline code / fenced code carry their content INSIDE delimiters; locate the
  * verbatim content within the node's slice so the segment maps exactly, and
  * fall back to an atomic whole-node segment when it isn't contiguous
- * (indented code blocks, exotic escapes).
+ * (indented code blocks, exotic escapes). Fenced content starts on the line
+ * AFTER the opening fence — searching from the top would bind a body that
+ * echoes the info string (```python whose body is `python`) to the fence.
  */
-function innerSegment(ctx: RenderContext, node: Nodes & { value: string }): { segment: ReactNode } {
+function innerSegment(
+  ctx: RenderContext,
+  node: Nodes & { value: string },
+  { afterFirstLine = false }: { afterFirstLine?: boolean } = {},
+): { segment: ReactNode } {
   const offsets = offsetsOf(node);
   if (offsets === null) return { segment: node.value };
   const slice = ctx.source.slice(offsets.start, offsets.end);
-  const inner = node.value.length === 0 ? -1 : slice.indexOf(node.value);
+  let searchFrom = 0;
+  // Indented code blocks have no fence line — only skip a real one.
+  if (afterFirstLine && /^[`~]/.test(slice)) {
+    const firstLineEnd = slice.indexOf("\n");
+    searchFrom = firstLineEnd === -1 ? slice.length : firstLineEnd + 1;
+  }
+  const inner = node.value.length === 0 ? -1 : slice.indexOf(node.value, searchFrom);
   if (inner === -1) {
     return {
       segment: <Segment value={node.value} start={offsets.start} end={offsets.end} atomic={true} />,
@@ -184,7 +196,7 @@ function RenderNode({ ctx, node }: { ctx: RenderContext; node: RootContent }): R
     case "inlineCode":
       return <code>{innerSegment(ctx, node).segment}</code>;
     case "code": {
-      const { segment } = innerSegment(ctx, node);
+      const { segment } = innerSegment(ctx, node, { afterFirstLine: true });
       return (
         <pre {...blockAttrs(node)} data-language={node.lang ?? undefined}>
           <code>{segment}</code>

--- a/packages/iterate/src/annotated-markdown/sentinels.ts
+++ b/packages/iterate/src/annotated-markdown/sentinels.ts
@@ -41,6 +41,10 @@ type SentinelToken =
       id: string;
       author: string;
       createdAt: string;
+      /** From the optional `modified=<instant>` attribute. */
+      modifiedAt: string | null;
+      /** Absolute range of the modified value, for minimal re-stamp splices. */
+      modifiedValueRange: SourceRange | null;
       inReplyTo: string | null;
       deleted: boolean;
       attrsEnd: number;
@@ -81,9 +85,18 @@ export function isValidCreatedAt(value: string): boolean {
   );
 }
 
+/**
+ * Accepts the written W3C spelling (`{"selector":[{type:"TextQuoteSelector",…},
+ * {type:"TextPositionSelector",…}]}`) plus the pre-W3C spelling
+ * (`{quote:{…},position:{…}}`) this codec wrote before the rename — read-only
+ * compatibility for files born in that window; the writer emits W3C only.
+ */
 export function validateAnchorSelector(value: unknown): AnchorSelector | null {
   if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
   const keys = Object.keys(value);
+  if (keys.length === 1 && keys[0] === "selector") {
+    return validateW3cSelectorList((value as { selector: unknown }).selector);
+  }
   if (keys.some((k) => k !== "quote" && k !== "position")) return null;
   const { quote, position } = value as { quote?: unknown; position?: unknown };
   if (typeof quote !== "object" || quote === null || Array.isArray(quote)) return null;
@@ -94,21 +107,79 @@ export function validateAnchorSelector(value: unknown): AnchorSelector | null {
     prefix?: unknown;
     suffix?: unknown;
   };
+  const validQuote = validateQuoteParts(exact, prefix, suffix);
+  if (validQuote === null) return null;
+  const selector: AnchorSelector = { quote: validQuote };
+  if (position !== undefined) {
+    const validPosition = validatePositionParts(position);
+    if (validPosition === null) return null;
+    selector.position = validPosition;
+  }
+  return selector;
+}
+
+function validateQuoteParts(
+  exact: unknown,
+  prefix: unknown,
+  suffix: unknown,
+): AnchorSelector["quote"] | null {
   if (typeof exact !== "string" || exact.length === 0 || exact.length > MAX_QUOTE_EXACT_LENGTH) {
     return null;
   }
-  if (typeof prefix !== "string" || prefix.length > MAX_QUOTE_CONTEXT_LENGTH) return null;
-  if (typeof suffix !== "string" || suffix.length > MAX_QUOTE_CONTEXT_LENGTH) return null;
-  const selector: AnchorSelector = { quote: { exact, prefix, suffix } };
-  if (position !== undefined) {
-    if (typeof position !== "object" || position === null || Array.isArray(position)) return null;
-    const positionKeys = Object.keys(position);
-    if (positionKeys.some((k) => k !== "start" && k !== "end")) return null;
-    const { start, end } = position as { start?: unknown; end?: unknown };
-    if (!Number.isInteger(start) || !Number.isInteger(end)) return null;
-    if ((start as number) < 0 || (end as number) < (start as number)) return null;
-    selector.position = { start: start as number, end: end as number };
+  if (prefix !== undefined && typeof prefix !== "string") return null;
+  if (suffix !== undefined && typeof suffix !== "string") return null;
+  const prefixValue = prefix ?? "";
+  const suffixValue = suffix ?? "";
+  if (prefixValue.length > MAX_QUOTE_CONTEXT_LENGTH) return null;
+  if (suffixValue.length > MAX_QUOTE_CONTEXT_LENGTH) return null;
+  return { exact, prefix: prefixValue, suffix: suffixValue };
+}
+
+function validatePositionParts(position: unknown): { start: number; end: number } | null {
+  if (typeof position !== "object" || position === null || Array.isArray(position)) return null;
+  const positionKeys = Object.keys(position);
+  if (positionKeys.some((k) => k !== "start" && k !== "end")) return null;
+  const { start, end } = position as { start?: unknown; end?: unknown };
+  if (!Number.isInteger(start) || !Number.isInteger(end)) return null;
+  if ((start as number) < 0 || (end as number) < (start as number)) return null;
+  return { start: start as number, end: end as number };
+}
+
+function validateW3cSelectorList(list: unknown): AnchorSelector | null {
+  if (!Array.isArray(list) || list.length === 0 || list.length > 2) return null;
+  let quote: AnchorSelector["quote"] | null = null;
+  let position: { start: number; end: number } | null = null;
+  for (const entry of list) {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) return null;
+    const { type } = entry as { type?: unknown };
+    if (type === "TextQuoteSelector") {
+      if (quote !== null) return null;
+      const entryKeys = Object.keys(entry);
+      if (entryKeys.some((k) => k !== "type" && k !== "exact" && k !== "prefix" && k !== "suffix"))
+        return null;
+      const { exact, prefix, suffix } = entry as {
+        exact?: unknown;
+        prefix?: unknown;
+        suffix?: unknown;
+      };
+      quote = validateQuoteParts(exact, prefix, suffix);
+      if (quote === null) return null;
+      continue;
+    }
+    if (type === "TextPositionSelector") {
+      if (position !== null) return null;
+      const entryKeys = Object.keys(entry);
+      if (entryKeys.some((k) => k !== "type" && k !== "start" && k !== "end")) return null;
+      const { start, end } = entry as { start?: unknown; end?: unknown };
+      position = validatePositionParts({ start, end });
+      if (position === null) return null;
+      continue;
+    }
+    return null;
   }
+  if (quote === null) return null;
+  const selector: AnchorSelector = { quote };
+  if (position !== null) selector.position = position;
   return selector;
 }
 
@@ -255,6 +326,10 @@ export function parseSentinelLine(lineContent: string, lineStart: number): Senti
   if (created === undefined || !isValidCreatedAt(created.value)) {
     return malformed("`created` must be an ISO-8601 UTC instant like 2026-07-28T08:30:00Z");
   }
+  const modified = take("modified");
+  if (modified !== undefined && !isValidCreatedAt(modified.value)) {
+    return malformed("`modified` must be an ISO-8601 UTC instant like 2026-07-28T08:30:00Z");
+  }
   const inReplyTo = take("in-reply-to");
   if (inReplyTo !== undefined && !isValidId(inReplyTo.value))
     return malformed("invalid `in-reply-to`");
@@ -270,6 +345,14 @@ export function parseSentinelLine(lineContent: string, lineStart: number): Senti
       id: id.value,
       author: author.value,
       createdAt: created.value,
+      modifiedAt: modified?.value ?? null,
+      modifiedValueRange:
+        modified === undefined
+          ? null
+          : {
+              start: lineStart + modified.valueStart,
+              end: lineStart + modified.valueStart + modified.value.length,
+            },
       inReplyTo: inReplyTo?.value ?? null,
       deleted: deleted !== undefined,
       attrsEnd,
@@ -293,10 +376,12 @@ export function formatCommentBegin(comment: {
   id: string;
   author: string;
   createdAt: string;
+  modifiedAt?: string | null;
   inReplyTo?: string | null;
   deleted?: boolean;
 }): string {
   let attrs = `id=${comment.id} author=${comment.author} created=${comment.createdAt}`;
+  if (comment.modifiedAt != null) attrs += ` modified=${comment.modifiedAt}`;
   if (comment.inReplyTo != null) attrs += ` in-reply-to=${comment.inReplyTo}`;
   if (comment.deleted === true) attrs += " deleted=true";
   return `<!-- task-comment:v1 begin ${attrs} -->`;
@@ -307,8 +392,16 @@ export function formatCommentEnd(id: string): string {
 }
 
 export function formatAnchorSentinel(selector: AnchorSelector): string {
-  const canonical: AnchorSelector = { quote: { ...selector.quote } };
-  if (selector.position !== undefined) canonical.position = { ...selector.position };
+  // Written in W3C Web Annotation spelling (TextQuoteSelector +
+  // TextPositionSelector) so the persisted form is the interop form. Offsets
+  // stay UTF-16 code units (see README divergences) — third-party readers
+  // counting code points recover via the quote selector.
+  const canonical: { selector: Record<string, unknown>[] } = {
+    selector: [{ type: "TextQuoteSelector", ...selector.quote }],
+  };
+  if (selector.position !== undefined) {
+    canonical.selector.push({ type: "TextPositionSelector", ...selector.position });
+  }
   // `--` cannot appear inside an HTML comment; JSON only produces it inside
   // string literals, where a `-` escape is transparent to JSON.parse.
   const json = JSON.stringify(canonical).replace(/-(?=-)/g, "\\u002d");

--- a/packages/iterate/src/annotated-markdown/sentinels.ts
+++ b/packages/iterate/src/annotated-markdown/sentinels.ts
@@ -98,6 +98,9 @@ export function validateAnchorSelector(value: unknown): AnchorSelector | null {
     return validateW3cSelectorList((value as { selector: unknown }).selector);
   }
   if (keys.some((k) => k !== "quote" && k !== "position")) return null;
+  // The key filter above proves only these two keys exist; the cast just
+  // names them as unknown members for the structural checks that follow —
+  // TypeScript can't narrow an object's members through Object.keys.
   const { quote, position } = value as { quote?: unknown; position?: unknown };
   if (typeof quote !== "object" || quote === null || Array.isArray(quote)) return null;
   const quoteKeys = Object.keys(quote);
@@ -141,6 +144,8 @@ function validatePositionParts(position: unknown): { start: number; end: number 
   if (positionKeys.some((k) => k !== "start" && k !== "end")) return null;
   const { start, end } = position as { start?: unknown; end?: unknown };
   if (!Number.isInteger(start) || !Number.isInteger(end)) return null;
+  // Number.isInteger proved both are numbers; it isn't a type guard in
+  // TypeScript's lib, so the casts restate what was just validated.
   if ((start as number) < 0 || (end as number) < (start as number)) return null;
   return { start: start as number, end: end as number };
 }
@@ -151,6 +156,9 @@ function validateW3cSelectorList(list: unknown): AnchorSelector | null {
   let position: { start: number; end: number } | null = null;
   for (const entry of list) {
     if (typeof entry !== "object" || entry === null || Array.isArray(entry)) return null;
+    // Each entry is proven a plain object above; the casts along this path
+    // only name members as unknown for validation (unknown-object members
+    // aren't reachable without an assertion), never assume validated shapes.
     const { type } = entry as { type?: unknown };
     if (type === "TextQuoteSelector") {
       if (quote !== null) return null;

--- a/packages/iterate/src/annotated-markdown/types.ts
+++ b/packages/iterate/src/annotated-markdown/types.ts
@@ -68,6 +68,8 @@ export interface ThreadComment {
   author: string;
   /** ISO-8601 UTC instant exactly as written in the sentinel. */
   createdAt: string;
+  /** Last-edit instant from the optional `modified` attribute. */
+  modifiedAt: string | null;
   inReplyTo: string | null;
   deleted: boolean;
   /** Presentation name from a `#### Lee · 2026-07-28 08:30 UTC` heading. */

--- a/packages/iterate/tsconfig.sdk.json
+++ b/packages/iterate/tsconfig.sdk.json
@@ -5,6 +5,7 @@
   // tsc instead (see the sdk entry in tsdown.config.ts + the build script).
   "files": [
     "src/annotated-markdown/index.ts",
+    "src/annotated-markdown/react/index.ts",
     "src/sdk.ts",
     "src/client.ts",
     "src/node.ts",
@@ -32,7 +33,7 @@
     // convention); legal under emitDeclarationOnly, and the emitted d.ts keeps
     // the .ts specifiers, which consumers resolve to the sibling .d.ts.
     "rewriteRelativeImportExtensions": true,
-    "lib": ["ESNext", "DOM"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "strict": true,
     "declaration": true,
     "emitDeclarationOnly": true,

--- a/packages/iterate/tsdown.config.ts
+++ b/packages/iterate/tsdown.config.ts
@@ -163,6 +163,9 @@ export default defineConfig([
       // joining this group adds no chunk coupling. Declarations come from the
       // tsconfig.sdk.json tsc pass like the rest of the group.
       "annotated-markdown": "src/annotated-markdown/index.ts",
+      // The React viewer imports the codec entry's modules — same group so
+      // they share one chunk instead of inlining a second copy.
+      "annotated-markdown-react": "src/annotated-markdown/react/index.ts",
     },
     format: "esm",
     dts: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1213,6 +1213,18 @@ importers:
       '@tanstack/react-query':
         specifier: 5.101.2
         version: 5.101.2(react@19.2.7)
+      approx-string-match:
+        specifier: ^2.0.0
+        version: 2.0.0
+      mdast-util-from-markdown:
+        specifier: ^2.0.3
+        version: 2.0.3
+      mdast-util-gfm:
+        specifier: ^3.1.0
+        version: 3.1.0
+      micromark-extension-gfm:
+        specifier: ^3.0.0
+        version: 3.0.0
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -1235,6 +1247,9 @@ importers:
       '@iterate-com/ui':
         specifier: workspace:*
         version: link:../ui
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.13
@@ -7312,6 +7327,9 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  approx-string-match@2.0.0:
+    resolution: {integrity: sha512-03v8MsWnZYV4Svv82EYWoVw1RIKAJ/zubmhG1FYvhJwOsBnLPxx6CPHF2dXN/yW8uwHK+653j52IwiNluJR97w==}
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
@@ -19991,10 +20009,10 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser-playwright@4.0.15(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(playwright@1.60.0)(vite@8.0.9(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.0.15)':
+  '@vitest/browser-playwright@4.0.15(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(playwright@1.60.0)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.0.15)':
     dependencies:
-      '@vitest/browser': 4.0.15(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(vite@8.0.9(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.0.15)
-      '@vitest/mocker': 4.0.15(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(vite@8.0.9(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/browser': 4.0.15(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.0.15)
+      '@vitest/mocker': 4.0.15(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       playwright: 1.60.0
       tinyrainbow: 3.1.0
       vitest: 4.0.15(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/browser-playwright@4.0.15)(@vitest/ui@4.0.15)(jiti@2.7.0)(jsdom@27.4.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
@@ -20111,9 +20129,9 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser@4.0.15(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(vite@8.0.9(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.0.15)':
+  '@vitest/browser@4.0.15(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.0.15)':
     dependencies:
-      '@vitest/mocker': 4.0.15(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(vite@8.0.9(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 4.0.15(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/utils': 4.0.15
       magic-string: 0.30.21
       pixelmatch: 7.1.0
@@ -20292,16 +20310,6 @@ snapshots:
       msw: 2.13.3(@types/node@26.1.1)(typescript@5.9.3)
       vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/mocker@4.0.15(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(vite@8.0.9(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 4.0.15
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.13.3(@types/node@26.1.1)(typescript@5.9.3)
-      vite: 8.0.9(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
-    optional: true
-
   '@vitest/mocker@4.1.10(msw@2.13.3(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.10
@@ -20445,7 +20453,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.0.15(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/browser-playwright@4.0.15)(@vitest/ui@4.0.15)(jiti@2.7.0)(jsdom@27.4.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.0.15(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/browser-playwright@4.0.15)(@vitest/ui@4.0.15)(jiti@2.7.0)(jsdom@27.4.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.3(@types/node@22.19.13)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
     optional: true
 
   '@vitest/utils@4.0.15':
@@ -20693,6 +20701,8 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+
+  approx-string-match@2.0.0: {}
 
   arg@5.0.2: {}
 
@@ -28225,7 +28235,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 26.1.1
-      '@vitest/browser-playwright': 4.0.15(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(playwright@1.60.0)(vite@8.0.9(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.0.15)
+      '@vitest/browser-playwright': 4.0.15(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(playwright@1.60.0)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.0.15)
       '@vitest/ui': 4.0.15(vitest@4.0.15)
       jsdom: 27.4.0(@noble/hashes@2.2.0)
     transitivePeerDependencies:


### PR DESCRIPTION
Builds the inline-annotation experience on top of #2318's codec: the tasks **Preview tab becomes the annotation surface** — highlight any passage to comment on it (plannotator-style), threads paint as per-author highlights, and everything still lands in the markdown file itself as ordinary bytes. Stacked on `markdown-with-comments`.

The design follows a three-way research pass (Exa OSS-landscape sweep, a plannotator source deep-dive, a codex gpt-5.6-sol architecture review) that converged on: source-stamped rendering + CSS Custom Highlight painting + W3C selector spelling — plannotator's interaction patterns, **not** its rendered-space anchors.

## Play with it (preview-11)

The annotation UI lives in the **vessel** (apps/tasks) + the package, so you run this branch's vessel locally against the deployed preview-11 platform:

```bash
git checkout annotated-markdown-viewer
echo "OS_BASE_URL=https://os.iterate-preview-11.com" > apps/tasks/.dev.vars
(cd apps/tasks && pnpm dev --port 5199 --strictPort)          # the branch's UI

# second shell — 15-min token + header-stamping proxy:
cd apps/os
SECRET=$(doppler secrets get APP_CONFIG_PROJECT_APP_SESSION_SECRET --plain --config preview_11)
TOKEN=$(SESSION_SECRET="$SECRET" node ../tasks/scripts/mint-local-token.mjs prj_f148da0fe9f84a1bb3bfac3a56c0a60a)
node ../tasks/scripts/local-proxy.mjs 5200 5199 prj_f148da0fe9f84a1bb3bfac3a56c0a60a "$TOKEN"
```

Then open **http://localhost:5200/w/play-2?repo=%2Frepos%2Fconfig** — the `annot-play` project on preview-11 is already seeded with three demo tasks (a painted W3C-anchored thread, a deliberately drifted anchor, and a clean file to annotate yourself). Token lasts 15 minutes; re-run the second block to refresh.

## The file format

One task, one markdown file — this is what a file looks like after two rounds of annotation (real bytes from the live demo):

```md
---
state: in-progress
owner: jonas
---

# Inline comments on the rendered preview

The preview is now the annotation surface. Select any passage and leave a
comment — the thread lands **inside the markdown file** as sentinel blocks,
so it commits and diffs like prose.

<!-- task-discussions:v1 -->

## Discussion

<!-- task-thread:v1 begin id=th_01KYPS5022HJ3YKSKY9Z5ZMZTK status=open -->
<a id="thread-th_01KYPS5022HJ3YKSKY9Z5ZMZTK"></a>
### T2 · Open

<!-- task-anchor:v1 {"selector":[{"type":"TextQuoteSelector","exact":"commits and diffs like prose","prefix":"ile** as sentinel blocks,\nso it ","suffix":".\n\n## How anchors survive\n\nAncho"},{"type":"TextPositionSelector","start":200,"end":228}]} -->

<!-- task-comment:v1 begin id=cm_01KYPS5022G4W9Y65XWV6MQYGQ author=usr-local-dev created=2026-07-29T11:11:27.298Z -->
#### usr-local-dev · 2026-07-29 11:11 UTC

This sentence is the whole pitch — quote it in the launch note.

<!-- task-comment:v1 end id=cm_01KYPS5022G4W9Y65XWV6MQYGQ -->

<!-- task-thread:v1 end id=th_01KYPS5022HJ3YKSKY9Z5ZMZTK -->
```

Format facts worth knowing:

- **The anchor is a W3C Web Annotation selector list** — `TextQuoteSelector` (exact + up-to-32-char prefix/suffix context) plus `TextPositionSelector` (body-relative offsets). This PR renames the sentinel spelling from the codec's private `{quote, position}` shape to the standard's, while the old spelling is still read (nothing real shipped with it). Being a W3C dialect means `@recogito/text-annotator`, Hypothesis import/export, and `#:~:text=` links are derivations, not integrations.
- Note the `prefix` above: `ile** as sentinel blocks,\nso it ` — anchors live in **source space**, so context crosses markdown syntax (`**`) and newlines byte-exactly.
- **Offsets are UTF-16 code units** (native JS indices; splice math needs them). W3C counts code points — a documented divergence that only matters after astral characters, and third-party readers recover through the quote selector, which is exactly what the resolution ladder is for.
- Select-to-comment threads set **no inline `[T1](…)` marker** (`insertMarker: false`): highlights carry the location in our surface, so the prose stays untouched; markers remain supported and remain the ladder's first rung when present.
- `modified=<instant>` is a new optional comment attribute — `editComment` stamps/re-stamps it in place and the UI shows "(edited)".
- Everything else is #2318's grammar unchanged: column-0 sentinels, fail-open transactional parsing (a broken store renders the raw file rather than guessing), splice-only edits, tombstones, one store per file. **GitHub and every generic renderer show the doc and the human-readable `## Discussion` section; the sentinels are invisible.**

## Resolution ladder (where a highlight comes from)

`resolveThreadAnchor(body, threadId, selector)` walks: **inline marker → position (verified against the quote) → unique exact quote (context-disambiguated) → fuzzy** → `attached | needs_review | orphaned`. The wrong text is never painted with confidence: review-band matches paint amber with a panel badge, orphans get a badge only.

This PR upgrades the fuzzy rung from bigram-Dice sliding windows to **`approx-string-match`** (the bitap engine the Hypothesis client settled on after a decade of production anchoring) with weighted candidate ranking — quote similarity dominates, surviving prefix/suffix context and closeness to the recorded position break ties, and quotes under 8 chars never fuzzy-match (their spurious-match lesson). Reported confidence stays the quote similarity alone, so the 0.8 attach / 0.6 review thresholds keep their meaning.

## The viewer (`iterate/annotated-markdown/react`, new package entry)

Three modules, ~600 lines, no new UI dependencies:

**`render.tsx` — a source-stamped renderer.** Parses body markdown with `mdast-util-from-markdown` + GFM and renders the mdast tree straight to React elements. The contract is in the DOM it emits:

| Stamp | On | Meaning |
| --- | --- | --- |
| `data-ams` / `data-ame` | every text-run `<span>` | body-relative source start/end of that run |
| `data-amx` | atomic runs | rendered chars ≠ source slice (decoded entity/escape, fence-relative content) — indivisible unit |
| `data-amb` / `data-ambe` | every block element | the block's source range |

Fidelity details: an entity like `&amp;` splits its text run into identity-prefix + atomic-core + identity-suffix so one entity doesn't make a paragraph indivisible; fenced-code content is located **after the fence line** (a ```` ```python ```` block whose body is `python` binds to the body, not the info string); raw HTML renders as literal code text — it never becomes DOM, so sanitization is by construction; only `http(s)`/`mailto`/`#` links and `http(s)` images stay active.

**`projection.ts` — `buildProjection(root)`.** Reads the stamps off the live DOM (never reconstructs by text comparison — the codex review's hard rule) and answers both directions: `domRangeToSource(selection)` for creating anchors, `sourceRangeToDomRanges(range)` for painting, plus `sourceOffsetAtPoint(x, y)` (caret hit-testing, because CSS highlights aren't elements you can click). Atomic runs snap interior offsets to their edges — honest widening instead of invented offsets.

**`highlights.ts` — CSS Custom Highlight API painting.** Ranges live in `CSS.highlights`, a registry *beside* the DOM — React re-renders never fight injected spans (the failure mode plannotator documents as "the only thing that needs care" with its `<mark>`-wrapping approach). Names are `amv-a-<author-slug>` / `amv-selected` / `amv-pending` / `amv-review`; the tasks app styles them with `::highlight()` rules generated from `authorColor` — the same per-user palette as collab cursors and redlines. Baseline browser support since mid-2025 (Firefox 140 closed the gap).

## The tasks app

- **Select-to-comment** (`workspace-task-preview.tsx`, rewritten): mouseup with a selection → projection maps it to source → pending highlight paints + a floating **Comment** bubble at the selection → composer (same `CommentComposer` as the strip, ⌘-Enter, Escape) → `createAnchorSelector` + `addThread` with the W3C anchor.
- **One mutation lane** (`use-discussion-apply.ts`, extracted from #2318's strip): busy-gated while the collab editor attaches, re-parses at apply time, reports only landed outcomes (the optimistic write lane can roll back). If the document moved between selection and submit, the op re-finds the selected text and **refuses ambiguity** rather than anchoring wrongly.
- **Painted threads + sync**: open anchored threads paint in their author's color; click a highlight → its panel card selects and scrolls (once per selection — live edits don't yank the viewport); click a card → the highlight flashes selected and scrolls into view. Selected/pending layers paint last so they win overlaps.
- **Panel upgrades** (`task-comments.tsx`): anchored threads order by resolved document position (document-level threads below), each wears its quote with an author-colored border, drifted anchors badge **ANCHOR NEEDS REVIEW** / **ANCHOR LOST** in amber, edited comments show "(edited)" with the exact instant on hover.
- Fail-open files keep the old read-only streamdown preview verbatim — when the codec refuses a file, nothing interprets it.

## Screenshots (all against the deployed preview-11 platform)

### A W3C-anchored thread paints on load
The seed stores a quote-only selector (no position); it resolves through the unique-quote rung and paints in Sam's color. Panel shows the quote header with the author-colored border.
![painted](https://raw.githubusercontent.com/iterate/iterate/assets/annotated-markdown-viewer/10-preview11-painted.png)

### Highlight to annotate: select any passage → Comment bubble
This selection deliberately crosses a `**bold**` span — the anchor's source-space quote will carry the markers.
![bubble](https://raw.githubusercontent.com/iterate/iterate/assets/annotated-markdown-viewer/11-crossbold-bubble.png)

### Composer at the selection, thread lands painted
Two threads, two author colors, ordered by document position in the panel.
![two](https://raw.githubusercontent.com/iterate/iterate/assets/annotated-markdown-viewer/12-two-highlights-preview11.png)

### Replies thread inline (⌘-Enter submits)
![reply](https://raw.githubusercontent.com/iterate/iterate/assets/annotated-markdown-viewer/13-reply-in-thread.png)

### Resolving folds the thread — and un-paints its highlight
![resolved](https://raw.githubusercontent.com/iterate/iterate/assets/annotated-markdown-viewer/14-resolved-folds.png)

### Drifted anchor → amber, never a wrong confident paint
This file's stored quote says "golden checklist ahead of each deployment" but the text now reads "amber checklist before every deploy" — the fuzzy rung finds the region (dotted amber), the panel badges **ANCHOR NEEDS REVIEW**, and the stored quote stays visible for the human.
![drift](https://raw.githubusercontent.com/iterate/iterate/assets/annotated-markdown-viewer/16-needs-review-amber.png)

### Document-level threads (no anchor) still work
![doc-level](https://raw.githubusercontent.com/iterate/iterate/assets/annotated-markdown-viewer/17-doc-level-thread.png)

### The board wears the counts
![board](https://raw.githubusercontent.com/iterate/iterate/assets/annotated-markdown-viewer/15-board-badges.png)

### Click a highlight → its thread selects (from the local run)
![sync](https://raw.githubusercontent.com/iterate/iterate/assets/annotated-markdown-viewer/07-click-selects-thread.png)

### What the file actually contains after browser annotation
The browser-created thread wrote the W3C selector above — no inline marker in the prose, prefix crossing the `**` markup, position selector included.
![raw](https://raw.githubusercontent.com/iterate/iterate/assets/annotated-markdown-viewer/08-editor-eof-store.png)

## Changed files

**`packages/iterate`**
- `src/annotated-markdown/react/{render.tsx, projection.ts, highlights.ts, index.ts}` — the viewer (new entry `iterate/annotated-markdown/react`, wired through exports/publishConfig/tsdown/tsconfig.sdk).
- `src/annotated-markdown/sentinels.ts` — W3C selector-list read/write (legacy spelling read-only), `modified` attribute parse/format with value-range for in-place re-stamps.
- `src/annotated-markdown/anchors.ts` — `approx-string-match` fuzzy rung with weighted ranking + short-quote guard.
- `src/annotated-markdown/edits.ts` — `editComment(…, { modifiedAt })`.
- `src/annotated-markdown/{types.ts, parse.ts}` — `ThreadComment.modifiedAt`.
- `src/annotated-markdown/README.md` — grammar updated (W3C spelling, `modified`, offset-units divergence).
- Tests: `react/projection.test.tsx` (round-trip corpus: emphasis, inline/fenced/indented code incl. the info-string echo trap, tables, entities, emoji, raw HTML, block ranges) + spelling-matrix and `modified` tests. **343 package tests** (#2318 shipped 148).

**`apps/tasks`**
- `src/components/workspace-task-preview.tsx` — rewritten as the annotation surface (fail-open path preserved verbatim).
- `src/lib/use-discussion-apply.ts` — the shared landed-outcome mutation lane.
- `src/components/task-comments.tsx` — quote headers, anchor badges, position ordering, selection sync, "(edited)".
- `src/components/workspace-task-sheet.tsx` — shared `selectedThreadId` between preview and strip.
- `README.md` — Task comments section extended.

## Explicitly not in this PR (researched, designed, next)

- **HTML documents** — not yet. Raw HTML *inside markdown* renders as literal text by design; annotating standalone `.html` files comes next with the same thread JSON + selectors in an EOF store and anchors measured over extracted text content (per the W3C embedding Note). The logical model is already host-agnostic.
- **Rich editing of the rendered view** — research verdict: CodeMirror 6 live-preview (the markdown text stays the model, so byte-fidelity is structural and `#` becomes a heading because it *is* one) over ProseMirror-family WYSIWYG, whose serializers normalize whole documents by their maintainers' own statements. Needs a raw-splice adapter (CM6 normalizes line endings) — its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large UI and codec surface area with whole-file comment mutations and anchor resolution; mitigated by fail-open parsing, ambiguity refusal on stale selections, and extensive projection/grammar tests, but highlight/CSS API behavior and collab timing remain worth manual QA.
> 
> **Overview**
> Turns the tasks **Preview** tab into the inline annotation surface: structured task bodies render through the new **`iterate/annotated-markdown/react`** entry (source-stamped GFM → React, DOM↔body projection, CSS Custom Highlight painting). Open anchored threads highlight in author colors; **select text → Comment bubble → composer** adds a thread with a **W3C** `TextQuoteSelector` + `TextPositionSelector` anchor and **`insertMarker: false`** so prose stays clean. Preview and the comments strip share **`selectedThreadId`** (click highlight ↔ scroll/select thread card); drift shows amber **needs review** / **anchor lost** instead of confident wrong paint.
> 
> **Tasks UI:** `use-discussion-apply` centralizes the busy-gated, re-parse-at-apply, landed-write mutation lane for preview and panel. Comments list anchored threads by document position, show quoted passage headers, and stamp **`modifiedAt`** on edits with an “(edited)” affordance. Unparseable files still use the old read-only streamdown preview.
> 
> **Codec / package:** Anchor sentinels **write W3C selector lists** (legacy `{quote,position}` still parsed). Fuzzy reconciliation moves from sliding-window bigram similarity to **`approx-string-match`** with ranked candidates and a short-quote guard. Adds **`modified`** on comment begin sentinels. New mdast/micromark GFM deps and publish/build wiring for the React subpath.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e012f89818d839db66884226bfaf7d49115df13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +923 -62 | +678 -57 🟩🟩🟩🟩🟩 |
| UI components | +498 -79 | +403 -60 🟩🟩🟩⬜⬜ |
| Tests | +394 -2 | +352 -2 🟩🟩⬜⬜⬜ |
| Config | +13 -1 | +13 -1 🟩⬜⬜⬜⬜ |
| Docs | +24 -5 | +22 -5 🟩⬜⬜⬜⬜ |
| Generated | +27 -17 | +25 -16 🟩⬜⬜⬜⬜ |
| **Total** | **+1,879 -166** | **+1,493 -141** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 7d1183e and 8e012f8, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T11:47:43.711Z",
      "deployedAt": "2026-07-29T11:46:02.946Z",
      "headSha": "8e012f89818d839db66884226bfaf7d49115df13",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/177688776020355",
      "shortSha": "8e012f8",
      "cleanupDurationMs": 10940,
      "deployDurationMs": 86371,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 35636,
      "deployReadinessDurationMs": 50732,
      "deployedWorkerName": "os-preview-9",
      "deployedWorkerVersion": "c3673c6e-51b6-4797-9c97-a8fb68e57bef",
      "workerSizeKib": 19909.94,
      "workerGzipKib": 5028.85,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5039.69
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-29T11:47:33.646Z",
      "deployedAt": "2026-07-29T11:31:28.143Z",
      "headSha": "7f960f10f8aedc3646e88832d1d6ba440ad9a213",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/241815496633637",
      "shortSha": "7f960f1",
      "cleanupDurationMs": 872,
      "deployDurationMs": 13266,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 13091,
      "deployReadinessDurationMs": 168,
      "deployedWorkerName": "semaphore-preview-9",
      "deployedWorkerVersion": "df6bc8f7-f511-4d93-b437-8fca9a708860",
      "testDurationMs": 12956,
      "testRetries": null,
      "workerSizeKib": 1915.51,
      "workerGzipKib": 441.11,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T11:47:36.432Z",
      "deployedAt": "2026-07-29T11:45:44.113Z",
      "headSha": "8e012f89818d839db66884226bfaf7d49115df13",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/177688776020355",
      "shortSha": "8e012f8",
      "cleanupDurationMs": 3657,
      "deployDurationMs": 16842,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 16800,
      "deployReadinessDurationMs": 38,
      "deployedWorkerName": "auth-preview-9",
      "deployedWorkerVersion": "fc6e5489-910a-4202-b53f-9307791627cc",
      "workerSizeKib": 3976.81,
      "workerGzipKib": 814.16,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-29T11:47:40.146Z",
      "deployedAt": "2026-07-29T11:31:28.650Z",
      "headSha": "7f960f10f8aedc3646e88832d1d6ba440ad9a213",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/241815496633637",
      "shortSha": "7f960f1",
      "cleanupDurationMs": 7368,
      "deployDurationMs": 57390,
      "deployConfigDurationMs": 7,
      "deployCommandDurationMs": 13595,
      "deployReadinessDurationMs": 43787,
      "deployedWorkerName": "streams-example-app-preview-9",
      "deployedWorkerVersion": "83cf90f0-9333-42ba-9db2-fb21b83ae556",
      "testDurationMs": 51277,
      "testRetries": null,
      "workerSizeKib": 5239.09,
      "workerGzipKib": 1485.09,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T11:47:33.521Z",
      "deployedAt": "2026-07-29T11:31:21.189Z",
      "headSha": "8e012f89818d839db66884226bfaf7d49115df13",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/177688776020355",
      "shortSha": "8e012f8",
      "cleanupDurationMs": 741,
      "deployDurationMs": 58,
      "deployConfigDurationMs": 5,
      "deployReuseProofDurationMs": 10,
      "deployedWorkerName": "dummy-petshop-preview-9",
      "deployedWorkerVersion": "c9f8e549-4b97-48f5-bb7a-0a497467ac42",
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `8e012f8` | [https://auth.iterate-preview-9.com](https://auth.iterate-preview-9.com) | 814.2 KiB | 16.8s |  |  | 3.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/177688776020355) | 2026-07-29T11:47:36.432Z | Preview app released. |
| Dummy Petshop | released | `8e012f8` | [https://dummy-petshop.iterate-preview-9.com](https://dummy-petshop.iterate-preview-9.com) | 198.3 KiB | 58ms |  |  | 741ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/177688776020355) | 2026-07-29T11:47:33.521Z | Preview app released. |
| OS | released | `8e012f8` | [https://os.iterate-preview-9.com](https://os.iterate-preview-9.com) | 4.91 MiB (-10.8 KiB vs main) | 86.4s |  |  | 10.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/177688776020355) | 2026-07-29T11:47:43.711Z | Preview app released. |
| Semaphore | released | `7f960f1` | [https://semaphore.iterate-preview-9.com](https://semaphore.iterate-preview-9.com) | 441.1 KiB | 13.3s | 13.0s |  | 872ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/241815496633637) | 2026-07-29T11:47:33.646Z | Preview app released. |
| Streams Example App | released | `7f960f1` | [https://streams.iterate-preview-9.com](https://streams.iterate-preview-9.com) | 1.45 MiB | 57.4s | 51.3s |  | 7.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/241815496633637) | 2026-07-29T11:47:40.146Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->