### PR TITLE
Emit repo commit facts for OS-owned writes

### DIFF
--- a/apps/os/e2e/vitest/itx-workers.e2e.test.ts
+++ b/apps/os/e2e/vitest/itx-workers.e2e.test.ts
@@ -16,6 +16,7 @@ test("Project repos, workers, runScript, and dynamic worker refs compose", async
     .get(`dynamic-worker-${crypto.randomUUID().slice(0, 8)}`)
     .create({});
   const description = await project.__describe();
+  using root = project.streams.get("/");
 
   // The seeded root worker routes via x-iterate-app (static homepage
   // otherwise); an unknown selection echoes back in the 404 body, giving the
@@ -37,6 +38,7 @@ test("Project repos, workers, runScript, and dynamic worker refs compose", async
     worker: "404 unknown app: script-probe",
   });
 
+  const rootOffsetBeforeCommit = (await root.runtimeState()).coreProcessorState.maxOffset;
   const commit = await project.repo.commitFiles({
     changes: [
       {
@@ -89,6 +91,17 @@ test("Project repos, workers, runScript, and dynamic worker refs compose", async
     noChanges: false,
   });
   expect(commit.commitOid).toMatch(/^[0-9a-f]{40}$/);
+  expect(
+    await root.waitForEvent({
+      afterOffset: rootOffsetBeforeCommit,
+      eventTypes: ["events.iterate.com/project/worker-updated"],
+      predicate: (event) => event.payload?.commitOid === commit.commitOid,
+      timeoutMs: 180_000,
+    }),
+  ).toMatchObject({
+    payload: { commitOid: commit.commitOid },
+    type: "events.iterate.com/project/worker-updated",
+  });
   // @ts-expect-error - dynamic project worker method from committed source
   expect(await project.worker.someMethod()).toEqual({
     projectId: description.projectId,

--- a/apps/os/src/domains/repos/repo-durable-object.ts
+++ b/apps/os/src/domains/repos/repo-durable-object.ts
@@ -96,6 +96,12 @@ const GITHUB_LINK_KV_KEY = "github-link:v1";
 // compares it against the durable head cursor and re-materializes only when
 // main actually moved.
 const REPO_HEAD_TREE_KEY = "repo-head-tree:v1";
+// One OS-owned default-branch push may be durable in Artifacts before its
+// repo-stream fact crosses into the Stream Durable Object. Keep that exact
+// event here until the append acknowledges; a retry flushes it before making
+// another mutation, so an already-landed Git commit cannot become a silent
+// no-op with no repo/commit-completed fact.
+const PENDING_COMMIT_COMPLETED_KV_KEY = "pending-commit-completed:v1";
 // The lazy head-record publication computes the whole-snapshot contentHash
 // (worker builds want it hot) only when the manifest is small enough for
 // that to be a cheap in-store read; bigger repos leave the record to the
@@ -710,6 +716,7 @@ export class RepoDurableObject extends DurableObject<Env> {
   }
 
   async #commitFiles(input: CommitRepoFilesInput): Promise<CommitRepoFilesResult> {
+    await this.#flushPendingCommitCompleted();
     const parsed = parseCommitFilesInput(input);
     const repo = await this.gitAccess();
     const branch = parsed.branch ?? repo.defaultBranch;
@@ -720,7 +727,10 @@ export class RepoDurableObject extends DurableObject<Env> {
       // surfaces as an error: retrying the mutation through ANY lane could
       // apply it twice.
       const attempt = await this.#commitFilesLazy(parsed);
-      if (attempt.kind === "completed") return attempt.result;
+      if (attempt.kind === "completed") {
+        await this.#flushPendingCommitCompleted();
+        return attempt.result;
+      }
       if (attempt.kind === "indeterminate") {
         throw new Error(
           `commit push is indeterminate (proposed ${attempt.proposedCommitOid}): ${attempt.detail} — ` +
@@ -739,6 +749,13 @@ export class RepoDurableObject extends DurableObject<Env> {
       token: repo.token,
     });
     this.#recordPushedHead(result);
+    if (!result.noChanges && result.branch === REPO_DEFAULT_BRANCH) {
+      this.#stageCommitCompleted({
+        beforeCommitOid: result.parentCommitOid,
+        branch: result.branch,
+        commitOid: result.commitOid,
+      });
+    }
 
     // `commitFiles()` is our read-your-write boundary: once it returns, the
     // durable head cache names the pushed commit, so the next worker source
@@ -750,6 +767,7 @@ export class RepoDurableObject extends DurableObject<Env> {
     if (!result.noChanges) {
       this.#scheduleGithubMirrorPush(result.branch);
     }
+    await this.#flushPendingCommitCompleted();
 
     return {
       branch: result.branch,
@@ -800,6 +818,11 @@ export class RepoDurableObject extends DurableObject<Env> {
         branch,
         commitOid: applied.commitOid,
         parentCommitOid: applied.parentCommitOid,
+      });
+      this.#stageCommitCompleted({
+        beforeCommitOid: applied.parentCommitOid,
+        branch,
+        commitOid: applied.commitOid,
       });
       this.#scheduleGithubMirrorPush(branch);
       this.ctx.storage.kv.delete(repoHeadStorageKey(branch));
@@ -882,6 +905,7 @@ export class RepoDurableObject extends DurableObject<Env> {
   }
 
   async #edit(input: EditRepoFileInput): Promise<EditRepoFileResult> {
+    await this.#flushPendingCommitCompleted();
     const parsed = parseEditRepoFileInput(input);
     const repo = await this.gitAccess();
     const branch = parsed.branch ?? repo.defaultBranch;
@@ -898,6 +922,13 @@ export class RepoDurableObject extends DurableObject<Env> {
       token: repo.token,
     });
     this.#recordPushedHead(result);
+    if (!result.noChanges && result.branch === REPO_DEFAULT_BRANCH) {
+      this.#stageCommitCompleted({
+        beforeCommitOid: result.parentCommitOid,
+        branch: result.branch,
+        commitOid: result.commitOid,
+      });
+    }
 
     // Same read-your-write boundary as commitFiles(): the durable head cache
     // names the pushed commit before the RPC resolves.
@@ -908,6 +939,7 @@ export class RepoDurableObject extends DurableObject<Env> {
     if (!result.noChanges) {
       this.#scheduleGithubMirrorPush(result.branch);
     }
+    await this.#flushPendingCommitCompleted();
 
     return {
       branch: result.branch,
@@ -985,6 +1017,35 @@ export class RepoDurableObject extends DurableObject<Env> {
         commitOid: result.commitOid,
       }),
     );
+  }
+
+  #stageCommitCompleted(input: {
+    beforeCommitOid: string | null;
+    branch: string;
+    commitOid: string;
+  }): void {
+    if (this.ctx.storage.kv.get<unknown>(PENDING_COMMIT_COMPLETED_KV_KEY) !== undefined) {
+      throw new Error("Cannot replace an unappended repo/commit-completed event.");
+    }
+    this.ctx.storage.kv.put(
+      PENDING_COMMIT_COMPLETED_KV_KEY,
+      RepoProcessorContract.parseEventInput({
+        type: "events.iterate.com/repo/commit-completed",
+        idempotencyKey: `repo/commit-completed:${input.beforeCommitOid ?? "none"}:${input.commitOid}:${input.branch}`,
+        payload: input,
+      }),
+    );
+  }
+
+  async #flushPendingCommitCompleted(): Promise<void> {
+    const pending = this.ctx.storage.kv.get<unknown>(PENDING_COMMIT_COMPLETED_KV_KEY);
+    if (pending === undefined) return;
+    // The runtime parser accepts unknown input; its generic signature keeps
+    // typed callers' discriminated return type, so this storage boundary must
+    // widen the unknown value only for the parser call.
+    const event = RepoProcessorContract.parseEventInput(pending as { type: string });
+    await this.#stream.append(event);
+    this.ctx.storage.kv.delete(PENDING_COMMIT_COMPLETED_KV_KEY);
   }
 
   #invalidateArtifactState(branch: string) {
