### PR TITLE
Honor filters while hosted processors catch up

### DIFF
--- a/apps/os/src/domains/streams/stream-processor-runner.test.ts
+++ b/apps/os/src/domains/streams/stream-processor-runner.test.ts
@@ -1464,6 +1464,49 @@ describe("StreamProcessorRunner caught-up processing (delivery.caughtUp)", () =>
     });
   });
 
+  it("lets a scan-owning source advance a filtered gap without an unfiltered self-pull", async () => {
+    const journal = makeJournal();
+    const requested = journal.seed({ type: REQUESTED, payload: { id: "a" } });
+    journal.seed({ type: NOISE, payload: {} });
+
+    const headCalls: { open: string[]; event: number | null }[] = [];
+    const harness = makeHarness({
+      journal,
+      hooks: {
+        onHead: (args) => {
+          headCalls.push({ open: [...args.state.open], event: args.event?.offset ?? null });
+        },
+      },
+    });
+    const { processEventBatch } = await harness.runner.openEventBatchCallback(undefined, {
+      sourceScansAllEvents: true,
+    });
+
+    await processEventBatch({
+      streamId: TEST_STREAM_ID,
+      events: [requested],
+      scannedAfterOffset: 0,
+      scannedThroughOffset: 1,
+      streamMaxOffset: 2,
+    });
+    await tick();
+
+    // The runner has not read the raw NOISE row behind the configured source
+    // filter. It waits for the source's explicit scan-progress frame.
+    expect(harness.store.record?.processing.acknowledgedThroughOffset).toBe(1);
+    expect(headCalls).toEqual([]);
+
+    await processEventBatch({
+      streamId: TEST_STREAM_ID,
+      events: [],
+      scannedAfterOffset: 1,
+      scannedThroughOffset: 2,
+      streamMaxOffset: 2,
+    });
+    expect(harness.store.record?.processing.acknowledgedThroughOffset).toBe(2);
+    expect(headCalls).toEqual([{ open: ["a"], event: null }]);
+  });
+
   it("runs blockProcessorWhile registrations in strict FIFO order — fold-derived work lands after per-event work", async () => {
     // The head event registers TWO blockers in one `processEvent` body: a
     // per-event append first, a fold-derived append second. Registration

--- a/packages/iterate/src/processors/stream-processor-registry.ts
+++ b/packages/iterate/src/processors/stream-processor-registry.ts
@@ -643,18 +643,22 @@ export function createStreamProcessorRegistry<Live extends object = Record<strin
       if (!z.uuid().safeParse(args.stream.streamId).success) {
         throw new Error(`wakeStreamProcessor streamId must be a UUID`);
       }
-      // The runner owns all frame semantics: serialization, offset dedupe,
-      // whole-attempt keepalive, and the trailing unfiltered catch-up. The
-      // registry adds only the transport boundary: the stream's callback call
-      // returns immediately, while this DO reports the eventual attempt
-      // outcome through the batch's independent one-shot capability.
+      // The runner owns frame serialization, offset dedupe, and whole-attempt
+      // keepalive. The hosted source owns catch-up: it scans every raw offset
+      // and sends empty frames for configured-filter gaps, so an unfiltered
+      // runner pull would bypass that filter. The registry otherwise adds only
+      // the transport boundary: the stream's callback call returns
+      // immediately, while this DO reports the eventual attempt outcome
+      // through the batch's independent one-shot capability.
       //
       // That separation is load-bearing. Processor blockers routinely append
       // back to the same stream that delivered them. Returning `attempt` from
       // this RPC makes the stream pull a result that cannot settle until the
       // nested append reaches the stream again — a cyclic actor-drain tree
       // that workerd can retain until idle teardown.
-      const opened = await entry.runner.openEventBatchCallback(args.stream.streamId);
+      const opened = await entry.runner.openEventBatchCallback(args.stream.streamId, {
+        sourceScansAllEvents: true,
+      });
       const processEventBatch = (batch: StreamWakeEventBatch) => {
         const { reportDeliveryResult, ...frame } = batch;
         if (

--- a/packages/iterate/src/processors/stream-processor-runner.ts
+++ b/packages/iterate/src/processors/stream-processor-runner.ts
@@ -316,7 +316,17 @@ export class StreamProcessorRunner<
    * hosting transport may adapt how the promise is observed, but must not
    * duplicate these semantics.
    */
-  async openEventBatchCallback(expectedStreamId?: string): Promise<{
+  async openEventBatchCallback(
+    expectedStreamId?: string,
+    options?: {
+      /**
+       * The callback source scans every raw offset and sends empty batches for
+       * filtered gaps. It is therefore the sole catch-up driver: a second,
+       * unfiltered journal pull here would bypass the source's filter.
+       */
+      sourceScansAllEvents?: boolean;
+    },
+  ): Promise<{
     checkpointOffset: number;
     processEventBatch: (batch: StreamProcessorEventBatch) => Promise<void>;
   }> {
@@ -338,35 +348,32 @@ export class StreamProcessorRunner<
         // next fire to revival); the transport observes the same rejection
         // through the returned promise and owns the redelivery.
         this.durability?.recovery?.keepAliveWhile(() => attempt);
-        // Hosted-processor batches contain only consumed event types but carry the
-        // stream's maximum offset, so a successful
-        // batch can leave the acknowledged cursor behind `streamMaxOffset`
-        // with remaining unconsumed durable events nothing else will ever send —
-        // the cursor remains below that maximum offset, the last consumed event's
-        // `delivery.caughtUp` never becomes true, and the obligation the batch
-        // opened gets stuck. Every such batch therefore gets a type-unfiltered
-        // read that folds the remaining events through `streamMaxOffset`. Its final
-        // page either marks the last consumed event caught up or makes an
-        // eventless caught-up call when those events contain no consumed event. It
-        // runs on the runner's chain — serialized
-        // with batches, reading the freshest cursor — and is kept alive,
-        // NOT the promise returned to the transport: a failed follow-up read
-        // reads as FAILURE to the keepalive, blocking the quiet-clean disarm
-        // and routing the next alarm fire to revival, whose unfiltered
-        // catch-up is this pull's retry. A failed main attempt takes the
-        // stream's ordinary redelivery instead; no trailing pull follows it.
-        this.#runInBackground(() =>
-          attempt.then(
-            () =>
-              this.#enqueue(async () => {
-                const { processing } = this.#requireProgress();
-                if (processing.acknowledgedThroughOffset < batch.streamMaxOffset) {
-                  await this.#selfCatchUp();
-                }
-              }),
-            () => undefined,
-          ),
-        );
+        // Direct callback batches can contain only consumed event types while
+        // carrying a later raw stream maximum. Without another reader, an
+        // unconsumed tail would keep `delivery.caughtUp` false and strand any
+        // obligation the batch opened. The runner therefore pulls the raw
+        // journal after a successful direct batch. The pull is serialized with
+        // delivery, kept alive independently from the transport promise, and
+        // retried by durable recovery if it fails.
+        //
+        // Hosted stream delivery is different: its source already scans every
+        // raw offset and sends empty frames across configured-filter gaps.
+        // That transport must remain the only catch-up driver or a runner pull
+        // would consume events the subscription explicitly excluded.
+        if (options?.sourceScansAllEvents !== true) {
+          this.#runInBackground(() =>
+            attempt.then(
+              () =>
+                this.#enqueue(async () => {
+                  const { processing } = this.#requireProgress();
+                  if (processing.acknowledgedThroughOffset < batch.streamMaxOffset) {
+                    await this.#selfCatchUp();
+                  }
+                }),
+              () => undefined,
+            ),
+          );
+        }
         return attempt;
       },
     };

