### PR TITLE
auth: ES256 signing for Cloudflare Access + getUserGrants directory RPC

### DIFF
--- a/apps/auth-contract/src/worker.ts
+++ b/apps/auth-contract/src/worker.ts
@@ -1,6 +1,7 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
 import type {
   IterateAuthAccessTokenOrganizationClaim,
+  IterateAuthOrganizationClaim,
   IterateAuthProjectClaim,
 } from "@iterate-com/shared/auth-claims";
 import type {
@@ -83,6 +84,17 @@ export abstract class AuthWorker<Env = unknown> extends WorkerEntrypoint<Env> {
   ): Promise<ProjectCreationResult>;
   abstract getProjectBySlug(input: ProjectInput): Promise<ProjectRecord | null>;
   abstract listProjectsForUser(input: { userId: string }): Promise<UserProjectRecord[]>;
+  /**
+   * Everything a user can reach in one call: the organization + project grants an
+   * access token would carry for them, keyed on `userId` and unfiltered by scope.
+   * The same `{ organizations, projects }` shape the token/session already speak —
+   * for a directory / org-switcher view when identity comes from a wall, not a
+   * grants-bearing token. (`listProjectsForUser` stays as the narrow membership probe.)
+   */
+  abstract getUserGrants(input: { userId: string }): Promise<{
+    organizations: IterateAuthOrganizationClaim[];
+    projects: IterateAuthProjectClaim[];
+  }>;
   abstract mintProjectAppSession(
     input: MintProjectAppSessionInput,
   ): Promise<{ token: string } | null>;

--- a/apps/auth/scripts/deploy.ts
+++ b/apps/auth/scripts/deploy.ts
@@ -28,7 +28,10 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createBuiltInPrompts, createCli, isAgent, yamlTableConsoleLogger } from "trpc-cli";
 import { authEnvs } from "../../../envs.ts";
-import { authSigningPrivateJwkForEnvironment } from "../../../scripts/lib/bake-auth-jwks.ts";
+import {
+  authSigningEs256PrivateJwkForEnvironment,
+  authSigningPrivateJwkForEnvironment,
+} from "../../../scripts/lib/bake-auth-jwks.ts";
 import { deployApp } from "../../../scripts/lib/deploy-app.ts";
 import { run } from "../../../scripts/lib/deploy-helpers.ts";
 import { DEFAULT_ADMIN_ALLOWLIST } from "../src/config.ts";
