### PR TITLE
Fix six small e2e reliability defects

### DIFF
--- a/apps/os/e2e/vitest/agent-codemode-fence.itx.e2e.test.ts
+++ b/apps/os/e2e/vitest/agent-codemode-fence.itx.e2e.test.ts
@@ -11,6 +11,7 @@
  * user-visible message never went out.
  */
 import { test } from "vitest";
+import { ScriptExecutionSettlement } from "../../src/domains/capability-host/script-execution-settlement.ts";
 import { createTestProject } from "../test-support/create-test-project.ts";
 import { waitForCondition } from "../test-support/wait-for-condition.ts";
 import { appendSyntheticProviderOutput } from "./itx-test-support.ts";
@@ -31,29 +32,34 @@ test(
       `  await itx.chat.sendMessage("Tail (${marker}):\\n\`\`\`text\\n" + "0123456789".slice(-4) + "\\n\`\`\`");`,
       "}",
     ].join("\n");
-    await appendSyntheticProviderOutput(
+    const { assistantContext } = await appendSyntheticProviderOutput(
       agent.stream,
       `Reading the saved output now.\n\n\`\`\`ts\n${script}\n\`\`\``,
     );
+    const executionId = `agent-output:${assistantContext.offset}`;
 
-    // Sync on the script finishing, keeping its error (if any) so a
-    // regression reports the actual script failure instead of a poll timeout.
-    let completionError: string | null = null;
+    // Sync on this synthetic reply's exact script. Other work can settle on the
+    // same agent stream, so the first settlement is not a completion boundary
+    // for this request.
+    let settlement: ReturnType<typeof ScriptExecutionSettlement.parse> | undefined;
     await waitForCondition(
       async () => {
         const events = await agent.stream.getEvents({
           eventTypes: ["events.iterate.com/capability-host/script-run-settled"],
           limit: 100,
         });
-        const completion = events.at(0);
+        const completion = events.find((event) => event.payload?.executionId === executionId);
         if (completion === undefined) return false;
-        completionError =
-          typeof completion.payload?.error === "string" ? completion.payload.error : null;
+        settlement = ScriptExecutionSettlement.parse(completion.payload?.settlement);
         return true;
       },
-      { description: "the agent's script to finish", intervalMs: 1_000, timeoutMs: 120_000 },
+      {
+        description: `the agent's script ${executionId} to finish`,
+        intervalMs: 1_000,
+        timeoutMs: 120_000,
+      },
     );
-    expect(completionError).toBeNull();
+    expect(settlement).toMatchObject({ status: "succeeded" });
 
     // The user-visible outcome: the exact message the script sent, fence and
     // all — proof the code AFTER the embedded ``` executed.

--- a/apps/os/e2e/vitest/integrations-github.e2e.test.ts
+++ b/apps/os/e2e/vitest/integrations-github.e2e.test.ts
@@ -34,16 +34,18 @@ import {
   shouldSkipPetshopE2e,
 } from "./petshop-support.ts";
 
-const RUN = crypto.randomUUID().slice(0, 8);
-
 // Local runs opt in explicitly; preview CI supplies its leased Petshop URL
 // and fails closed if orchestration ever drops it.
 test.skipIf(shouldSkipPetshopE2e())(
   "bring-your-own App: mint installation token in the Secret DO, act as the installation, re-mint on expiry",
   async () => {
+    // Vitest retries re-enter this callback. Keep the project, Secret, App,
+    // installation, and keypair in one fresh attempt-local identity so durable
+    // write-only state can never be paired with a later attempt's public key.
+    const run = crypto.randomUUID().slice(0, 8);
     const petshop = petshopBaseUrl();
-    const appId = `gh-app-${RUN}`;
-    const installationId = `gh-inst-${RUN}`;
+    const appId = `gh-app-${run}`;
+    const installationId = `gh-inst-${run}`;
 
     // The App keypair. Its PRIVATE half (PKCS#8 PEM) goes into the connection
     // secret's material and is only ever signed with inside the DO; its PUBLIC
@@ -57,10 +59,10 @@ test.skipIf(shouldSkipPetshopE2e())(
 
     using session = withItxSession();
     using itx = session.authenticate({ type: "admin-secret", secret: adminSecret() });
-    using project = await itx.projects.get(`github-${RUN}`).create({});
+    using project = await itx.projects.get(`github-${run}`).create({});
     await project.__describe();
 
-    const connectionPath = `/secrets/integrations/mygithub-${RUN}/acme`;
+    const connectionPath = `/secrets/integrations/mygithub-${run}/acme`;
 
     // Connection secret: the App private key in material, the installation to
     // act as in the strategy config (the installation id is public). Egress is

--- a/apps/os/e2e/vitest/integrations-petshop.e2e.test.ts
+++ b/apps/os/e2e/vitest/integrations-petshop.e2e.test.ts
@@ -28,7 +28,6 @@ import {
   shouldSkipPetshopE2e,
 } from "./petshop-support.ts";
 
-const RUN = crypto.randomUUID().slice(0, 8);
 const REDIRECT_URI = "https://example.com/callback";
 
 // Local runs can opt in by pointing PETSHOP_BASE_URL at a fixture. Preview CI
@@ -37,6 +36,9 @@ const REDIRECT_URI = "https://example.com/callback";
 test.skipIf(shouldSkipPetshopE2e())(
   "two OAuth clients, two connections: connect, call, forced-expiry refresh",
   async () => {
+    // A retry must not remint clients while reusing durable write-only Secret
+    // state. Give the complete provider/project fixture a fresh identity.
+    const run = crypto.randomUUID().slice(0, 8);
     const petshop = petshopBaseUrl();
     // Both instances get a unique project-owned (userspace) client. Their
     // credentials live IN each connection secret's material, next to the
@@ -44,13 +46,13 @@ test.skipIf(shouldSkipPetshopE2e())(
     // seeded client is reserved for the concurrently running first-party test.
     const [clientA, clientB] = await Promise.all([petshopMintClient(), petshopMintClient()]);
     const instances = [
-      { ...clientA, slug: `petshop-home-${RUN}`, connection: "jonas" },
-      { ...clientB, slug: `petshop-work-${RUN}`, connection: "ops" },
+      { ...clientA, slug: `petshop-home-${run}`, connection: "jonas" },
+      { ...clientB, slug: `petshop-work-${run}`, connection: "ops" },
     ];
 
     using session = withItxSession();
     using itx = session.authenticate({ type: "admin-secret", secret: adminSecret() });
-    using project = await itx.projects.get(`petshop-${RUN}`).create({});
+    using project = await itx.projects.get(`petshop-${run}`).create({});
     await project.__describe();
 
     for (const instance of instances) {
@@ -124,14 +126,15 @@ test.skipIf(shouldSkipPetshopE2e())(
 test.skipIf(shouldSkipPetshopE2e())(
   "first-party lane: client credential resolves from platform config, same strategy",
   async () => {
+    const run = crypto.randomUUID().slice(0, 8);
     const petshop = petshopBaseUrl();
-    const slug = `petshop-firstparty-${RUN}`;
+    const slug = `petshop-firstparty-${run}`;
     const connectionPath = `/secrets/integrations/${slug}/acme`;
     const { clientId, clientSecret } = PETSHOP_DEFAULT_CLIENT;
 
     using session = withItxSession();
     using itx = session.authenticate({ type: "admin-secret", secret: adminSecret() });
-    using project = await itx.projects.get(`petshop-fp-${RUN}`).create({});
+    using project = await itx.projects.get(`petshop-fp-${run}`).create({});
     await project.__describe();
 
     const code = await petshopAuthorize({ clientId, redirectUri: REDIRECT_URI });

--- a/apps/os/e2e/vitest/integrations-userspace.e2e.test.ts
+++ b/apps/os/e2e/vitest/integrations-userspace.e2e.test.ts
@@ -18,9 +18,10 @@ import { startEgressEcho } from "./itx-capability-fixtures.ts";
 import { petshopBaseUrl, petshopExpireTokens, shouldSkipPetshopE2e } from "./petshop-support.ts";
 import { adminSecret, withItxSession } from "./test-helpers.ts";
 
-const RUN_SUFFIX = crypto.randomUUID().slice(0, 8);
-
 test("a project mounts ocado into the collection; connections + secret confinement hold", async () => {
+  // Vitest retries re-enter this callback. Keep durable project/Secret names
+  // attempt-local with the echo origin they authorize.
+  const runSuffix = crypto.randomUUID().slice(0, 8);
   const echo = await startEgressEcho();
   try {
     using session = withItxSession();
@@ -28,7 +29,7 @@ test("a project mounts ocado into the collection; connections + secret confineme
       type: "admin-secret",
       secret: adminSecret(),
     });
-    using project = await itx.projects.get(`ocado-${RUN_SUFFIX}`).create({});
+    using project = await itx.projects.get(`ocado-${runSuffix}`).create({});
     await project.__describe();
     const integrations = project.integrations as any;
 
@@ -78,8 +79,8 @@ test("a project mounts ocado into the collection; connections + secret confineme
     // Two connections of one integration, secrets at the same fully
     // qualified paths a built-in would use.
     const secrets = {
-      family: `ocado-session-family-${RUN_SUFFIX}`,
-      mum: `ocado-session-mum-${RUN_SUFFIX}`,
+      family: `ocado-session-family-${runSuffix}`,
+      mum: `ocado-session-mum-${runSuffix}`,
     };
     for (const [connection, material] of Object.entries(secrets)) {
       using secret = project.secrets.get(`/secrets/integrations/ocado/${connection}/session`);
@@ -188,9 +189,10 @@ test("a project mounts ocado into the collection; connections + secret confineme
 // the grammar guard, per-connection __describe (the connect recipe lives
 // there), and a loud method miss out of the replayed client.
 test("builtin waitrose: grammar, __describe, and method-miss stay loud", async () => {
+  const runSuffix = crypto.randomUUID().slice(0, 8);
   using session = withItxSession();
   using itx = session.authenticate({ type: "admin-secret", secret: adminSecret() });
-  using project = await itx.projects.get(`waitrose-builtin-${RUN_SUFFIX}`).create({});
+  using project = await itx.projects.get(`waitrose-builtin-${runSuffix}`).create({});
   await project.__describe();
   const integrations = project.integrations as any;
 
@@ -238,12 +240,13 @@ test("builtin waitrose: grammar, __describe, and method-miss stay loud", async (
 test.skipIf(shouldSkipPetshopE2e())(
   "waitrose-session strategy: username/password secret mints on first use, re-mints on 401, session works on the API",
   async () => {
+    const runSuffix = crypto.randomUUID().slice(0, 8);
     const petshop = petshopBaseUrl();
-    const username = `mum-${RUN_SUFFIX}@example.com`;
+    const username = `mum-${runSuffix}@example.com`;
 
     using session = withItxSession();
     using itx = session.authenticate({ type: "admin-secret", secret: adminSecret() });
-    using project = await itx.projects.get(`waitrose-live-${RUN_SUFFIX}`).create({});
+    using project = await itx.projects.get(`waitrose-live-${runSuffix}`).create({});
     await project.__describe();
 
     // The connection secret: the account credential and NOTHING token-shaped.

--- a/apps/os/e2e/vitest/itx-egress.e2e.test.ts
+++ b/apps/os/e2e/vitest/itx-egress.e2e.test.ts
@@ -160,16 +160,26 @@ test("an in-flight refresh cannot resurrect material after an egress event", asy
   });
 
   using probe = egressProbeWorker(project);
-  const request = probe.probeFetch({
-    headerValue: `Bearer getSecret("${secretPath}", { field: "accessToken" })`,
-    url: `${provider.url}/resource`,
-  });
-  await refreshStarted;
-  await project.streams.get(secretPath).append({
-    type: "events.iterate.com/secret/updated",
-    payload: { egress: { urls: [attacker.url] } },
-  });
-  releaseRefresh();
+  const request = Promise.resolve(
+    probe.probeFetch({
+      headerValue: `Bearer getSecret("${secretPath}", { field: "accessToken" })`,
+      url: `${provider.url}/resource`,
+    }),
+  );
+  try {
+    await waitForBarrierOrRequest({
+      barrier: refreshStarted,
+      description: "the OAuth refresh request to reach its provider",
+      request,
+      timeoutMs: 30_000,
+    });
+    await project.streams.get(secretPath).append({
+      type: "events.iterate.com/secret/updated",
+      payload: { egress: { urls: [attacker.url] } },
+    });
+  } finally {
+    releaseRefresh();
+  }
 
   await expect(request).resolves.toEqual({ stale: true });
   expect(await secret.__describe()).toMatchObject({
@@ -225,16 +235,26 @@ test("a repeated refresh event before its snapshot cannot resurrect material", a
   });
 
   using probe = egressProbeWorker(project);
-  const request = probe.probeFetch({
-    headerValue: `Bearer getSecret("${secretPath}", { field: "accessToken" })`,
-    url: `${provider.url}/resource`,
-  });
-  await resourceStarted;
-  await project.streams.get(secretPath).append({
-    type: "events.iterate.com/secret/updated",
-    payload: { refresh },
-  });
-  releaseResource();
+  const request = Promise.resolve(
+    probe.probeFetch({
+      headerValue: `Bearer getSecret("${secretPath}", { field: "accessToken" })`,
+      url: `${provider.url}/resource`,
+    }),
+  );
+  try {
+    await waitForBarrierOrRequest({
+      barrier: resourceStarted,
+      description: "the resource request to reach its provider",
+      request,
+      timeoutMs: 30_000,
+    });
+    await project.streams.get(secretPath).append({
+      type: "events.iterate.com/secret/updated",
+      payload: { refresh },
+    });
+  } finally {
+    releaseResource();
+  }
 
   await expect(request).resolves.toEqual({ stale: true });
   expect(tokenRequests).toBe(0);
@@ -575,3 +595,38 @@ test("Project egress intercept catches explicit and worker fetches before secret
     await echo.close();
   }
 });
+
+async function waitForBarrierOrRequest({
+  barrier,
+  description,
+  request,
+  timeoutMs,
+}: {
+  barrier: Promise<void>;
+  description: string;
+  request: Promise<unknown>;
+  timeoutMs: number;
+}): Promise<void> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      barrier,
+      request.then(
+        () => {
+          throw new Error(`Egress request settled before ${description}`);
+        },
+        (error: unknown) => {
+          throw error;
+        },
+      ),
+      new Promise<never>((_resolve, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new Error(`Timed out after ${timeoutMs}ms waiting for ${description}`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  }
+}

--- a/apps/os/src/domains/streams/stream-processor-runner.test.ts
+++ b/apps/os/src/domains/streams/stream-processor-runner.test.ts
@@ -1659,6 +1659,24 @@ describe("StreamProcessorRunner.waitUntilEvent", () => {
     );
   });
 
+  it("predicate form remains pending until a matching future delivery is acknowledged", async () => {
+    const harness = makeHarness();
+    let settled = false;
+    const waiting = harness.runner.waitUntilEvent({
+      predicate: (event) => event.type === REQUESTED && event.payload?.id === "match",
+      timeoutMs: 500,
+    });
+    waiting.finally(() => (settled = true)).catch(() => undefined);
+
+    await tick();
+    expect(settled).toBe(false);
+
+    harness.journal.seed({ type: REQUESTED, payload: { id: "match" } });
+    await harness.deliverBatches([harness.journal.rows().slice()]);
+    await expect(waiting).resolves.toBeUndefined();
+    expect(settled).toBe(true);
+  });
+
   it("offset form reaches an already-appended event by SELF-PULL — read-your-writes never depends on push delivery", async () => {
     const harness = makeHarness();
     // Read-your-writes: the event is already on the stream, but NO delivery is

--- a/apps/os/src/itx/examples-source.ts
+++ b/apps/os/src/itx/examples-source.ts
@@ -186,8 +186,10 @@ return await itx.projects.get(pid).__describe();
     fn: async (itx, vars: { path?: string }) => {
       // Transient signal: callbacks already open see it; product state never will.
       const stream = itx.streams.get(vars.path ?? "/repl/ephemeral-demo");
+      const operationId = crypto.randomUUID();
       const [tick] = await stream.append({
         type: "events.iterate.repl/progress-ticked",
+        idempotencyKey: `ephemeral-events:${operationId}:progress-ticked`,
         ephemeral: true,
         payload: { percent: 50 },
       });
@@ -195,6 +197,7 @@ return await itx.projects.get(pid).__describe();
       // The durable truth is its own ordinary event — THIS is what processors fold.
       const [done] = await stream.append({
         type: "events.iterate.repl/work-completed",
+        idempotencyKey: `ephemeral-events:${operationId}:work-completed`,
         payload: { result: "ok" },
       });
 

--- a/apps/os/src/itx/examples.generated.test.ts
+++ b/apps/os/src/itx/examples.generated.test.ts
@@ -8,10 +8,16 @@
 // message, not just the freshness diff.
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { generateItxExamples } from "../../scripts/generate-itx-examples.ts";
 import { ITX_EXAMPLE_SOURCES } from "./examples-source.ts";
 import { ITX_EXAMPLES } from "./examples.ts";
+
+// Generated catalogue entries are script bodies, so this mirrors the runtime
+// door that supplies `itx` and `vars` as parameters.
+const AsyncFunction = async function () {}.constructor as new (
+  ...args: string[]
+) => (...args: unknown[]) => Promise<unknown>;
 
 test("examples.generated.ts is fresh (pnpm generate:itx-examples)", () => {
   expect(
@@ -26,4 +32,41 @@ test("every source entry ships: same ids, same order, code everywhere", () => {
   for (const example of ITX_EXAMPLES) {
     expect(example.code.length, `example ${example.id} has an empty body`).toBeGreaterThan(0);
   }
+});
+
+test("the ephemeral example keys every append for lifecycle-safe replay", async () => {
+  const example = ITX_EXAMPLES.find((candidate) => candidate.id === "ephemeral-events");
+  expect(example).toBeDefined();
+
+  const events: Array<Record<string, unknown> & { offset: number }> = [];
+  const append = vi.fn(async (event: Record<string, unknown>) => {
+    const committed = { ...event, offset: events.length + 1 };
+    events.push(committed);
+    return [committed];
+  });
+  const getEvents = vi.fn(async (options?: { includeEphemeral?: boolean }) =>
+    options?.includeEphemeral ? events : events.filter((event) => event.ephemeral !== true),
+  );
+  const run = new AsyncFunction("itx", "vars", example!.code);
+
+  await run(
+    {
+      streams: {
+        get: () => ({ append, getEvents }),
+      },
+    },
+    { path: "/test/ephemeral" },
+  );
+
+  const [tick, done] = append.mock.calls.map(([event]) => event);
+  expect(tick).toMatchObject({
+    ephemeral: true,
+    idempotencyKey: expect.stringMatching(/^ephemeral-events:.+:progress-ticked$/),
+  });
+  expect(done).toMatchObject({
+    idempotencyKey: expect.stringMatching(/^ephemeral-events:.+:work-completed$/),
+  });
+  expect(String(tick!.idempotencyKey).replace(/:progress-ticked$/, "")).toBe(
+    String(done!.idempotencyKey).replace(/:work-completed$/, ""),
+  );
 });

--- a/apps/os/src/itx/examples.generated.ts
+++ b/apps/os/src/itx/examples.generated.ts
@@ -156,8 +156,10 @@ return { deviceId, requestOffset: requested.offset };
     code: `
 // Transient signal: callbacks already open see it; product state never will.
 const stream = itx.streams.get(vars.path ?? "/repl/ephemeral-demo");
+const operationId = crypto.randomUUID();
 const [tick] = await stream.append({
   type: "events.iterate.repl/progress-ticked",
+  idempotencyKey: \`ephemeral-events:\${operationId}:progress-ticked\`,
   ephemeral: true,
   payload: { percent: 50 },
 });
@@ -165,6 +167,7 @@ const [tick] = await stream.append({
 // The durable truth is its own ordinary event — THIS is what processors fold.
 const [done] = await stream.append({
   type: "events.iterate.repl/work-completed",
+  idempotencyKey: \`ephemeral-events:\${operationId}:work-completed\`,
   payload: { result: "ok" },
 });
 

--- a/apps/streams-example-app/e2e/playwright/stream-browser.spec.ts
+++ b/apps/streams-example-app/e2e/playwright/stream-browser.spec.ts
@@ -91,10 +91,14 @@ test("sidebar stream gate pauses and resumes ordinary appends", async ({ page })
   await expect(eventMeta(page, "events.iterate.com/stream/paused").first()).toBeVisible();
 
   // Ordinary appends are rejected while the gate is paused.
-  await appendComposerEvent(page, {
-    type: "events.iterate.com/debug/playwright-paused-rejected",
-    payload: { streamPath, value: crypto.randomUUID() },
-  });
+  await appendComposerEvent(
+    page,
+    {
+      type: "events.iterate.com/debug/playwright-paused-rejected",
+      payload: { streamPath, value: crypto.randomUUID() },
+    },
+    "error",
+  );
   await expect(page.getByTestId("composer-state").first()).toHaveText("error");
   await expect(eventMeta(page, "events.iterate.com/debug/playwright-paused-rejected")).toHaveCount(
     0,
@@ -1203,12 +1207,21 @@ function eventRowByOffset(scope: Page | Locator, offset: number) {
   return scope.locator(`[data-testid='event-meta'][data-event-offset='${offset}']`);
 }
 
-async function appendComposerEvent(scope: Page | Locator, event: unknown) {
-  await scope
-    .getByLabel("Event JSON")
-    .first()
-    .fill(JSON.stringify(event, null, 2));
-  await scope.getByRole("button", { name: "Append event" }).first().click();
+async function appendComposerEvent(
+  scope: Page | Locator,
+  event: unknown,
+  expectedState: "appended" | "error" = "appended",
+) {
+  const composer = scope.getByTestId("stream-composer").first();
+  await composer.getByLabel("Event JSON").fill(JSON.stringify(event, null, 2));
+  await composer.getByRole("button", { name: "Append event" }).click();
+
+  // appendBatch owns bounded, idempotent recovery for a tagged Durable Object
+  // reset. Synchronize on this operation instead of racing a downstream event
+  // assertion; terminal application errors remain immediate failures.
+  const terminalState = composer.getByTestId("composer-state");
+  await expect(terminalState).toHaveText(/^(?:appended|error)$/, { timeout: 45_000 });
+  expect(await terminalState.textContent()).toBe(expectedState);
 }
 
 function splitPane(page: Page, streamPath: string) {

--- a/packages/iterate/src/processors/stream-processor-runner.ts
+++ b/packages/iterate/src/processors/stream-processor-runner.ts
@@ -486,10 +486,7 @@ export class StreamProcessorRunner<
       // No await between the check above and registering the waiter below
       // (the helper below registers synchronously), so a batch cannot
       // advance the cursor past `offset` in the gap and be missed.
-      const reached = this.#waitForEventCondition(
-        { kind: "offset", offset },
-        { signal, timeoutMs },
-      );
+      const reached = this.#registerEventWaiter({ kind: "offset", offset }, { signal, timeoutMs });
       // Self-pull, not wait-and-hope: this form's contract is read-your-writes
       // over an append that already committed. A waiting caller must not depend
       // only on an open callback that may stop responding or on a wake call
@@ -508,7 +505,8 @@ export class StreamProcessorRunner<
       return await reached.promise;
     }
     const { predicate, signal, timeoutMs } = args;
-    await this.#waitForEventCondition({ kind: "predicate", predicate }, { signal, timeoutMs });
+    await this.#registerEventWaiter({ kind: "predicate", predicate }, { signal, timeoutMs })
+      .promise;
   }
 
   /** Release processor resources. Idempotent; a disposed runner rejects new work. */
@@ -1156,7 +1154,7 @@ export class StreamProcessorRunner<
     }
   }
 
-  #waitForEventCondition(
+  #registerEventWaiter(
     match:
       | { kind: "predicate"; predicate: (event: StreamEvent) => boolean }
       | { kind: "offset"; offset: number },


### PR DESCRIPTION
## Summary

This extracts the six small, evidence-backed reliability fixes from #2313 into one focused PR. It deliberately leaves the larger architectural, compatibility, assertion-relaxation, and timeout-only changes behind.

## What changed

1. **Actually await predicate-based stream event waiters**
   - `StreamProcessorRunner.waitUntilEvent({ predicate })` was awaiting the waiter handle object instead of its promise, so it could resolve immediately.
   - Rename the private helper to `#registerEventWaiter` to make its return contract explicit and await `.promise` in both call paths.
   - Add a regression proving the predicate form remains pending until a matching future event is delivered and acknowledged.

2. **Correlate the code-mode fence test with its exact script settlement**
   - Derive the execution ID from the synthetic assistant output offset.
   - Find that exact `script-run-settled` event instead of accepting the first unrelated settlement on the agent stream.
   - Parse the real nested settlement payload and require `status: "succeeded"`.

3. **Make retried integration fixtures attempt-local**
   - Generate GitHub, userspace, and Petshop project/secret/provider identities inside each Vitest callback.
   - A retry now gets a coherent fresh fixture instead of reusing durable write-only state with newly minted credentials.
   - Petshop remints both clients inside the fresh attempt rather than memoizing partial fixture state across attempts.

4. **Bound egress race barriers and preserve the real failure**
   - Race each provider barrier against the in-flight request and a 30-second synchronization timeout.
   - Surface an early request rejection directly and fail loudly if the request succeeds before the intended race point.
   - Release the blocked provider in `finally`, including when the barrier itself times out or rejects.

5. **Give the ephemeral-events example replay-safe keys**
   - Generate one operation ID per invocation and key both the ephemeral progress append and durable completion append from it.
   - Execute the generated example in a regression test and verify both keys share the operation prefix.

6. **Synchronize stream composer tests on terminal UI state**
   - Scope composer interactions to the active composer.
   - Wait for the append operation to reach `appended` or `error` before downstream assertions.
   - Assert unexpected terminal errors immediately, while preserving the existing paused-stream error expectation.

## Why this is low risk

- The production change fixes a concrete promise/handle bug and has a direct regression test.
- The remaining changes tighten test identity, correlation, synchronization, and bounded failure reporting without relaxing product assertions.
- No compatibility shim, retry broadening, blanket timeout increase, production data change, or error suppression is included.

## Deliberately excluded from #2313

- broad rollout, sandbox-admission, hedging, SSR, and script-execution architecture changes
- relaxed wake-count assertions and sequentialized two-tab bootstrap coverage
- generic CLI timeout increases and internal transport retries
- changes already independently fixed on `main`

I will summarize the exact taken/excluded/next-candidate split on #2313 after this PR is green.

## Validation

- `pnpm install --frozen-lockfile`
- focused unit regressions: 36 tests passed
- affected-package typechecks passed
- focused lint passed with zero warnings/errors
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm test`: 242 files passed; 2,458 tests passed; 12 expected failures and 1 skip remained as declared by the repository

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The production change fixes real stream-wait semantics in `waitUntilEvent`; remaining edits are test and example hardening, but the runner fix affects any predicate-based waits in production.
> 
> **Overview**
> Fixes **`StreamProcessorRunner.waitUntilEvent({ predicate })`** so it awaits the registered waiter’s **`.promise`** (renamed helper **`#registerEventWaiter`**), with a unit test that the predicate stays pending until a matching event is acknowledged.
> 
> **E2E / Playwright:** correlate the code-mode fence test to **`executionId`** from the synthetic assistant offset; move integration fixture **`run`** IDs inside each test callback for Vitest retries; add **`waitForBarrierOrRequest`** for egress race tests; key ephemeral-events example appends with a shared **`operationId`**; wait for stream composer **terminal state** before follow-on assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdff976726de43b2338a93ace56f6bf55740abb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +7 -6 | +7 -6 🟩⬜⬜⬜⬜ |
| Tests | +159 -59 | +135 -55 🟩🟩🟩🟩🟥 |
| Generated | +47 -1 | +36 -1 🟩⬜⬜⬜⬜ |
| **Total** | **+213 -66** | **+178 -62** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between dc057d5 and bdff976, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T16:22:45.191Z",
      "deployedAt": "2026-07-29T16:04:24.501Z",
      "headSha": "bdff976726de43b2338a93ace56f6bf55740abb7",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-15.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/556279664494534",
      "shortSha": "bdff976",
      "cleanupDurationMs": 11100,
      "deployDurationMs": 89113,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 87917,
      "deployReadinessDurationMs": 1193,
      "deployedWorkerName": "os-preview-15",
      "deployedWorkerVersion": "c372ba81-8752-4b45-b003-bbe50dd07357",
      "testDurationMs": 231697,
      "testRetries": null,
      "workerSizeKib": 19935.14,
      "workerGzipKib": 5034.02,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5044.73
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T16:22:37.529Z",
      "deployedAt": "2026-07-29T16:03:21.028Z",
      "headSha": "bdff976726de43b2338a93ace56f6bf55740abb7",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-15.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/556279664494534",
      "shortSha": "bdff976",
      "cleanupDurationMs": 3435,
      "deployDurationMs": 24900,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 24440,
      "deployReadinessDurationMs": 455,
      "deployedWorkerName": "auth-preview-15",
      "deployedWorkerVersion": "aac75ffb-bbec-4e35-989f-35b235a829c1",
      "testDurationMs": 11417,
      "testRetries": null,
      "workerSizeKib": 3980.14,
      "workerGzipKib": 814.82,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-29T16:22:41.621Z",
      "deployedAt": "2026-07-29T16:03:12.539Z",
      "headSha": "bdff976726de43b2338a93ace56f6bf55740abb7",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-15.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/556279664494534",
      "shortSha": "bdff976",
      "cleanupDurationMs": 7525,
      "deployDurationMs": 16825,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 15951,
      "deployReadinessDurationMs": 869,
      "deployedWorkerName": "streams-example-app-preview-15",
      "deployedWorkerVersion": "2c28d4f0-1994-43ce-9685-f178099d3001",
      "testDurationMs": 70327,
      "testRetries": "1 retried: node-hosted stream processor (e2e) > hosts echo in-process over an event callback connection (vitest x1) — internal error; reference = 7in8p83a35hqu1lokspa71nv",
      "workerSizeKib": 5257.23,
      "workerGzipKib": 1488.99,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T16:22:34.809Z",
      "deployedAt": "2026-07-29T16:03:02.879Z",
      "headSha": "bdff976726de43b2338a93ace56f6bf55740abb7",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-15.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/556279664494534",
      "shortSha": "bdff976",
      "cleanupDurationMs": 711,
      "deployDurationMs": 6589,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 6257,
      "deployReadinessDurationMs": 293,
      "deployedWorkerName": "dummy-petshop-preview-15",
      "deployedWorkerVersion": "c4cd2829-a241-48ce-9a1e-26b64339d48f",
      "testDurationMs": 10463,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+8d74450be93a83fb5cd1785d6e4e10d734e94acd",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `bdff976` | [https://auth.iterate-preview-15.com](https://auth.iterate-preview-15.com) | 814.8 KiB | 24.9s | 11.4s |  | 3.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/556279664494534) | 2026-07-29T16:22:37.529Z | Preview app released. |
| Dummy Petshop | released | `bdff976` | [https://dummy-petshop.iterate-preview-15.com](https://dummy-petshop.iterate-preview-15.com) | 198.3 KiB | 6.6s | 10.5s |  | 711ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/556279664494534) | 2026-07-29T16:22:34.809Z | Preview app released. |
| OS | released | `bdff976` | [https://os.iterate-preview-15.com](https://os.iterate-preview-15.com) | 4.92 MiB (-10.7 KiB vs main) | 89.1s | 231.7s |  | 11.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/556279664494534) | 2026-07-29T16:22:45.191Z | Preview app released. |
| Streams Example App | released | `bdff976` | [https://streams.iterate-preview-15.com](https://streams.iterate-preview-15.com) | 1.45 MiB | 16.8s | 70.3s | 1 retried: node-hosted stream processor (e2e) > hosts echo in-process over an event callback connection (vitest x1) — internal error; reference = 7in8p83a35hqu1lokspa71nv | 7.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/556279664494534) | 2026-07-29T16:22:41.621Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->