### PR TITLE
fix(os): decouple birth checks from retry keys

### DIFF
--- a/apps/os/e2e/vitest/slack-agent.e2e.test.ts
+++ b/apps/os/e2e/vitest/slack-agent.e2e.test.ts
@@ -161,6 +161,23 @@ test.skipIf(signingSecret === null)(
       120_000,
     );
 
+    // Router-created agents are normal agents through the public handle. Their
+    // birth event has a source-lifetime suffix on its retry key, so existence
+    // must come from reduced agent state rather than one exact key spelling.
+    using routedAgent = project.agents.get(agentStreamPath);
+    const activity = `Slack e2e public append ${runSuffix}`;
+    await expect(
+      routedAgent.append({
+        type: "events.iterate.com/agent/summary-updated",
+        payload: { activity },
+      }),
+    ).resolves.toMatchObject([
+      {
+        type: "events.iterate.com/agent/summary-updated",
+        payload: { activity },
+      },
+    ]);
+
     // --- LLM reply: codemode script execution requested on the agent stream.
     // The Slack prompt tells the model to reply via its connection's postMessage.
     const withScript = await waitFor(

--- a/apps/os/src/domains/capability-host/capability-host-run-script.test.ts
+++ b/apps/os/src/domains/capability-host/capability-host-run-script.test.ts
@@ -10,12 +10,22 @@ import {
 
 const PROJECT_ID = "prj_test";
 const PATH = "/agents/test";
+const SOURCE_STREAM_ID = "11111111-1111-4111-8111-111111111111";
 const SCRIPT_REQUESTED = "events.iterate.com/capability-host/script-run-requested";
 const SCRIPT_SETTLED = "events.iterate.com/capability-host/script-run-settled";
 
 async function bornStream() {
   const stream = new MemoryStream(PATH);
-  await stream.append(...capabilityHostCreationEvents({ path: PATH, projectId: PROJECT_ID }));
+  const creation = capabilityHostCreationEvents({ path: PATH, projectId: PROJECT_ID }).map(
+    (event) =>
+      event.idempotencyKey === undefined
+        ? event
+        : {
+            ...event,
+            idempotencyKey: `${event.idempotencyKey}@source-stream:${SOURCE_STREAM_ID}`,
+          },
+  );
+  await stream.append(...creation);
   return stream;
 }
 
@@ -33,6 +43,7 @@ function settleBeforeRequestAcknowledgement(
 ): CapabilityHostScriptStream {
   return {
     getEvent: (input) => stream.getEvent(input),
+    getEvents: (input) => stream.getEvents(input),
     waitForEvent: (input) => stream.waitForEvent(input),
     append: async (...inputs: StreamEventInput[]) => {
       const committed = await stream.append(...inputs);
@@ -60,7 +71,6 @@ describe("runCapabilityHostScript", () => {
         command: command(now),
         now: () => now,
         path: PATH,
-        projectId: PROJECT_ID,
         stream: settleBeforeRequestAcknowledgement(stream, {
           status: "succeeded",
           result: 42,
@@ -84,7 +94,6 @@ describe("runCapabilityHostScript", () => {
         command: command(startedAt),
         now,
         path: PATH,
-        projectId: PROJECT_ID,
         stream: settleBeforeRequestAcknowledgement(stream, {
           status: "succeeded",
           result: 42,
@@ -102,7 +111,6 @@ describe("runCapabilityHostScript", () => {
       command: command(now),
       now: () => now,
       path: PATH,
-      projectId: PROJECT_ID,
       stream,
     });
     await vi.waitFor(() => {
@@ -138,7 +146,6 @@ describe("runCapabilityHostScript", () => {
         command: command(now),
         now: () => now,
         path: PATH,
-        projectId: PROJECT_ID,
         stream,
       }),
     ).rejects.toThrow(`capability host at ${PATH} has not been created`);

--- a/apps/os/src/domains/capability-host/capability-host-script-run.ts
+++ b/apps/os/src/domains/capability-host/capability-host-script-run.ts
@@ -1,4 +1,4 @@
-import type { StreamEvent, StreamEventInput } from "iterate/processors";
+import type { StreamEvent, StreamEventInput, StreamEventReadInput } from "iterate/processors";
 import type { CapabilityHost } from "../../itx-api.generated.ts";
 import { isStreamWaitTimeoutError } from "../streams/stream-unavailable.ts";
 import { CapabilityHostProcessorContract } from "./capability-host-processor-contract.ts";
@@ -24,6 +24,7 @@ export type CapabilityHostScriptStream = {
   getEvent(
     input: { offset: number; idempotencyKey?: never } | { idempotencyKey: string; offset?: never },
   ): Promise<StreamEvent | undefined>;
+  getEvents(input: StreamEventReadInput): Promise<StreamEvent[]>;
   waitForEvent(input: {
     afterOffset?: number;
     eventTypes?: readonly string[];
@@ -46,19 +47,19 @@ export async function runCapabilityHostScript(input: {
   command: RunScriptCommand;
   now?: () => number;
   path: string;
-  projectId: string;
   stream: CapabilityHostScriptStream;
 }): Promise<Awaited<ReturnType<CapabilityHost["runScript"]>>> {
-  const { command, path, projectId, stream } = input;
+  const { command, path, stream } = input;
   const now = input.now ?? Date.now;
   if (now() >= command.expiresAt) {
     throw new Error(`Script execution "${command.executionId}" expired before it was requested.`);
   }
 
-  const created = await stream.getEvent({
-    idempotencyKey: `capability-host/created:${projectId}:${path}`,
+  const [created] = await stream.getEvents({
+    eventTypes: [CREATED],
+    limit: 1,
   });
-  if (created?.type !== CREATED) {
+  if (created === undefined) {
     throw new Error(`capability host at ${path} has not been created`);
   }
 

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -4147,15 +4147,14 @@ class EmailCapabilityRpcTarget extends IterateRpcTarget<"EmailCapability"> {
    */
   async #threadIdFromBirthCertificate(): Promise<string | null> {
     if (!this.props.scopePath.startsWith("/agents/")) return null;
-    const event = await integrationStreamStub(this.props.projectId, this.props.scopePath).getEvent({
-      idempotencyKey: `email-agent/created:${this.props.projectId}:${this.props.scopePath}`,
+    const [event] = await integrationStreamStub(
+      this.props.projectId,
+      this.props.scopePath,
+    ).getEvents({
+      eventTypes: ["events.iterate.com/email-agent/created"],
+      limit: 1,
     });
     if (event === undefined) return null;
-    if (event.type !== "events.iterate.com/email-agent/created") {
-      throw new Error(
-        `email agent birth key on "${this.props.scopePath}" names unexpected event type "${event.type}"`,
-      );
-    }
     return EmailProcessorContract.events[
       "events.iterate.com/email-agent/created"
     ].payloadSchema.parse(event.payload).config.threadId;
@@ -4315,17 +4314,34 @@ class EmailCapabilityRpcTarget extends IterateRpcTarget<"EmailCapability"> {
   }
 }
 
-async function assertAgentCreated(input: { path: string; projectId: string }): Promise<void> {
-  const event = await integrationStreamStub(input.projectId, input.path).getEvent({
-    idempotencyKey: `agent/created:${input.projectId}:${input.path}`,
+function agentProcessorRelay(input: {
+  auth: ItxAuth;
+  path: string;
+  projectId: string;
+}): ProcessorRelayRpcTarget<AgentProcessorState> {
+  return new ProcessorRelayRpcTarget<AgentProcessorState>({
+    auth: input.auth,
+    host: () =>
+      // Workers generates the concrete Agent DO stub, while the shared relay
+      // accepts the smaller processor-host surface. The DO implements that
+      // surface; the double assertion only bridges those RPC types.
+      env.AGENT.getByName(
+        DurableObjectNameCodec.stringify({
+          projectId: input.projectId,
+          path: input.path,
+        }),
+      ) as unknown as ProcessorHostStub,
   });
-  if (event === undefined) {
+}
+
+async function assertAgentCreated(input: {
+  auth: ItxAuth;
+  path: string;
+  projectId: string;
+}): Promise<void> {
+  const { state } = await agentProcessorRelay(input).snapshot();
+  if (state.birthCertificate === null) {
     throw new Error(`agent at "${input.path}" has not been created`);
-  }
-  if (event.type !== "events.iterate.com/agent/created") {
-    throw new Error(
-      `agent birth key on "${input.path}" names unexpected event type "${event.type}"`,
-    );
   }
 }
 
@@ -4371,7 +4387,11 @@ class AgentChatRpcTarget extends IterateRpcTarget<"AgentChat"> {
     message: string,
     options?: { files?: Array<{ contentType: string; data: FileData; filename: string }> },
   ): Promise<StreamEvent> {
-    await assertAgentCreated({ path: this.props.path, projectId: this.props.projectId });
+    await assertAgentCreated({
+      auth: this.props.auth,
+      path: this.props.path,
+      projectId: this.props.projectId,
+    });
     const trimmed = message.trim();
     if (trimmed === "") throw new Error("itx.chat.sendMessage requires a non-empty message.");
     const files =
@@ -4478,12 +4498,10 @@ class AgentRpcTarget extends IterateRpcTarget<"Agent"> {
 
   /** The agent stream processor (snapshot/state). */
   get processor(): StreamProcessorRpc<AgentProcessorState> {
-    return new ProcessorRelayRpcTarget<AgentProcessorState>({
+    return agentProcessorRelay({
       auth: this.#props.auth,
-      // Workers generates the concrete Agent DO stub, while the shared relay
-      // accepts the smaller processor-host surface. The DO implements that
-      // surface; the double assertion only bridges those RPC types.
-      host: () => this.durableObjectStub as unknown as ProcessorHostStub,
+      path: this.#path,
+      projectId: this.#props.projectId,
     });
   }
 
@@ -4770,7 +4788,11 @@ class AgentRpcTarget extends IterateRpcTarget<"Agent"> {
   }
 
   async #assertCreated(): Promise<void> {
-    await assertAgentCreated({ path: this.#path, projectId: this.#props.projectId });
+    await assertAgentCreated({
+      auth: this.#props.auth,
+      path: this.#path,
+      projectId: this.#props.projectId,
+    });
   }
 }
 
@@ -5311,7 +5333,6 @@ class CapabilityHostRpcTarget extends IterateRpcTarget<"CapabilityHost"> {
         await runCapabilityHostScript({
           command,
           path: this.#props.path,
-          projectId: this.#props.projectId,
           stream: this.#stream,
         }),
     });

--- a/packages/iterate/src/processors/stream-processor.ts
+++ b/packages/iterate/src/processors/stream-processor.ts
@@ -618,7 +618,9 @@ export abstract class StreamProcessor<
     // never loop back here, so they are not timed. A sibling retains rows
     // across deletion/recreation of the source path, so its committed key
     // includes the source lifetime; offset 1 from A and offset 1 from B are
-    // different causes and must both be able to land.
+    // different causes and must both be able to land. Idempotency keys are
+    // retry identities, not semantic entity identities: readers determine
+    // meaning from event types or reduced processor state, never key spelling.
     if (args.targetPath !== this.path) {
       events = events.map((event) =>
         event.idempotencyKey === undefined


### PR DESCRIPTION
## What changed

- resolve agent existence from the agent processor's reduced birth state
- find email-agent and capability-host births by semantic event type
- cover router-created Slack agents through the public agent append handle
- exercise capability-host creation with the source-lifetime-suffixed retry key emitted by `appendTo`
- document that idempotency keys are retry identities, not semantic entity identities

## Before

A router creates the destination agent through a sibling processor append. `appendTo` deliberately includes the source stream lifetime in every keyed sibling event so a recreated source stream can safely emit the same logical offset again.

The routed birth therefore lands as an event like:

```json
{
  "type": "events.iterate.com/agent/created",
  "idempotencyKey": "agent/created:prj_example:/agents/slack/T123/C456/TS789@source-stream:0454c123-8d42-4bda-9aed-54fe12853557",
  "payload": {
    "config": "..."
  }
}
```

The agent processor consumed that event and had a non-null birth certificate. However, the public agent RPC gate treated the canonical retry-key spelling as the agent's identity:

```ts
const event = await integrationStreamStub(projectId, path).getEvent({
  idempotencyKey: `agent/created:${projectId}:${path}`,
});

if (event === undefined) {
  throw new Error(`agent at "${path}" has not been created`);
}
```

That lookup asked for:

```text
agent/created:prj_example:/agents/slack/T123/C456/TS789
```

It could not match the durable event's source-lifetime-suffixed retry key. The resulting state was internally contradictory:

```text
stream birth event       present
agent processor state    born
agent collection         born
public agent append      throws "has not been created"
```

This was deterministic key mismatch, not a timing race or damaged Iterate project.

The same key-as-identity assumption also existed when resolving email-agent births and checking capability-host creation.

## After

Agent existence now comes from the authoritative reduced processor state:

```ts
const { state } = await agentProcessorRelay({ auth, path, projectId }).snapshot();

if (state.birthCertificate === null) {
  throw new Error(`agent at "${path}" has not been created`);
}
```

The processor snapshot catches up to the stream and answers the semantic question directly: did a valid agent birth reduce?

For consumers that need the birth event itself, email-agent and capability-host reads select the semantic event type instead of guessing its retry key:

```ts
const [created] = await stream.getEvents({
  eventTypes: [CREATED],
  limit: 1,
});

if (created === undefined) {
  throw new Error(`capability host at ${path} has not been created`);
}
```

The durable event is unchanged and still carries the correct source-lifetime retry identity:

```json
{
  "type": "events.iterate.com/agent/created",
  "idempotencyKey": "agent/created:prj_example:/agents/slack/T123/C456/TS789@source-stream:0454c123-8d42-4bda-9aed-54fe12853557"
}
```

But its meaning is now read from processor state or event type:

```text
stream birth event       present
agent processor state    born
agent collection         born
public agent append      succeeds
```

## Invariant

Idempotency keys identify append retries. They are not semantic entity IDs and readers must not depend on their spelling. The source comment beside `appendTo` now records that invariant.

This is a forward-only cleanup: there is no key parsing, fallback lookup, migration, or compatibility path.

Production incident: https://os.iterate.com/projects/iterate/streams/agents/slack/t0675psn873/c0bla09fhkl/ts-1785336227-189589

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm test`
- preview deploy + e2e: 64 Playwright tests passed; 48 Vitest files passed
- routed Slack regression: `slack-agent.e2e.test.ts` passed against the deployed preview worker in 31.4s

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how agent, email-agent, and capability-host "exists" gates work on public RPC paths; correctness fix for routed agents but touches core stream/agent boundaries.
> 
> **Overview**
> Fixes a production bug where **router-created agents** could be born in processor state but still fail public RPCs like `append` because gates looked up a **canonical** birth idempotency key while `appendTo` stores births with a `@source-stream:` suffix on that key.
> 
> **Agent existence** now uses the processor relay snapshot (`birthCertificate !== null`) instead of `getEvent` on `agent/created:${projectId}:${path}`. **Email-agent** and **capability-host** creation checks query the first matching **event type** via `getEvents` rather than assuming key spelling. `runCapabilityHostScript` drops the unused `projectId` parameter and extends the script stream type with `getEvents`.
> 
> Adds Slack e2e coverage that a routed agent can append through `project.agents.get(path)`, and unit tests that capability-host creation events carry source-lifetime-suffixed keys. Documents in `stream-processor` that idempotency keys are retry identities, not semantic entity IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35d456de0403aa4722a8dd778b5946ec57254c35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T16:47:01.271Z",
      "deployedAt": "2026-07-29T16:39:36.979Z",
      "headSha": "35d456de0403aa4722a8dd778b5946ec57254c35",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/225909571380958",
      "shortSha": "35d456d",
      "cleanupDurationMs": 20930,
      "deployDurationMs": 82234,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 81183,
      "deployReadinessDurationMs": 1047,
      "deployedWorkerName": "os-preview-3",
      "deployedWorkerVersion": "8880baed-2c30-4b55-99bd-5ef31e79d394",
      "testDurationMs": 210201,
      "testRetries": null,
      "workerSizeKib": 19935.33,
      "workerGzipKib": 5033.98,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5045.17
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-29T16:46:41.080Z",
      "deployedAt": "2026-07-29T16:38:36.878Z",
      "headSha": "35d456de0403aa4722a8dd778b5946ec57254c35",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/225909571380958",
      "shortSha": "35d456d",
      "cleanupDurationMs": 736,
      "deployDurationMs": 21282,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 21080,
      "deployReadinessDurationMs": 198,
      "deployedWorkerName": "semaphore-preview-3",
      "deployedWorkerVersion": "09fb4299-e02b-4c98-bccd-42b26a076198",
      "testDurationMs": 40851,
      "testRetries": null,
      "workerSizeKib": 1915.51,
      "workerGzipKib": 441.11,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T16:46:44.648Z",
      "deployedAt": "2026-07-29T16:38:42.640Z",
      "headSha": "35d456de0403aa4722a8dd778b5946ec57254c35",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/225909571380958",
      "shortSha": "35d456d",
      "cleanupDurationMs": 4300,
      "deployDurationMs": 27210,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 26841,
      "deployReadinessDurationMs": 365,
      "deployedWorkerName": "auth-preview-3",
      "deployedWorkerVersion": "46648a51-ac00-40eb-98af-69d3a49d569e",
      "testDurationMs": 12727,
      "testRetries": null,
      "workerSizeKib": 3978.26,
      "workerGzipKib": 814.56,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-29T16:46:48.124Z",
      "deployedAt": "2026-07-29T16:38:41.591Z",
      "headSha": "35d456de0403aa4722a8dd778b5946ec57254c35",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/225909571380958",
      "shortSha": "35d456d",
      "cleanupDurationMs": 7775,
      "deployDurationMs": 31391,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 25790,
      "deployReadinessDurationMs": 5594,
      "deployedWorkerName": "streams-example-app-preview-3",
      "deployedWorkerVersion": "933527a6-d253-4779-b50f-e453ababeb09",
      "testDurationMs": 84536,
      "testRetries": null,
      "workerSizeKib": 5257.06,
      "workerGzipKib": 1489,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T16:46:41.386Z",
      "deployedAt": "2026-07-29T16:05:35.657Z",
      "headSha": "35d456de0403aa4722a8dd778b5946ec57254c35",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/225909571380958",
      "shortSha": "35d456d",
      "cleanupDurationMs": 1034,
      "deployDurationMs": 220,
      "deployConfigDurationMs": 35,
      "deployReuseProofDurationMs": 182,
      "deployedWorkerName": "dummy-petshop-preview-3",
      "deployedWorkerVersion": "a3fec391-2691-4ee3-9bc0-96d9d7d43b7a",
      "testDurationMs": 11630,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+8d74450be93a83fb5cd1785d6e4e10d734e94acd",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `35d456d` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 814.6 KiB | 27.2s | 12.7s |  | 4.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/225909571380958) | 2026-07-29T16:46:44.648Z | Preview app released. |
| Dummy Petshop | released | `35d456d` | [https://dummy-petshop.iterate-preview-3.com](https://dummy-petshop.iterate-preview-3.com) | 198.3 KiB | 220ms | 11.6s |  | 1.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/225909571380958) | 2026-07-29T16:46:41.386Z | Preview app released. |
| OS | released | `35d456d` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 4.92 MiB (-11.2 KiB vs main) | 82.2s | 210.2s |  | 20.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/225909571380958) | 2026-07-29T16:47:01.271Z | Preview app released. |
| Semaphore | released | `35d456d` | [https://semaphore.iterate-preview-3.com](https://semaphore.iterate-preview-3.com) | 441.1 KiB | 21.3s | 40.9s |  | 736ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/225909571380958) | 2026-07-29T16:46:41.080Z | Preview app released. |
| Streams Example App | released | `35d456d` | [https://streams.iterate-preview-3.com](https://streams.iterate-preview-3.com) | 1.45 MiB | 31.4s | 84.5s |  | 7.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/225909571380958) | 2026-07-29T16:46:48.124Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +55 -31 | +40 -25 🟩🟩🟩🟥🟥 |
| Tests | +29 -5 | +25 -5 🟩🟩⬜⬜⬜ |
| **Total** | **+84 -36** | **+65 -30** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between b44a703 and 35d456d, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->