### PR TITLE
Acknowledge GitHub App permission updates

### DIFF
--- a/apps/os/src/domains/integrations/integration-api.test.ts
+++ b/apps/os/src/domains/integrations/integration-api.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "vitest";
+import { handleIntegrationApiRequest } from "./integration-api.ts";
+import type { RequestContext } from "~/request-context.ts";
+
+const unusedContext = {} as RequestContext;
+
+test("acknowledges a state-less GitHub App permission update", async () => {
+  const response = await handleIntegrationApiRequest({
+    auth: null,
+    context: unusedContext,
+    request: new Request(
+      "https://os.iterate.com/api/integrations/github/callback?code=ignored&installation_id=115079265&setup_action=update",
+    ),
+  });
+
+  expect(response?.status).toBe(200);
+  expect(await response?.text()).toBe("GitHub App permissions updated. You can close this tab.");
+});
+
+test("still rejects a state-less GitHub project connection callback", async () => {
+  const response = await handleIntegrationApiRequest({
+    auth: null,
+    context: unusedContext,
+    request: new Request(
+      "https://os.iterate.com/api/integrations/github/callback?installation_id=115079265&setup_action=install",
+    ),
+  });
+
+  expect(response?.status).toBe(400);
+  expect(await response?.json()).toEqual({ error: "Missing OAuth state." });
+});

--- a/apps/os/src/domains/integrations/integration-api.ts
+++ b/apps/os/src/domains/integrations/integration-api.ts
@@ -55,6 +55,20 @@ async function handleOAuthCallback(input: {
   const error = url.searchParams.get("error");
   const state = url.searchParams.get("state");
 
+  // GitHub revisits the App's setup URL after an administrator accepts new
+  // permissions. That update is already complete and is not an Iterate
+  // connection attempt, so it has no project-bound OAuth state to verify.
+  if (
+    input.provider === "github" &&
+    !state &&
+    url.searchParams.get("setup_action") === "update" &&
+    url.searchParams.get("installation_id")
+  ) {
+    return new Response("GitHub App permissions updated. You can close this tab.", {
+      headers: { "content-type": "text/plain; charset=utf-8" },
+    });
+  }
+
   if (!state) return Response.json({ error: "Missing OAuth state." }, { status: 400 });
   const unverified = parseOAuthStateUnverified(state);
   if (!unverified || unverified.provider !== input.provider) {


### PR DESCRIPTION
## What changed

- Recognize the state-less `setup_action=update` callback GitHub sends after an administrator accepts new App permissions.
- Return a small completion page for that callback.
- Keep project installation and connection callbacks behind the existing signed-state check.
- Add regression coverage for both cases.

## Root cause

GitHub revisits the App setup URL after a permission update without OS-minted OAuth state. OS treated that administrative completion callback as a project connection callback and returned `Missing OAuth state`.

## Impact

GitHub App permission updates now finish with a clear success page without weakening project-bound OAuth state validation.

## Validation

- `pnpm --dir apps/os exec vitest run src/domains/integrations/integration-api.test.ts --reporter=default`
- `pnpm --dir apps/os typecheck`
- Targeted oxlint and oxfmt checks
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow early-return on a specific GitHub callback shape; project-bound OAuth state checks for installs and connections are unchanged.
> 
> **Overview**
> Fixes GitHub OAuth callbacks that arrive **without** signed state after an admin accepts new App permissions (`setup_action=update` with `installation_id`). Those hits used to fail with **Missing OAuth state** because they are not project connection flows.
> 
> `handleOAuthCallback` now returns a **200** plain-text success message for that pattern only. State-less **install** callbacks and all other GitHub connect paths still require OAuth state and behave as before.
> 
> Regression tests cover the permission-update success path and that state-less install is still rejected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d84dfc603221bd54d25523929c42f506c0a255a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T16:08:22.491Z",
      "deployedAt": "2026-07-29T16:01:16.785Z",
      "headSha": "d84dfc603221bd54d25523929c42f506c0a255a2",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-18.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/453685529979345",
      "shortSha": "d84dfc6",
      "cleanupDurationMs": 10208,
      "deployDurationMs": 83858,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 82615,
      "deployReadinessDurationMs": 1240,
      "deployedWorkerName": "os-preview-18",
      "deployedWorkerVersion": "0ce0ba4a-c081-4106-bb29-705d58bb9db9",
      "testDurationMs": 323383,
      "testRetries": "1 retried: invalid receiver-specific combinations and expressions never commit (vitest x1) — waitUntilProcessed timed out after 90000ms waiting for offset 7",
      "workerSizeKib": 19935.24,
      "workerGzipKib": 5034.23,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5044.73
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T16:08:15.349Z",
      "deployedAt": "2026-07-29T16:00:23.056Z",
      "headSha": "d84dfc603221bd54d25523929c42f506c0a255a2",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-18.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/453685529979345",
      "shortSha": "d84dfc6",
      "cleanupDurationMs": 3064,
      "deployDurationMs": 29201,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 28884,
      "deployReadinessDurationMs": 314,
      "deployedWorkerName": "auth-preview-18",
      "deployedWorkerVersion": "74ce6573-0387-4036-93b6-9e61079a3261",
      "testDurationMs": 11747,
      "testRetries": null,
      "workerSizeKib": 3980.14,
      "workerGzipKib": 814.96,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T16:08:13.654Z",
      "deployedAt": "2026-07-29T16:00:04.443Z",
      "headSha": "d84dfc603221bd54d25523929c42f506c0a255a2",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-18.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/453685529979345",
      "shortSha": "d84dfc6",
      "cleanupDurationMs": 1367,
      "deployDurationMs": 10505,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 10217,
      "deployReadinessDurationMs": 232,
      "deployedWorkerName": "dummy-petshop-preview-18",
      "deployedWorkerVersion": "c2258964-c4bf-4656-8443-4ec37571f5d0",
      "testDurationMs": 21087,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+8d74450be93a83fb5cd1785d6e4e10d734e94acd",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `d84dfc6` | [https://auth.iterate-preview-18.com](https://auth.iterate-preview-18.com) | 815.0 KiB | 29.2s | 11.7s |  | 3.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/453685529979345) | 2026-07-29T16:08:15.349Z | Preview app released. |
| Dummy Petshop | released | `d84dfc6` | [https://dummy-petshop.iterate-preview-18.com](https://dummy-petshop.iterate-preview-18.com) | 198.3 KiB | 10.5s | 21.1s |  | 1.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/453685529979345) | 2026-07-29T16:08:13.654Z | Preview app released. |
| OS | released | `d84dfc6` | [https://os.iterate-preview-18.com](https://os.iterate-preview-18.com) | 4.92 MiB (-10.5 KiB vs main) | 83.9s | 323.4s | 1 retried: invalid receiver-specific combinations and expressions never commit (vitest x1) — waitUntilProcessed timed out after 90000ms waiting for offset 7 | 10.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/453685529979345) | 2026-07-29T16:08:22.491Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +14 -0 | +10 -0 🟩🟩⬜⬜⬜ |
| Tests | +31 -0 | +25 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+45 -0** | **+35 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between dc057d5 and d84dfc6, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->