### PR TITLE
Deploy the tasks vessel from CI on main pushes

### DIFF
--- a/.depot/workflows/deploy-tasks.yml
+++ b/.depot/workflows/deploy-tasks.yml
@@ -14,6 +14,10 @@ on:
     paths:
       - .depot/workflows/deploy-tasks.yml
       - apps/tasks/**
+      # The vessel bundles shared apps/os sources through its `~` alias
+      # (vite.config.ts) — those trees must redeploy it too.
+      - apps/os/src/components/**
+      - apps/os/src/domains/workspaces/**
       - packages/iterate/**
       - packages/ui/**
   workflow_dispatch:

--- a/.depot/workflows/deploy-tasks.yml
+++ b/.depot/workflows/deploy-tasks.yml
@@ -1,0 +1,71 @@
+name: Deploy Tasks
+permissions:
+  contents: read
+  deployments: write
+concurrency:
+  # Every ref deploys to the same production Worker. Never interrupt a
+  # credentialed deployment midway through its rollout.
+  group: deploy-tasks-production
+  cancel-in-progress: false
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .depot/workflows/deploy-tasks.yml
+      - apps/tasks/**
+      - packages/iterate/**
+      - packages/ui/**
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref to deploy. Leave empty for the current branch or commit.
+        required: false
+        type: string
+        default: ""
+jobs:
+  deploy:
+    runs-on:
+      size: 2x8
+      image: 0p91s0lz49.registry.depot.dev/iterate-preview-ci:node24-pnpm10-worktree
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          clean: false
+          ref: ${{ inputs.ref || github.sha }}
+      - name: Reconcile dependencies (baked)
+        run: pnpm install --frozen-lockfile --prefer-offline
+      # The tasks vessel is deliberately outside envs.ts / the deploy fleet
+      # (see apps/tasks/wrangler.jsonc): one manually-shaped Worker, secrets
+      # from the os prd config (its Cloudflare token), account pinned to the
+      # prd account envs.ts declares.
+      - name: Deploy apps/tasks
+        working-directory: apps/tasks
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: 04b3b57291ef2626c6a8daa9d47065a7
+        run: doppler run --project os --config prd -- pnpm run deploy
+  notify:
+    needs:
+      - deploy
+    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && (needs.deploy.result == 'success' || needs.deploy.result == 'failure')
+    runs-on:
+      size: 2x8
+      image: 0p91s0lz49.registry.depot.dev/iterate-preview-ci:node24-pnpm10-worktree
+    timeout-minutes: 10
+    env:
+      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          clean: false
+      - name: Reconcile dependencies (baked)
+        run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Notify Slack
+        env:
+          APP_DISPLAY_NAME: Tasks
+          PUBLIC_URL: https://tasks.iterate.com
+        run: pnpm tsx scripts/ci/notify.ts deploy-${{ needs.deploy.result }}

--- a/.depot/workflows/deploy-tasks.yml
+++ b/.depot/workflows/deploy-tasks.yml
@@ -45,8 +45,13 @@ jobs:
         working-directory: apps/tasks
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: 04b3b57291ef2626c6a8daa9d47065a7
-        run: doppler run --project os --config prd -- pnpm run deploy
+        # The account pin is applied AFTER doppler injects its secrets —
+        # `doppler run` overrides pre-set env vars by default, so a step-env
+        # pin could silently lose to a config-supplied value.
+        run: >-
+          doppler run --project os --config prd --
+          env CLOUDFLARE_ACCOUNT_ID=04b3b57291ef2626c6a8daa9d47065a7
+          pnpm run deploy
   notify:
     needs:
       - deploy

--- a/scripts/ci/depot-workflows.test.ts
+++ b/scripts/ci/depot-workflows.test.ts
@@ -77,6 +77,14 @@ const deploymentWorkflows = [
     },
   },
   {
+    file: ".depot/workflows/deploy-tasks.yml",
+    group: "deploy-tasks-production",
+    jobs: {
+      deploy: { size: "2x8", timeoutMinutes: 20 },
+      notify: { size: "2x8", timeoutMinutes: 10 },
+    },
+  },
+  {
     file: ".depot/workflows/deploy-tunnels.yml",
     group: "deploy-tunnels-production",
     jobs: {


### PR DESCRIPTION
Follow-up to #2318/#2343: the tasks vessel (`tasks.iterate.com`) deploys manually by design, so the annotation feature reached prd's platform but left the vessel on its 2026-07-23 build until a hand deploy. This adds `.depot/workflows/deploy-tasks.yml`:

- **push to main**, path-filtered to the workflow itself, `apps/tasks/**`, `packages/iterate/**`, `packages/ui/**`
- **workflow_dispatch** with an optional `ref` input (same shape as the fleet workflows)
- deploy job mirrors `deploy-streams-example-app.yml`: baked image, frozen install, `doppler run --project os --config prd -- pnpm run deploy` in `apps/tasks` with the prd `CLOUDFLARE_ACCOUNT_ID` pinned (the value envs.ts declares); Slack notify on main-push outcomes

Proof: dispatched from this branch via the Depot CLI (`depot ci dispatch --workflow deploy-tasks.yml --ref deploy-tasks-workflow`) — run linked in the comments once green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces credentialed auto-deploy to production for a manually-shaped Worker; path filters and account pinning reduce blast radius but misconfiguration could deploy wrong code or account.
> 
> **Overview**
> Adds **automated production deployment** for the tasks vessel (`tasks.iterate.com`), which previously required manual deploys.
> 
> The new `.depot/workflows/deploy-tasks.yml` runs on **push to `main`** (path-filtered to `apps/tasks/**`, shared `packages/iterate/**` and `packages/ui/**`, OS component/workspace trees bundled via the vessel’s Vite `~` alias, and the workflow file itself) and supports **manual `workflow_dispatch`** with an optional `ref`. Deploy uses the same baked CI image and frozen `pnpm install` as other fleet workflows, runs `doppler run --project os --config prd -- pnpm run deploy` from `apps/tasks`, and **pins `CLOUDFLARE_ACCOUNT_ID` after Doppler** so config secrets cannot override the intended prd account. A **Slack notify** job runs on main-push deploy success or failure. `depot-workflows.test.ts` registers the workflow for deployment-safety checks (concurrency group `deploy-tasks-production`, no cancel-in-progress).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49e006c497920d89bb3ee190f2b633cc1842edba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +8 -0 | +8 -0 🟩⬜⬜⬜⬜ |
| CI & scripts | +80 -0 | +80 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+88 -0** | **+88 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 9f90578 and 49e006c, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->