### PR TITLE
Filter integration directory reads on webhook ingress

### DIFF
--- a/apps/os/src/domains/integrations/integration-router-reconciliation.test.ts
+++ b/apps/os/src/domains/integrations/integration-router-reconciliation.test.ts
@@ -10,6 +10,10 @@ const network = vi.hoisted(() => {
   };
   const streams = new Map<string, StoredEvent[]>();
   const appendBatches: Array<{ inputs: Omit<StoredEvent, "offset">[]; name: string }> = [];
+  const eventReads: Array<{
+    input: { afterOffset?: number; eventTypes?: string[]; limit?: number };
+    name: string;
+  }> = [];
   return {
     STREAM: {
       getByName(name: string) {
@@ -29,6 +33,7 @@ const network = vi.hoisted(() => {
             });
           },
           getEvents(input: { afterOffset?: number; eventTypes?: string[]; limit?: number } = {}) {
+            eventReads.push({ input, name });
             const { afterOffset = 0, eventTypes, limit = 500 } = input;
             return stored
               .filter(
@@ -44,8 +49,10 @@ const network = vi.hoisted(() => {
     reset() {
       streams.clear();
       appendBatches.length = 0;
+      eventReads.length = 0;
     },
     appendBatches,
+    eventReads,
     streams,
   };
 });
@@ -95,6 +102,17 @@ describe("explicit webhook router creation", () => {
       slug: "slack",
     });
 
+    expect(network.eventReads).toContainEqual({
+      input: {
+        afterOffset: 0,
+        eventTypes: [
+          "events.iterate.com/integration/connection-claimed",
+          "events.iterate.com/integration/connection-unclaimed",
+        ],
+        limit: 500,
+      },
+      name: expect.any(String),
+    });
     expect(network.appendBatches).toHaveLength(1);
     expect(network.appendBatches[0]?.inputs).toEqual([
       expect.objectContaining({

--- a/apps/os/src/domains/integrations/integration-streams.ts
+++ b/apps/os/src/domains/integrations/integration-streams.ts
@@ -16,13 +16,17 @@ export function integrationStreamStub(projectId: string | null, path: string) {
   );
 }
 
-/** All events of one stream, oldest first, paged through the getEvents cursor. */
-async function readAllStreamEvents(projectId: string | null, path: string): Promise<StreamEvent[]> {
+/** All selected events of one stream, oldest first, paged through the getEvents cursor. */
+async function readAllStreamEvents(
+  projectId: string | null,
+  path: string,
+  eventTypes: readonly string[],
+): Promise<StreamEvent[]> {
   const stream = integrationStreamStub(projectId, path);
   const events: StreamEvent[] = [];
   let afterOffset = 0;
   for (;;) {
-    const page = await stream.getEvents({ afterOffset, limit: 500 });
+    const page = await stream.getEvents({ afterOffset, eventTypes, limit: 500 });
     events.push(...page);
     if (page.length < 500) return events;
     afterOffset = page[page.length - 1]!.offset;
@@ -30,6 +34,10 @@ async function readAllStreamEvents(projectId: string | null, path: string): Prom
 }
 
 const FILTERED_PAGE_SIZE = 500;
+const CONNECTION_DIRECTORY_EVENT_TYPES = [
+  "events.iterate.com/integration/connection-claimed",
+  "events.iterate.com/integration/connection-unclaimed",
+] as const;
 
 /**
  * The latest event matching any of the requested types.
@@ -119,7 +127,15 @@ export async function lookupConnectionClaim(
   slug: string,
   externalId: string,
 ): Promise<ConnectionClaim | null> {
-  const events = await readAllStreamEvents(null, INTEGRATION_DIRECTORY_STREAM_PATH);
+  // The directory stream also contains ordinary stream lifecycle events. Webhook
+  // ingress is bursty, so hydrating every unrelated event here multiplies one
+  // GitHub delivery into a large SQLite/body-read workload on a single DO.
+  // Storage-side event-type filtering leaves only the tiny claim history.
+  const events = await readAllStreamEvents(
+    null,
+    INTEGRATION_DIRECTORY_STREAM_PATH,
+    CONNECTION_DIRECTORY_EVENT_TYPES,
+  );
   return foldConnectionDirectory(events).get(directoryKey(slug, externalId)) ?? null;
 }
 


### PR DESCRIPTION
## What

- restrict connection-directory replay to claim and unclaim events
- keep the existing ownership fold and pagination semantics
- assert webhook routing asks stream storage for the narrow event set

## Why

Production webhook retries exposed that the directory has 1,535 total stream events but only 9 ownership events. Each ingress request was reading and deserializing all 1,535 rows, overloading and resetting the shared Stream Durable Object under a burst.

## Validation

- targeted integration tests: 7 passed
- apps/os typecheck
- oxlint on changed files
- diff check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path webhook ingress on a singleton directory Durable Object; incorrect filtering could mis-route or drop claims, though the fold logic and event-type set mirror existing ownership semantics.
> 
> **Overview**
> **Webhook routing no longer replays the full integration directory stream** when resolving which project owns an external id. `lookupConnectionClaim` now pages `getEvents` with only `connection-claimed` and `connection-unclaimed` types, so bursty ingress does not deserialize thousands of unrelated lifecycle rows on the shared Stream Durable Object.
> 
> `readAllStreamEvents` takes a required `eventTypes` list and passes it through on every page; ownership folding and pagination semantics are unchanged. Tests record `getEvents` inputs and assert webhook routing requests that narrow filter set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da0d284dd1d0a242920d39f4b8f26cb975200498. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +20 -4 | +14 -3 🟩🟩🟩🟩🟥 |
| Tests | +18 -0 | +16 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+38 -4** | **+30 -3** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between dcbf515 and da0d284, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T17:05:57.165Z",
      "deployedAt": "2026-07-29T17:04:26.729Z",
      "headSha": "da0d284dd1d0a242920d39f4b8f26cb975200498",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/334414177362250",
      "shortSha": "da0d284",
      "cleanupDurationMs": 9983,
      "deployDurationMs": 84616,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 84447,
      "deployReadinessDurationMs": 167,
      "deployedWorkerName": "os-preview-12",
      "deployedWorkerVersion": "0a9564cd-5f6c-4fba-8a55-3e8a9d005f61",
      "workerSizeKib": 19935.54,
      "workerGzipKib": 5034.21,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5044.69
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T17:05:49.750Z",
      "deployedAt": "2026-07-29T17:03:29.516Z",
      "headSha": "da0d284dd1d0a242920d39f4b8f26cb975200498",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/334414177362250",
      "shortSha": "da0d284",
      "cleanupDurationMs": 2565,
      "deployDurationMs": 27603,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 27232,
      "deployReadinessDurationMs": 368,
      "deployedWorkerName": "auth-preview-12",
      "deployedWorkerVersion": "3f9a463c-72e1-4510-9323-58bbf4f5775e",
      "workerSizeKib": 3978.26,
      "workerGzipKib": 814.7,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T17:05:47.919Z",
      "deployedAt": "2026-07-29T17:03:08.406Z",
      "headSha": "da0d284dd1d0a242920d39f4b8f26cb975200498",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/334414177362250",
      "shortSha": "da0d284",
      "cleanupDurationMs": 733,
      "deployDurationMs": 6365,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 6098,
      "deployReadinessDurationMs": 240,
      "deployedWorkerName": "dummy-petshop-preview-12",
      "deployedWorkerVersion": "03b11ba4-ebde-4dc2-9330-9f33e12cc87c",
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+8d74450be93a83fb5cd1785d6e4e10d734e94acd",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `da0d284` | [https://auth.iterate-preview-12.com](https://auth.iterate-preview-12.com) | 814.7 KiB | 27.6s |  |  | 2.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/334414177362250) | 2026-07-29T17:05:49.750Z | Preview app released. |
| Dummy Petshop | released | `da0d284` | [https://dummy-petshop.iterate-preview-12.com](https://dummy-petshop.iterate-preview-12.com) | 198.3 KiB | 6.4s |  |  | 733ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/334414177362250) | 2026-07-29T17:05:47.919Z | Preview app released. |
| OS | released | `da0d284` | [https://os.iterate-preview-12.com](https://os.iterate-preview-12.com) | 4.92 MiB (-10.5 KiB vs main) | 84.6s |  |  | 10.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/334414177362250) | 2026-07-29T17:05:57.165Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->