@@ -60,10 +63,20 @@ export default async function deploy(
     // projectDirectoryKvId is not auth's concern.
     resources: (env) => ({ authDbId: env.resources.authDbId }),
     requiredSecrets: REQUIRED_SECRETS,
+    // Optional ES256 signing key: shipped to the worker only when the env's
+    // Doppler config carries it. Its presence flips id/access token signing to
+    // ES256 (for Cloudflare Access), keeping the Ed25519 public key in the JWKS.
+    optionalSecrets: ["AUTH_FORGE_ES256_PRIVATE_JWK"],
     prepare: (ctx, secretValues, credentials) => {
       // Validate the fixed signing key and the production-key opt-in
       // before migrations or any other deployed state can change.
       authSigningPrivateJwkForEnvironment({
+        dopplerConfig: ctx.env.dopplerConfig,
+        envName: ctx.name,
+        secrets: ctx.secrets,
+      });
+      // Validate the optional ES256 key's shape now (no-op when unset).
+      authSigningEs256PrivateJwkForEnvironment({
         dopplerConfig: ctx.env.dopplerConfig,
         envName: ctx.name,
         secrets: ctx.secrets,

--- a/apps/auth/src/config.ts
+++ b/apps/auth/src/config.ts
@@ -1,6 +1,9 @@
 import { parseAppConfigFromEnv, publicValue, redacted, Redacted } from "@iterate-com/shared/config";
 import { z } from "zod/v4";
-import { parseAuthSigningPrivateJwk } from "../../../scripts/lib/bake-auth-jwks.ts";
+import {
+  parseAuthSigningEs256PrivateJwk,
+  parseAuthSigningPrivateJwk,
+} from "../../../scripts/lib/bake-auth-jwks.ts";
 
 /**
  * Default glob allowlist promoting matching emails to platform admin.
@@ -67,6 +70,12 @@ export const AppConfig = z.object({
 export type AppConfig = z.output<typeof AppConfig> & {
   /** Doppler-owned Ed25519 key used by Better Auth to sign JWTs. */
   authSigningPrivateJwk: Redacted<string>;
+  /**
+   * Optional Doppler-owned ES256 (P-256) key. When present, Better Auth signs
+   * new id/access tokens with it (Cloudflare Access rejects EdDSA) while the
+   * Ed25519 public key stays in the JWKS for existing verifiers.
+   */
+  authSigningEs256PrivateJwk?: Redacted<string>;
 };
 
 /**
@@ -82,6 +91,14 @@ export function parseConfig(env: unknown): AppConfig {
   }
   parseAuthSigningPrivateJwk(privateJwk);
 
+  // Optional ES256 key: validate its shape now (fail fast) when present.
+  const es256PrivateJwkRaw = rawEnv.AUTH_FORGE_ES256_PRIVATE_JWK;
+  const es256PrivateJwk =
+    typeof es256PrivateJwkRaw === "string" && es256PrivateJwkRaw.trim() !== ""
+      ? es256PrivateJwkRaw
+      : undefined;
+  if (es256PrivateJwk) parseAuthSigningEs256PrivateJwk(es256PrivateJwk);
+
   return {
     ...parseAppConfigFromEnv({
       configSchema: AppConfig,
@@ -89,5 +106,6 @@ export function parseConfig(env: unknown): AppConfig {
       env: rawEnv,
     }),
     authSigningPrivateJwk: new Redacted(privateJwk),
+    ...(es256PrivateJwk ? { authSigningEs256PrivateJwk: new Redacted(es256PrivateJwk) } : {}),
   };
 }

--- a/apps/auth/src/server/auth-jwt.test.ts
+++ b/apps/auth/src/server/auth-jwt.test.ts
@@ -23,3 +23,50 @@ test("signs and publishes the same Doppler-owned key", async () => {
   assert.equal(verified.protectedHeader.kid, "from-doppler");
   assert.equal(verified.payload.sub, "usr_test");
 });
+
+test("with an ES256 key, signs ES256 and publishes both public keys", async () => {
+  const { privateKey: edPrivateKey } = await generateKeyPair("EdDSA", {
+    crv: "Ed25519",
+    extractable: true,
+  });
+  const edPrivateJwk = {
+    ...(await exportJWK(edPrivateKey)),
+    alg: "EdDSA",
+    kid: "ed25519-from-doppler",
+  };
+  const { privateKey: ecPrivateKey } = await generateKeyPair("ES256", { extractable: true });
+  const es256PrivateJwk = {
+    ...(await exportJWK(ecPrivateKey)),
+    alg: "ES256",
+    kid: "es256-from-doppler",
+  };
+
+  const auth = betterAuth({
+    baseURL: "https://auth.example.com",
+    secret: "test-secret-at-least-thirty-two-characters",
+    plugins: [authJwt(JSON.stringify(edPrivateJwk), JSON.stringify(es256PrivateJwk))],
+  });
+
+  const { token } = await auth.api.signJWT({ body: { payload: { sub: "usr_test" } } });
+  const jwks = await auth.api.getJwks();
+
+  // Both public keys are published; neither carries the private component.
+  assert.equal(jwks.keys.length, 2);
+  assert.equal(
+    jwks.keys.every((k) => !Object.hasOwn(k, "d")),
+    true,
+  );
+  const kids = jwks.keys.map((k) => k.kid).sort();
+  assert.deepEqual(kids, ["ed25519-from-doppler", "es256-from-doppler"]);
+  const algs = jwks.keys.map((k) => k.alg).sort();
+  assert.deepEqual(algs, ["ES256", "EdDSA"]);
+
+  // The token is signed with the ES256 key (newest), and verifies against the
+  // published JWKS by kid — exactly what jose relying parties (and Cloudflare
+  // Access, which only accepts ES*/RS*/PS*) do.
+  assert.equal(token.split(".").length, 3);
+  const verified = await jwtVerify(token, createLocalJWKSet(jwks));
+  assert.equal(verified.protectedHeader.alg, "ES256");
+  assert.equal(verified.protectedHeader.kid, "es256-from-doppler");
+  assert.equal(verified.payload.sub, "usr_test");
+});