@@ -1195,9 +1256,9 @@ export class RepoDurableObject extends DurableObject<Env> {
   // of GitHub's availability — and a best-effort push mirrors every commit.
   // git push is cumulative, so a failed mirror push self-heals on the next
   // commit; `pushToGithub` repairs on demand. GitHub push webhooks ask the repo
-  // processor to fast-forward Artifacts through `syncFromGithub`; the ensuing
-  // Artifacts queue event remains the sole source of commit facts. The public
-  // sync verb is also the explicit repair/forced-adoption lane.
+  // processor to fast-forward Artifacts through `syncFromGithub`; that
+  // OS-owned write appends its commit fact directly. The public sync verb is
+  // also the explicit repair/forced-adoption lane.
   // ===========================================================================
 
   /** The current GitHub link, or null when this repo is not linked. */
@@ -1354,6 +1415,7 @@ export class RepoDurableObject extends DurableObject<Env> {
   }
 
   async #syncFromGithub(input: { depth?: number; force?: boolean }): Promise<GithubSyncResult> {
+    await this.#flushPendingCommitCompleted();
     const link = this.#requireGithubLink();
     const branch = REPO_DEFAULT_BRANCH;
     const previous = this.ctx.storage.kv.get<unknown>(repoHeadStorageKey(branch));
@@ -1428,7 +1490,9 @@ export class RepoDurableObject extends DurableObject<Env> {
     // the cache; getHead's lags-the-push guard keeps it unavailable until the
     // adopted head is authoritative.
     this.#recordPushedHead({ branch, commitOid: headOid });
+    this.#stageCommitCompleted({ beforeCommitOid: previousCommitOid, branch, commitOid: headOid });
     this.ctx.storage.kv.delete(repoHeadStorageKey(branch));
+    await this.#flushPendingCommitCompleted();
 
     await this.#stream.append({
       type: "events.iterate.com/repo/github-synced",
@@ -1466,11 +1530,15 @@ export class RepoDurableObject extends DurableObject<Env> {
   }
 
   async #resetFromGithub(input: { depth?: number }): Promise<GithubResetResult> {
+    await this.#flushPendingCommitCompleted();
     assertGithubHistoryDepth(input.depth, "resetFromGithub");
     const link = this.#requireGithubLink();
     const branch = REPO_DEFAULT_BRANCH;
     const previous = this.ctx.storage.kv.get<unknown>(repoHeadStorageKey(branch));
-    const previousCommitOid = isRepoHeadRecord(previous) ? previous.commitOid : null;
+    const previousCommitOid = githubSyncBaseCommitOid({
+      cachedHeadCommitOid: isRepoHeadRecord(previous) ? previous.commitOid : null,
+      pushedFloor: this.#branchAuthority(branch).pushedFloor,
+    });
     const token = await this.#mintGithubToken(link);
     const headOid = await this.#githubBranchHead({ branch, link, token });
 
@@ -1506,7 +1574,15 @@ export class RepoDurableObject extends DurableObject<Env> {
     // succeeded even if an immediate clone still reaches a lagging replica.
     // The next getHead call waits for the adopted head before serving it.
     this.#recordPushedHead({ branch, commitOid: headOid });
+    if (previousCommitOid !== headOid) {
+      this.#stageCommitCompleted({
+        beforeCommitOid: previousCommitOid,
+        branch,
+        commitOid: headOid,
+      });
+    }
     this.ctx.storage.kv.delete(repoHeadStorageKey(branch));
+    await this.#flushPendingCommitCompleted();
 
     await this.#stream.append({
       type: "events.iterate.com/repo/github-synced",

--- a/apps/os/src/domains/repos/repo-processor-contract.ts
+++ b/apps/os/src/domains/repos/repo-processor-contract.ts
@@ -156,7 +156,7 @@ export const RepoProcessorContract = defineProcessorContract({
     },
     "events.iterate.com/repo/commit-completed": {
       description:
-        "The repo's default branch advanced, normalized from a Cloudflare Artifacts pushed event. This includes pushes made outside OS through Git.",
+        "The repo's default branch advanced. OS-owned writes append this fact directly; Cloudflare Artifacts pushed events normalize external Git writes into the same fact.",
       payloadSchema: z.object({
         beforeCommitOid: z.string().trim().min(1).nullable().meta({
           description: "The branch head before the push, or null for a newly created ref.",

--- a/apps/os/src/domains/repos/repo-processor-implementation.ts
+++ b/apps/os/src/domains/repos/repo-processor-implementation.ts
@@ -37,17 +37,17 @@ import { isRepoNotSeededError, isRetryableArtifactsInfrastructureError } from ".
  * terminal fact is journaled and the durable obligation remains open for
  * redelivery/revival.
  *
- * Commit facts come from ONE source: the Cloudflare Artifacts event queue.
- * Each `repo/cloudflare-artifact-event-received` push on the default branch
- * is projected into the in-memory branch-head cache (including ref
- * DELETIONS, which produce no commit facts but must still evict a warm head)
- * and, when it carries a commit, normalized into `repo/commit-completed`,
- * idempotency-keyed on the (before, after, branch) coordinates — per-event
- * `blockProcessorWhile` work: each fact derives from an event that is
- * delivered once, so a dropped append would lose it forever, and the stable
- * keys collapse redeliveries. The default branch is known from the moment
- * create-requested reduces (every creation mode targets main), so a push
- * racing the terminal certificate still lands its facts.
+ * Every default-branch advance becomes one `repo/commit-completed` fact.
+ * OS-owned writes append it directly from the Repo Durable Object's durable
+ * outbox. External Git pushes arrive as
+ * `repo/cloudflare-artifact-event-received`: each push is projected into
+ * branch-head authority (including ref DELETIONS, which produce no commit
+ * facts but must still evict a warm head) and, when it carries a commit,
+ * normalized into that same fact. Both paths use the (before, after, branch)
+ * idempotency key, so a later queue observation of an OS write deduplicates.
+ * The default branch is known from the moment create-requested reduces (every
+ * creation mode targets main), so a push racing the terminal certificate
+ * still lands its facts.
  *
  * GitHub is an ingress lane, not a second source of commit facts. A
  * received `github/webhook-received` push delivery — source-checked

--- a/tasks/quarantined-cloudflare-artifacts-event-delivery.md
+++ b/tasks/quarantined-cloudflare-artifacts-event-delivery.md
@@ -29,10 +29,10 @@ shared Cloudflare account control plane before it could become ready.
 ## Quarantined behavior
 
 - Cloudflare Artifacts pushes are not consumed from an OS Worker queue.
-- Normal and externally initiated pushes therefore do not automatically emit
-  `repo/cloudflare-artifact-event-received`, `repo/commit-completed`, or
-  `repo/task-*` stream facts. Repository contents, direct reads/writes,
-  builds, and project readiness remain active.
+- OS-owned default-branch writes and GitHub adoptions emit
+  `repo/commit-completed` directly. Raw pushes made outside OS still do not
+  automatically emit `repo/cloudflare-artifact-event-received`,
+  `repo/commit-completed`, or `repo/task-*` stream facts.
 - The live e2e contract is explicitly skipped in
   `apps/os/e2e/vitest/artifact-event-delivery.e2e.test.ts`.
 
@@ -48,8 +48,6 @@ shared Cloudflare account control plane before it could become ready.
   audited deletion of the retired subscriptions and queues; verify there is no
   producer traffic or retained-message backlog. Do not put subscription/queue
   enumeration or cleanup back into project creation or steady-state deploys.
-- Emit commit facts directly for OS-owned writes and imports so they do not
-  depend on eventual account-level events.
 - Choose a bounded, deployment-global mechanism for genuinely external
   Artifact pushes. It must not perform per-project control-plane
   reconciliation and must expose queueing, saturation, and failure telemetry.


### PR DESCRIPTION
## What changed

- Append `events.iterate.com/repo/commit-completed` directly after OS-owned default-branch writes and GitHub adoptions.
- Keep the exact event in a one-entry durable outbox until the repo stream acknowledges it.
- Use the same `(before, after, branch)` idempotency key as the quarantined Cloudflare Artifacts event path, so a later duplicate observation collapses.
- Extend the real project/repo/worker composition test to prove a config `commitFiles` call reaches a matching `project/worker-updated` event.
- Narrow the existing quarantine task: raw external Artifact pushes remain unsupported; OS-owned writes no longer depend on that queue.

## Why

PR #2299 made config repo commits the platform signal for rebuilding a project worker and then publishing `project/worker-updated`. Production verification exposed that the Cloudflare Artifacts event queue is deliberately quarantined, so an OS-owned config commit could succeed without ever producing `repo/commit-completed`; the project processor therefore had nothing to react to.

The Repo Durable Object already knows the exact successful push transition. Publishing the literal repo fact there is the shortest authoritative path and avoids account-level queue reconciliation. The durable outbox covers the narrow failure window where the Git push lands but the cross-Durable-Object stream append fails: the RPC stays failed, the exact pending fact survives, and the next serialized write retries it before changing the repo again.

## Impact

Config changes made through OS now drive the existing chain:

```text
repo.commitFiles/edit/syncFromGithub/resetFromGithub
  -> repo/commit-completed
  -> project processor waits for the new worker to answer
  -> project/worker-updated
  -> userspace lifecycle hook
```

No backfill or compatibility processor is added. Raw external Git pushes remain explicitly quarantined and tracked in `tasks/quarantined-cloudflare-artifacts-event-delivery.md`.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test` — 2,449 passed, 12 expected failures, 1 skipped
- `doppler run --config dev -- pnpm --dir apps/os e2e --run e2e/vitest/itx-workers.e2e.test.ts --project node` — 5 passed
- Production verification of PR #2299 reproduced the missing commit fact before this fix and confirmed the worker lifecycle after the fact was supplied.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes repo mutation ordering and stream fact emission on the critical config-commit → worker rebuild path; failure handling relies on the outbox retrying before further writes, but cross-DO append failures could still leave RPCs failed until retry.
> 
> **Overview**
> **OS-owned default-branch advances now publish `repo/commit-completed` directly from the Repo Durable Object**, instead of depending on the quarantined Cloudflare Artifacts event queue. That unblocks the existing chain from config `commitFiles` / `edit` through `project/worker-updated` when pushes succeed in Artifacts but never surface as queue events.
> 
> The Repo DO **stages the exact event in a one-entry KV outbox** (`pending-commit-completed:v1`) after successful pushes on the lazy and clone lanes, then **flushes it to the repo stream** before later mutations and at the start of serialized writes. The same `(before, after, branch)` idempotency key as the external queue path prevents duplicates if both paths ever observe the same transition. **GitHub `syncFromGithub` and `resetFromGithub`** also stage and flush commit facts when the adopted head changes, with `githubSyncBaseCommitOid` used for the before-oid on reset.
> 
> Contract and processor docs now describe **two ingress paths** (direct append vs normalized Artifacts events) into one fact. The quarantine task is narrowed: OS-owned writes are covered; raw external Artifact pushes remain unsupported. **E2E** waits on `project/worker-updated` after a real `commitFiles` to prove the full composition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49e3bd5a40a84ababd1d914f72f8ec7e5c14a81d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +93 -17 | +66 -3 🟩🟩🟩🟩🟩 |
| Tests | +13 -0 | +13 -0 🟩⬜⬜⬜⬜ |
| Docs | +4 -6 | +4 -6 🟥⬜⬜⬜⬜ |
| **Total** | **+110 -23** | **+83 -9** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 9f90578 and 49e3bd5, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T12:54:38.569Z",
      "deployedAt": "2026-07-29T12:49:32.540Z",
      "headSha": "49e3bd5a40a84ababd1d914f72f8ec7e5c14a81d",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/418572560112272",
      "shortSha": "49e3bd5",
      "cleanupDurationMs": 13091,
      "deployDurationMs": 75777,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 73772,
      "deployReadinessDurationMs": 2003,
      "deployedWorkerName": "os-preview-13",
      "deployedWorkerVersion": "a1a22b04-c643-41b6-93e1-41b894c07f23",
      "testDurationMs": 216689,
      "testRetries": null,
      "workerSizeKib": 19944.53,
      "workerGzipKib": 5036.14,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5046.15
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T12:54:28.947Z",
      "deployedAt": "2026-07-29T12:48:35.659Z",
      "headSha": "49e3bd5a40a84ababd1d914f72f8ec7e5c14a81d",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/418572560112272",
      "shortSha": "49e3bd5",
      "cleanupDurationMs": 3468,
      "deployDurationMs": 17166,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 16886,
      "deployReadinessDurationMs": 274,
      "deployedWorkerName": "auth-preview-13",
      "deployedWorkerVersion": "aafc1dc4-f573-4973-8281-ead24729bc2a",
      "testDurationMs": 10529,
      "testRetries": null,
      "workerSizeKib": 3977.32,
      "workerGzipKib": 814.34,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T12:54:26.318Z",
      "deployedAt": "2026-07-29T12:40:54.789Z",
      "headSha": "49e3bd5a40a84ababd1d914f72f8ec7e5c14a81d",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/418572560112272",
      "shortSha": "49e3bd5",
      "cleanupDurationMs": 837,
      "deployDurationMs": 231,
      "deployConfigDurationMs": 8,
      "deployReuseProofDurationMs": 192,
      "deployedWorkerName": "dummy-petshop-preview-13",
      "deployedWorkerVersion": "866c49ed-6339-4556-b52b-07543c47f1cb",
      "testDurationMs": 5226,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+cc56a9d0c920cce4bc24e703912c29950d3dbf26",
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-29T12:54:26.403Z",
      "deployedAt": "2026-07-29T12:48:31.453Z",
      "headSha": "49e3bd5a40a84ababd1d914f72f8ec7e5c14a81d",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/418572560112272",
      "shortSha": "49e3bd5",
      "cleanupDurationMs": 918,
      "deployDurationMs": 12844,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 12681,
      "deployReadinessDurationMs": 158,
      "deployedWorkerName": "semaphore-preview-13",
      "deployedWorkerVersion": "253c6d38-0898-43dd-9526-01e11dc0af99",
      "testDurationMs": 48087,
      "testRetries": null,
      "workerSizeKib": 1915.51,
      "workerGzipKib": 441.11,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-29T12:54:33.525Z",
      "deployedAt": "2026-07-29T12:48:38.756Z",
      "headSha": "49e3bd5a40a84ababd1d914f72f8ec7e5c14a81d",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/418572560112272",
      "shortSha": "49e3bd5",
      "cleanupDurationMs": 8039,
      "deployDurationMs": 23139,
      "deployConfigDurationMs": 7,
      "deployCommandDurationMs": 19982,
      "deployReadinessDurationMs": 3150,
      "deployedWorkerName": "streams-example-app-preview-13",
      "deployedWorkerVersion": "4d2d94bd-cfdc-4ef8-a940-e50210adc73f",
      "testDurationMs": 84062,
      "testRetries": null,
      "workerSizeKib": 5256.46,
      "workerGzipKib": 1489.03,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `49e3bd5` | [https://auth.iterate-preview-13.com](https://auth.iterate-preview-13.com) | 814.3 KiB | 17.2s | 10.5s |  | 3.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/418572560112272) | 2026-07-29T12:54:28.947Z | Preview app released. |
| Dummy Petshop | released | `49e3bd5` | [https://dummy-petshop.iterate-preview-13.com](https://dummy-petshop.iterate-preview-13.com) | 198.3 KiB | 231ms | 5.2s |  | 837ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/418572560112272) | 2026-07-29T12:54:26.318Z | Preview app released. |
| OS | released | `49e3bd5` | [https://os.iterate-preview-13.com](https://os.iterate-preview-13.com) | 4.92 MiB (-10.0 KiB vs main) | 75.8s | 216.7s |  | 13.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/418572560112272) | 2026-07-29T12:54:38.569Z | Preview app released. |
| Semaphore | released | `49e3bd5` | [https://semaphore.iterate-preview-13.com](https://semaphore.iterate-preview-13.com) | 441.1 KiB | 12.8s | 48.1s |  | 918ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/418572560112272) | 2026-07-29T12:54:26.403Z | Preview app released. |
| Streams Example App | released | `49e3bd5` | [https://streams.iterate-preview-13.com](https://streams.iterate-preview-13.com) | 1.45 MiB | 23.1s | 84.1s |  | 8.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/418572560112272) | 2026-07-29T12:54:33.525Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->