### PR TITLE
Serialize task transforms; keep composer drafts across failed remaps

### DIFF
--- a/apps/tasks/src/components/workspace-task-preview.tsx
+++ b/apps/tasks/src/components/workspace-task-preview.tsx
@@ -203,7 +203,11 @@ function AnnotatedPreview({
       else push(`a-${slugForAuthor(authorOf(thread))}`, ranges);
       if (thread.id === selectedThreadId) push("selected", ranges);
     }
-    if (pending !== null) push("pending", projection.sourceRangeToDomRanges(pending.range));
+    // A pending range only paints against the body it was computed on — a
+    // kept-for-its-draft stale selection must not highlight the wrong text.
+    if (pending !== null && pending.sourceBody === body) {
+      push("pending", projection.sourceRangeToDomRanges(pending.range));
+    }
     // Registration order is paint order: selected and pending go last so
     // they win where highlights overlap.
     const ordered = [...groups.entries()].sort(
@@ -239,24 +243,29 @@ function AnnotatedPreview({
   // Live edits move the body under a pending selection: re-find the selected
   // text so the pending paint stays on the right passage (and the bubble
   // follows it — this runs AFTER the layout effect rebuilt the projection
-  // for the new body), dropping the selection when it can't be re-found
-  // unambiguously (the submit path would refuse it anyway).
+  // for the new body). When it can't be re-found unambiguously: a bare
+  // bubble just drops, but an OPEN composer keeps its typed draft — the
+  // stale selection stops painting (the paint effect checks sourceBody) and
+  // submit's own re-find surfaces "reselect and retry" while the text
+  // survives for the user to copy.
   useEffect(() => {
     setPending((current) => {
       if (current === null || current.sourceBody === body) return current;
       const exact = current.sourceBody.slice(current.range.start, current.range.end);
       const first = body.indexOf(exact);
-      if (first === -1 || body.indexOf(exact, first + 1) !== -1) {
-        setComposerOpen(false);
-        return null;
-      }
-      const range = { start: first, end: first + exact.length };
       const projection = projectionRef.current;
       const wrapper = wrapperRef.current;
-      const rect = projection?.sourceRangeToDomRanges(range)[0]?.getBoundingClientRect();
+      const range =
+        first !== -1 && body.indexOf(exact, first + 1) === -1
+          ? { start: first, end: first + exact.length }
+          : null;
+      const rect =
+        range === null
+          ? undefined
+          : projection?.sourceRangeToDomRanges(range)[0]?.getBoundingClientRect();
       const wrapperRect = wrapper?.getBoundingClientRect();
-      if (rect === undefined || wrapperRect === undefined) {
-        setComposerOpen(false);
+      if (range === null || rect === undefined || wrapperRect === undefined) {
+        if (composerOpen) return current;
         return null;
       }
       return {
@@ -266,7 +275,7 @@ function AnnotatedPreview({
         left: Math.max(0, rect.left - wrapperRect.left),
       };
     });
-  }, [body]);
+  }, [body, composerOpen]);
 
   const onMouseUp = useCallback(() => {
     if (identity === null || composerOpen) return;

--- a/apps/tasks/src/routes/w.$checkoutId.tsx
+++ b/apps/tasks/src/routes/w.$checkoutId.tsx
@@ -223,14 +223,20 @@ function WorkspaceBoardPage() {
   // One transform at a time: the strip and the preview each own an apply
   // hook, and on the write lane two overlapping submits would read the same
   // snapshot and the later write would clobber the earlier one. Chaining
-  // defers each transform until the previous write LANDED, so it reads the
-  // post-write source.
+  // defers each transform until the previous write LANDED — and the run
+  // must read THROUGH A REF at that moment: the call-time task object (and
+  // any render's board identity) is a snapshot from before the queue ahead
+  // of it drained.
   const mutationChainRef = useRef<Promise<unknown>>(Promise.resolve());
+  const boardFilesRef = useRef(board.files);
+  useEffect(() => {
+    boardFilesRef.current = board.files;
+  });
   const mutateTask = useCallback(
     (task: BoardTask, transform: (source: string) => string): Promise<boolean> => {
       const run = (): Promise<boolean> => {
         if (applyLive(task.path, transform)) return Promise.resolve(true);
-        const current = sourceOf(task);
+        const current = boardFilesRef.current?.[task.path] ?? sourceOf(task);
         const next = transform(current);
         // A refused or no-op transform (a comment op backing off, a status
         // already set) must not dirty the file or spend a write RPC.

--- a/apps/tasks/src/routes/w.$checkoutId.tsx
+++ b/apps/tasks/src/routes/w.$checkoutId.tsx
@@ -220,15 +220,26 @@ function WorkspaceBoardPage() {
    * LANDED — the write lane is optimistic and rolls back on RPC failure, so
    * callers that promised the user something (a comment composer clearing
    * its draft) must wait for this, not for the sync transform. */
+  // One transform at a time: the strip and the preview each own an apply
+  // hook, and on the write lane two overlapping submits would read the same
+  // snapshot and the later write would clobber the earlier one. Chaining
+  // defers each transform until the previous write LANDED, so it reads the
+  // post-write source.
+  const mutationChainRef = useRef<Promise<unknown>>(Promise.resolve());
   const mutateTask = useCallback(
     (task: BoardTask, transform: (source: string) => string): Promise<boolean> => {
-      if (applyLive(task.path, transform)) return Promise.resolve(true);
-      const current = sourceOf(task);
-      const next = transform(current);
-      // A refused or no-op transform (a comment op backing off, a status
-      // already set) must not dirty the file or spend a write RPC.
-      if (next === current) return Promise.resolve(true);
-      return board.writeTask(task.path, next);
+      const run = (): Promise<boolean> => {
+        if (applyLive(task.path, transform)) return Promise.resolve(true);
+        const current = sourceOf(task);
+        const next = transform(current);
+        // A refused or no-op transform (a comment op backing off, a status
+        // already set) must not dirty the file or spend a write RPC.
+        if (next === current) return Promise.resolve(true);
+        return board.writeTask(task.path, next);
+      };
+      const chained = mutationChainRef.current.then(run, run);
+      mutationChainRef.current = chained;
+      return chained;
     },
     [applyLive, board, sourceOf],
   );


### PR DESCRIPTION
Follow-up to #2318, fixing the two Bugbot findings that raced in at the moment of merge (both threads replied on #2318 pointing here):

- **Cross-surface comment writes can clobber** — the comments strip and the preview each own a `useDiscussionApply`, so two overlapping submits on the write lane (dead/absent collab session) could read the same snapshot and the later `writeTask` overwrote the earlier one. `mutateTask` now chains every transform behind the previous write's landed outcome — each transform reads the post-write source. The chain lives at the route chokepoint, so state/label changes serialize with comment ops too.
- **Draft lost when selection remaps away** — a live edit that made a pending selection unfindable unmounted an open composer and discarded the typed draft. The selection now survives when the composer is open: it stops painting (the paint effect requires the range's own body) and submit's re-find surfaces "reselect and retry" while the text stays for the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the central `mutateTask` write path and comment UX on live edits; scope is bounded to the workspace task sheet but overlapping writes and draft retention are user-visible correctness fixes.
> 
> **Overview**
> Follow-up to concurrent comment/write races on the workspace board.
> 
> **Serialized task mutations** — `mutateTask` now queues every whole-file transform (comments strip, preview select-to-comment, state/labels) so only one runs at a time on the write lane. Each queued step reads the latest file source from a ref after prior writes land, avoiding two overlapping `writeTask` calls clobbering each other when both surfaces shared a stale snapshot.
> 
> **Composer draft when selection goes stale** — If live edits move the document and a pending comment selection can’t be remapped unambiguously, an open composer no longer closes and wipes typed text. The pending highlight is skipped when its `sourceBody` doesn’t match the current body (so wrong text isn’t highlighted), while submit still re-finds the anchor and can show “reselect and retry.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73aba70776c1a48c61472c0dd768841531f0c29b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +24 -7 | +15 -5 🟩🟩🟩🟥⬜ |
| UI components | +21 -12 | +14 -10 🟩🟩🟩🟥🟥 |
| **Total** | **+45 -19** | **+29 -15** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between af77e56 and 73aba70, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->