### PR TITLE
fix: tighten e2e reliability diagnostics

### DIFF
--- a/apps/dummy-petshop/src/github-app.test.ts
+++ b/apps/dummy-petshop/src/github-app.test.ts
@@ -11,7 +11,7 @@
  */
 import { createHmac } from "node:crypto";
 import { createServer } from "node:http";
-import { describe, expect, test } from "vitest";
+import { beforeAll, describe, expect, test } from "vitest";
 import { listenOnFetchSafePort } from "@iterate-com/shared/test-support/fetch-safe-port";
 import { seedPets } from "./pets.ts";
 import { randomSealKey } from "./seal.ts";
@@ -75,6 +75,16 @@ async function generateAppKeys(): Promise<{ privateKey: CryptoKey; publicKeyPem:
   };
 }
 
+type AppKeys = Awaited<ReturnType<typeof generateAppKeys>>;
+
+let appKeys: AppKeys;
+let attackerKeys: AppKeys;
+
+beforeAll(async () => {
+  // RSA generation dominates this suite and every test only reads the keys.
+  [appKeys, attackerKeys] = await Promise.all([generateAppKeys(), generateAppKeys()]);
+}, 30_000);
+
 /**
  * Sign an App JWT the SAME way the OS side's secrets `sign()` does: RS256 over
  * the ASCII `header.payload`, signature base64url, joined `header.payload.sig`.
@@ -107,7 +117,7 @@ function appJwtClaims(
 describe("GitHub App installation-token minting", () => {
   test("a signed App JWT exchanges for an installation token that works on the API", async () => {
     const shop = makeShop();
-    const { privateKey, publicKeyPem } = await generateAppKeys();
+    const { privateKey, publicKeyPem } = appKeys;
 
     // Register ONLY the public key against the seeded installation.
     const registered = await shop("/__backdoor/apps", postJson({ publicKeyPem }));
@@ -141,7 +151,7 @@ describe("GitHub App installation-token minting", () => {
 
   test("registering a distinct app id + installation id mints a token naming them", async () => {
     const shop = makeShop();
-    const { privateKey, publicKeyPem } = await generateAppKeys();
+    const { privateKey, publicKeyPem } = appKeys;
     const created = await shop(
       "/__backdoor/apps",
       postJson({ appId: "app-42", installationId: "install-42", publicKeyPem }),
@@ -160,11 +170,10 @@ describe("GitHub App installation-token minting", () => {
 
   test("a JWT signed by a different key than the registered one is rejected 401", async () => {
     const shop = makeShop();
-    const { publicKeyPem } = await generateAppKeys();
+    const { publicKeyPem } = appKeys;
     await shop("/__backdoor/apps", postJson({ publicKeyPem }));
 
-    const attacker = await generateAppKeys();
-    const jwt = await signAppJwt(attacker.privateKey, appJwtClaims(DEFAULT_APP_ID));
+    const jwt = await signAppJwt(attackerKeys.privateKey, appJwtClaims(DEFAULT_APP_ID));
     const response = await mintInstallationToken(shop, DEFAULT_INSTALLATION_ID, jwt);
     expect(response.status).toBe(401);
     expect(await response.json()).toMatchObject({
@@ -175,7 +184,7 @@ describe("GitHub App installation-token minting", () => {
 
   test("an expired App JWT is rejected 401", async () => {
     const shop = makeShop();
-    const { privateKey, publicKeyPem } = await generateAppKeys();
+    const { privateKey, publicKeyPem } = appKeys;
     await shop("/__backdoor/apps", postJson({ publicKeyPem }));
 
     const jwt = await signAppJwt(
@@ -192,7 +201,7 @@ describe("GitHub App installation-token minting", () => {
 
   test("a JWT whose iss is not the app id is rejected 401", async () => {
     const shop = makeShop();
-    const { privateKey, publicKeyPem } = await generateAppKeys();
+    const { privateKey, publicKeyPem } = appKeys;
     await shop("/__backdoor/apps", postJson({ publicKeyPem }));
 
     const jwt = await signAppJwt(
@@ -209,7 +218,7 @@ describe("GitHub App installation-token minting", () => {
 
   test("the seeded installation is keyless until a key is registered; unknown ids 401", async () => {
     const shop = makeShop();
-    const { privateKey } = await generateAppKeys();
+    const { privateKey } = appKeys;
     const jwt = await signAppJwt(privateKey, appJwtClaims(DEFAULT_APP_ID));
 
     // No key registered yet → keyless installation → 401.
@@ -223,7 +232,7 @@ describe("GitHub App installation-token minting", () => {
 
   test("a missing or malformed Authorization JWT is rejected 401", async () => {
     const shop = makeShop();
-    const { publicKeyPem } = await generateAppKeys();
+    const { publicKeyPem } = appKeys;
     await shop("/__backdoor/apps", postJson({ publicKeyPem }));
 
     const noAuth = await shop(`/app/installations/${DEFAULT_INSTALLATION_ID}/access_tokens`, {
@@ -269,7 +278,7 @@ describe("GitHub App installation webhooks", () => {
 
   test("echo mode returns a body signed with the app's webhookSecret (OS verifies this)", async () => {
     const shop = makeShop();
-    const { publicKeyPem } = await generateAppKeys();
+    const { publicKeyPem } = appKeys;
     await shop("/__backdoor/apps", postJson({ publicKeyPem, webhookSecret: "wh-secret-123" }));
 
     const fired = await (
@@ -289,7 +298,7 @@ describe("GitHub App installation webhooks", () => {
 
   test("badSignature deliveries do not verify against the webhookSecret", async () => {
     const shop = makeShop();
-    const { publicKeyPem } = await generateAppKeys();
+    const { publicKeyPem } = appKeys;
     await shop("/__backdoor/apps", postJson({ publicKeyPem, webhookSecret: "wh-secret-123" }));
 
     const fired = await (
@@ -300,7 +309,7 @@ describe("GitHub App installation webhooks", () => {
 
   test("deliver mode POSTs the x-hub-signature-256 header (GitHub shape) a receiver verifies", async () => {
     const shop = makeShop();
-    const { publicKeyPem } = await generateAppKeys();
+    const { publicKeyPem } = appKeys;
     await shop("/__backdoor/apps", postJson({ publicKeyPem, webhookSecret: "wh-secret-123" }));
     const receiver = await startReceiver();
     try {

--- a/apps/os/src/domains/streams/stream-event-sender.test.ts
+++ b/apps/os/src/domains/streams/stream-event-sender.test.ts
@@ -1984,8 +1984,17 @@ describe("StreamConnections hosted delivery watchdog", () => {
       "stream durable callback unavailable; backing off before waking it again",
       {
         connectionKey: "processor",
-        errorMessage: "transport closed",
         source: "rpc-broken",
+        errorName: "Error",
+        errorMessage: "transport closed",
+        projectId: "project",
+        streamPath: "/source",
+        streamId: "11111111-1111-4111-8111-111111111111",
+        configuredAtOffset: 12,
+        cursorChangedAtOffset: 12,
+        connectionGeneration: 7,
+        deliveredThroughOffset: 0,
+        streamMaxOffset: 3,
       },
     );
     expect(errorLog).not.toHaveBeenCalled();
@@ -2108,11 +2117,24 @@ describe("StreamConnections hosted delivery watchdog", () => {
     const h = connectionsHarness();
     const calls: DeliveryCall[] = [];
     const disposed = vi.fn();
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const connection = h.connections.openHosted({
       connectionKey: "processor",
       expectedHostedDelivery: h.expectedDelivery,
       processEventBatch: recordingProcessEventBatch(calls, disposed),
       replayAfterOffset: 0,
+      openedBy: {
+        processor: {
+          announcement: {
+            slug: "test-processor",
+            version: "1.0.0",
+            description: "Test processor",
+            consumes: [],
+            emits: [],
+            ownedEvents: [],
+          },
+        },
+      },
     });
     connection.sendQueued();
     expect(calls).toHaveLength(1);
@@ -2129,11 +2151,74 @@ describe("StreamConnections hosted delivery watchdog", () => {
     expect(connection.isLive()).toBe(false);
     expect(disposed).toHaveBeenCalledTimes(1);
     expect(h.durableDeliveryWakes).toHaveBeenCalledTimes(1);
+    expect(errorLog).toHaveBeenCalledWith(
+      "stream durable callback failed; backing off before waking it again",
+      {
+        connectionKey: "processor",
+        source: "delivery",
+        errorName: "Error",
+        errorMessage: `hosted processor batch acknowledgement timed out after ${DEFAULT_DELIVERY_TIMEOUT_MS}ms`,
+        projectId: "project",
+        streamPath: "/source",
+        streamId: "11111111-1111-4111-8111-111111111111",
+        configuredAtOffset: 12,
+        cursorChangedAtOffset: 12,
+        connectionGeneration: 7,
+        deliveredThroughOffset: 1,
+        streamMaxOffset: 3,
+        pendingDeliveryStartedAt: "1970-01-01T00:00:01.000Z",
+        pendingDeliveryDeadlineAt: "1970-01-01T00:00:21.000Z",
+        processorSlug: "test-processor",
+        processorContractVersion: "1.0.0",
+      },
+    );
 
     calls[0]!.report("ok");
     await flushMicrotasks();
     expect(calls).toHaveLength(1);
     expect(h.deliveryFailures).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps ITX and Cloudflare references when a hosted processor reports an opaque failure", async () => {
+    const h = connectionsHarness();
+    const calls: DeliveryCall[] = [];
+    const warnLog = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const connection = h.connections.openHosted({
+      connectionKey: "processor",
+      expectedHostedDelivery: h.expectedDelivery,
+      processEventBatch: recordingProcessEventBatch(calls, () => undefined),
+      replayAfterOffset: 0,
+    });
+    connection.sendQueued();
+
+    (calls[0]!.batch as StreamWakeEventBatch).reportDeliveryResult({
+      outcome: "error",
+      error: {
+        name: "Error",
+        message:
+          "Internal error in Durable Object storage caused object to be reset; reference = h9ikm3iuo9v4aofff54akrbo",
+        itxCallId: "log_0123456789abcdef0123456789abcdef",
+        retryable: true,
+      },
+    });
+
+    expect(warnLog).toHaveBeenCalledWith(
+      "stream durable callback unavailable; backing off before waking it again",
+      expect.objectContaining({
+        connectionKey: "processor",
+        source: "delivery",
+        errorName: "Error",
+        itxCallId: "log_0123456789abcdef0123456789abcdef",
+        cloudflareErrorReference: "h9ikm3iuo9v4aofff54akrbo",
+      }),
+    );
+    expect(h.deliveryFailures).toHaveBeenCalledOnce();
+    expect(h.store.get("processor")).toMatchObject({
+      attempt: 1,
+      inFlightDeadlineAt: null,
+      inFlightConnectionGeneration: null,
+    });
+    expect(connection.isLive()).toBe(false);
   });
 
   it("idle teardown never acknowledges a batch that has not completed", () => {

--- a/apps/os/src/domains/streams/stream-event-sender.ts
+++ b/apps/os/src/domains/streams/stream-event-sender.ts
@@ -1512,6 +1512,44 @@ function connectionError(error: unknown): string {
   return boundedErrorMessage(error) ?? "unknown error";
 }
 
+function deliveryErrorDiagnostics(error: unknown): {
+  errorName: string;
+  errorMessage: string;
+  itxCallId?: string;
+  cloudflareErrorReference?: string;
+} {
+  const errorMessage = connectionError(error);
+  let errorName = "NonErrorThrowable";
+  let itxCallId: string | undefined;
+  try {
+    if (typeof error === "object" && error !== null) {
+      const candidateName: unknown = Reflect.get(error, "name");
+      const candidateItxCallId: unknown = Reflect.get(error, "itxCallId");
+      if (typeof candidateName === "string" && candidateName.length > 0) {
+        errorName = candidateName.slice(0, 200);
+      }
+      if (
+        typeof candidateItxCallId === "string" &&
+        candidateItxCallId.length > 0 &&
+        candidateItxCallId.length <= 200
+      ) {
+        itxCallId = candidateItxCallId;
+      }
+    }
+  } catch {
+    // A hostile remote throwable must not break the failure/retry transition.
+  }
+  const cloudflareErrorReference = /\breference\s*=\s*([a-z0-9]{8,128})\b/iu.exec(
+    errorMessage,
+  )?.[1];
+  return {
+    errorName,
+    errorMessage,
+    ...(itxCallId === undefined ? {} : { itxCallId }),
+    ...(cloudflareErrorReference === undefined ? {} : { cloudflareErrorReference }),
+  };
+}
+
 /**
  * Runtime state machine for session callbacks and hosted-processor callbacks.
  *
@@ -1651,7 +1689,35 @@ export class StreamConnections {
     ) {
       return;
     }
-    const details = { connectionKey, errorMessage: connectionError(error), source };
+    const state = this.#hooks.coreState();
+    const pendingDeliveryStartedAtMs = connection.pendingDeliveryStartedAtMs();
+    const pendingDeliveryDeadlineAtMs = connection.pendingDeliveryDeadlineAtMs();
+    const processorAnnouncement = connection.openedBy?.processor?.announcement;
+    const details = {
+      connectionKey,
+      source,
+      ...deliveryErrorDiagnostics(error),
+      projectId: state.projectId,
+      streamPath: state.path,
+      streamId: state.streamId,
+      configuredAtOffset: expectedDelivery.configuredAtOffset,
+      cursorChangedAtOffset: expectedDelivery.cursorChangedAtOffset,
+      connectionGeneration: expectedDelivery.connectionGeneration,
+      deliveredThroughOffset: connection.deliveredThroughOffset,
+      streamMaxOffset: state.maxOffset,
+      ...(pendingDeliveryStartedAtMs === null
+        ? {}
+        : { pendingDeliveryStartedAt: new Date(pendingDeliveryStartedAtMs).toISOString() }),
+      ...(pendingDeliveryDeadlineAtMs === null
+        ? {}
+        : { pendingDeliveryDeadlineAt: new Date(pendingDeliveryDeadlineAtMs).toISOString() }),
+      ...(processorAnnouncement === undefined
+        ? {}
+        : {
+            processorSlug: processorAnnouncement.slug,
+            processorContractVersion: processorAnnouncement.version,
+          }),
+    };
     if (error instanceof EventFilterEvaluationError) {
       console.info("stream hosted callback filter condition failed; backing off", details);
     } else if (source === "rpc-broken" || isDurableObjectLifecycleError(error)) {
@@ -2138,6 +2204,11 @@ function parseWakeDeliveryResult(
   return {
     outcome: "error",
     error: Object.assign(error, {
+      ...(typeof serialized.itxCallId === "string" &&
+      serialized.itxCallId.length > 0 &&
+      serialized.itxCallId.length <= 200
+        ? { itxCallId: serialized.itxCallId }
+        : {}),
       ...(serialized.durableObjectReset === true ? { durableObjectReset: true } : {}),
       ...(serialized.overloaded === true ? { overloaded: true } : {}),
       ...(serialized.retryable === true ? { retryable: true } : {}),

--- a/apps/os/src/domains/streams/stream-processor-registry.test.ts
+++ b/apps/os/src/domains/streams/stream-processor-registry.test.ts
@@ -519,10 +519,11 @@ describe("wakeStreamProcessor", () => {
     });
   });
 
-  it("reports processor failures with lifecycle classification intact", async () => {
+  it("reports processor failures with lifecycle classification and ITX correlation intact", async () => {
     const h = makeHarness();
     const lifecycleReset = Object.assign(new Error("subscriber incarnation reset"), {
       durableObjectReset: true,
+      itxCallId: "log_0123456789abcdef0123456789abcdef",
       retryable: true,
     });
     h.hooks.alpha.onProcess = (args) => {
@@ -551,6 +552,7 @@ describe("wakeStreamProcessor", () => {
           name: "Error",
           message: "subscriber incarnation reset",
           durableObjectReset: true,
+          itxCallId: "log_0123456789abcdef0123456789abcdef",
           retryable: true,
         },
       });

--- a/apps/os/src/itx-api-graph.generated.ts
+++ b/apps/os/src/itx-api-graph.generated.ts
@@ -2707,7 +2707,7 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
     name: "StreamWakeDeliveryError",
     kind: "typeAlias",
     sourceText:
-      "/**\n * Serializable failure reported after a durable wake delivery finishes.\n *\n * The result crosses an independent one-way RPC hop, so preserve the\n * lifecycle flags the stream uses to distinguish a dead Durable Object from\n * an application failure. Error prototypes and arbitrary properties do not\n * survive that hop reliably.\n */\nexport type StreamWakeDeliveryError = {\n  name: string;\n  message: string;\n  durableObjectReset?: true;\n  overloaded?: true;\n  retryable?: true;\n};",
+      "/**\n * Serializable failure reported after a durable wake delivery finishes.\n *\n * The result crosses an independent one-way RPC hop, so preserve the lifecycle\n * flags and ITX call correlation that distinguish and locate failures. Error\n * prototypes and arbitrary properties do not survive that hop reliably.\n */\nexport type StreamWakeDeliveryError = {\n  name: string;\n  message: string;\n  /** Wide-log ID of the failed ITX call, when the failure crossed that boundary. */\n  itxCallId?: string;\n  durableObjectReset?: true;\n  overloaded?: true;\n  retryable?: true;\n};",
     summary: "Serializable failure reported after a durable wake delivery finishes.",
     memberSummaries: {},
     referencedTypeNames: [],