--- a/apps/auth/src/server/auth-jwt.ts
+++ b/apps/auth/src/server/auth-jwt.ts
@@ -1,27 +1,67 @@
 import { jwt } from "better-auth/plugins";
-import { parseAuthSigningPrivateJwk } from "../../../../scripts/lib/bake-auth-jwks.ts";
+import {
+  parseAuthSigningEs256PrivateJwk,
+  parseAuthSigningPrivateJwk,
+} from "../../../../scripts/lib/bake-auth-jwks.ts";
 
 export type AuthJwtPlugin = ReturnType<typeof jwt>;
 
-/** Better Auth JWT plugin backed by the one immutable key supplied by Doppler. */
-export function authJwt(privateJwkJson: string): AuthJwtPlugin {
+/**
+ * Better Auth JWT plugin backed by the immutable key(s) supplied by Doppler.
+ *
+ * The Ed25519 (EdDSA) key is always present. When an ES256 (P-256) key is also
+ * supplied, it is returned as the *newest* key: better-auth's signJWT signs with
+ * the latest key by `createdAt`, so new id_tokens and access tokens are signed
+ * with ES256 while both public keys stay in the JWKS. This exists because
+ * Cloudflare Access's generic-OIDC verifier accepts only RS/ES/PS-family — never
+ * EdDSA. jose relying parties (OS, CLI, kernel) select the verification key by
+ * `kid` from the JWKS, so they keep verifying without change.
+ */
+export function authJwt(privateJwkJson: string, es256PrivateJwkJson?: string): AuthJwtPlugin {
   const { d, ...publicJwk } = parseAuthSigningPrivateJwk(privateJwkJson);
-  const key = {
+  const ed25519Key = {
     id: publicJwk.kid,
     alg: "EdDSA" as const,
     crv: "Ed25519" as const,
     publicKey: JSON.stringify(publicJwk),
     privateKey: JSON.stringify({ ...publicJwk, d }),
+    // Epoch 0 keeps the Ed25519 key strictly older than any ES256 key below, so
+    // when both exist getLatestKey picks ES256.
     createdAt: new Date(0),
   };
+
+  const es256Key = es256PrivateJwkJson
+    ? (() => {
+        const { d: es256D, ...es256PublicJwk } =
+          parseAuthSigningEs256PrivateJwk(es256PrivateJwkJson);
+        return {
+          id: es256PublicJwk.kid,
+          alg: "ES256" as const,
+          crv: "P-256" as const,
+          publicKey: JSON.stringify(es256PublicJwk),
+          privateKey: JSON.stringify({ ...es256PublicJwk, d: es256D }),
+          // Newer than the Ed25519 key so signJWT signs new tokens with ES256.
+          createdAt: new Date(1),
+        };
+      })()
+    : null;
+
+  // getJwks returns every key: the JWKS route publishes each public half (with
+  // its own alg/crv/kid), and signJWT signs with the newest.
+  const keys = es256Key ? [es256Key, ed25519Key] : [ed25519Key];
 
   return jwt({
     jwks: {
       disablePrivateKeyEncryption: true,
-      keyPairConfig: { alg: "EdDSA", crv: "Ed25519" },
+      // keyPairConfig.alg drives the discovery doc's
+      // id_token_signing_alg_values_supported. Advertise ES256 whenever the
+      // ES256 key is the one new tokens are signed with; otherwise EdDSA.
+      // ES256's curve (P-256) is implicit in better-auth's JWKOptions type
+      // (crv is `never` for ES256); the actual P-256 key comes from the JWK.
+      keyPairConfig: es256Key ? { alg: "ES256" } : { alg: "EdDSA", crv: "Ed25519" },
     },
     adapter: {
-      getJwks: async () => [key],
+      getJwks: async () => keys,
       createJwk: async () => {
         throw new Error("Auth JWT signing keys are rotated in Doppler, not generated at runtime");
       },

--- a/apps/auth/src/server/auth.ts
+++ b/apps/auth/src/server/auth.ts
@@ -53,7 +53,10 @@ export const auth = betterAuth({
   baseURL: config.authAppOrigin,
   plugins: getAuthPlugins({
     authAppOrigin: config.authAppOrigin,
-    jwtPlugin: authJwt(config.authSigningPrivateJwk.exposeSecret()),
+    jwtPlugin: authJwt(
+      config.authSigningPrivateJwk.exposeSecret(),
+      config.authSigningEs256PrivateJwk?.exposeSecret(),
+    ),
     emailOtpEnabled: config.emailOtpEnabled,
     fixedTestOtpEnabled: config.fixedTestOtpEnabled,
     emailBinding: env.EMAIL,

--- a/apps/auth/src/server/env.ts
+++ b/apps/auth/src/server/env.ts
@@ -29,6 +29,12 @@ export interface CloudflareEnv {
   APP_CONFIG_BETTER_AUTH_SECRET: string;
   /** Doppler-owned Ed25519 key used for OAuth/OIDC JWT signatures. */
   AUTH_FORGE_PRIVATE_JWK: string;
+  /**
+   * Optional Doppler-owned ES256 (P-256) key. When set, new id/access tokens
+   * are signed with it (Cloudflare Access rejects EdDSA); the Ed25519 public
+   * key stays in the JWKS so existing verifiers keep working.
+   */
+  AUTH_FORGE_ES256_PRIVATE_JWK?: string;
   /** Dedicated project-app-session signing secret, shared with os for local
    * verification. Optional: unset falls back to APP_CONFIG_BETTER_AUTH_SECRET. */
   APP_CONFIG_PROJECT_APP_SESSION_SECRET?: string;

--- a/apps/auth/src/server/worker.ts
+++ b/apps/auth/src/server/worker.ts
@@ -42,6 +42,7 @@ import {
   mintProjectId,
   userCanAccessProject,
 } from "./project-directory.ts";
+import { buildAccessTokenGrantClaims } from "./oauth-project-selection.ts";
 
 const app = hono();
 const AUTH_ISSUER_PATH = "/api/auth";
@@ -209,6 +210,16 @@ export default class AuthWorker extends AuthWorkerContract<CloudflareEnv> {
 
   listProjectsForUser(input: { userId: string }) {
     return listProjectsForUser(input, db);
+  }
+
+  async getUserGrants(input: { userId: string }) {
+    // Reuse the single source of truth for "what a token grants": no scopes + no
+    // selection => every organization and project this user can reach.
+    const { organizations, projects } = await buildAccessTokenGrantClaims(
+      { userId: input.userId, requestedScopes: [], selection: null },
+      db,
+    );
+    return { organizations, projects };
   }
 
   mintProjectAppSession(input: MintProjectAppSessionInput) {

--- a/envs.ts
+++ b/envs.ts
@@ -258,7 +258,7 @@ export const envs = {
   preview_19: previewSlot(19, {
     projectDirectoryKvId: "916fa97c2ec84067997012702f242646",
     workerBuildCacheKvId: "a22450ba186a40549cfe2cff29079aca",
-    authDbId: "f9facd1f-0699-4766-8aa4-b00c7a59ff34",
+    authDbId: "42efe1e4-194f-4c61-8e62-810ec35fbf43",
   }),
 } satisfies Record<string, DeployedEnv>;
 

--- a/scripts/lib/bake-auth-jwks.ts
+++ b/scripts/lib/bake-auth-jwks.ts
@@ -77,7 +77,80 @@ export function authSigningPrivateJwkForEnvironment(
   return parseAuthSigningPrivateJwk(privateJwkJson);
 }
 
+/**
+ * Optional second signing key: an ES256 (P-256) private JWK. Cloudflare Access's
+ * generic-OIDC verifier only accepts RS/ES/PS-family id_token signatures — never
+ * EdDSA — so when this key is present Auth signs new id/access tokens with ES256
+ * (see auth-jwt.ts) while still publishing the Ed25519 public key. jose relying
+ * parties select the verification key by `kid`, so both algorithms verify.
+ */
+export type AuthSigningEs256PrivateJwk = Record<string, unknown> & {
+  alg: "ES256";
+  crv: "P-256";
+  d: string;
+  kid: string;
+  kty: "EC";
+  x: string;
+  y: string;
+};
+
+export function parseAuthSigningEs256PrivateJwk(value: string): AuthSigningEs256PrivateJwk {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value) as unknown;
+  } catch (error) {
+    throw new Error("AUTH_FORGE_ES256_PRIVATE_JWK must be valid JSON", { cause: error });
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(
+      "AUTH_FORGE_ES256_PRIVATE_JWK must be a private ES256 (P-256) JWK with alg, crv, d, kid, kty, x, and y",
+    );
+  }
+  const candidate = parsed as Record<string, unknown>;
+  if (
+    candidate.alg !== "ES256" ||
+    candidate.crv !== "P-256" ||
+    typeof candidate.d !== "string" ||
+    candidate.d.length === 0 ||
+    typeof candidate.kid !== "string" ||
+    candidate.kid.length === 0 ||
+    candidate.kty !== "EC" ||
+    typeof candidate.x !== "string" ||
+    candidate.x.length === 0 ||
+    typeof candidate.y !== "string" ||
+    candidate.y.length === 0
+  ) {
+    throw new Error(
+      "AUTH_FORGE_ES256_PRIVATE_JWK must be a private ES256 (P-256) JWK with alg, crv, d, kid, kty, x, and y",
+    );
+  }
+
+  return parsed as AuthSigningEs256PrivateJwk;
+}
+
+/**
+ * The ES256 signing key for an environment, or null when the env has no
+ * `AUTH_FORGE_ES256_PRIVATE_JWK`. Optional so envs that have not adopted the
+ * second key keep signing EdDSA-only.
+ */
+export function authSigningEs256PrivateJwkForEnvironment(
+  input: AuthSigningEnvironment,
+): AuthSigningEs256PrivateJwk | null {
+  const privateJwkJson = input.secrets.AUTH_FORGE_ES256_PRIVATE_JWK?.trim();
+  if (!privateJwkJson) return null;
+  return parseAuthSigningEs256PrivateJwk(privateJwkJson);
+}
+
 export function bakeStaticAuthJwks(input: AuthSigningEnvironment): string {
   const { d: _privateKey, ...publicJwk } = authSigningPrivateJwkForEnvironment(input);
+  // When the env also carries an ES256 key, publish its public half so relying
+  // parties (OS, Semaphore) that verify tokens against this baked JWKS accept
+  // the ES256-signed tokens Auth now issues, selecting the key by `kid`.
+  const es256 = authSigningEs256PrivateJwkForEnvironment(input);
+  if (es256) {
+    const { d: _es256Private, ...es256Public } = es256;
+    return JSON.stringify({ keys: [es256Public, publicJwk] });
+  }
   return JSON.stringify({ keys: [publicJwk] });
 }


### PR DESCRIPTION
## What & why

Two auth changes that unblock the **"Cloudflare Access is the wall,
auth.iterate.com is the IdP behind it"** model: **(1)** ES256 token signing so
Access can accept iterate auth as an IdP, and **(2)** a `getUserGrants` RPC so a
wall-authenticated caller can read a user's org/project directory in one call.

### 1. ES256 signing (for Cloudflare Access)

Cloudflare Access's **generic-OIDC** verifier accepts only `RS*/ES*/PS*`
id_token signatures — **never EdDSA** — so `auth.iterate.com` (which signs
EdDSA/Ed25519) could not be used as a "log in with iterate" IdP for Access.
This is the entire blocker described in
`tasks/auth-cloudflare-access-oidc-compatibility.md`.

This PR adds an **optional ES256 signing key**. When the Doppler secret
`AUTH_FORGE_ES256_PRIVATE_JWK` is present, better-auth signs new **id and
access tokens** with ES256 while still publishing the Ed25519 public key in
the JWKS. Everything is gated on that optional secret: envs without it sign
EdDSA exactly as before, so this is a no-op for prod until we deliberately
add the key.

## How it works

better-auth's `signJWT` always signs with the **newest key by `createdAt`**
and there is one signature per JWT, so this **switches** the signing alg to
ES256 rather than truly dual-signing each token. That's safe because:

- The JWKS endpoint (`/api/auth/jwks`) publishes **both** public keys (ES256
  + EdDSA), each with its own `kid`. jose relying parties (`@iterate-com/auth/server`
  in OS, the CLI, the kernel) select the verification key by `kid` — **none
  pin `alg: "EdDSA"`** (audited), so they keep verifying with no change.
- Discovery's `id_token_signing_alg_values_supported` follows
  `keyPairConfig.alg`, now `["ES256"]` when the key is present.
- `bakeStaticAuthJwks` (the public JWKS baked into OS/Semaphore at *their*
  deploy time) also emits the ES256 public key when the env carries it, so
  those relying parties accept ES256 access tokens locally. Harmless no-op
  until the ES256 secret is added to their Doppler configs.

Key files:
- `apps/auth/src/server/auth-jwt.ts` — accepts an optional ES256 JWK, returns
  both keys (ES256 newest), sets `keyPairConfig.alg`.
- `scripts/lib/bake-auth-jwks.ts` — ES256 JWK parser + dual-key baking.
- `apps/auth/src/config.ts`, `.../server/env.ts`, `.../server/auth.ts` — thread
  the optional secret through.
- `apps/auth/scripts/deploy.ts` — ships the optional secret via `optionalSecrets`.
- `apps/auth/src/server/auth-jwt.test.ts` — new test: with an ES256 key, the
  token is ES256-signed, both public keys are published, and it verifies by kid.

### 2. `getUserGrants` directory RPC

When the wall (Cloudflare Access) authenticates the human, the kernel/OS receives
a plain identity JWT (`sub`/`email`) — **not** a grants-bearing iterate token. So
"which orgs/projects can this user reach" has to be a directory lookup keyed on
`userId`, not a token claim. Rather than proliferate `listXForUser` methods, this
adds **one** RPC that returns everything at once:

```ts
getUserGrants(input: { userId: string }): Promise<{
  organizations: IterateAuthOrganizationClaim[];
  projects: IterateAuthProjectClaim[];
}>
```

It's a thin wrapper over `buildAccessTokenGrantClaims` — the code's own *"single
source of truth for what an access token grants"* — called with no scopes and no
selection, i.e. **every** org and project the user can reach. So it returns the
exact `{ organizations, projects }` bundle the token/session already speak; no new
shape to learn, and it can't drift from what a real token would grant. The narrow
`listProjectsForUser` stays as the membership probe OS uses today.

Files: `apps/auth-contract/src/worker.ts` (the abstract method),
`apps/auth/src/server/worker.ts` (the impl).

## Risk / migration note

This is a **switch, not a per-token dual-sign** (impossible: one signature
per JWT). The safety net is that verification is key-selected by `kid` and no
verifier pins the algorithm. To roll it out to prod safely: add the ES256
public key to OS/Semaphore's baked JWKS (this PR's `bakeStaticAuthJwks`
already does that automatically once `AUTH_FORGE_ES256_PRIVATE_JWK` is in
their Doppler configs) **before** enabling the ES256 key on prod auth, so
in-flight EdDSA and new ES256 access tokens both verify during the cutover.

## Proven live (preview slot)

Deployed to `auth-preview-19` and wired an end-to-end Cloudflare Access
integration on the dev/preview Zero-Trust org
(`iterate-dev-preview.cloudflareaccess.com`):

- `https://auth.iterate-preview-19.com/api/auth/jwks` serves **ES256 + EdDSA**
  (kids `auth-es256-…`, `iterate-forge-preview`); discovery advertises
  `id_token_signing_alg_values_supported: ["ES256"]`.
- Registered a **confidential** OAuth client (`client_secret_basic`, PKCE) with
  the Access callback redirect URI.
- Created an Access **generic-OIDC IdP** pointing at the preview auth, a
  `self_hosted` app (`auto_redirect_to_identity`), and an `allow` policy with
  `email_domain: nustom.com`.
- Hitting the protected host redirects **through Cloudflare Access to the
  iterate auth login page** (Continue with email / Continue with Google) —
  proving Access accepts iterate auth as a generic-OIDC IdP. The final
  interactive login (Google / email OTP) is the only human step.

`envs.ts`: refreshed `preview_19` `authDbId` (its D1 had been GC'd; recreated
via `ensure-resources`).

## Not in this PR
- Enabling the ES256 key on **prod** auth (needs the baked-JWKS rollout above +
  a prod OAuth client + prod Access org).
- The runbook doc under `apps/auth/docs/` (acceptance criterion #6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T14:33:17.891Z",
      "deployedAt": "2026-07-29T14:27:31.046Z",
      "headSha": "1bfbe573556d9e9c7b27de7508b61f51866f577b",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/440184077747260",
      "shortSha": "1bfbe57",
      "cleanupDurationMs": 13994,
      "deployDurationMs": 50967,
      "deployConfigDurationMs": 1,
      "deployCommandDurationMs": 48585,
      "deployReadinessDurationMs": 2379,
      "deployedWorkerName": "os-preview-17",
      "deployedWorkerVersion": "03ef9be2-9a0e-4f2d-8e44-443d8db0756e",
      "testDurationMs": 222809,
      "testRetries": null,
      "workerSizeKib": 19944.53,
      "workerGzipKib": 5036.14,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5046.35
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-29T14:33:04.949Z",
      "deployedAt": "2026-07-29T14:04:39.205Z",
      "headSha": "a5c518b3fabd6a4d8b59e69ff73cb36ef7165b4a",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/440184077747260",
      "shortSha": "a5c518b",
      "cleanupDurationMs": 1051,
      "deployDurationMs": 13178,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 12969,
      "deployReadinessDurationMs": 204,
      "deployedWorkerName": "semaphore-preview-17",
      "deployedWorkerVersion": "4fea7af5-91a4-45f8-935f-93cddb9d736d",
      "testDurationMs": 31478,
      "testRetries": null,
      "workerSizeKib": 1915.51,
      "workerGzipKib": 441.11,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T14:33:07.620Z",
      "deployedAt": "2026-07-29T14:27:03.341Z",
      "headSha": "1bfbe573556d9e9c7b27de7508b61f51866f577b",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/440184077747260",
      "shortSha": "1bfbe57",
      "cleanupDurationMs": 3720,
      "deployDurationMs": 21266,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 20877,
      "deployReadinessDurationMs": 384,
      "deployedWorkerName": "auth-preview-17",
      "deployedWorkerVersion": "81b9297a-155b-49d5-a32b-bc8887b1503a",
      "testDurationMs": 9795,
      "testRetries": null,
      "workerSizeKib": 3979.96,
      "workerGzipKib": 814.85,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-29T14:33:12.159Z",
      "deployedAt": "2026-07-29T14:04:45.528Z",
      "headSha": "a5c518b3fabd6a4d8b59e69ff73cb36ef7165b4a",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/440184077747260",
      "shortSha": "a5c518b",
      "cleanupDurationMs": 8257,
      "deployDurationMs": 78705,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 19289,
      "deployReadinessDurationMs": 59410,
      "deployedWorkerName": "streams-example-app-preview-17",
      "deployedWorkerVersion": "cb912b19-1adb-4e71-a046-2aa9c9cf4b0b",
      "testDurationMs": 63840,
      "testRetries": null,
      "workerSizeKib": 5256.46,
      "workerGzipKib": 1489.03,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T14:33:04.805Z",
      "deployedAt": "2026-07-29T14:04:32.007Z",
      "headSha": "1bfbe573556d9e9c7b27de7508b61f51866f577b",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/440184077747260",
      "shortSha": "1bfbe57",
      "cleanupDurationMs": 902,
      "deployDurationMs": 257,
      "deployConfigDurationMs": 4,
      "deployReuseProofDurationMs": 214,
      "deployedWorkerName": "dummy-petshop-preview-17",
      "deployedWorkerVersion": "39c095d7-c2c0-4530-922a-86503c1013ca",
      "testDurationMs": 5393,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+011b744a6d8ed45df3b41560673e3b186b1c3b42",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `1bfbe57` | [https://auth.iterate-preview-17.com](https://auth.iterate-preview-17.com) | 814.9 KiB | 21.3s | 9.8s |  | 3.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/440184077747260) | 2026-07-29T14:33:07.620Z | Preview app released. |
| Dummy Petshop | released | `1bfbe57` | [https://dummy-petshop.iterate-preview-17.com](https://dummy-petshop.iterate-preview-17.com) | 198.3 KiB | 257ms | 5.4s |  | 902ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/440184077747260) | 2026-07-29T14:33:04.805Z | Preview app released. |
| OS | released | `1bfbe57` | [https://os.iterate-preview-17.com](https://os.iterate-preview-17.com) | 4.92 MiB (-10.2 KiB vs main) | 51.0s | 222.8s |  | 14.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/440184077747260) | 2026-07-29T14:33:17.891Z | Preview app released. |
| Semaphore | released | `a5c518b` | [https://semaphore.iterate-preview-17.com](https://semaphore.iterate-preview-17.com) | 441.1 KiB | 13.2s | 31.5s |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/440184077747260) | 2026-07-29T14:33:04.949Z | Preview app released. |
| Streams Example App | released | `a5c518b` | [https://streams.iterate-preview-17.com](https://streams.iterate-preview-17.com) | 1.45 MiB | 78.7s | 63.8s |  | 8.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/440184077747260) | 2026-07-29T14:33:12.159Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +75 -8 | +38 -7 🟩🟩🟩🟥⬜ |
| Tests | +47 -0 | +38 -0 🟩🟩🟩🟩⬜ |
| CI & scripts | +87 -1 | +53 -1 🟩🟩🟩🟩🟩 |
| Other | +1 -1 | +1 -1 🟩⬜⬜⬜⬜ |
| **Total** | **+210 -10** | **+130 -9** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 3cfd41f and a5c518b, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes OIDC token signing algorithms and JWKS shape when the optional key is enabled; mistakes in rollout order could break token verification until relying parties have the ES256 public key in baked JWKS.
> 
> **Overview**
> Adds an **optional** Doppler secret `AUTH_FORGE_ES256_PRIVATE_JWK` so auth can sign new OIDC **id and access tokens** with **ES256** (required for Cloudflare Access generic-OIDC) while still publishing the existing **EdDSA** public key in the JWKS. Environments without the secret keep **EdDSA-only** behavior.
> 
> The JWT plugin treats the ES256 key as the newest signer (`createdAt`), so new tokens use ES256; discovery advertises `ES256` when that key is present. Deploy validates and optionally ships the secret; `bakeStaticAuthJwks` includes the ES256 public key when configured so OS/Semaphore baked JWKS accept ES256 tokens by `kid`. A new unit test covers dual-key JWKS and ES256 verification.
> 
> Also updates `preview_19` `authDbId` after D1 recreation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5c518b3fabd6a4d8b59e69ff73cb36ef7165b4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
