### PR TITLE
auth: ES256-only signing — retire EdDSA (single-key JWKS + mint)

### DIFF
--- a/apps/auth/scripts/deploy.ts
+++ b/apps/auth/scripts/deploy.ts
@@ -28,10 +28,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createBuiltInPrompts, createCli, isAgent, yamlTableConsoleLogger } from "trpc-cli";
 import { authEnvs } from "../../../envs.ts";
-import {
-  authSigningEs256PrivateJwkForEnvironment,
-  authSigningPrivateJwkForEnvironment,
-} from "../../../scripts/lib/bake-auth-jwks.ts";
+import { authSigningEs256PrivateJwkForEnvironment } from "../../../scripts/lib/bake-auth-jwks.ts";
 import { deployApp } from "../../../scripts/lib/deploy-app.ts";
 import { run } from "../../../scripts/lib/deploy-helpers.ts";
 import { DEFAULT_ADMIN_ALLOWLIST } from "../src/config.ts";
@@ -63,19 +60,9 @@ export default async function deploy(
     // projectDirectoryKvId is not auth's concern.
     resources: (env) => ({ authDbId: env.resources.authDbId }),
     requiredSecrets: REQUIRED_SECRETS,
-    // Optional ES256 signing key: shipped to the worker only when the env's
-    // Doppler config carries it. Its presence flips id/access token signing to
-    // ES256 (for Cloudflare Access), keeping the Ed25519 public key in the JWKS.
-    optionalSecrets: ["AUTH_FORGE_ES256_PRIVATE_JWK"],
     prepare: (ctx, secretValues, credentials) => {
-      // Validate the fixed signing key and the production-key opt-in
-      // before migrations or any other deployed state can change.
-      authSigningPrivateJwkForEnvironment({
-        dopplerConfig: ctx.env.dopplerConfig,
-        envName: ctx.name,
-        secrets: ctx.secrets,
-      });
-      // Validate the optional ES256 key's shape now (no-op when unset).
+      // Validate the single ES256 signing key's shape and the production-key
+      // opt-in before migrations or any other deployed state can change.
       authSigningEs256PrivateJwkForEnvironment({
         dopplerConfig: ctx.env.dopplerConfig,
         envName: ctx.name,

--- a/apps/auth/scripts/generate-wrangler-config.ts
+++ b/apps/auth/scripts/generate-wrangler-config.ts
@@ -38,9 +38,9 @@ export const LOCAL_DEV_AUTH_DB_ID = "local-dev-auth-db";
  * `deploy.ts` fails before deploying when the Doppler config is missing one.
  */
 export const REQUIRED_SECRETS = [
-  // One Doppler-owned key signs Auth JWTs; relying-party deploys derive only
+  // The single ES256 key signs Auth JWTs; relying-party deploys derive only
   // its public half, so they never wait for Auth's live JWKS endpoint.
-  "AUTH_FORGE_PRIVATE_JWK",
+  "AUTH_FORGE_ES256_PRIVATE_JWK",
   "APP_CONFIG_BETTER_AUTH_SECRET",
   "APP_CONFIG_EMAIL_SENDER_DOMAIN",
   "APP_CONFIG_GOOGLE_CLIENT_ID",

--- a/apps/auth/src/config.ts
+++ b/apps/auth/src/config.ts
@@ -1,9 +1,6 @@
 import { parseAppConfigFromEnv, publicValue, redacted, Redacted } from "@iterate-com/shared/config";
 import { z } from "zod/v4";
-import {
-  parseAuthSigningEs256PrivateJwk,
-  parseAuthSigningPrivateJwk,
-} from "../../../scripts/lib/bake-auth-jwks.ts";
+import { parseAuthSigningEs256PrivateJwk } from "../../../scripts/lib/bake-auth-jwks.ts";
 
 /**
  * Default glob allowlist promoting matching emails to platform admin.
@@ -68,14 +65,12 @@ export const AppConfig = z.object({
 });
 
 export type AppConfig = z.output<typeof AppConfig> & {
-  /** Doppler-owned Ed25519 key used by Better Auth to sign JWTs. */
-  authSigningPrivateJwk: Redacted<string>;
   /**
-   * Optional Doppler-owned ES256 (P-256) key. When present, Better Auth signs
-   * new id/access tokens with it (Cloudflare Access rejects EdDSA) while the
-   * Ed25519 public key stays in the JWKS for existing verifiers.
+   * The single Doppler-owned ES256 (P-256) key Better Auth signs every JWT
+   * with. ES256 is the sole algorithm (Cloudflare Access rejects EdDSA); its
+   * public half is the only key in the JWKS.
    */
-  authSigningEs256PrivateJwk?: Redacted<string>;
+  authSigningEs256PrivateJwk: Redacted<string>;
 };
 
 /**
@@ -85,19 +80,12 @@ export type AppConfig = z.output<typeof AppConfig> & {
  */
 export function parseConfig(env: unknown): AppConfig {
   const rawEnv = env as Record<string, unknown>;
-  const privateJwk = rawEnv.AUTH_FORGE_PRIVATE_JWK;
-  if (typeof privateJwk !== "string" || privateJwk.trim() === "") {
-    throw new Error("AUTH_FORGE_PRIVATE_JWK is required");
+  const es256PrivateJwk = rawEnv.AUTH_FORGE_ES256_PRIVATE_JWK;
+  if (typeof es256PrivateJwk !== "string" || es256PrivateJwk.trim() === "") {
+    throw new Error("AUTH_FORGE_ES256_PRIVATE_JWK is required");
   }
-  parseAuthSigningPrivateJwk(privateJwk);
-
-  // Optional ES256 key: validate its shape now (fail fast) when present.
-  const es256PrivateJwkRaw = rawEnv.AUTH_FORGE_ES256_PRIVATE_JWK;
-  const es256PrivateJwk =
-    typeof es256PrivateJwkRaw === "string" && es256PrivateJwkRaw.trim() !== ""
-      ? es256PrivateJwkRaw
-      : undefined;
-  if (es256PrivateJwk) parseAuthSigningEs256PrivateJwk(es256PrivateJwk);
+  // Validate its shape now (fail fast).
+  parseAuthSigningEs256PrivateJwk(es256PrivateJwk);
 
   return {
     ...parseAppConfigFromEnv({
@@ -105,7 +93,6 @@ export function parseConfig(env: unknown): AppConfig {
       prefix: "APP_CONFIG_",
       env: rawEnv,
     }),
-    authSigningPrivateJwk: new Redacted(privateJwk),
-    ...(es256PrivateJwk ? { authSigningEs256PrivateJwk: new Redacted(es256PrivateJwk) } : {}),
+    authSigningEs256PrivateJwk: new Redacted(es256PrivateJwk),
   };
 }

--- a/apps/auth/src/server/auth-jwt.test.ts
+++ b/apps/auth/src/server/auth-jwt.test.ts
@@ -4,9 +4,9 @@ import { betterAuth } from "better-auth";
 import { createLocalJWKSet, exportJWK, generateKeyPair, jwtVerify } from "jose";
 import { authJwt } from "./auth-jwt.ts";
 
-test("signs and publishes the same Doppler-owned key", async () => {
-  const { privateKey } = await generateKeyPair("EdDSA", { crv: "Ed25519", extractable: true });
-  const privateJwk = { ...(await exportJWK(privateKey)), alg: "EdDSA", kid: "from-doppler" };
+test("signs ES256 and publishes the single Doppler-owned key", async () => {
+  const { privateKey } = await generateKeyPair("ES256", { extractable: true });
+  const privateJwk = { ...(await exportJWK(privateKey)), alg: "ES256", kid: "from-doppler" };
   const auth = betterAuth({
     baseURL: "https://auth.example.com",
     secret: "test-secret-at-least-thirty-two-characters",
@@ -15,58 +15,19 @@ test("signs and publishes the same Doppler-owned key", async () => {
 
   const { token } = await auth.api.signJWT({ body: { payload: { sub: "usr_test" } } });
   const jwks = await auth.api.getJwks();
-  const verified = await jwtVerify(token, createLocalJWKSet(jwks));
 
+  // Exactly one key is published, and it does not carry the private component.
   assert.equal(jwks.keys.length, 1);
   assert.equal(Object.hasOwn(jwks.keys[0]!, "d"), false);
   assert.equal(jwks.keys[0]!.kid, "from-doppler");
-  assert.equal(verified.protectedHeader.kid, "from-doppler");
-  assert.equal(verified.payload.sub, "usr_test");
-});
+  assert.equal(jwks.keys[0]!.alg, "ES256");
 
-test("with an ES256 key, signs ES256 and publishes both public keys", async () => {
-  const { privateKey: edPrivateKey } = await generateKeyPair("EdDSA", {
-    crv: "Ed25519",
-    extractable: true,
-  });
-  const edPrivateJwk = {
-    ...(await exportJWK(edPrivateKey)),
-    alg: "EdDSA",
-    kid: "ed25519-from-doppler",
-  };
-  const { privateKey: ecPrivateKey } = await generateKeyPair("ES256", { extractable: true });
-  const es256PrivateJwk = {
-    ...(await exportJWK(ecPrivateKey)),
-    alg: "ES256",
-    kid: "es256-from-doppler",
-  };
-
-  const auth = betterAuth({
-    baseURL: "https://auth.example.com",
-    secret: "test-secret-at-least-thirty-two-characters",
-    plugins: [authJwt(JSON.stringify(edPrivateJwk), JSON.stringify(es256PrivateJwk))],
-  });
-
-  const { token } = await auth.api.signJWT({ body: { payload: { sub: "usr_test" } } });
-  const jwks = await auth.api.getJwks();
-
-  // Both public keys are published; neither carries the private component.
-  assert.equal(jwks.keys.length, 2);
-  assert.equal(
-    jwks.keys.every((k) => !Object.hasOwn(k, "d")),
-    true,
-  );
-  const kids = jwks.keys.map((k) => k.kid).sort();
-  assert.deepEqual(kids, ["ed25519-from-doppler", "es256-from-doppler"]);
-  const algs = jwks.keys.map((k) => k.alg).sort();
-  assert.deepEqual(algs, ["ES256", "EdDSA"]);
-
-  // The token is signed with the ES256 key (newest), and verifies against the
-  // published JWKS by kid — exactly what jose relying parties (and Cloudflare
-  // Access, which only accepts ES*/RS*/PS*) do.
+  // The token is signed ES256 and verifies against the published JWKS by kid —
+  // exactly what jose relying parties (and Cloudflare Access, which only
+  // accepts ES*/RS*/PS*) do.
   assert.equal(token.split(".").length, 3);
   const verified = await jwtVerify(token, createLocalJWKSet(jwks));
   assert.equal(verified.protectedHeader.alg, "ES256");
-  assert.equal(verified.protectedHeader.kid, "es256-from-doppler");
+  assert.equal(verified.protectedHeader.kid, "from-doppler");
   assert.equal(verified.payload.sub, "usr_test");
 });

--- a/apps/auth/src/server/auth-jwt.ts
+++ b/apps/auth/src/server/auth-jwt.ts
@@ -1,67 +1,38 @@
 import { jwt } from "better-auth/plugins";
-import {
-  parseAuthSigningEs256PrivateJwk,
-  parseAuthSigningPrivateJwk,
-} from "../../../../scripts/lib/bake-auth-jwks.ts";
+import { parseAuthSigningEs256PrivateJwk } from "../../../../scripts/lib/bake-auth-jwks.ts";
 
 export type AuthJwtPlugin = ReturnType<typeof jwt>;
 
 /**
- * Better Auth JWT plugin backed by the immutable key(s) supplied by Doppler.
- *
- * The Ed25519 (EdDSA) key is always present. When an ES256 (P-256) key is also
- * supplied, it is returned as the *newest* key: better-auth's signJWT signs with
- * the latest key by `createdAt`, so new id_tokens and access tokens are signed
- * with ES256 while both public keys stay in the JWKS. This exists because
- * Cloudflare Access's generic-OIDC verifier accepts only RS/ES/PS-family — never
- * EdDSA. jose relying parties (OS, CLI, kernel) select the verification key by
- * `kid` from the JWKS, so they keep verifying without change.
+ * Better Auth JWT plugin backed by the single immutable ES256 (P-256) key
+ * supplied by Doppler (`AUTH_FORGE_ES256_PRIVATE_JWK`). ES256 is the sole
+ * signing algorithm: Cloudflare Access's generic-OIDC verifier accepts only
+ * RS/ES/PS-family id_token signatures — never EdDSA. All id_tokens and access
+ * tokens are signed with it, and its public half is the only key in the JWKS.
+ * jose relying parties (OS, CLI, kernel) select the verification key by `kid`.
  */
-export function authJwt(privateJwkJson: string, es256PrivateJwkJson?: string): AuthJwtPlugin {
-  const { d, ...publicJwk } = parseAuthSigningPrivateJwk(privateJwkJson);
-  const ed25519Key = {
+export function authJwt(es256PrivateJwkJson: string): AuthJwtPlugin {
+  const { d, ...publicJwk } = parseAuthSigningEs256PrivateJwk(es256PrivateJwkJson);
+  const es256Key = {
     id: publicJwk.kid,
-    alg: "EdDSA" as const,
-    crv: "Ed25519" as const,
+    alg: "ES256" as const,
+    crv: "P-256" as const,
     publicKey: JSON.stringify(publicJwk),
     privateKey: JSON.stringify({ ...publicJwk, d }),
-    // Epoch 0 keeps the Ed25519 key strictly older than any ES256 key below, so
-    // when both exist getLatestKey picks ES256.
     createdAt: new Date(0),
   };
-
-  const es256Key = es256PrivateJwkJson
-    ? (() => {
-        const { d: es256D, ...es256PublicJwk } =
-          parseAuthSigningEs256PrivateJwk(es256PrivateJwkJson);
-        return {
-          id: es256PublicJwk.kid,
-          alg: "ES256" as const,
-          crv: "P-256" as const,
-          publicKey: JSON.stringify(es256PublicJwk),
-          privateKey: JSON.stringify({ ...es256PublicJwk, d: es256D }),
-          // Newer than the Ed25519 key so signJWT signs new tokens with ES256.
-          createdAt: new Date(1),
-        };
-      })()
-    : null;
-
-  // getJwks returns every key: the JWKS route publishes each public half (with
-  // its own alg/crv/kid), and signJWT signs with the newest.
-  const keys = es256Key ? [es256Key, ed25519Key] : [ed25519Key];
 
   return jwt({
     jwks: {
       disablePrivateKeyEncryption: true,
       // keyPairConfig.alg drives the discovery doc's
-      // id_token_signing_alg_values_supported. Advertise ES256 whenever the
-      // ES256 key is the one new tokens are signed with; otherwise EdDSA.
-      // ES256's curve (P-256) is implicit in better-auth's JWKOptions type
-      // (crv is `never` for ES256); the actual P-256 key comes from the JWK.
-      keyPairConfig: es256Key ? { alg: "ES256" } : { alg: "EdDSA", crv: "Ed25519" },
+      // id_token_signing_alg_values_supported. ES256's curve (P-256) is
+      // implicit in better-auth's JWKOptions type (crv is `never` for ES256);
+      // the actual P-256 key comes from the JWK.
+      keyPairConfig: { alg: "ES256" },
     },
     adapter: {
-      getJwks: async () => keys,
+      getJwks: async () => [es256Key],
       createJwk: async () => {
         throw new Error("Auth JWT signing keys are rotated in Doppler, not generated at runtime");
       },

--- a/apps/auth/src/server/auth.ts
+++ b/apps/auth/src/server/auth.ts
@@ -53,10 +53,7 @@ export const auth = betterAuth({
   baseURL: config.authAppOrigin,
   plugins: getAuthPlugins({
     authAppOrigin: config.authAppOrigin,
-    jwtPlugin: authJwt(
-      config.authSigningPrivateJwk.exposeSecret(),
-      config.authSigningEs256PrivateJwk?.exposeSecret(),
-    ),
+    jwtPlugin: authJwt(config.authSigningEs256PrivateJwk.exposeSecret()),
     emailOtpEnabled: config.emailOtpEnabled,
     fixedTestOtpEnabled: config.fixedTestOtpEnabled,
     emailBinding: env.EMAIL,

--- a/apps/auth/src/server/env.ts
+++ b/apps/auth/src/server/env.ts
@@ -27,14 +27,18 @@ export interface CloudflareEnv {
   APP_CONFIG_PUBLIC_URL?: string;
   /** better-auth signing secret (sessions, JWTs, project-ingress tokens). */
   APP_CONFIG_BETTER_AUTH_SECRET: string;
-  /** Doppler-owned Ed25519 key used for OAuth/OIDC JWT signatures. */
-  AUTH_FORGE_PRIVATE_JWK: string;
   /**
-   * Optional Doppler-owned ES256 (P-256) key. When set, new id/access tokens
-   * are signed with it (Cloudflare Access rejects EdDSA); the Ed25519 public
-   * key stays in the JWKS so existing verifiers keep working.
+   * The single Doppler-owned ES256 (P-256) key used for OAuth/OIDC JWT
+   * signatures. Cloudflare Access rejects EdDSA, so ES256 is the sole
+   * algorithm; its public half is the only key in the JWKS.
    */
-  AUTH_FORGE_ES256_PRIVATE_JWK?: string;
+  AUTH_FORGE_ES256_PRIVATE_JWK: string;
+  /**
+   * Retired Ed25519 key. No longer read by the worker (ES256 is the sole
+   * signing key); the Doppler secret may still be present, so the binding is
+   * kept optional to avoid a shape mismatch.
+   */
+  AUTH_FORGE_PRIVATE_JWK?: string;
   /** Dedicated project-app-session signing secret, shared with os for local
    * verification. Optional: unset falls back to APP_CONFIG_BETTER_AUTH_SECRET. */
   APP_CONFIG_PROJECT_APP_SESSION_SECRET?: string;

--- a/apps/mobile/e2e/chat-roundtrip.e2e.test.ts
+++ b/apps/mobile/e2e/chat-roundtrip.e2e.test.ts
@@ -47,7 +47,7 @@ test("phone client seam: new mobile chat gets a live agent reply", async () => {
 
   // The phone lane: bearer token over the app's own dial.
   const token = await mintForgedAccessToken({
-    forgePrivateJwk: requireEnv("AUTH_FORGE_PRIVATE_JWK"),
+    forgePrivateJwk: requireEnv("AUTH_FORGE_ES256_PRIVATE_JWK"),
     issuer: requireEnv("APP_CONFIG_ITERATE_AUTH__ISSUER"),
     audience: process.env.APP_CONFIG_ITERATE_AUTH__RESOURCE?.trim() || portlessOrigin(baseUrl),
     email: "mobile-e2e@nustom.com",

--- a/apps/mobile/e2e/example-runner.e2e.test.ts
+++ b/apps/mobile/e2e/example-runner.e2e.test.ts
@@ -26,7 +26,7 @@ test("phone example runner: egress-rules-configured runs for real against a real
   const { projectId } = await created.__describe();
 
   const token = await mintForgedAccessToken({
-    forgePrivateJwk: requireEnv("AUTH_FORGE_PRIVATE_JWK"),
+    forgePrivateJwk: requireEnv("AUTH_FORGE_ES256_PRIVATE_JWK"),
     issuer: requireEnv("APP_CONFIG_ITERATE_AUTH__ISSUER"),
     audience: process.env.APP_CONFIG_ITERATE_AUTH__RESOURCE?.trim() || portlessOrigin(baseUrl),
     email: "mobile-examples-e2e@nustom.com",

--- a/apps/os/scripts/generate-wrangler-config.test.ts
+++ b/apps/os/scripts/generate-wrangler-config.test.ts
@@ -14,18 +14,21 @@ import {
 
 it("does not emit the local forge JWKS into deployed builds", () => {
   const forgePrivateJwk = JSON.stringify({
-    kty: "OKP",
+    kty: "EC",
     kid: "test-forge",
-    crv: "Ed25519",
-    alg: "EdDSA",
-    x: "public-key",
+    crv: "P-256",
+    alg: "ES256",
+    x: "public-x",
+    y: "public-y",
     d: "private-key",
   });
 
   expect(localDevAuthJwks({ forgePrivateJwk, deployedEnv: "prd" })).toBeUndefined();
   expect(localDevAuthJwks({ forgePrivateJwk, deployedEnv: undefined })).toBe(
     JSON.stringify({
-      keys: [{ kty: "OKP", kid: "test-forge", crv: "Ed25519", alg: "EdDSA", x: "public-key" }],
+      keys: [
+        { kty: "EC", kid: "test-forge", crv: "P-256", alg: "ES256", x: "public-x", y: "public-y" },
+      ],
     }),
   );
 });

--- a/apps/os/scripts/generate-wrangler-config.ts
+++ b/apps/os/scripts/generate-wrangler-config.ts
@@ -501,7 +501,7 @@ function localDevBindings() {
     ...authBinding,
   });
   const localAuthJwks = localDevAuthJwks({
-    forgePrivateJwk: process.env.AUTH_FORGE_PRIVATE_JWK,
+    forgePrivateJwk: process.env.AUTH_FORGE_ES256_PRIVATE_JWK,
     deployedEnv: process.env.CLOUDFLARE_ENV,
   });
   return {
@@ -529,8 +529,8 @@ function localDevBindings() {
           }
         : {}),
       // Local dev trusts forge-minted sessions by deriving the public key from
-      // AUTH_FORGE_PRIVATE_JWK. Do not read APP_CONFIG_ITERATE_AUTH__JWKS from
-      // Doppler here: stale snapshots caused login verification failures.
+      // AUTH_FORGE_ES256_PRIVATE_JWK. Do not read APP_CONFIG_ITERATE_AUTH__JWKS
+      // from Doppler here: stale snapshots caused login verification failures.
       ...(localAuthJwks ? { APP_CONFIG_ITERATE_AUTH__JWKS: localAuthJwks } : {}),
     },
   };
@@ -555,7 +555,7 @@ export function localDevAuthJwks(input: {
   return bakeStaticAuthJwks({
     envName: "dev",
     dopplerConfig: process.env.DOPPLER_CONFIG ?? "local dev",
-    secrets: { AUTH_FORGE_PRIVATE_JWK: forgePrivateJwk },
+    secrets: { AUTH_FORGE_ES256_PRIVATE_JWK: forgePrivateJwk },
   });
 }
 

--- a/apps/streams-example-app/e2e/auth.ts
+++ b/apps/streams-example-app/e2e/auth.ts
@@ -26,10 +26,10 @@ export function resolveDeployedEnv(workerUrl: string | undefined) {
 export async function mintAdminAccessToken(workerUrl: string | undefined) {
   const env = resolveDeployedEnv(workerUrl);
   if (!env) return null;
-  const forgePrivateJwk = process.env.AUTH_FORGE_PRIVATE_JWK?.trim();
+  const forgePrivateJwk = process.env.AUTH_FORGE_ES256_PRIVATE_JWK?.trim();
   if (!forgePrivateJwk) {
     throw new Error(
-      "AUTH_FORGE_PRIVATE_JWK is required to run e2e against a deployed playground. " +
+      "AUTH_FORGE_ES256_PRIVATE_JWK is required to run e2e against a deployed playground. " +
         "Run under the env's Doppler config (doppler run --project streams-example-app --config <env> -- ...).",
     );
   }
@@ -49,11 +49,11 @@ export async function mintAdminAccessToken(workerUrl: string | undefined) {
 export async function mintAdminBrowserTokens(workerUrl: string | undefined) {
   const env = resolveDeployedEnv(workerUrl);
   if (!env) return null;
-  const forgePrivateJwk = process.env.AUTH_FORGE_PRIVATE_JWK?.trim();
+  const forgePrivateJwk = process.env.AUTH_FORGE_ES256_PRIVATE_JWK?.trim();
   const clientId = process.env.APP_CONFIG_ITERATE_AUTH__CLIENT_ID?.trim();
   if (!forgePrivateJwk || !clientId) {
     throw new Error(
-      "AUTH_FORGE_PRIVATE_JWK and APP_CONFIG_ITERATE_AUTH__CLIENT_ID are required to run browser " +
+      "AUTH_FORGE_ES256_PRIVATE_JWK and APP_CONFIG_ITERATE_AUTH__CLIENT_ID are required to run browser " +
         "e2e against a deployed playground. Run under the env's Doppler config.",
     );
   }

--- a/scripts/auth/forge-token.ts
+++ b/scripts/auth/forge-token.ts
@@ -12,13 +12,15 @@ import {
  * must authenticate against a relying-party worker (os, semaphore).
  *
  * Auth signs JWTs with the private half from Doppler
- * (AUTH_FORGE_PRIVATE_JWK), and relying-party deploys trust its derived public
- * half. This signs with that same key fully offline, with no auth worker call.
+ * (AUTH_FORGE_ES256_PRIVATE_JWK), and relying-party deploys trust its derived
+ * public half. This signs with that same key fully offline, with no auth
+ * worker call. The algorithm is read from the JWK's `alg`, so it follows the
+ * key (ES256).
  */
 
 /** Inputs for one forge-signed access token (the bearer credential relying parties verify). */
 export interface ForgeAccessTokenInput {
-  /** The forge private JWK as its JSON string (Doppler AUTH_FORGE_PRIVATE_JWK). */
+  /** The forge private JWK as its JSON string (Doppler AUTH_FORGE_ES256_PRIVATE_JWK). */
   forgePrivateJwk: string;
   /** Token issuer — the env's auth issuer, e.g. https://auth.iterate.com/api/auth */
   issuer: string;

--- a/scripts/auth/generate-forge-key.ts
+++ b/scripts/auth/generate-forge-key.ts
@@ -15,9 +15,10 @@ import { exportJWK, generateKeyPair } from "jose";
 //
 //   pnpm tsx scripts/auth/generate-forge-key.ts --kid iterate-forge-prd
 //
-// Store the printed JWK as AUTH_FORGE_PRIVATE_JWK in the target Doppler config
-// (for prod, also set AUTH_FORGE_ALLOW_PRODUCTION=true). The deploy strips the
-// private `d` field before shipping the public half — nothing else to do.
+// Store the printed JWK as AUTH_FORGE_ES256_PRIVATE_JWK in the target Doppler
+// config (for prod, also set AUTH_FORGE_ALLOW_PRODUCTION=true). The deploy
+// strips the private `d` field before shipping the public half — nothing else
+// to do.
 
 const { values: args } = parseArgs({
   options: {
@@ -30,13 +31,13 @@ if (args.help || !args.kid) {
   console.log(
     "Usage: pnpm tsx scripts/auth/generate-forge-key.ts --kid <key-id>\n" +
       "  e.g. --kid iterate-forge-prd\n\n" +
-      "Prints a private Ed25519 JWK to stdout. Store it as AUTH_FORGE_PRIVATE_JWK\n" +
-      "in the target Doppler config.",
+      "Prints a private ES256 (P-256) JWK to stdout. Store it as\n" +
+      "AUTH_FORGE_ES256_PRIVATE_JWK in the target Doppler config.",
   );
   process.exit(args.kid ? 0 : 1);
 }
 
-const { privateKey } = await generateKeyPair("EdDSA", { crv: "Ed25519", extractable: true });
+const { privateKey } = await generateKeyPair("ES256", { extractable: true });
 const jwk = await exportJWK(privateKey);
 
 // Order matches the existing keys for easy diffing; alg/kid are what the mint
@@ -45,9 +46,10 @@ const forgeJwk = {
   crv: jwk.crv,
   d: jwk.d,
   x: jwk.x,
+  y: jwk.y,
   kty: jwk.kty,
   kid: args.kid,
-  alg: "EdDSA",
+  alg: "ES256",
 };
 
 console.log(JSON.stringify(forgeJwk));

--- a/scripts/auth/mint-session.ts
+++ b/scripts/auth/mint-session.ts
@@ -7,7 +7,7 @@ import { forgedSubjectForEmail, mintForgedAccessToken, mintForgedIdToken } from 
 // Mint an OS session for any identity — dev, preview, and production.
 //
 // Auth and every relying party use one environment signing key whose private
-// half lives in Doppler (`AUTH_FORGE_PRIVATE_JWK`, from `_shared/dev` /
+// half lives in Doppler (`AUTH_FORGE_ES256_PRIVATE_JWK`, from `_shared/dev` /
 // `_shared/preview` and the prd app configs). This script signs an access+id
 // token pair with that key — fully offline, no auth worker involved — so you
 // can be any user instantly. The key is a master key; in prod it is gated
@@ -104,10 +104,10 @@ function resolveBaseUrl(): string {
   );
 }
 
-const forgePrivateJwkJson = process.env.AUTH_FORGE_PRIVATE_JWK?.trim();
+const forgePrivateJwkJson = process.env.AUTH_FORGE_ES256_PRIVATE_JWK?.trim();
 if (!forgePrivateJwkJson) {
   throw new Error(
-    "AUTH_FORGE_PRIVATE_JWK is not in the environment. Run under a Doppler config that carries " +
+    "AUTH_FORGE_ES256_PRIVATE_JWK is not in the environment. Run under a Doppler config that carries " +
       "the forge key — dev, preview, or prd (e.g. `doppler run --project os --config dev -- pnpm auth:mint ...`). " +
       "Prod additionally requires AUTH_FORGE_ALLOW_PRODUCTION=true in each consuming app's deploy config.",
   );

--- a/scripts/auth/semaphore-token.ts
+++ b/scripts/auth/semaphore-token.ts
@@ -8,7 +8,7 @@ import { mintForgedAccessToken } from "./forge-token.ts";
  * Semaphore sits behind the same apps/auth relying-party auth as os, so CLIs
  * authenticate with a real identity: an explicit pre-minted bearer token via
  * SEMAPHORE_API_TOKEN, else an admin access token forge-minted offline from
- * AUTH_FORGE_PRIVATE_JWK (the same mechanism as `pnpm auth:mint`).
+ * AUTH_FORGE_ES256_PRIVATE_JWK (the same mechanism as `pnpm auth:mint`).
  */
 
 /** Resolve the auth issuer for a deployed semaphore base URL via the root envs.ts. */
@@ -50,11 +50,11 @@ export function createSemaphoreTokenProvider(input: {
     if (explicit) return Promise.resolve(explicit);
 
     minted ??= (async () => {
-      const forgePrivateJwk = env.AUTH_FORGE_PRIVATE_JWK?.trim();
+      const forgePrivateJwk = env.AUTH_FORGE_ES256_PRIVATE_JWK?.trim();
       if (!forgePrivateJwk) {
         throw new Error(
           "Authenticating against semaphore needs SEMAPHORE_API_TOKEN (a pre-minted bearer token) " +
-            "or AUTH_FORGE_PRIVATE_JWK in the environment. Run under a Doppler config that carries " +
+            "or AUTH_FORGE_ES256_PRIVATE_JWK in the environment. Run under a Doppler config that carries " +
             "the forge key (e.g. `doppler run --project _shared --config prd`).",
         );
       }

--- a/scripts/lib/bake-auth-jwks.test.ts
+++ b/scripts/lib/bake-auth-jwks.test.ts
@@ -1,25 +1,35 @@
 import { describe, expect, it } from "vitest";
-import { bakeStaticAuthJwks, parseAuthSigningPrivateJwk } from "./bake-auth-jwks.ts";
+import { bakeStaticAuthJwks, parseAuthSigningEs256PrivateJwk } from "./bake-auth-jwks.ts";
 
 const privateJwk = {
-  alg: "EdDSA",
-  crv: "Ed25519",
+  alg: "ES256",
+  crv: "P-256",
   d: "private",
   kid: "auth-signing",
-  kty: "OKP",
-  x: "public",
+  kty: "EC",
+  x: "public-x",
+  y: "public-y",
 };
 
 describe("bakeStaticAuthJwks", () => {
-  it("derives the public JWKS from the Doppler-owned private key", () => {
+  it("derives the public ES256 JWKS from the Doppler-owned private key", () => {
     const baked = bakeStaticAuthJwks({
       dopplerConfig: "preview_1",
       envName: "preview_1",
-      secrets: { AUTH_FORGE_PRIVATE_JWK: JSON.stringify(privateJwk) },
+      secrets: { AUTH_FORGE_ES256_PRIVATE_JWK: JSON.stringify(privateJwk) },
     });
 
     expect(JSON.parse(baked)).toEqual({
-      keys: [{ alg: "EdDSA", crv: "Ed25519", kid: "auth-signing", kty: "OKP", x: "public" }],
+      keys: [
+        {
+          alg: "ES256",
+          crv: "P-256",
+          kid: "auth-signing",
+          kty: "EC",
+          x: "public-x",
+          y: "public-y",
+        },
+      ],
     });
   });
 
@@ -28,16 +38,16 @@ describe("bakeStaticAuthJwks", () => {
       bakeStaticAuthJwks({
         dopplerConfig: "prd",
         envName: "prd",
-        secrets: { AUTH_FORGE_PRIVATE_JWK: JSON.stringify(privateJwk) },
+        secrets: { AUTH_FORGE_ES256_PRIVATE_JWK: JSON.stringify(privateJwk) },
       }),
     ).toThrow(/AUTH_FORGE_ALLOW_PRODUCTION=true/);
   });
 });
 
-describe("parseAuthSigningPrivateJwk", () => {
-  it("rejects a public-only or non-Ed25519 key", () => {
+describe("parseAuthSigningEs256PrivateJwk", () => {
+  it("rejects a public-only or non-ES256 key", () => {
     expect(() =>
-      parseAuthSigningPrivateJwk(JSON.stringify({ ...privateJwk, d: undefined })),
-    ).toThrow(/private Ed25519 JWK/);
+      parseAuthSigningEs256PrivateJwk(JSON.stringify({ ...privateJwk, d: undefined })),
+    ).toThrow(/private ES256 \(P-256\) JWK/);
   });
 });

--- a/scripts/lib/bake-auth-jwks.ts
+++ b/scripts/lib/bake-auth-jwks.ts
@@ -1,51 +1,3 @@
-/**
- * One Doppler-owned Ed25519 key signs Auth JWTs and lets relying-party deploys
- * derive the matching public JWKS without waiting for a deployed Auth worker.
- * The private half is shipped only to Auth; OS, Semaphore, and Streams receive
- * only the derived public key.
- */
-export type AuthSigningPrivateJwk = Record<string, unknown> & {
-  alg: "EdDSA";
-  crv: "Ed25519";
-  d: string;
-  kid: string;
-  kty: "OKP";
-  x: string;
-};
-
-export function parseAuthSigningPrivateJwk(value: string): AuthSigningPrivateJwk {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(value) as unknown;
-  } catch (error) {
-    throw new Error("AUTH_FORGE_PRIVATE_JWK must be valid JSON", { cause: error });
-  }
-
-  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-    throw new Error(
-      "AUTH_FORGE_PRIVATE_JWK must be a private Ed25519 JWK with alg, crv, d, kid, kty, and x",
-    );
-  }
-  const candidate = parsed as Record<string, unknown>;
-  if (
-    candidate.alg !== "EdDSA" ||
-    candidate.crv !== "Ed25519" ||
-    typeof candidate.d !== "string" ||
-    candidate.d.length === 0 ||
-    typeof candidate.kid !== "string" ||
-    candidate.kid.length === 0 ||
-    candidate.kty !== "OKP" ||
-    typeof candidate.x !== "string" ||
-    candidate.x.length === 0
-  ) {
-    throw new Error(
-      "AUTH_FORGE_PRIVATE_JWK must be a private Ed25519 JWK with alg, crv, d, kid, kty, and x",
-    );
-  }
-
-  return parsed as AuthSigningPrivateJwk;
-}
-
 type AuthSigningEnvironment = {
   /** The env name from envs.ts, e.g. "prd" or "preview_3". */
   envName: string;
@@ -55,34 +7,13 @@ type AuthSigningEnvironment = {
   secrets: Record<string, string | undefined>;
 };
 
-export function authSigningPrivateJwkForEnvironment(
-  input: AuthSigningEnvironment,
-): AuthSigningPrivateJwk {
-  const privateJwkJson = input.secrets.AUTH_FORGE_PRIVATE_JWK?.trim();
-  if (!privateJwkJson) {
-    throw new Error(`${input.dopplerConfig} is missing AUTH_FORGE_PRIVATE_JWK`);
-  }
-
-  if (input.envName === "prd") {
-    const allowProduction = /^(1|true|yes)$/i.test(input.secrets.AUTH_FORGE_ALLOW_PRODUCTION ?? "");
-    if (!allowProduction) {
-      throw new Error(
-        `AUTH_FORGE_PRIVATE_JWK is present in ${input.dopplerConfig} (production-serving) without ` +
-          "AUTH_FORGE_ALLOW_PRODUCTION=true. Set the flag to deliberately authorize production " +
-          "Auth signing and offline identity minting.",
-      );
-    }
-  }
-
-  return parseAuthSigningPrivateJwk(privateJwkJson);
-}
-
 /**
- * Optional second signing key: an ES256 (P-256) private JWK. Cloudflare Access's
- * generic-OIDC verifier only accepts RS/ES/PS-family id_token signatures — never
- * EdDSA — so when this key is present Auth signs new id/access tokens with ES256
- * (see auth-jwt.ts) while still publishing the Ed25519 public key. jose relying
- * parties select the verification key by `kid`, so both algorithms verify.
+ * The single ES256 (P-256) private JWK that signs Auth JWTs and lets
+ * relying-party deploys derive the matching public JWKS without waiting for a
+ * deployed Auth worker. The private half is shipped only to Auth; OS,
+ * Semaphore, and Streams receive only the derived public key. ES256 is the
+ * sole algorithm: Cloudflare Access's generic-OIDC verifier accepts only
+ * RS/ES/PS-family id_token signatures — never EdDSA.
  */
 export type AuthSigningEs256PrivateJwk = Record<string, unknown> & {
   alg: "ES256";
@@ -130,27 +61,40 @@ export function parseAuthSigningEs256PrivateJwk(value: string): AuthSigningEs256
 }
 
 /**
- * The ES256 signing key for an environment, or null when the env has no
- * `AUTH_FORGE_ES256_PRIVATE_JWK`. Optional so envs that have not adopted the
- * second key keep signing EdDSA-only.
+ * The single ES256 signing key for an environment. Required: every env that
+ * serves Auth (or bakes a relying-party JWKS) must carry
+ * `AUTH_FORGE_ES256_PRIVATE_JWK`. Production is additionally gated behind
+ * `AUTH_FORGE_ALLOW_PRODUCTION=true` — the same fail-closed opt-in that
+ * protected the Ed25519 key — because holding this key allows offline identity
+ * minting against production.
  */
 export function authSigningEs256PrivateJwkForEnvironment(
   input: AuthSigningEnvironment,
-): AuthSigningEs256PrivateJwk | null {
+): AuthSigningEs256PrivateJwk {
   const privateJwkJson = input.secrets.AUTH_FORGE_ES256_PRIVATE_JWK?.trim();
-  if (!privateJwkJson) return null;
+  if (!privateJwkJson) {
+    throw new Error(`${input.dopplerConfig} is missing AUTH_FORGE_ES256_PRIVATE_JWK`);
+  }
+
+  if (input.envName === "prd") {
+    const allowProduction = /^(1|true|yes)$/i.test(input.secrets.AUTH_FORGE_ALLOW_PRODUCTION ?? "");
+    if (!allowProduction) {
+      throw new Error(
+        `AUTH_FORGE_ES256_PRIVATE_JWK is present in ${input.dopplerConfig} (production-serving) without ` +
+          "AUTH_FORGE_ALLOW_PRODUCTION=true. Set the flag to deliberately authorize production " +
+          "Auth signing and offline identity minting.",
+      );
+    }
+  }
+
   return parseAuthSigningEs256PrivateJwk(privateJwkJson);
 }
 
 export function bakeStaticAuthJwks(input: AuthSigningEnvironment): string {
-  const { d: _privateKey, ...publicJwk } = authSigningPrivateJwkForEnvironment(input);
-  // When the env also carries an ES256 key, publish its public half so relying
-  // parties (OS, Semaphore) that verify tokens against this baked JWKS accept
-  // the ES256-signed tokens Auth now issues, selecting the key by `kid`.
+  // ES256 is the sole signing key: publish only its public half. Relying
+  // parties (OS, Semaphore) verify tokens against this baked JWKS, selecting
+  // the key by `kid`.
   const es256 = authSigningEs256PrivateJwkForEnvironment(input);
-  if (es256) {
-    const { d: _es256Private, ...es256Public } = es256;
-    return JSON.stringify({ keys: [es256Public, publicJwk] });
-  }
-  return JSON.stringify({ keys: [publicJwk] });
+  const { d: _es256Private, ...es256Public } = es256;
+  return JSON.stringify({ keys: [es256Public] });
 }

--- a/specs/test-support/forged-session.ts
+++ b/specs/test-support/forged-session.ts
@@ -28,8 +28,8 @@ const OsPlaywrightAuthEnv = z.object({
   APP_CONFIG_ITERATE_AUTH__CLIENT_ID: z.string().min(1),
   /** Auth issuer used for both forged access and id tokens. */
   APP_CONFIG_ITERATE_AUTH__ISSUER: z.url(),
-  /** Private half of the Auth signing key whose public half OS trusts. */
-  AUTH_FORGE_PRIVATE_JWK: z
+  /** Private half of the ES256 Auth signing key whose public half OS trusts. */
+  AUTH_FORGE_ES256_PRIVATE_JWK: z
     .string()
     .min(1)
     .refine((value) => {
@@ -262,7 +262,7 @@ async function loadOsPlaywrightAuthConfig(): Promise<OsPlaywrightAuthConfig> {
   return {
     adminApiSecret: env.APP_CONFIG_ADMIN_API_SECRET,
     clientId: env.APP_CONFIG_ITERATE_AUTH__CLIENT_ID,
-    forgePrivateJwk: env.AUTH_FORGE_PRIVATE_JWK,
+    forgePrivateJwk: env.AUTH_FORGE_ES256_PRIVATE_JWK,
     issuer: env.APP_CONFIG_ITERATE_AUTH__ISSUER,
   };
 }


### PR DESCRIPTION
## What & why

Follow-up to #2346 (which added optional ES256 alongside EdDSA). This makes **ES256 the sole signing key** and **retires EdDSA entirely** — the clean single-key end state. After this, `auth.iterate.com`'s JWKS publishes **one** key (ES256), and EdDSA (`AUTH_FORGE_PRIVATE_JWK`) is no longer used for signing, JWKS, or minting.

## The one subtlety: offline minting

The EdDSA key wasn't only for OIDC tokens — it also signs **offline minted sessions** (`auth:mint`, all the forged-session e2e fixtures, semaphore/streams/mobile e2e), and those minted tokens are **verified against the same baked JWKS** by `kid` (`apps/auth/src/lib/server.ts` `createLocalJWKSet` + `jwtVerify`). So naively dropping EdDSA from the JWKS would break all mint tooling.

The fix is trivial: `scripts/auth/forge-token.ts` already reads `alg` from the JWK, so pointing the ~6 mint entry points at `AUTH_FORGE_ES256_PRIVATE_JWK` makes minted tokens **ES256** — verified fine by the ES256-only JWKS. One key now signs everything (OIDC + mint).

## Changes (19 files, +150 −282)

- **`scripts/lib/bake-auth-jwks.ts`** — publish only the ES256 public key; `authSigningEs256PrivateJwkForEnvironment` is now **required** and carries the fail-closed prod opt-in gate (`AUTH_FORGE_ALLOW_PRODUCTION`); the EdDSA type/parser/accessor are deleted.
- **`apps/auth/src/server/auth-jwt.ts`** — single required ES256 key, `keyPairConfig { alg: "ES256" }` (drives discovery `id_token_signing_alg_values_supported: ["ES256"]`).
- **`apps/auth/src/{config.ts, server/env.ts, server/auth.ts}`**, **`apps/auth/scripts/{deploy.ts, generate-wrangler-config.ts}`** — `AUTH_FORGE_ES256_PRIVATE_JWK` becomes the required signing secret; EdDSA field/checks dropped.
- **Mint entry points** — `scripts/auth/{mint-session,semaphore-token}.ts`, `specs/test-support/forged-session.ts`, `apps/streams-example-app/e2e/auth.ts`, `apps/mobile/e2e/{chat-roundtrip,example-runner}.e2e.test.ts`, `apps/os/scripts/generate-wrangler-config.ts` (local-dev JWKS) — read the ES256 key. `forge-token.ts` needed no code change.
- **`scripts/auth/generate-forge-key.ts`** — emits an ES256 P-256 JWK.
- **3 test files** updated to the ES256-only shape.

## Rollout

Redeploy **auth + os + semaphore + streams-example-app** (each re-bakes its JWKS ES256-only). **Existing EdDSA sessions stop verifying → forced re-login** — intentional and accepted; new sign-ins and re-minted sessions are ES256. No deploy-ordering needed. The `AUTH_FORGE_PRIVATE_JWK` Doppler secret is left in place (unused by signing now; a couple of preview/sync scripts still reference its *name*) — deleting it from Doppler is an optional further cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes production authentication signing and JWKS trust for every relying party; existing EdDSA tokens stop verifying after deploy (forced re-login), and misconfigured Doppler ES256 keys would break login and mint tooling.
> 
> **Overview**
> Makes **ES256 the only** Auth JWT signing algorithm and **drops EdDSA** from signing, JWKS baking, deploy secrets, and offline mint. **`AUTH_FORGE_ES256_PRIVATE_JWK`** is required everywhere **`AUTH_FORGE_PRIVATE_JWK`** used to be; the baked JWKS publishes **one** ES256 public key.
> 
> **Auth worker:** `auth-jwt.ts` wires a single ES256 key into Better Auth (`keyPairConfig` advertises ES256 in discovery). `config.ts` and deploy/wrangler required secrets no longer validate or ship the Ed25519 key; `env.ts` keeps an optional `AUTH_FORGE_PRIVATE_JWK` binding only so stale Doppler bindings do not break shape.
> 
> **JWKS baking:** `bake-auth-jwks.ts` deletes the Ed25519 parser/accessor and requires ES256 with the same production **`AUTH_FORGE_ALLOW_PRODUCTION`** gate.
> 
> **Relying parties & tooling:** OS local-dev JWKS derivation, `auth:mint`, semaphore/streams/mobile e2e, Playwright forged sessions, and **`generate-forge-key.ts`** (now emits ES256 P-256) all read the ES256 secret. `forge-token.ts` already signs with the JWK’s `alg`, so minted tokens stay verifiable against the ES256-only JWKS.
> 
> **Rollout note:** After redeploying auth + apps that re-bake JWKS, **existing EdDSA-issued sessions/tokens will not verify** — users re-login or re-mint; no special deploy ordering beyond redeploying consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dba3eab9777158cf779aaf5e1c9c0f368b5b2f65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +39 -80 | +15 -46 🟩🟥🟥⬜⬜ |
| Mobile | +2 -2 | +2 -2 🟩⬜⬜⬜⬜ |
| Tests | +44 -70 | +40 -62 🟩🟩🟥🟥🟥 |
| CI & scripts | +62 -127 | +28 -76 🟩🟥🟥🟥🟥 |
| Other | +3 -3 | +2 -2 🟩⬜⬜⬜⬜ |
| **Total** | **+150 -282** | **+87 -188** 🟩🟩🟥🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between dc057d5 and dba3eab, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T16:29:45.228Z",
      "deployedAt": "2026-07-29T16:24:15.008Z",
      "headSha": "dba3eab9777158cf779aaf5e1c9c0f368b5b2f65",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-10.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/244818740924669",
      "shortSha": "dba3eab",
      "cleanupDurationMs": 13317,
      "deployDurationMs": 39786,
      "deployConfigDurationMs": 1,
      "deployCommandDurationMs": 38677,
      "deployReadinessDurationMs": 1107,
      "deployedWorkerName": "os-preview-10",
      "deployedWorkerVersion": "9280b4d6-bec2-4ffd-86e5-77c82908fa99",
      "testDurationMs": 225360,
      "testRetries": "1 retried: agent runs an itx script that appends a proof event, then replies (vitest x1) — expected [ 'stream/created', …(29) ] to include 'capability-host/script-run-settled'",
      "workerSizeKib": 19934.96,
      "workerGzipKib": 5034.12,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5044.84
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-29T16:29:32.624Z",
      "deployedAt": "2026-07-29T16:15:51.428Z",
      "headSha": "dba3eab9777158cf779aaf5e1c9c0f368b5b2f65",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-10.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/244818740924669",
      "shortSha": "dba3eab",
      "cleanupDurationMs": 710,
      "deployDurationMs": 14957,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 14754,
      "deployReadinessDurationMs": 199,
      "deployedWorkerName": "semaphore-preview-10",
      "deployedWorkerVersion": "630097ae-635f-4728-81dd-4c2ddf712d33",
      "testDurationMs": 23037,
      "testRetries": null,
      "workerSizeKib": 1915.51,
      "workerGzipKib": 441.11,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T16:29:35.264Z",
      "deployedAt": "2026-07-29T16:23:56.893Z",
      "headSha": "dba3eab9777158cf779aaf5e1c9c0f368b5b2f65",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-10.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/244818740924669",
      "shortSha": "dba3eab",
      "cleanupDurationMs": 3349,
      "deployDurationMs": 21070,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 20558,
      "deployReadinessDurationMs": 507,
      "deployedWorkerName": "auth-preview-10",
      "deployedWorkerVersion": "067dcfe6-508f-400e-b996-abb5b2434c90",
      "testDurationMs": 10165,
      "testRetries": null,
      "workerSizeKib": 3978.26,
      "workerGzipKib": 814.53,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-29T16:29:39.347Z",
      "deployedAt": "2026-07-29T16:15:51.313Z",
      "headSha": "dba3eab9777158cf779aaf5e1c9c0f368b5b2f65",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-10.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/244818740924669",
      "shortSha": "dba3eab",
      "cleanupDurationMs": 7429,
      "deployDurationMs": 54756,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 14636,
      "deployReadinessDurationMs": 40114,
      "deployedWorkerName": "streams-example-app-preview-10",
      "deployedWorkerVersion": "561fc51f-7f38-42b9-9dbe-8d1212269ab1",
      "testDurationMs": 49350,
      "testRetries": null,
      "workerSizeKib": 5257.05,
      "workerGzipKib": 1488.96,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T16:29:32.782Z",
      "deployedAt": "2026-07-29T16:15:43.083Z",
      "headSha": "dba3eab9777158cf779aaf5e1c9c0f368b5b2f65",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-10.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/244818740924669",
      "shortSha": "dba3eab",
      "cleanupDurationMs": 861,
      "deployDurationMs": 64,
      "deployConfigDurationMs": 5,
      "deployReuseProofDurationMs": 30,
      "deployedWorkerName": "dummy-petshop-preview-10",
      "deployedWorkerVersion": "787590f1-ef0b-4957-be72-d04acd6c00ce",
      "testDurationMs": 5741,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+8d74450be93a83fb5cd1785d6e4e10d734e94acd",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `dba3eab` | [https://auth.iterate-preview-10.com](https://auth.iterate-preview-10.com) | 814.5 KiB | 21.1s | 10.2s |  | 3.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/244818740924669) | 2026-07-29T16:29:35.264Z | Preview app released. |
| Dummy Petshop | released | `dba3eab` | [https://dummy-petshop.iterate-preview-10.com](https://dummy-petshop.iterate-preview-10.com) | 198.3 KiB | 64ms | 5.7s |  | 861ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/244818740924669) | 2026-07-29T16:29:32.782Z | Preview app released. |
| OS | released | `dba3eab` | [https://os.iterate-preview-10.com](https://os.iterate-preview-10.com) | 4.92 MiB (-10.7 KiB vs main) | 39.8s | 225.4s | 1 retried: agent runs an itx script that appends a proof event, then replies (vitest x1) — expected [ 'stream/created', …(29) ] to include 'capability-host/script-run-settled' | 13.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/244818740924669) | 2026-07-29T16:29:45.228Z | Preview app released. |
| Semaphore | released | `dba3eab` | [https://semaphore.iterate-preview-10.com](https://semaphore.iterate-preview-10.com) | 441.1 KiB | 15.0s | 23.0s |  | 710ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/244818740924669) | 2026-07-29T16:29:32.624Z | Preview app released. |
| Streams Example App | released | `dba3eab` | [https://streams.iterate-preview-10.com](https://streams.iterate-preview-10.com) | 1.45 MiB | 54.8s | 49.4s |  | 7.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/244818740924669) | 2026-07-29T16:29:39.347Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->