--- a/apps/os/src/itx-api.generated.ts
+++ b/apps/os/src/itx-api.generated.ts
@@ -4649,14 +4649,15 @@ export type WorkerBundlerCreateWorkerOptions = WorkerBundlerOptions & {
 /**
  * Serializable failure reported after a durable wake delivery finishes.
  *
- * The result crosses an independent one-way RPC hop, so preserve the
- * lifecycle flags the stream uses to distinguish a dead Durable Object from
- * an application failure. Error prototypes and arbitrary properties do not
- * survive that hop reliably.
+ * The result crosses an independent one-way RPC hop, so preserve the lifecycle
+ * flags and ITX call correlation that distinguish and locate failures. Error
+ * prototypes and arbitrary properties do not survive that hop reliably.
  */
 export type StreamWakeDeliveryError = {
   name: string;
   message: string;
+  /** Wide-log ID of the failed ITX call, when the failure crossed that boundary. */
+  itxCallId?: string;
   durableObjectReset?: true;
   overloaded?: true;
   retryable?: true;

--- a/packages/iterate/src/itx-api.generated.ts
+++ b/packages/iterate/src/itx-api.generated.ts
@@ -4649,14 +4649,15 @@ export type WorkerBundlerCreateWorkerOptions = WorkerBundlerOptions & {
 /**
  * Serializable failure reported after a durable wake delivery finishes.
  *
- * The result crosses an independent one-way RPC hop, so preserve the
- * lifecycle flags the stream uses to distinguish a dead Durable Object from
- * an application failure. Error prototypes and arbitrary properties do not
- * survive that hop reliably.
+ * The result crosses an independent one-way RPC hop, so preserve the lifecycle
+ * flags and ITX call correlation that distinguish and locate failures. Error
+ * prototypes and arbitrary properties do not survive that hop reliably.
  */
 export type StreamWakeDeliveryError = {
   name: string;
   message: string;
+  /** Wide-log ID of the failed ITX call, when the failure crossed that boundary. */
+  itxCallId?: string;
   durableObjectReset?: true;
   overloaded?: true;
   retryable?: true;

--- a/packages/iterate/src/processors/rpc-types.ts
+++ b/packages/iterate/src/processors/rpc-types.ts
@@ -136,14 +136,15 @@ export type ProcessEventBatch = (batch: StreamEventBatch) => unknown;
 /**
  * Serializable failure reported after a durable wake delivery finishes.
  *
- * The result crosses an independent one-way RPC hop, so preserve the
- * lifecycle flags the stream uses to distinguish a dead Durable Object from
- * an application failure. Error prototypes and arbitrary properties do not
- * survive that hop reliably.
+ * The result crosses an independent one-way RPC hop, so preserve the lifecycle
+ * flags and ITX call correlation that distinguish and locate failures. Error
+ * prototypes and arbitrary properties do not survive that hop reliably.
  */
 export type StreamWakeDeliveryError = {
   name: string;
   message: string;
+  /** Wide-log ID of the failed ITX call, when the failure crossed that boundary. */
+  itxCallId?: string;
   durableObjectReset?: true;
   overloaded?: true;
   retryable?: true;

--- a/packages/iterate/src/processors/stream-processor-registry.ts
+++ b/packages/iterate/src/processors/stream-processor-registry.ts
@@ -172,23 +172,29 @@ type RegistryEntry = {
   runner: StreamProcessorRunner<any>;
 };
 
+const WakeDeliveryThrowableFields = z.object({
+  durableObjectReset: z.unknown().optional(),
+  itxCallId: z.unknown().optional(),
+  message: z.unknown().optional(),
+  name: z.unknown().optional(),
+  overloaded: z.unknown().optional(),
+  retryable: z.unknown().optional(),
+});
+
 function serializeWakeDeliveryError(error: unknown): StreamWakeDeliveryError {
-  const candidate =
-    typeof error === "object" && error !== null
-      ? (error as {
-          durableObjectReset?: unknown;
-          message?: unknown;
-          name?: unknown;
-          overloaded?: unknown;
-          retryable?: unknown;
-        })
-      : undefined;
+  const parsed = WakeDeliveryThrowableFields.safeParse(error);
+  const candidate = parsed.success ? parsed.data : undefined;
   return {
     name: typeof candidate?.name === "string" ? candidate.name : "Error",
     message:
       typeof candidate?.message === "string"
         ? candidate.message
         : String(error) || "unknown delivery failure",
+    ...(typeof candidate?.itxCallId === "string" &&
+    candidate.itxCallId.length > 0 &&
+    candidate.itxCallId.length <= 200
+      ? { itxCallId: candidate.itxCallId }
+      : {}),
     ...(candidate?.durableObjectReset === true ? { durableObjectReset: true as const } : {}),
     ...(candidate?.overloaded === true ? { overloaded: true as const } : {}),
     ...(candidate?.retryable === true ? { retryable: true as const } : {}),

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -29,6 +29,7 @@ const PreviewWorkflowConcurrency = z.object({
 const {
   ENVIRONMENT_CONFIG_LEASE_RESOURCE_TYPE,
   acquireAnyEnvironmentConfigLease,
+  announceRetryTelemetry,
   adoptLeaseHeldBySemaphore,
   claimEnvironmentConfigLease,
   describeForcePushCompareHazard,
@@ -788,6 +789,54 @@ describe("preview test commands", () => {
     const source = readFileSync(resolve(repoRoot, "scripts/preview/preview.ts"), "utf8");
 
     expect(source).not.toContain("E2E_RETRY_TELEMETRY_FILE");
+  });
+
+  test("announces a recovered retry as a notice without overriding the command exit code", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    try {
+      announceRetryTelemetry("os", {
+        retried: [
+          {
+            lane: "vitest",
+            name: "recovers",
+            retryCount: 1,
+            passedAfterRetry: true,
+          },
+        ],
+      });
+
+      expect(log).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "::notice title=Preview e2e retries::os: 1 retried: recovers (vitest x1). Every listed retry passed;",
+        ),
+      );
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  test("warns when retry telemetry still contains a failed test", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    try {
+      announceRetryTelemetry("os", {
+        retried: [
+          {
+            lane: "playwright",
+            name: "still broken",
+            retryCount: 1,
+            passedAfterRetry: false,
+          },
+        ],
+      });
+
+      expect(log).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "::warning title=Preview e2e retries::os: 1 retried: still broken (playwright x1, still failed). At least one listed retry still failed;",
+        ),
+      );
+    } finally {
+      log.mockRestore();
+    }
   });
 
   test("builds a focused Vitest invocation from the OS app", () => {

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -2062,10 +2062,14 @@ function announceRetryTelemetry(slug: string, summary: PreviewRetrySummary) {
   if (!rendered) {
     return;
   }
-  const level = summary.retried.length >= 4 ? "warning" : "notice";
+  const retryStillFailed = summary.retried.some((record) => !record.passedAfterRetry);
+  const level = retryStillFailed || summary.retried.length >= 4 ? "warning" : "notice";
+  const outcome = retryStillFailed
+    ? "At least one listed retry still failed; the test command's final exit code remains authoritative for this run."
+    : "Every listed retry passed; retry telemetry does not override the test command's final exit code.";
   console.log(
-    `::${level} title=Preview e2e retries::${slug}: ${rendered}. The retry passed and does not fail ` +
-      `this run; quarantine recurring or pathologically slow unrelated flakes per docs/testing.md.`,
+    `::${level} title=Preview e2e retries::${slug}: ${rendered}. ${outcome} ` +
+      "Quarantine recurring or pathologically slow unrelated flakes per docs/testing.md.",
   );
 }
 
@@ -6151,6 +6155,7 @@ function resolvePreviewCompareBaseSha(params: {
 export const previewInternals = {
   ENVIRONMENT_CONFIG_LEASE_RESOURCE_TYPE,
   acquireAnyEnvironmentConfigLease,
+  announceRetryTelemetry,
   adoptLeaseHeldBySemaphore,
   assignEnvironmentConfigLease,
   claimEnvironmentConfigLease,


### PR DESCRIPTION
## What

This extracts the first three small, no-regrets reliability improvements from the follow-up review of #2313:

1. **Hoist dummy GitHub App RSA fixtures**
   - Generate the valid and attacker 2048-bit keypairs once per test file, in parallel, behind a bounded `beforeAll`.
   - Preserve the distinct attacker key in the bad-signature case, so the behavior under test is unchanged.

2. **Make preview retry annotations truthful**
   - Report recovered retries as recovered.
   - Escalate any still-failing retry to a warning and explicitly state that the test command exit code remains authoritative.
   - Keep the existing high-retry warning threshold.

3. **Make hosted processor delivery failures attributable**
   - Preserve the originating ITX call ID across the one-way wake result.
   - Extract opaque Cloudflare reset references without trusting arbitrary thrown values.
   - Add the exact project, stream, cursor, batch, connection generation, pending deadline, processor slug, and processor contract version to the terminal delivery warning.
   - Keep retry, backoff, connection-close, and delivery semantics unchanged.

Generated ITX API artifacts are refreshed for the optional `itxCallId` wire field.

## Why

The RSA setup was repeated in every test despite being immutable fixture data. In the focused file this reduced test execution from **1.33s to 156ms** in the baseline comparison while retaining the same 12 assertions.

Preview output previously used success-shaped wording whenever retry telemetry existed, even if a recorded retry still failed. That made a red run harder to read precisely when the signal mattered most.

For hosted delivery failures, production traces showed four timeouts clustered inside eight seconds around a rollout, followed 1.5 seconds later by a Durable Object storage reset. That is useful evidence, but the warning omitted the stream coordinates and cross-boundary identifiers needed to join a specific wake attempt to its originating ITX call and Cloudflare reset. This PR closes that observability gap without changing recovery behavior.

## Production evidence behind the diagnostic change

- Sampled hosted delivery timeout: `2026-07-29T16:34:44.325Z`
- Four hosted timeout warnings appeared across projects within eight seconds.
- A nearby `StreamDurableObject.appendIfStreamId` failure reported an internal storage reset 1.515 seconds after the sampled timeout.
- Trace: https://dash.cloudflare.com/04b3b57291ef2626c6a8daa9d47065a7/observability/traces/d90f94068119cd3dcc8b885a973d3d9d

The timing strongly suggests a rollout/storage-reset cluster; it does not establish that the sampled append caused the sampled wake timeout. The new fields are specifically what will make that distinction provable next time.

## Validation

Before the final rebase:

```text
pnpm install && pnpm typecheck && pnpm lint && pnpm format && pnpm test
```

All passed. The OS suite completed with 243 files, 2,462 passing tests, 12 expected failures, and 1 skipped test.

After rebasing onto current `main`:

```text
63 stream/generated API tests passed
137 preview tests passed
12 dummy-petshop GitHub App tests passed
all 18 workspace typechecks passed
lint passed with 0 warnings and 0 errors
```

The new retry and causal-attribution assertions were first observed failing, then made green.

## Risk

Low and bounded:

- Test-only RSA fixture lifecycle change.
- Annotation wording/severity only; command exit status remains authoritative.
- One optional serialized diagnostic field and richer structured logs; no delivery-state or retry-policy change.

Source mining PR: #2313.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are test fixture hoisting, CI annotation wording, and optional diagnostic fields on structured logs; no changes to auth, retry policy, or delivery state machines.
> 
> **Overview**
> Improves **test speed**, **preview retry messaging**, and **hosted stream delivery logs** without changing delivery or retry behavior.
> 
> **dummy-petshop GitHub App tests** now generate the app and attacker RSA keypairs once in a shared `beforeAll` (parallel), instead of per test—same assertions, less RSA work.
> 
> **Preview e2e retry telemetry** (`announceRetryTelemetry`) distinguishes recovered retries from ones that still failed: still-failing retries (or many retries) emit **warnings** and state that the test command’s exit code stays authoritative; recovered-only cases stay **notices**.
> 
> **Hosted processor wake failures** gain observability across the RPC boundary: optional `itxCallId` on `StreamWakeDeliveryError`, preserved through serialize/parse in the registry and `stream-event-sender`. Terminal hosted-callback logs add structured fields (project, stream, cursor offsets, connection generation, pending batch deadlines, processor slug/version) plus safe extraction of Cloudflare `reference = …` from error messages. Tests lock in the new log shapes and ITX correlation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f486e08edd5f9bf3145d5dec0c5b523170e62576. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +93 -15 | +80 -6 🟩🟩🟩⬜⬜ |
| Tests | +160 -15 | +148 -15 🟩🟩🟩🟩🟩 |
| CI & scripts | +8 -3 | +8 -3 🟩⬜⬜⬜⬜ |
| Generated | +11 -9 | +1 -1 🟩⬜⬜⬜⬜ |
| **Total** | **+272 -42** | **+237 -25** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 1e00086 and f486e08, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T17:23:21.087Z",
      "deployedAt": "2026-07-29T17:09:24.970Z",
      "headSha": "f486e08edd5f9bf3145d5dec0c5b523170e62576",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/47091498996007",
      "shortSha": "f486e08",
      "cleanupDurationMs": 22116,
      "deployDurationMs": 122517,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 68161,
      "deployReadinessDurationMs": 54352,
      "deployedWorkerName": "os-preview-13",
      "deployedWorkerVersion": "737839d1-168a-4aed-82d9-005be4e66b22",
      "testDurationMs": 291023,
      "testRetries": "1 retried: is MITM-intercepted and routed through project egress with secret substitution (vitest x1) — Test timed out in 180000ms. If this is a long-running test, pass a timeout value as the last argument or configure it globally with \"testTimeout\".",
      "workerSizeKib": 19938.21,
      "workerGzipKib": 5034.79,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5044.88
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-29T17:22:59.913Z",
      "deployedAt": "2026-07-29T17:08:31.669Z",
      "headSha": "f486e08edd5f9bf3145d5dec0c5b523170e62576",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/47091498996007",
      "shortSha": "f486e08",
      "cleanupDurationMs": 940,
      "deployDurationMs": 15057,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 14857,
      "deployReadinessDurationMs": 194,
      "deployedWorkerName": "semaphore-preview-13",
      "deployedWorkerVersion": "ffaa3076-4148-4d20-9c60-8e38cd8ab3d2",
      "testDurationMs": 20762,
      "testRetries": null,
      "workerSizeKib": 1915.51,
      "workerGzipKib": 441.11,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T17:23:02.726Z",
      "deployedAt": "2026-07-29T17:08:35.844Z",
      "headSha": "f486e08edd5f9bf3145d5dec0c5b523170e62576",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/47091498996007",
      "shortSha": "f486e08",
      "cleanupDurationMs": 3751,
      "deployDurationMs": 19077,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 19032,
      "deployReadinessDurationMs": 41,
      "deployedWorkerName": "auth-preview-13",
      "deployedWorkerVersion": "7e700c6f-9376-4903-b123-35d695b97728",
      "testDurationMs": 10232,
      "testRetries": null,
      "workerSizeKib": 3978.26,
      "workerGzipKib": 814.64,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-29T17:23:06.717Z",
      "deployedAt": "2026-07-29T17:08:31.790Z",
      "headSha": "f486e08edd5f9bf3145d5dec0c5b523170e62576",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/47091498996007",
      "shortSha": "f486e08",
      "cleanupDurationMs": 7741,
      "deployDurationMs": 15694,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 14977,
      "deployReadinessDurationMs": 712,
      "deployedWorkerName": "streams-example-app-preview-13",
      "deployedWorkerVersion": "361ea0fe-2bf3-47b0-8281-fb277cbcb422",
      "testDurationMs": 53740,
      "testRetries": null,
      "workerSizeKib": 5259.42,
      "workerGzipKib": 1489.5,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T17:22:59.865Z",
      "deployedAt": "2026-07-29T17:08:22.815Z",
      "headSha": "f486e08edd5f9bf3145d5dec0c5b523170e62576",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/47091498996007",
      "shortSha": "f486e08",
      "cleanupDurationMs": 886,
      "deployDurationMs": 6219,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 5969,
      "deployReadinessDurationMs": 212,
      "deployedWorkerName": "dummy-petshop-preview-13",
      "deployedWorkerVersion": "d80ecda1-a7c1-4f93-a450-d84b31a8b09f",
      "testDurationMs": 5970,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+8d74450be93a83fb5cd1785d6e4e10d734e94acd",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `f486e08` | [https://auth.iterate-preview-13.com](https://auth.iterate-preview-13.com) | 814.6 KiB | 19.1s | 10.2s |  | 3.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/47091498996007) | 2026-07-29T17:23:02.726Z | Preview app released. |
| Dummy Petshop | released | `f486e08` | [https://dummy-petshop.iterate-preview-13.com](https://dummy-petshop.iterate-preview-13.com) | 198.3 KiB | 6.2s | 6.0s |  | 886ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/47091498996007) | 2026-07-29T17:22:59.865Z | Preview app released. |
| OS | released | `f486e08` | [https://os.iterate-preview-13.com](https://os.iterate-preview-13.com) | 4.92 MiB (-10.1 KiB vs main) | 122.5s | 291.0s | 1 retried: is MITM-intercepted and routed through project egress with secret substitution (vitest x1) — Test timed out in 180000ms. If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout". | 22.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/47091498996007) | 2026-07-29T17:23:21.087Z | Preview app released. |
| Semaphore | released | `f486e08` | [https://semaphore.iterate-preview-13.com](https://semaphore.iterate-preview-13.com) | 441.1 KiB | 15.1s | 20.8s |  | 940ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/47091498996007) | 2026-07-29T17:22:59.913Z | Preview app released. |
| Streams Example App | released | `f486e08` | [https://streams.iterate-preview-13.com](https://streams.iterate-preview-13.com) | 1.45 MiB | 15.7s | 53.7s |  | 7.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/47091498996007) | 2026-07-29T17:23:06.717Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->