### PR TITLE
auth: drop retired EdDSA AUTH_FORGE_PRIVATE_JWK — ES256 is the sole forge key

### DIFF
--- a/apps/auth/README.md
+++ b/apps/auth/README.md
@@ -152,7 +152,7 @@ auth's `/project-access` page. The MCP server advertises auth as its
 authorization server.
 
 **(b) JWT verification — one Doppler-owned signing key.** Auth's Better Auth
-JWT adapter signs with `AUTH_FORGE_PRIVATE_JWK`. OS, Semaphore, and Streams
+JWT adapter signs with `AUTH_FORGE_ES256_PRIVATE_JWK`. OS, Semaphore, and Streams
 derive only its public half during deploy and verify locally; they neither wait
 for Auth's live JWKS nor fall back to it at runtime. `pnpm auth:mint` uses the
 same private key, so minted and Auth-issued tokens have one trust path.

--- a/apps/auth/src/server/env.ts
+++ b/apps/auth/src/server/env.ts
@@ -29,16 +29,11 @@ export interface CloudflareEnv {
   APP_CONFIG_BETTER_AUTH_SECRET: string;
   /**
    * The single Doppler-owned ES256 (P-256) key used for OAuth/OIDC JWT
-   * signatures. Cloudflare Access rejects EdDSA, so ES256 is the sole
-   * algorithm; its public half is the only key in the JWKS.
+   * signatures — the sole forge/signing key now that the old EdDSA key is
+   * retired. Cloudflare Access rejects EdDSA, so ES256 is the only algorithm;
+   * its public half is the only key in the JWKS.
    */
   AUTH_FORGE_ES256_PRIVATE_JWK: string;
-  /**
-   * Retired Ed25519 key. No longer read by the worker (ES256 is the sole
-   * signing key); the Doppler secret may still be present, so the binding is
-   * kept optional to avoid a shape mismatch.
-   */
-  AUTH_FORGE_PRIVATE_JWK?: string;
   /** Dedicated project-app-session signing secret, shared with os for local
    * verification. Optional: unset falls back to APP_CONFIG_BETTER_AUTH_SECRET. */
   APP_CONFIG_PROJECT_APP_SESSION_SECRET?: string;

--- a/apps/os/docs/architecture-and-operations.md
+++ b/apps/os/docs/architecture-and-operations.md
@@ -188,7 +188,7 @@ ensures two OAuth clients (web + MCP/CLI) via the auth contract's
 `APP_CONFIG_ITERATE_AUTH__*` OAuth/client values back to Doppler. It does not
 write `APP_CONFIG_ITERATE_AUTH__JWKS`: generated local config and deployed OS
 derive the public JWKS directly from the environment's Doppler-owned
-`AUTH_FORGE_PRIVATE_JWK`. Auth signs with the private half; OS receives only
+`AUTH_FORGE_ES256_PRIVATE_JWK`. Auth signs with the private half; OS receives only
 the public half and never fetches Auth during deploy or verification.
 
 It requires `APP_CONFIG_SERVICE_AUTH_TOKEN` (run through Doppler for the auth project).

--- a/apps/os/docs/headless-local-debugging.md
+++ b/apps/os/docs/headless-local-debugging.md
@@ -35,7 +35,7 @@ Gotchas:
 - The Doppler scope for `apps/auth` must resolve to a config that exists. If
   `pnpm dev-all` dies with `Could not find requested config 'dev_<you>'`, point it
   at the shared dev config: `doppler configure set config dev --scope apps/auth`.
-- Local Auth and OS read the same `AUTH_FORGE_PRIVATE_JWK`. Auth signs with its
+- Local Auth and OS read the same `AUTH_FORGE_ES256_PRIVATE_JWK`. Auth signs with its
   private half and generated OS config derives the public JWKS, exactly like a
   deployment; no live JWKS fallback is involved.
 

--- a/apps/os/docs/operator-sessions.md
+++ b/apps/os/docs/operator-sessions.md
@@ -322,5 +322,5 @@ Implementation ownership:
   dashboard application.
 
 `pnpm auth:mint` remains a separate non-production auth-testing tool. It forges
-a complete auth-worker identity and requires `AUTH_FORGE_PRIVATE_JWK`; it is
+a complete auth-worker identity and requires `AUTH_FORGE_ES256_PRIVATE_JWK`; it is
 not the production support path for opening a project.

--- a/apps/semaphore/README.md
+++ b/apps/semaphore/README.md
@@ -21,7 +21,7 @@ admin** identity:
   `iterate_session` cookie.
 - **API/CLI:** `Authorization: Bearer <access token>`, verified as a JWT
   against Auth's Doppler-derived public signing key. CLIs
-  mint admin tokens offline with the config's `AUTH_FORGE_PRIVATE_JWK`
+  mint admin tokens offline with the config's `AUTH_FORGE_ES256_PRIVATE_JWK`
   (`scripts/auth/semaphore-token.ts`, same mechanism as `pnpm auth:mint`), or
   accept a pre-minted token via `SEMAPHORE_API_TOKEN`.
 

--- a/apps/semaphore/e2e/helpers.ts
+++ b/apps/semaphore/e2e/helpers.ts
@@ -26,7 +26,7 @@ export function requireSemaphoreBaseUrl() {
 /**
  * Bearer-token provider for the suite: SEMAPHORE_API_TOKEN (a pre-minted
  * bearer token), else an admin access token forge-minted from the Doppler
- * config's AUTH_FORGE_PRIVATE_JWK — semaphore verifies both against the same
+ * config's AUTH_FORGE_ES256_PRIVATE_JWK — semaphore verifies both against the same
  * apps/auth relying-party setup as os.
  */
 export function semaphoreApiTokenProvider(baseURL: string) {

--- a/apps/semaphore/scripts/seed-environment-config-leases.ts
+++ b/apps/semaphore/scripts/seed-environment-config-leases.ts
@@ -18,7 +18,7 @@ export async function seedEnvironmentConfigLeases(input: SeedEnvironmentConfigLe
 
   const semaphore = createSemaphoreClient({
     // SEMAPHORE_API_TOKEN (a pre-minted bearer token), else forge-mint an
-    // admin access token from the config's AUTH_FORGE_PRIVATE_JWK.
+    // admin access token from the config's AUTH_FORGE_ES256_PRIVATE_JWK.
     apiKey: createSemaphoreTokenProvider({
       baseUrl: semaphoreBaseUrl,
       email: "semaphore-seed@iterate.com",

--- a/apps/semaphore/scripts/sync-auth-client.ts
+++ b/apps/semaphore/scripts/sync-auth-client.ts
@@ -72,18 +72,18 @@ upsertAuthSeedOAuthClient({
   skipConsent: true,
 });
 
-const forgePrivateJwk = getDopplerSecret("os", "prd", "AUTH_FORGE_PRIVATE_JWK");
+const forgePrivateJwk = getDopplerSecret("os", "prd", "AUTH_FORGE_ES256_PRIVATE_JWK");
 const allowProduction = getDopplerSecret("os", "prd", "AUTH_FORGE_ALLOW_PRODUCTION");
 if (!forgePrivateJwk || !allowProduction) {
   throw new Error(
-    "os/prd is missing AUTH_FORGE_PRIVATE_JWK or AUTH_FORGE_ALLOW_PRODUCTION — cannot mirror the forge key.",
+    "os/prd is missing AUTH_FORGE_ES256_PRIVATE_JWK or AUTH_FORGE_ALLOW_PRODUCTION — cannot mirror the forge key.",
   );
 }
 setDopplerSecrets("semaphore", "prd", {
-  AUTH_FORGE_PRIVATE_JWK: forgePrivateJwk,
+  AUTH_FORGE_ES256_PRIVATE_JWK: forgePrivateJwk,
   AUTH_FORGE_ALLOW_PRODUCTION: allowProduction,
 });
-setDopplerSecrets("_shared", "prd", { AUTH_FORGE_PRIVATE_JWK: forgePrivateJwk });
+setDopplerSecrets("_shared", "prd", { AUTH_FORGE_ES256_PRIVATE_JWK: forgePrivateJwk });
 console.log("forge key mirrored into semaphore/prd and _shared/prd");
 console.log(`done — issuer ${authIssuer}`);
 

--- a/apps/streams-example-app/scripts/sync-auth-client.ts
+++ b/apps/streams-example-app/scripts/sync-auth-client.ts
@@ -75,15 +75,15 @@ upsertAuthSeedOAuthClient({
   skipConsent: true,
 });
 
-const forgePrivateJwk = getDopplerSecret("os", "prd", "AUTH_FORGE_PRIVATE_JWK");
+const forgePrivateJwk = getDopplerSecret("os", "prd", "AUTH_FORGE_ES256_PRIVATE_JWK");
 const allowProduction = getDopplerSecret("os", "prd", "AUTH_FORGE_ALLOW_PRODUCTION");
 if (!forgePrivateJwk || !allowProduction) {
   throw new Error(
-    "os/prd is missing AUTH_FORGE_PRIVATE_JWK or AUTH_FORGE_ALLOW_PRODUCTION — cannot mirror the forge key.",
+    "os/prd is missing AUTH_FORGE_ES256_PRIVATE_JWK or AUTH_FORGE_ALLOW_PRODUCTION — cannot mirror the forge key.",
   );
 }
 setDopplerSecrets("streams-example-app", "prd", {
-  AUTH_FORGE_PRIVATE_JWK: forgePrivateJwk,
+  AUTH_FORGE_ES256_PRIVATE_JWK: forgePrivateJwk,
   AUTH_FORGE_ALLOW_PRODUCTION: allowProduction,
 });
 console.log("forge key mirrored into streams-example-app/prd");

--- a/docs/adding-preview-slots.md
+++ b/docs/adding-preview-slots.md
@@ -263,7 +263,7 @@ Doppler state, so its exact config list belongs in the approved plan.
 Verify names, inheritance, and required-secret presence without printing
 values. Auth must have its OAuth seed and runtime secrets; OS, Semaphore, and
 Streams must have matching per-slot Auth client IDs and secrets; Semaphore and
-Streams must have `AUTH_FORGE_PRIVATE_JWK`. OS must also have
+Streams must have `AUTH_FORGE_ES256_PRIVATE_JWK`. OS must also have
 `APP_CONFIG_INTEGRATIONS__PETSHOP`; an OS deploy cannot infer the Dummy Petshop
 client.
 

--- a/docs/dev-environments.md
+++ b/docs/dev-environments.md
@@ -50,7 +50,7 @@ pnpm dev          # fully-local OS dev server on http://localhost:<port>
   but they should not carry app/MCP/project-host URL overrides.
 
   Don't add old flat auth OAuth/JWKS vars in these configs. Auth signs JWTs
-  with `AUTH_FORGE_PRIVATE_JWK`; local and deployed relying parties derive its
+  with `AUTH_FORGE_ES256_PRIVATE_JWK`; local and deployed relying parties derive its
   public JWKS locally from the same Doppler value. Doppler
   `APP_CONFIG_ITERATE_AUTH__JWKS` snapshots should be absent: generated config
   and deploy scripts own that derived binding, so a manually pinned copy can
@@ -171,9 +171,9 @@ security model. The forge-key flow below remains useful in non-production when
 testing the real OAuth-session shape, arbitrary organization claims, or auth UI
 behavior.
 
-Auth signs JWTs with one Doppler-owned Ed25519 key. OS and the other relying
+Auth signs JWTs with one Doppler-owned ES256 (P-256) key. OS and the other relying
 workers trust only its public half, derived locally during config generation or
-deploy from `AUTH_FORGE_PRIVATE_JWK` (inherited from `_shared/dev` /
+deploy from `AUTH_FORGE_ES256_PRIVATE_JWK` (inherited from `_shared/dev` /
 `_shared/preview` / `_shared/prd`). The same private key powers offline
 identity minting, so minting is instant and does not call the auth worker:
 
@@ -274,7 +274,7 @@ APP_CONFIG_BASE_URL=https://os-preview-3.iterate.com \
 
 Forged-session specs validate one env contract: `APP_CONFIG_ADMIN_API_SECRET`
 for project fixture setup, plus `APP_CONFIG_ITERATE_AUTH__CLIENT_ID`,
-`APP_CONFIG_ITERATE_AUTH__ISSUER`, and `AUTH_FORGE_PRIVATE_JWK` for JWT
+`APP_CONFIG_ITERATE_AUTH__ISSUER`, and `AUTH_FORGE_ES256_PRIVATE_JWK` for JWT
 minting. Those values are expected to come from the same `os` Doppler config as
 the worker under test. The access-token resource is derived from the target OS
 base URL (`http://localhost` for loopback local dev, otherwise the normalized
@@ -301,7 +301,7 @@ doppler run --project os --config prd -- pnpm auth:mint --email someone@nustom.c
 # open the printed URL → signed in on https://os.iterate.com as that user
 ```
 
-The forge key is a **master key**: anyone holding `AUTH_FORGE_PRIVATE_JWK`
+The forge key is a **master key**: anyone holding `AUTH_FORGE_ES256_PRIVATE_JWK`
 from `os/prd` can mint a session as any user, including admins. There is no
 audit trail yet — an audited mint endpoint on the auth worker is the planned
 replacement. Until then, guard that Doppler value like any production secret
@@ -309,7 +309,7 @@ and prefer minting a scoped (non-admin) identity when you can.
 
 Because the prd signing key is god-mode, Auth and relying-party deploys refuse
 to use it unless you opt in explicitly: their prd Doppler configs must resolve
-both `AUTH_FORGE_PRIVATE_JWK` and `AUTH_FORGE_ALLOW_PRODUCTION=true`. A key
+both `AUTH_FORGE_ES256_PRIVATE_JWK` and `AUTH_FORGE_ALLOW_PRODUCTION=true`. A key
 that lands in a prod config without the flag fails the deploy loudly rather
 than silently arming Auth signing and offline minting (each environment also
 uses its own key id — `iterate-forge-dev`/`-preview`/`-prd` — so a leak is
@@ -586,7 +586,7 @@ need no deploy-time coordination. Provisioning/rotation:
 `doppler run --project _shared --config prd -- pnpm preview provision-auth-preview-configs --rotate`.
 
 JWT signing is independent of `APP_CONFIG_BETTER_AUTH_SECRET`: the Better Auth
-JWT adapter reads the fixed `AUTH_FORGE_PRIVATE_JWK` from Doppler and does not
+JWT adapter reads the fixed `AUTH_FORGE_ES256_PRIVATE_JWK` from Doppler and does not
 store generated signing keys in D1. Rotating the Better Auth secret therefore
 needs no JWKS cleanup.
 

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -3698,9 +3698,13 @@ function previewProvisionedIntegrationSecrets() {
 }
 
 async function ensureAuthPreviewConfigs(input: { rotate: boolean; slots: number[] }) {
-  const authSigningPrivateJwk = getDopplerSecret("_shared", "preview", "AUTH_FORGE_PRIVATE_JWK");
+  const authSigningPrivateJwk = getDopplerSecret(
+    "_shared",
+    "preview",
+    "AUTH_FORGE_ES256_PRIVATE_JWK",
+  );
   if (!authSigningPrivateJwk) {
-    throw new Error("_shared/preview is missing AUTH_FORGE_PRIVATE_JWK");
+    throw new Error("_shared/preview is missing AUTH_FORGE_ES256_PRIVATE_JWK");
   }
 
   // This is deliberately inherited, not copied: every app's preview
@@ -3708,10 +3712,10 @@ async function ensureAuthPreviewConfigs(input: { rotate: boolean; slots: number[
   // of truth. Fail closed if that topology has drifted instead of writing a
   // second app-local copy that could later shadow the shared key.
   for (const project of ["auth", "os", "semaphore", "streams-example-app"]) {
-    const effectiveKey = getDopplerSecret(project, "preview", "AUTH_FORGE_PRIVATE_JWK");
+    const effectiveKey = getDopplerSecret(project, "preview", "AUTH_FORGE_ES256_PRIVATE_JWK");
     if (effectiveKey !== authSigningPrivateJwk) {
       throw new Error(
-        `${project}/preview must inherit AUTH_FORGE_PRIVATE_JWK from _shared/preview`,
+        `${project}/preview must inherit AUTH_FORGE_ES256_PRIVATE_JWK from _shared/preview`,
       );
     }
   }


### PR DESCRIPTION
## What & why

Auth now signs **ES256-only** (#2353); EdDSA was retired from signing, the JWKS, and minting. This removes the **last deploy-time references** to the retired EdDSA secret `AUTH_FORGE_PRIVATE_JWK`, switching them to the ES256 key `AUTH_FORGE_ES256_PRIVATE_JWK` — so the Doppler secret can be safely deleted afterward.

This is the **code half** of "delete the unused secret." Once merged, `AUTH_FORGE_PRIVATE_JWK` is deleted from Doppler (`_shared/{prd,preview,dev}` + `os/prd`). Order matters: the code must stop reading it *before* the secret is removed, or the next preview/deploy would read a missing secret.

## Changes (13 files)

- **`apps/{semaphore,streams-example-app}/scripts/sync-auth-client.ts`** — read the forge key as `AUTH_FORGE_ES256_PRIVATE_JWK` (from `os/prd`), and (semaphore) mirror it to `_shared/prd` under the ES256 name. `forge-token.ts` reads `alg` from the JWK, so minting the client-registration token just works.
- **`scripts/preview/preview.ts`** — the guard that validates the forge key is present in `_shared/preview` and inherited by each project's `preview` config now checks `AUTH_FORGE_ES256_PRIVATE_JWK` (this guard is exactly what would have caught the earlier preview gap).
- **`apps/auth/src/server/env.ts`** — remove the now-unused optional `AUTH_FORGE_PRIVATE_JWK` binding.
- Docs + comments across `apps/{auth,semaphore,os}`, `docs/{dev-environments,adding-preview-slots}.md` — updated to the ES256 key.

`AUTH_FORGE_ALLOW_PRODUCTION` is untouched (still the prod opt-in gate). `grep -rn AUTH_FORGE_PRIVATE_JWK` across the repo is now **zero**. Gates: typecheck (auth/os/semaphore/streams/scripts), oxlint, knip — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No signing or verification logic changes—only secret name alignment and doc updates so the old Doppler secret can be removed without deploy failures.
> 
> **Overview**
> Completes the **ES256-only** forge migration by removing the last references to the retired EdDSA Doppler secret `AUTH_FORGE_PRIVATE_JWK` and standardizing on **`AUTH_FORGE_ES256_PRIVATE_JWK`** everywhere.
> 
> **Runtime / tooling:** `apps/auth/src/server/env.ts` drops the unused optional `AUTH_FORGE_PRIVATE_JWK` binding. Preview provisioning (`scripts/preview/preview.ts`) and prd `sync-auth-client` scripts for **semaphore** and **streams-example-app** now read and mirror the ES256 key name (semaphore still copies into `_shared/prd`).
> 
> **Docs:** READMEs and operator/dev runbooks are updated so JWT signing, `pnpm auth:mint`, preview provisioning checks, and local `dev-all` all document the ES256 secret—enabling safe deletion of `AUTH_FORGE_PRIVATE_JWK` from Doppler after merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97424e06eed6ecc10dc0a947ddc74eccde2d436d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +3 -8 | +0 -0 ⬜⬜⬜⬜⬜ |
| Tests | +1 -1 | +0 -0 ⬜⬜⬜⬜⬜ |
| CI & scripts | +16 -12 | +15 -11 🟩🟩🟩🟥🟥 |
| Docs | +13 -13 | +13 -13 🟩🟩🟩🟥🟥 |
| **Total** | **+33 -34** | **+28 -24** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 58d51c1 and 97424e0, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T16:57:12.105Z",
      "deployedAt": "2026-07-29T16:50:41.536Z",
      "headSha": "97424e06eed6ecc10dc0a947ddc74eccde2d436d",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/273787054794882",
      "shortSha": "97424e0",
      "cleanupDurationMs": 21267,
      "deployDurationMs": 90887,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 80960,
      "deployReadinessDurationMs": 9924,
      "deployedWorkerName": "os-preview-8",
      "deployedWorkerVersion": "4bfde68e-bc27-4e76-99c4-61df1e3f4cd2",
      "testDurationMs": 217548,
      "testRetries": null,
      "workerSizeKib": 19935.5,
      "workerGzipKib": 5034.49,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5044.74
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-29T16:56:51.744Z",
      "deployedAt": "2026-07-29T16:49:33.236Z",
      "headSha": "97424e06eed6ecc10dc0a947ddc74eccde2d436d",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/273787054794882",
      "shortSha": "97424e0",
      "cleanupDurationMs": 904,
      "deployDurationMs": 12871,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 12657,
      "deployReadinessDurationMs": 209,
      "deployedWorkerName": "semaphore-preview-8",
      "deployedWorkerVersion": "02c06012-be32-4798-b179-e3022a17197f",
      "testDurationMs": 34943,
      "testRetries": null,
      "workerSizeKib": 1915.51,
      "workerGzipKib": 441.11,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T16:56:54.871Z",
      "deployedAt": "2026-07-29T16:49:40.243Z",
      "headSha": "97424e06eed6ecc10dc0a947ddc74eccde2d436d",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/273787054794882",
      "shortSha": "97424e0",
      "cleanupDurationMs": 4029,
      "deployDurationMs": 20022,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 19662,
      "deployReadinessDurationMs": 353,
      "deployedWorkerName": "auth-preview-8",
      "deployedWorkerVersion": "b27e3f87-312d-4c4c-ab16-6a01d77dde3d",
      "testDurationMs": 16886,
      "testRetries": null,
      "workerSizeKib": 3978.26,
      "workerGzipKib": 814.41,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-29T16:56:59.024Z",
      "deployedAt": "2026-07-29T16:49:40.613Z",
      "headSha": "97424e06eed6ecc10dc0a947ddc74eccde2d436d",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/273787054794882",
      "shortSha": "97424e0",
      "cleanupDurationMs": 8179,
      "deployDurationMs": 20715,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 20032,
      "deployReadinessDurationMs": 678,
      "deployedWorkerName": "streams-example-app-preview-8",
      "deployedWorkerVersion": "3d55e2ed-c451-4d23-9322-f0bff9080c73",
      "testDurationMs": 69108,
      "testRetries": null,
      "workerSizeKib": 5257.23,
      "workerGzipKib": 1488.99,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T16:56:51.817Z",
      "deployedAt": "2026-07-29T16:49:26.177Z",
      "headSha": "97424e06eed6ecc10dc0a947ddc74eccde2d436d",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/273787054794882",
      "shortSha": "97424e0",
      "cleanupDurationMs": 970,
      "deployDurationMs": 5814,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 5557,
      "deployReadinessDurationMs": 212,
      "deployedWorkerName": "dummy-petshop-preview-8",
      "deployedWorkerVersion": "a1461863-ca87-426c-9f97-9a2b94e96339",
      "testDurationMs": 9303,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+8d74450be93a83fb5cd1785d6e4e10d734e94acd",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `97424e0` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 814.4 KiB | 20.0s | 16.9s |  | 4.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/273787054794882) | 2026-07-29T16:56:54.871Z | Preview app released. |
| Dummy Petshop | released | `97424e0` | [https://dummy-petshop.iterate-preview-8.com](https://dummy-petshop.iterate-preview-8.com) | 198.3 KiB | 5.8s | 9.3s |  | 970ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/273787054794882) | 2026-07-29T16:56:51.817Z | Preview app released. |
| OS | released | `97424e0` | [https://os.iterate-preview-8.com](https://os.iterate-preview-8.com) | 4.92 MiB (-10.3 KiB vs main) | 90.9s | 217.5s |  | 21.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/273787054794882) | 2026-07-29T16:57:12.105Z | Preview app released. |
| Semaphore | released | `97424e0` | [https://semaphore.iterate-preview-8.com](https://semaphore.iterate-preview-8.com) | 441.1 KiB | 12.9s | 34.9s |  | 904ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/273787054794882) | 2026-07-29T16:56:51.744Z | Preview app released. |
| Streams Example App | released | `97424e0` | [https://streams.iterate-preview-8.com](https://streams.iterate-preview-8.com) | 1.45 MiB | 20.7s | 69.1s |  | 8.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/273787054794882) | 2026-07-29T16:56:59.024Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->