--- a/packages/iterate/src/starter-apps/github-ai-linter/github-ai-linter.test.ts
+++ b/packages/iterate/src/starter-apps/github-ai-linter/github-ai-linter.test.ts
@@ -6,7 +6,11 @@ import { mightWakePullRequestAgent } from "./review-bot.ts";
 test("a linked connection gets a hosted review processor", async () => {
   const appended: Array<{ events: StreamEventInput[]; path: string }> = [];
   const app = GithubAiLinter.create(
-    projectEnv((path, ...events) => appended.push({ events, path })),
+    projectEnv(
+      (path, ...events) => appended.push({ events, path }),
+      {},
+      { "/integrations/github/iterate-installation": { maxOffset: 8_123 } },
+    ),
     {
       policyVersion: "2",
       rules: {
@@ -41,7 +45,9 @@ test("a linked connection gets a hosted review processor", async () => {
                 "get",
                 {
                   className: "ReviewBotApp",
-                  durableWorkerKey: expect.stringMatching(/^app-review-bot-[0-9a-f]{32}$/),
+                  durableWorkerKey: expect.stringMatching(
+                    /^github-ai-linter-review-bot-[0-9a-f]{32}$/,
+                  ),
                   path: "/",
                   type: "stateful",
                 },
@@ -50,6 +56,10 @@ test("a linked connection gets a hosted review processor", async () => {
               "wakeStreamProcessor",
             ],
             processorSlug: "review-bot",
+          },
+          filter: {
+            eventTypes: ["events.iterate.com/github/webhook-received"],
+            jsonataCondition: "offset > 8123",
           },
           subscriptionKey: "app-review-bot#review-bot",
         },
@@ -97,10 +107,19 @@ test("a linked connection gets a hosted review processor", async () => {
 test("a config worker update refreshes every linked connection processor", async () => {
   const appended: Array<{ events: StreamEventInput[]; path: string }> = [];
   const app = GithubAiLinter.create(
-    projectEnv((path, ...events) => appended.push({ events, path }), {
-      "/repos/config": "iterate-installation",
-      "/repos/product": "iterate-installation",
-    }),
+    projectEnv(
+      (path, ...events) => appended.push({ events, path }),
+      {
+        "/repos/config": "iterate-installation",
+        "/repos/product": "iterate-installation",
+      },
+      {
+        "/integrations/github/iterate-installation": {
+          existingReviewBotCutoff: 7_500,
+          maxOffset: 9_000,
+        },
+      },
+    ),
     {
       policyVersion: "3",
       rules: {
@@ -125,6 +144,10 @@ test("a config worker update refreshes every linked connection processor", async
           receiver: {
             action: "processor-wake",
             processorSlug: "review-bot",
+          },
+          filter: {
+            eventTypes: ["events.iterate.com/github/webhook-received"],
+            jsonataCondition: "offset > 7500",
           },
           subscriptionKey: "app-review-bot#review-bot",
         },
@@ -183,6 +206,7 @@ function webhookEvent(input: {
 function projectEnv(
   append: (path: string, ...events: StreamEventInput[]) => void,
   repoConnections: Record<string, string> = {},
+  connectionStreams: Record<string, { existingReviewBotCutoff?: number; maxOffset: number }> = {},
 ) {
   return {
     ITX: {
@@ -205,6 +229,31 @@ function projectEnv(
         streams: {
           get: (path: string) => ({
             append: async (...events: StreamEventInput[]) => append(path, ...events),
+            runtimeState: async () => {
+              const fixture = connectionStreams[path];
+              const existingReviewBotCutoff = fixture?.existingReviewBotCutoff;
+              return {
+                coreProcessorState: {
+                  maxOffset: fixture?.maxOffset ?? 0,
+                  subscriptions: {
+                    outbound: {
+                      byKey:
+                        existingReviewBotCutoff === undefined
+                          ? {}
+                          : {
+                              "app-review-bot#review-bot": {
+                                configuration: {
+                                  filter: {
+                                    jsonataCondition: `offset > ${existingReviewBotCutoff}`,
+                                  },
+                                },
+                              },
+                            },
+                    },
+                  },
+                },
+              };
+            },
           }),
         },
       }),

--- a/packages/iterate/src/starter-apps/github-ai-linter/index.ts
+++ b/packages/iterate/src/starter-apps/github-ai-linter/index.ts
@@ -1,5 +1,9 @@
 import type { ItxBinding, StreamEvent } from "../../sdk.ts";
-import { reviewBotSubscriptionEvent, type GithubAiLinterConfig } from "./worker-ref.ts";
+import {
+  REVIEW_BOT_SUBSCRIPTION_KEY,
+  reviewBotSubscriptionEvent,
+  type GithubAiLinterConfig,
+} from "./worker-ref.ts";
 
 export type { GithubAiLinterConfig } from "./worker-ref.ts";
 
@@ -39,9 +43,25 @@ export const GithubAiLinter = {
         }
         await Promise.all(
           [...new Set(connections)].map(async (connection) => {
-            await itx.streams
-              .get(`/integrations/github/${connection}`)
-              .append(await reviewBotSubscriptionEvent(event, connection, config));
+            const connectionStream = itx.streams.get(`/integrations/github/${connection}`);
+            const runtime = await connectionStream.runtimeState();
+            const existingCondition =
+              runtime.coreProcessorState.subscriptions.outbound.byKey[REVIEW_BOT_SUBSCRIPTION_KEY]
+                ?.configuration.filter?.jsonataCondition;
+            const existingCutoffMatch = existingCondition?.match(/^offset > ([0-9]+)$/);
+            const existingCutoff = existingCutoffMatch ? Number(existingCutoffMatch[1]) : null;
+
+            // First configuration deliberately starts at the current head: a
+            // semantic project restore must not replay historical webhooks.
+            // Later config-worker updates preserve that boundary so a refresh
+            // cannot skip webhooks that arrived since the bot was installed.
+            const startAfterOffset =
+              existingCutoff !== null && Number.isSafeInteger(existingCutoff)
+                ? existingCutoff
+                : runtime.coreProcessorState.maxOffset;
+            await connectionStream.append(
+              await reviewBotSubscriptionEvent(event, connection, config, startAfterOffset),
+            );
           }),
         );
       },

--- a/packages/iterate/src/starter-apps/github-ai-linter/worker-ref.ts
+++ b/packages/iterate/src/starter-apps/github-ai-linter/worker-ref.ts
@@ -14,15 +14,25 @@ export type GithubAiLinterConfig = {
 const configuredWorkerEntrypoint =
   "node_modules/iterate/dist/starter-apps/github-ai-linter/configured-worker.mjs";
 
+export const REVIEW_BOT_SUBSCRIPTION_KEY = "app-review-bot#review-bot";
+
 export async function reviewBotSubscriptionEvent(
   sourceEvent: StreamEvent,
   connection: string,
   config: GithubAiLinterConfig,
+  startAfterOffset: number,
 ): Promise<StreamEventInput> {
   return {
     type: "events.iterate.com/stream/subscription-configured",
     payload: {
-      subscriptionKey: "app-review-bot#review-bot",
+      subscriptionKey: REVIEW_BOT_SUBSCRIPTION_KEY,
+      // A restored connection stream can contain thousands of old webhooks.
+      // This cutoff gives a newly configured review bot future work only.
+      // Config refreshes preserve the original cutoff in index.ts.
+      filter: {
+        eventTypes: ["events.iterate.com/github/webhook-received"],
+        jsonataCondition: `offset > ${startAfterOffset}`,
+      },
       receiver: {
         action: "processor-wake",
         expression: [
@@ -86,7 +96,7 @@ async function reviewBotAppRef(
   return dynamicWorkerRef({
     className: "ReviewBotApp",
     config,
-    durableWorkerKey: `app-review-bot-${await durableIdentity(connection)}`,
+    durableWorkerKey: `github-ai-linter-review-bot-${await durableIdentity(connection)}`,
   });
 }
 


### PR DESCRIPTION
## What changed

- make hosted source delivery the sole raw-offset scanner, preventing the runner self-pull from bypassing subscription filters
- initialize restored GitHub AI linter review bots after the current connection head and preserve that cutoff on config refresh
- use a fresh canonical GitHub AI linter review-bot Durable Object key

## Why

The production restore smoke showed a fresh review bot timing out while replaying roughly 9,500 historical webhook-stream events. The source correctly filtered those events, but the runner launched an unfiltered trailing journal catch-up after the first empty batch. That second reader bypassed the configured cutoff and starved the source callback watchdog.

Hosted sources already scan every raw offset and emit empty progress frames for filtered gaps. Direct/browser callbacks retain the existing runner self-catch-up behavior.

## Verification

- packages/iterate typecheck
- apps/os typecheck, including config-repo template
- oxlint on all changed files
- StreamProcessorRunner focused suite: 33 passing
- GitHub AI linter focused suite: 3 passing

Production verification will follow the main rollout using the existing temporary iterate/config smoke PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core hosted processor catch-up semantics and alters GitHub review-bot subscription filters and DO identity keys, which can affect production restore behavior and webhook replay boundaries.
> 
> **Overview**
> Fixes hosted processors that could **replay thousands of filtered-out events** because the runner ran an unfiltered journal self-pull after the first filtered batch.
> 
> **Stream processor runner:** `openEventBatchCallback` accepts `sourceScansAllEvents`. When the hosted source already scans every raw offset and sends empty frames across filter gaps, the runner **skips** trailing `#selfCatchUp()` so it does not bypass subscription filters. Direct/browser callbacks still self-catch-up after successful batches.
> 
> **Registry:** `wakeStreamProcessor` opens callbacks with `sourceScansAllEvents: true`.
> 
> **GitHub AI linter:** Review-bot subscriptions now include a filter (`github/webhook-received` + `offset > N`). **First** link/configure uses the connection stream’s current `maxOffset` as the cutoff; **config refreshes** keep the existing cutoff from runtime state. Review-bot Durable Object keys use the `github-ai-linter-review-bot-` prefix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45a52be42e613ecd81f1bcb7add996c4ac38f503. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +83 -42 | +47 -20 🟩🟩🟥⬜⬜ |
| Tests | +98 -6 | +91 -6 🟩🟩🟩🟩🟩 |
| **Total** | **+181 -48** | **+138 -26** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 4decd18 and 45a52be, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T16:29:01.233Z",
      "deployedAt": "2026-07-29T16:23:57.557Z",
      "headSha": "45a52be42e613ecd81f1bcb7add996c4ac38f503",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/18833926864260",
      "shortSha": "45a52be",
      "cleanupDurationMs": 14797,
      "deployDurationMs": 74171,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 72831,
      "deployReadinessDurationMs": 1337,
      "deployedWorkerName": "os-preview-4",
      "deployedWorkerVersion": "5d053191-59f3-4d1c-a2ff-6b298f08840d",
      "testDurationMs": 223108,
      "testRetries": null,
      "workerSizeKib": 19935.32,
      "workerGzipKib": 5034.28,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5044.84
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-29T16:28:47.132Z",
      "deployedAt": "2026-07-29T16:23:04.395Z",
      "headSha": "45a52be42e613ecd81f1bcb7add996c4ac38f503",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/18833926864260",
      "shortSha": "45a52be",
      "cleanupDurationMs": 694,
      "deployDurationMs": 19871,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 19666,
      "deployReadinessDurationMs": 201,
      "deployedWorkerName": "semaphore-preview-4",
      "deployedWorkerVersion": "3edd0a57-fdfe-4688-9d4f-c17005392eac",
      "testDurationMs": 55497,
      "testRetries": null,
      "workerSizeKib": 1915.51,
      "workerGzipKib": 441.11,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T16:28:50.312Z",
      "deployedAt": "2026-07-29T16:23:10.784Z",
      "headSha": "45a52be42e613ecd81f1bcb7add996c4ac38f503",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/18833926864260",
      "shortSha": "45a52be",
      "cleanupDurationMs": 3870,
      "deployDurationMs": 26408,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 26053,
      "deployReadinessDurationMs": 349,
      "deployedWorkerName": "auth-preview-4",
      "deployedWorkerVersion": "56791da2-2077-4c2d-b061-7b0787c5881c",
      "testDurationMs": 3288,
      "testRetries": null,
      "workerSizeKib": 3980.14,
      "workerGzipKib": 814.9,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-29T16:28:53.848Z",
      "deployedAt": "2026-07-29T16:23:08.447Z",
      "headSha": "45a52be42e613ecd81f1bcb7add996c4ac38f503",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/18833926864260",
      "shortSha": "45a52be",
      "cleanupDurationMs": 7405,
      "deployDurationMs": 65676,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 23715,
      "deployReadinessDurationMs": 41954,
      "deployedWorkerName": "streams-example-app-preview-4",
      "deployedWorkerVersion": "13fc512d-d410-4f49-8cc5-ce7b62156c7e",
      "testDurationMs": 92835,
      "testRetries": null,
      "workerSizeKib": 5257.05,
      "workerGzipKib": 1488.96,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T16:28:47.283Z",
      "deployedAt": "2026-07-29T16:22:52.513Z",
      "headSha": "45a52be42e613ecd81f1bcb7add996c4ac38f503",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/18833926864260",
      "shortSha": "45a52be",
      "cleanupDurationMs": 838,
      "deployDurationMs": 8003,
      "deployConfigDurationMs": 8,
      "deployCommandDurationMs": 7731,
      "deployReadinessDurationMs": 215,
      "deployedWorkerName": "dummy-petshop-preview-4",
      "deployedWorkerVersion": "ce7dc0e7-2018-495f-b7af-60feb8fb4ad1",
      "testDurationMs": 27194,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+8d74450be93a83fb5cd1785d6e4e10d734e94acd",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `45a52be` | [https://auth.iterate-preview-4.com](https://auth.iterate-preview-4.com) | 814.9 KiB | 26.4s | 3.3s |  | 3.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/18833926864260) | 2026-07-29T16:28:50.312Z | Preview app released. |
| Dummy Petshop | released | `45a52be` | [https://dummy-petshop.iterate-preview-4.com](https://dummy-petshop.iterate-preview-4.com) | 198.3 KiB | 8.0s | 27.2s |  | 838ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/18833926864260) | 2026-07-29T16:28:47.283Z | Preview app released. |
| OS | released | `45a52be` | [https://os.iterate-preview-4.com](https://os.iterate-preview-4.com) | 4.92 MiB (-10.6 KiB vs main) | 74.2s | 223.1s |  | 14.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/18833926864260) | 2026-07-29T16:29:01.233Z | Preview app released. |
| Semaphore | released | `45a52be` | [https://semaphore.iterate-preview-4.com](https://semaphore.iterate-preview-4.com) | 441.1 KiB | 19.9s | 55.5s |  | 694ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/18833926864260) | 2026-07-29T16:28:47.132Z | Preview app released. |
| Streams Example App | released | `45a52be` | [https://streams.iterate-preview-4.com](https://streams.iterate-preview-4.com) | 1.45 MiB | 65.7s | 92.8s |  | 7.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/18833926864260) | 2026-07-29T16:28:53.848Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->