### PR TITLE
Remove unnecessary directory event assertion

### DIFF
--- a/apps/os/src/domains/integrations/integration-streams.ts
+++ b/apps/os/src/domains/integrations/integration-streams.ts
@@ -37,7 +37,7 @@ const FILTERED_PAGE_SIZE = 500;
 const CONNECTION_DIRECTORY_EVENT_TYPES = [
   "events.iterate.com/integration/connection-claimed",
   "events.iterate.com/integration/connection-unclaimed",
-] as const;
+];
 
 /**
  * The latest event matching any of the requested types.


### PR DESCRIPTION
## What

Remove the unnecessary const assertion from the integration-directory event list, addressing the Iterate AI linter review on #2358.

## Validation

- targeted integration tests: 7 passed
- apps/os typecheck
- oxlint on the changed file
- diff check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Typing-only cleanup on a constant event-type list; webhook routing and directory lookup behavior are unchanged.
> 
> **Overview**
> Removes the `as const` assertion on `CONNECTION_DIRECTORY_EVENT_TYPES` in `integration-streams.ts`, leaving the same two integration lifecycle event type strings.
> 
> The list is only passed into `readAllStreamEvents`, which already types `eventTypes` as `readonly string[]`, so the narrower literal tuple from `as const` added no useful typing and triggered linter feedback on the prior PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77af4ff33e7d20d9e1bffdc8b712cf88384c17b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +1 -1 | +1 -1 🟩🟩🟩🟥🟥 |
| **Total** | **+1 -1** | **+1 -1** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 1e00086 and 77af4ff, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T17:26:35.013Z",
      "deployedAt": "2026-07-29T17:13:21.349Z",
      "headSha": "77af4ff33e7d20d9e1bffdc8b712cf88384c17b4",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/537505312766696",
      "shortSha": "77af4ff",
      "cleanupDurationMs": 11502,
      "deployDurationMs": 50156,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 48938,
      "deployReadinessDurationMs": 1215,
      "deployedWorkerName": "os-preview-11",
      "deployedWorkerVersion": "51212304-d317-4244-8a09-55b394417aa4",
      "testDurationMs": 117571,
      "testRetries": null,
      "workerSizeKib": 19935.54,
      "workerGzipKib": 5034.21,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5044.88
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T17:26:26.545Z",
      "deployedAt": "2026-07-29T17:13:01.924Z",
      "headSha": "77af4ff33e7d20d9e1bffdc8b712cf88384c17b4",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/537505312766696",
      "shortSha": "77af4ff",
      "cleanupDurationMs": 3030,
      "deployDurationMs": 29543,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 29510,
      "deployReadinessDurationMs": 29,
      "deployedWorkerName": "auth-preview-11",
      "deployedWorkerVersion": "08a03c4d-5cc4-4bd8-8096-4e555b985739",
      "testDurationMs": 10622,
      "testRetries": null,
      "workerSizeKib": 3978.26,
      "workerGzipKib": 814.77,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T17:26:24.381Z",
      "deployedAt": "2026-07-29T17:12:42.517Z",
      "headSha": "77af4ff33e7d20d9e1bffdc8b712cf88384c17b4",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/537505312766696",
      "shortSha": "77af4ff",
      "cleanupDurationMs": 864,
      "deployDurationMs": 10308,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 10066,
      "deployReadinessDurationMs": 200,
      "deployedWorkerName": "dummy-petshop-preview-11",
      "deployedWorkerVersion": "3260d299-bfae-4ce0-b509-4ea7de52095e",
      "testDurationMs": 5378,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "aaaa0da8dde5dae44ddd3e1abf6dd64223d55315+8d74450be93a83fb5cd1785d6e4e10d734e94acd",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `77af4ff` | [https://auth.iterate-preview-11.com](https://auth.iterate-preview-11.com) | 814.8 KiB | 29.5s | 10.6s |  | 3.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/537505312766696) | 2026-07-29T17:26:26.545Z | Preview app released. |
| Dummy Petshop | released | `77af4ff` | [https://dummy-petshop.iterate-preview-11.com](https://dummy-petshop.iterate-preview-11.com) | 198.3 KiB | 10.3s | 5.4s |  | 864ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/537505312766696) | 2026-07-29T17:26:24.381Z | Preview app released. |
| OS | released | `77af4ff` | [https://os.iterate-preview-11.com](https://os.iterate-preview-11.com) | 4.92 MiB (-10.7 KiB vs main) | 50.2s | 117.6s |  | 11.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/537505312766696) | 2026-07-29T17:26:35.013Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->