### PR TITLE
Bound hosted processor catch-up

### DIFF
--- a/apps/os/src/domains/repos/config-repo-github-reviews.test.ts
+++ b/apps/os/src/domains/repos/config-repo-github-reviews.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GithubRepoLink, Project, StreamEvent, StreamEventInput } from "iterate/sdk";
-import { handleGithubPullRequestWebhook as handleGithubPullRequestWebhookWithPolicy } from "iterate/starter-apps/github-ai-linter/worker";
+import {
+  githubAiLinterEventTypes,
+  handleGithubPullRequestWebhook as handleGithubPullRequestWebhookWithPolicy,
+} from "iterate/starter-apps/github-ai-linter/worker";
 
 const testAndSpecFileGlobs = [
   "!**/*.{test,spec}.{js,jsx,mjs,cjs,ts,tsx,mts,cts}",
@@ -319,17 +322,7 @@ describe("userspace GitHub pull-request routing", () => {
         },
       },
     ]);
-    expect(test.subscribeToEventsFrom).toHaveBeenCalledWith(agentPath, {
-      sourceStreamPath: "/integrations/github/install-789",
-      subscriptionKey: "userspace:github-pr:/repos/config",
-      description: "Verified GitHub webhooks for acme/widgets#7",
-      filter: {
-        eventTypes: ["events.iterate.com/github/webhook-received"],
-        jsonataCondition:
-          "payload.associations.repository.id = 101 and payload.associations.pullRequest.number = 7",
-      },
-      start: "beginning",
-    });
+    expect(test.subscribeToEventsFrom).not.toHaveBeenCalled();
     expect(linterAgentEvents).toMatchObject([
       {
         idempotencyKey: "github-ai-linter/agent-policy:v1",
@@ -375,6 +368,9 @@ describe("userspace GitHub pull-request routing", () => {
           "github-ai-linter/subscription:install-789:101:7:policy:2:stream:/agents/repos/config/pr/7/ai-linter",
         payload: {
           subscriptionKey: "app-github-ai-linter#github-ai-linter",
+          filter: {
+            eventTypes: Object.values(githubAiLinterEventTypes),
+          },
           receiver: {
             action: "processor-wake",
             processorSlug: "github-ai-linter",
@@ -445,10 +441,7 @@ describe("userspace GitHub pull-request routing", () => {
     expect(test.create).toHaveBeenCalledWith(iterateAgentPath);
     expect(test.create).toHaveBeenCalledWith(iterateLinterPath);
     expect(test.appendBatches[0]?.path).toBe(iterateAgentPath);
-    expect(test.subscribeToEventsFrom).toHaveBeenCalledWith(
-      iterateAgentPath,
-      expect.objectContaining({ subscriptionKey: "userspace:github-pr:/repos/iterate" }),
-    );
+    expect(test.subscribeToEventsFrom).not.toHaveBeenCalled();
   });
 
   it("self-heals both agents from a later synchronize delivery", async () => {

--- a/apps/os/src/domains/streams/stream-event-sender.test.ts
+++ b/apps/os/src/domains/streams/stream-event-sender.test.ts
@@ -2123,13 +2123,16 @@ describe("StreamConnections hosted delivery watchdog", () => {
       streamEvent(3, "events.example.com/matched"),
       streamEvent(4, "events.example.com/ignored"),
     ];
+    const readLimits: number[] = [];
     const h = connectionsHarness({
       events,
-      readBatch: (afterOffset, beforeOffset, limit) =>
-        events
+      readBatch: (afterOffset, beforeOffset, limit) => {
+        readLimits.push(limit);
+        return events
           .filter((event) => event.offset > afterOffset && event.offset < beforeOffset)
           .slice(0, limit)
-          .map((event) => ({ event, byteLength: JSON.stringify(event).length })),
+          .map((event) => ({ event, byteLength: JSON.stringify(event).length }));
+      },
     });
     const calls: DeliveryCall[] = [];
     const connection = h.connections.openHosted({
@@ -2154,6 +2157,7 @@ describe("StreamConnections hosted delivery watchdog", () => {
       scannedThroughOffset: 4,
     });
     expect(calls[1]!.batch.events.map((event) => event.offset)).toEqual([3]);
+    expect(readLimits).toEqual([100, 100]);
   });
 
   it("turns a live callback timeout into a counted failure and ignores its late result", async () => {

--- a/apps/os/src/domains/streams/stream-event-sender.test.ts
+++ b/apps/os/src/domains/streams/stream-event-sender.test.ts
@@ -331,7 +331,7 @@ describe("StreamEventSender hosted processor delivery", () => {
     await h.settle();
 
     expect(h.wakeCalls).toHaveLength(1);
-    expect(attemptedOffsets).toEqual([[2, 3]]);
+    expect(attemptedOffsets).toEqual([[2]]);
     expect(h.store.get(PROCESSOR_KEY)).toMatchObject({
       acknowledgedOffset: 3,
       attempt: 1,
@@ -1753,6 +1753,7 @@ async function flushMicrotasks() {
 function connectionsHarness(
   options: {
     events?: StreamEvent[];
+    readBatch?: ConstructorParameters<typeof StreamConnections>[0]["hooks"]["readBatch"];
     onAppend?: (args: {
       connections: StreamConnections;
       state: CoreProcessorState;
@@ -1794,11 +1795,13 @@ function connectionsHarness(
     idleTeardownMs: 60_000,
     hooks: {
       // Force several batches so the test can observe the one-at-a-time gate.
-      readBatch: (afterOffset) =>
-        events
-          .filter((event) => event.offset > afterOffset)
-          .slice(0, 1)
-          .map((event) => ({ event, byteLength: JSON.stringify(event).length })),
+      readBatch:
+        options.readBatch ??
+        ((afterOffset) =>
+          events
+            .filter((event) => event.offset > afterOffset)
+            .slice(0, 1)
+            .map((event) => ({ event, byteLength: JSON.stringify(event).length }))),
       coreState: () => state,
       store,
       appendDeliveryEvent: (event) => {
@@ -2111,6 +2114,46 @@ describe("StreamConnections hosted delivery watchdog", () => {
       inFlightConnectionGeneration: 7,
     });
     expect(disposed).not.toHaveBeenCalled();
+  });
+
+  it("gives each matching hosted event an acknowledgement boundary without rescanning non-matches", async () => {
+    const events = [
+      streamEvent(1, "events.example.com/ignored"),
+      streamEvent(2, "events.example.com/matched"),
+      streamEvent(3, "events.example.com/matched"),
+      streamEvent(4, "events.example.com/ignored"),
+    ];
+    const h = connectionsHarness({
+      events,
+      readBatch: (afterOffset, beforeOffset, limit) =>
+        events
+          .filter((event) => event.offset > afterOffset && event.offset < beforeOffset)
+          .slice(0, limit)
+          .map((event) => ({ event, byteLength: JSON.stringify(event).length })),
+    });
+    const calls: DeliveryCall[] = [];
+    const connection = h.connections.openHosted({
+      connectionKey: "processor",
+      expectedHostedDelivery: h.expectedDelivery,
+      processEventBatch: recordingProcessEventBatch(calls, () => undefined),
+      replayAfterOffset: 0,
+      filter: compileEventFilter({ eventTypes: ["events.example.com/matched"] }),
+    });
+
+    connection.sendQueued();
+    expect(calls[0]!.batch).toMatchObject({
+      scannedAfterOffset: 0,
+      scannedThroughOffset: 2,
+    });
+    expect(calls[0]!.batch.events.map((event) => event.offset)).toEqual([2]);
+
+    calls[0]!.report("ok");
+    await flushMicrotasks();
+    expect(calls[1]!.batch).toMatchObject({
+      scannedAfterOffset: 2,
+      scannedThroughOffset: 4,
+    });
+    expect(calls[1]!.batch.events.map((event) => event.offset)).toEqual([3]);
   });
 
   it("turns a live callback timeout into a counted failure and ignores its late result", async () => {

--- a/apps/os/src/domains/streams/stream-event-sender.ts
+++ b/apps/os/src/domains/streams/stream-event-sender.ts
@@ -143,10 +143,12 @@ const DELIVERY_BATCH_LIMIT = 1000;
  * Hosted processors can turn one event into arbitrary Durable Object and
  * external work. Give each matching event its own acknowledgement boundary so
  * a slow event cannot make already-processed siblings time out and replay.
- * The source still scans up to DELIVERY_BATCH_LIMIT rows at once, so filters
- * skip irrelevant stretches without emitting one empty callback per row.
+ * Matching work is deliberately one-at-a-time. The separate scan limit keeps
+ * reconstructing and filtering a noisy source from filling the source Durable
+ * Object's memory before that one-event boundary can help.
  */
 const HOSTED_CALLBACK_EVENT_LIMIT = 1;
+const HOSTED_SCAN_EVENT_LIMIT = 100;
 
 /** Soft cap on a delivery batch's payload bytes (large events shrink the batch). */
 const DELIVERY_BATCH_BYTE_LIMIT = 1024 * 1024;
@@ -1978,7 +1980,7 @@ export class StreamConnections {
             const readEvents = this.#hooks.readBatch(
               deliveredThroughOffset,
               Number.MAX_SAFE_INTEGER,
-              DELIVERY_BATCH_LIMIT,
+              kind === "hosted" ? HOSTED_SCAN_EVENT_LIMIT : DELIVERY_BATCH_LIMIT,
             );
             const lastOffset = readEvents.at(-1)?.event.offset;
             if (lastOffset === undefined) {

--- a/apps/os/src/domains/streams/stream-event-sender.ts
+++ b/apps/os/src/domains/streams/stream-event-sender.ts
@@ -139,6 +139,15 @@ const MAX_FAILING_EVENT_SKIPS_SINCE_LAST_SUCCESS = 3;
  */
 const DELIVERY_BATCH_LIMIT = 1000;
 
+/**
+ * Hosted processors can turn one event into arbitrary Durable Object and
+ * external work. Give each matching event its own acknowledgement boundary so
+ * a slow event cannot make already-processed siblings time out and replay.
+ * The source still scans up to DELIVERY_BATCH_LIMIT rows at once, so filters
+ * skip irrelevant stretches without emitting one empty callback per row.
+ */
+const HOSTED_CALLBACK_EVENT_LIMIT = 1;
+
 /** Soft cap on a delivery batch's payload bytes (large events shrink the batch). */
 const DELIVERY_BATCH_BYTE_LIMIT = 1024 * 1024;
 
@@ -1985,10 +1994,21 @@ export class StreamConnections {
                       (entry) =>
                         entry.event.ephemeral !== true || entry.event.offset > openedAtOffset,
                     );
-              const delivered =
+              const matched =
                 args.filter === undefined
                   ? visible
                   : visible.filter((entry) => args.filter!.matches(entry.event));
+              const delivered =
+                kind === "hosted" ? matched.slice(0, HOSTED_CALLBACK_EVENT_LIMIT) : matched;
+              // If more matching hosted work remains in the scanned window,
+              // stop at the last event actually handed to the callback. The
+              // next acknowledged batch resumes immediately after it; all
+              // preceding non-matches have still been skipped durably.
+              const lastDeliveredOffset = delivered.at(-1)?.event.offset;
+              deliveredThroughOffset =
+                delivered.length < matched.length && lastDeliveredOffset !== undefined
+                  ? lastDeliveredOffset
+                  : lastOffset;
               events = delivered.map((entry) => entry.event);
               deliveredBytes = delivered.reduce((sum, entry) => sum + entry.byteLength, 0);
             }

--- a/packages/iterate/src/starter-apps/github-ai-linter/github-ai-linter.test.ts
+++ b/packages/iterate/src/starter-apps/github-ai-linter/github-ai-linter.test.ts
@@ -59,7 +59,7 @@ test("a linked connection gets a hosted review processor", async () => {
           },
           filter: {
             eventTypes: ["events.iterate.com/github/webhook-received"],
-            jsonataCondition: "offset > 8123",
+            jsonataCondition: expect.stringMatching(/^offset > 8123 and /),
           },
           subscriptionKey: "app-review-bot#review-bot",
         },
@@ -147,7 +147,7 @@ test("a config worker update refreshes every linked connection processor", async
           },
           filter: {
             eventTypes: ["events.iterate.com/github/webhook-received"],
-            jsonataCondition: "offset > 7500",
+            jsonataCondition: expect.stringMatching(/^offset > 7500 and /),
           },
           subscriptionKey: "app-review-bot#review-bot",
         },

--- a/packages/iterate/src/starter-apps/github-ai-linter/index.ts
+++ b/packages/iterate/src/starter-apps/github-ai-linter/index.ts
@@ -48,7 +48,11 @@ export const GithubAiLinter = {
             const existingCondition =
               runtime.coreProcessorState.subscriptions.outbound.byKey[REVIEW_BOT_SUBSCRIPTION_KEY]
                 ?.configuration.filter?.jsonataCondition;
-            const existingCutoffMatch = existingCondition?.match(/^offset > ([0-9]+)$/);
+            // Both the original cutoff-only condition and the narrowed
+            // condition start with this durable boundary. Keep accepting the
+            // old shape so the first config refresh upgrades in place without
+            // skipping webhooks which arrived since installation.
+            const existingCutoffMatch = existingCondition?.match(/^offset > ([0-9]+)(?:\s|$)/);
             const existingCutoff = existingCutoffMatch ? Number(existingCutoffMatch[1]) : null;
 
             // First configuration deliberately starts at the current head: a

--- a/packages/iterate/src/starter-apps/github-ai-linter/review-bot.ts
+++ b/packages/iterate/src/starter-apps/github-ai-linter/review-bot.ts
@@ -162,10 +162,10 @@ export async function handleGithubPullRequestWebhook(
     headSha !== undefined &&
     baseSha !== undefined;
 
-  // The durable agent subscription copies all later PR history. This router
-  // only acts when a delivery can create/wake the normal agent or request a
-  // linter analysis; status/edit/thread bookkeeping stays on the copied
-  // history without making this connection-level processor do work.
+  // The router turns the few webhooks which require work into explicit agent
+  // context or linter events below. The normal PR agent can read GitHub when
+  // asked; mirroring every raw webhook onto its stream only creates a second
+  // unbounded history and a source subscription per PR.
   if (!reviewLifecycleEvent && !mention) return;
 
   const linkedRepos =
@@ -200,9 +200,7 @@ export async function handleGithubPullRequestWebhook(
     streamPath: event.path,
     type: "event",
   };
-  // The durable receive rule below records every matching webhook on the
-  // agent stream with platform-authored source.copiedFrom history. These are
-  // only the companion agent events that should trigger work.
+  // These are the only companion agent events which should trigger work.
   const agentEvents: StreamEventInput[] = [];
 
   if (mention && author !== undefined && typeof requestBody === "string") {
@@ -237,16 +235,6 @@ export async function handleGithubPullRequestWebhook(
     );
   }
 
-  await agent.stream.subscribeToEventsFrom({
-    sourceStreamPath: event.path,
-    subscriptionKey: `userspace:github-pr:${repoPath}`,
-    description: `Verified GitHub webhooks for ${repository.owner}/${repository.repo}#${number}`,
-    filter: {
-      eventTypes: ["events.iterate.com/github/webhook-received"],
-      jsonataCondition: `payload.associations.repository.id = ${repository.id} and payload.associations.pullRequest.number = ${number}`,
-    },
-    start: "beginning",
-  });
   await agent.append(
     {
       type: "events.iterate.com/agents/context-added",

--- a/packages/iterate/src/starter-apps/github-ai-linter/worker-ref.ts
+++ b/packages/iterate/src/starter-apps/github-ai-linter/worker-ref.ts
@@ -16,6 +16,27 @@ const configuredWorkerEntrypoint =
 
 export const REVIEW_BOT_SUBSCRIPTION_KEY = "app-review-bot#review-bot";
 
+const REVIEW_BOT_RELEVANT_WEBHOOK_CONDITION = [
+  '(payload.delivery.name = "pull_request" and',
+  '(payload.body.action = "opened" or',
+  'payload.body.action = "ready_for_review" or',
+  'payload.body.action = "synchronize"))',
+  "or",
+  '((payload.delivery.name = "issue_comment" or',
+  'payload.delivery.name = "pull_request_review" or',
+  'payload.delivery.name = "pull_request_review_comment") and',
+  "$count(payload.associations.mentionedUsers) > 0)",
+].join(" ");
+
+/**
+ * The review router only needs lifecycle deliveries and explicit mentions.
+ * Filtering on the source stream keeps check/workflow webhook bursts out of
+ * the hosted processor while the offset prefix preserves the restore cutoff.
+ */
+function reviewBotSubscriptionCondition(startAfterOffset: number) {
+  return `offset > ${startAfterOffset} and (${REVIEW_BOT_RELEVANT_WEBHOOK_CONDITION})`;
+}
+
 export async function reviewBotSubscriptionEvent(
   sourceEvent: StreamEvent,
   connection: string,
@@ -31,7 +52,7 @@ export async function reviewBotSubscriptionEvent(
       // Config refreshes preserve the original cutoff in index.ts.
       filter: {
         eventTypes: ["events.iterate.com/github/webhook-received"],
-        jsonataCondition: `offset > ${startAfterOffset}`,
+        jsonataCondition: reviewBotSubscriptionCondition(startAfterOffset),
       },
       receiver: {
         action: "processor-wake",

--- a/packages/iterate/src/starter-apps/github-ai-linter/worker-ref.ts
+++ b/packages/iterate/src/starter-apps/github-ai-linter/worker-ref.ts
@@ -1,4 +1,5 @@
 import type { StatefulDynamicWorkerRef, StreamEvent, StreamEventInput } from "../../sdk.ts";
+import { githubAiLinterEventTypes } from "./contract.ts";
 import type { GithubAiLinterRuleSource } from "./rules.ts";
 
 export type GithubAiLinterConfig = {
@@ -85,6 +86,13 @@ export async function pullRequestLinterSubscriptionEvent(
     type: "events.iterate.com/stream/subscription-configured",
     payload: {
       subscriptionKey: "app-github-ai-linter#github-ai-linter",
+      // The linter Durable Object reduces this explicit protocol, not the
+      // surrounding agent's tool calls, LLM bookkeeping, or conversation.
+      // Source-side filtering makes a restart proportional to analyses rather
+      // than to every durable event the generic agent has ever appended.
+      filter: {
+        eventTypes: Object.values(githubAiLinterEventTypes),
+      },
       receiver: {
         action: "processor-wake",
         expression: [


### PR DESCRIPTION
## Summary

- give hosted processors one matching event per acknowledgement and cap each raw source scan at 100 rows
- narrow ReviewBot to PR lifecycle webhooks and explicit mentions
- deliver only the six declared GitHub AI-linter protocol events to each linter processor
- remove the redundant raw-webhook replay subscription from conversational PR agents; they receive explicit authorized context and can read GitHub normally
- preserve the production restore cutoff when config refreshes the ReviewBot subscription

## Why

The production rollout exposed two coupled replay storms. ReviewBot received 230 GitHub webhooks in one callback, while PR linter processors received every generic agent event. The conversational PR setup also repeatedly repointed one source replay subscription between different PRs and rescanned the full GitHub stream from the beginning. Those callbacks exceeded the 20-second acknowledgement window, replayed, and drove Durable Objects into storage resets and overload.

This change keeps the stream-processor model but makes the streams carry only the explicit work protocol.

## Verification

- apps/os targeted stream and GitHub review tests: 62 passed
- packages/iterate GitHub AI-linter tests: 3 passed
- apps/os typecheck: passed
- packages/iterate typecheck: passed
- targeted Oxlint: 0 warnings and errors
- targeted Oxfmt check: passed
- production ReviewBot recovery and exact-head proof will be repeated after this commit deploys

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T17:52:28.213Z",
      "deployedAt": "2026-07-29T17:46:54.706Z",
      "headSha": "7f1ccd0d5c28031dddf4565834c948e6d99575a9",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-18.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/370331834609971",
      "shortSha": "7f1ccd0",
      "cleanupDurationMs": 13004,
      "deployDurationMs": 40706,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 39486,
      "deployReadinessDurationMs": 1217,
      "deployedWorkerName": "os-preview-18",
      "deployedWorkerVersion": "37b24ddd-807c-443d-9c51-85bf19e69468",
      "testDurationMs": 208599,
      "testRetries": "6 retried: two OAuth clients, two connections: connect, call, forced-expiry refresh (vitest x1) — stream-unavailable: Internal error in Durable Object storage caused object to be reset; reference = la3gpo23usve5qo3m9hk6mcn · itx expression capabilities mount project workers, streams, method aliases, and functions (vitest x1) — Durable Object reset because its code was updated. · OS preview smoke (vitest x1) — stream-unavailable: Internal error in Durable Object storage caused object to be reset; reference = dotcn2ojvfp0opakuv2ge1uk · an external client authenticates with the project-secret credential and gets exactly its project (vitest x1) — stream-unavailable: Internal error in Durable Object storage caused object to be reset; reference = hme44qbmb8iq4cihvis4imte · stream-resume-after-suspend.spec.ts › feed resumes after the /api WebSocket goes half-open (no close frame) › preview-resilience (playwright x1) — TimeoutError: locator.waitFor: Timeout 30000ms exceeded. Call log: \u001b[2m - waiting for locator('[data-testid=\"agent-feed-message\"][data-kind=\"assistant\"]').first() to be visible\u001b[22m · reactivity.spec.ts › reactivity page repaints from a stream subscription after a page action › web (playwright x1) — TimeoutError: locator.waitFor: Timeout 30000ms exceeded. Call log: \u001b[2m - waiting for getByTestId('reactivity-event-list').getByText('reactivity-event-1') to be visible\u001b[22m \u001b[33m Loading finished (spinner disappeared after 34101ms) but the expected element was not ready.\u001b[0m",
      "workerSizeKib": 19939.06,
      "workerGzipKib": 5035.09,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5045.96
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T17:52:18.728Z",
      "deployedAt": "2026-07-29T17:46:31.685Z",
      "headSha": "7f1ccd0d5c28031dddf4565834c948e6d99575a9",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-18.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/370331834609971",
      "shortSha": "7f1ccd0",
      "cleanupDurationMs": 3516,
      "deployDurationMs": 16506,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 16462,
      "deployReadinessDurationMs": 39,
      "deployedWorkerName": "auth-preview-18",
      "deployedWorkerVersion": "66ac00db-22af-4438-b0c2-1360adfbbc2f",
      "testDurationMs": 10632,
      "testRetries": null,
      "workerSizeKib": 3978.26,
      "workerGzipKib": 814.67,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-29T17:52:26.571Z",
      "deployedAt": "2026-07-29T17:38:39.869Z",
      "headSha": "7f1ccd0d5c28031dddf4565834c948e6d99575a9",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-18.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/370331834609971",
      "shortSha": "7f1ccd0",
      "cleanupDurationMs": 11356,
      "deployDurationMs": 14766,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 14098,
      "deployReadinessDurationMs": 661,
      "deployedWorkerName": "streams-example-app-preview-18",
      "deployedWorkerVersion": "be655455-dc07-4f9b-ab8b-d345b2abeebe",
      "testDurationMs": 49399,
      "testRetries": null,
      "workerSizeKib": 5260.26,
      "workerGzipKib": 1489.8,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T17:52:16.208Z",
      "deployedAt": "2026-07-29T17:26:43.079Z",
      "headSha": "7f1ccd0d5c28031dddf4565834c948e6d99575a9",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-18.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/370331834609971",
      "shortSha": "7f1ccd0",
      "cleanupDurationMs": 993,
      "deployDurationMs": 86,
      "deployConfigDurationMs": 4,
      "deployReuseProofDurationMs": 40,
      "deployedWorkerName": "dummy-petshop-preview-18",
      "deployedWorkerVersion": "4cbbd541-37da-4c1e-be34-05c16169fc36",
      "testDurationMs": 5772,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+8d74450be93a83fb5cd1785d6e4e10d734e94acd",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `7f1ccd0` | [https://auth.iterate-preview-18.com](https://auth.iterate-preview-18.com) | 814.7 KiB | 16.5s | 10.6s |  | 3.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/370331834609971) | 2026-07-29T17:52:18.728Z | Preview app released. |
| Dummy Petshop | released | `7f1ccd0` | [https://dummy-petshop.iterate-preview-18.com](https://dummy-petshop.iterate-preview-18.com) | 198.3 KiB | 86ms | 5.8s |  | 993ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/370331834609971) | 2026-07-29T17:52:16.208Z | Preview app released. |
| OS | released | `7f1ccd0` | [https://os.iterate-preview-18.com](https://os.iterate-preview-18.com) | 4.92 MiB (-10.9 KiB vs main) | 40.7s | 208.6s | 6 retried: two OAuth clients, two connections: connect, call, forced-expiry refresh (vitest x1) — stream-unavailable: Internal error in Durable Object storage caused object to be reset; reference = la3gpo23usve5qo3m9hk6mcn · itx expression capabilities mount project workers, streams, method aliases, and functions (vitest x1) — Durable Object reset because its code was updated. · OS preview smoke (vitest x1) — stream-unavailable: Internal error in Durable Object storage caused object to be reset; reference = dotcn2ojvfp0opakuv2ge1uk · an external client authenticates with the project-secret credential and gets exactly its project (vitest x1) — stream-unavailable: Internal error in Durable Object storage caused object to be reset; reference = hme44qbmb8iq4cihvis4imte · stream-resume-after-suspend.spec.ts › feed resumes after the /api WebSocket goes half-open (no close frame) › preview-resilience (playwright x1) — TimeoutError: locator.waitFor: Timeout 30000ms exceeded. Call log: [2m - waiting for locator('[data-testid="agent-feed-message"][data-kind="assistant"]').first() to be visible[22m · reactivity.spec.ts › reactivity page repaints from a stream subscription after a page action › web (playwright x1) — TimeoutError: locator.waitFor: Timeout 30000ms exceeded. Call log: [2m - waiting for getByTestId('reactivity-event-list').getByText('reactivity-event-1') to be visible[22m [33m Loading finished (spinner disappeared after 34101ms) but the expected element was not ready.[0m | 13.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/370331834609971) | 2026-07-29T17:52:28.213Z | Preview app released. |
| Streams Example App | released | `7f1ccd0` | [https://streams.iterate-preview-18.com](https://streams.iterate-preview-18.com) | 1.45 MiB | 14.8s | 49.4s |  | 11.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/370331834609971) | 2026-07-29T17:52:26.571Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->