### PR TITLE
Separate two-tab bootstrap and kill-recovery contracts

### DIFF
--- a/apps/streams-example-app/e2e/playwright/stream-browser.spec.ts
+++ b/apps/streams-example-app/e2e/playwright/stream-browser.spec.ts
@@ -418,12 +418,9 @@ test("split view can mount the same stream twice and display appends", async ({ 
   await expect(eventMeta(page, type)).toHaveCount(2);
 });
 
-// Covers the original writer role requirement across browser tabs. Closing the elected writer
-// must release the lock, promote the reader, reconnect, and keep future appends live.
-test("two browser tabs update and hand off writer role after the writer closes", async ({
-  context,
-  page,
-}) => {
+// Dedicated simultaneous cold-bootstrap contract: two tabs racing from an empty local database
+// must converge on exactly one writer and one reader, share events, and hand off cleanly.
+test("simultaneous cold tabs converge and hand off the writer role", async ({ context, page }) => {
   const streamPath = `/e2e/${crypto.randomUUID()}`;
   const otherPage = await context.newPage();
 
@@ -436,8 +433,13 @@ test("two browser tabs update and hand off writer role after the writer closes",
     expect(eventMeta(otherPage, "events.iterate.com/stream/created").first()).toBeVisible(),
   ]);
 
-  const type = "events.iterate.com/debug/playwright-two-tabs";
-  await appendComposerEvent(page, {
+  const writer = (await isWriter(page)) ? page : otherPage;
+  const reader = writer === page ? otherPage : page;
+  await expect(writer.getByTestId("database-role")).toHaveText("writer");
+  await expect(reader.getByTestId("database-role")).toHaveText("reader");
+
+  const type = "events.iterate.com/debug/playwright-simultaneous-cold-tabs";
+  await appendComposerEvent(reader, {
     type,
     payload: { streamPath, value: crypto.randomUUID() },
   });
@@ -447,9 +449,6 @@ test("two browser tabs update and hand off writer role after the writer closes",
     expect(eventMeta(otherPage, type).first()).toBeVisible(),
   ]);
 
-  const writer = (await isWriter(page)) ? page : otherPage;
-  const reader = writer === page ? otherPage : page;
-  await expect(reader.getByTestId("database-role")).toContainText(/reader|writer/);
   await writer.close();
   await expect(reader.getByTestId("database-role")).toHaveText("writer");
 
@@ -998,27 +997,26 @@ test("killing the stream DO mid-blast loses no appends and duplicates none", asy
     .toBe(insertedCount);
 });
 
-// Same guarantee from a READER tab: appends ride the reader's own connection (no
-// writer role required), survive a mid-blast DO kill, and both tabs' databases contain
-// the exact same count.
-test("two tabs: reader blast survives a DO kill and both databases contain every event", async ({
+// Same guarantee from an established READER tab: appends ride the reader's own connection
+// (no writer role required), survive a mid-blast DO kill, and both tabs' databases contain
+// the exact same count. Cold writer election is intentionally outside this contract; the
+// simultaneous-cold-tabs test above owns that independent race.
+test("established reader blast survives a DO kill and both databases contain every event", async ({
   context,
   page,
 }) => {
   const streamPath = `/e2e/${crypto.randomUUID()}`;
-  const otherPage = await context.newPage();
-  await Promise.all([
-    page.goto(streamRoute({ path: streamPath })),
-    otherPage.goto(streamRoute({ path: streamPath })),
-  ]);
-  await Promise.all([
-    expect(eventMeta(page, "events.iterate.com/stream/created").first()).toBeVisible(),
-    expect(eventMeta(otherPage, "events.iterate.com/stream/created").first()).toBeVisible(),
-  ]);
+  await page.goto(streamRoute({ path: streamPath }));
+  await expect(eventMeta(page, "events.iterate.com/stream/created").first()).toBeVisible();
+  await expect(page.getByTestId("database-role")).toHaveText("writer");
 
-  const writer = (await isWriter(page)) ? page : otherPage;
-  const reader = writer === page ? otherPage : page;
-  await expect(reader.getByTestId("database-role")).toContainText(/reader|writer/);
+  const otherPage = await context.newPage();
+  await otherPage.goto(streamRoute({ path: streamPath }));
+  await expect(eventMeta(otherPage, "events.iterate.com/stream/created").first()).toBeVisible();
+  await expect(otherPage.getByTestId("database-role")).toHaveText("reader");
+
+  const writer = page;
+  const reader = otherPage;
 
   const insertedCount = 2000;
   await reader.getByLabel("Count").fill(String(insertedCount));


### PR DESCRIPTION
## What changes

- Strengthen the existing simultaneous cold-tab test into a dedicated concurrency contract: both tabs open together, converge on exactly one writer and one reader, share a reader-originated event, and hand off cleanly after the writer closes.
- Establish the writer and reader sequentially before the independent 2,000-event blast/DO-kill test, then retain its exact-count assertions in both local databases.

## Why

The previous heavy test combined two independent failure surfaces:

1. simultaneous cold-start writer election; and
2. reader-originated high-volume appends across a Durable Object restart.

That coupling made a setup race indistinguishable from a kill/reconnect/data-integrity failure. Merely making the setup sequential would have erased useful concurrent-bootstrap coverage, so this PR gives that behavior an explicit, smaller contract and removes it only from the heavy recovery contract.

This is test-only reliability work. It changes no production logic, timeout, retry, schema, or compatibility behavior, and it does not claim a runtime speedup—the gain is deterministic preconditions and attributable failures.

## Evidence

- Unchanged heavy-test baseline: `pnpm --dir apps/streams-example-app playwright --grep 'two tabs: reader blast survives a DO kill' --repeat-each=10` — **10/10 passed** in 4.0m, about 23s each.
- Split contracts: `pnpm --dir apps/streams-example-app playwright --grep 'simultaneous cold tabs|established reader blast' --repeat-each=10` — **20/20 passed** in 4.1m.
- Throttled stress (`E2E_CPU_THROTTLE=6 E2E_NET_LATENCY_MS=100`), both contracts repeated three times — **6/6 passed** in 1.7m.
- Full streams-example-app lane against an explicit local Vite server: Vitest **21/21 passed**; Playwright **31 passed, 1 intentional skip**, with zero local retries.
- Repository gate: `pnpm install && pnpm typecheck && pnpm lint && pnpm format && pnpm test` — passed; OS alone ran **2,456 passing tests**, 12 expected failures, and 1 skip.

## Provenance

This extracts the next small two-tab reliability candidate identified while mining #2313. The adjacent hosted-processor acknowledgement/recovery candidate landed independently as #2362 and has separate production evidence there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Playwright e2e tests in the streams example app; no production or runtime logic is modified.
> 
> **Overview**
> **Test-only** refactor in `stream-browser.spec.ts` that **decouples** two previously coupled multi-tab contracts so failures are easier to attribute.
> 
> The **simultaneous cold-bootstrap** scenario is now an explicit test (`simultaneous cold tabs converge and hand off the writer role`): both tabs open together, assertions require **exactly one writer and one reader**, a **reader-originated** append is shared across tabs, and closing the writer must promote the reader and keep appends working.
> 
> The **heavy DO-kill / 2k-event blast** test (`established reader blast survives a DO kill…`) no longer races cold writer election: the **first tab** is opened and asserted as **writer**, the **second** as **reader**, then the reader runs the blast while the writer kills the DO. Comments state cold election is owned by the new test only.
> 
> No production code, timeouts, or runtime behavior changes—only Playwright setup and naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac6b362ab9532ea385667da481d92996bd5b1e54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +24 -26 | +16 -21 🟩🟩🟥🟥🟥 |
| **Total** | **+24 -26** | **+16 -21** 🟩🟩🟥🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 7dfaa4b and ac6b362, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T18:39:06.039Z",
      "deployedAt": "2026-07-29T18:34:24.417Z",
      "headSha": "ac6b362ab9532ea385667da481d92996bd5b1e54",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/373384178704138",
      "shortSha": "ac6b362",
      "cleanupDurationMs": 2675,
      "deployDurationMs": 19957,
      "deployConfigDurationMs": 1,
      "deployCommandDurationMs": 19595,
      "deployReadinessDurationMs": 361,
      "deployedWorkerName": "auth-preview-4",
      "deployedWorkerVersion": "803a96d0-c51d-4f8d-b2e8-7da102babde7",
      "testDurationMs": 3269,
      "testRetries": null,
      "workerSizeKib": 3978.65,
      "workerGzipKib": 814.58,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-29T18:39:10.451Z",
      "deployedAt": "2026-07-29T18:34:21.918Z",
      "headSha": "ac6b362ab9532ea385667da481d92996bd5b1e54",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/373384178704138",
      "shortSha": "ac6b362",
      "cleanupDurationMs": 7084,
      "deployDurationMs": 17888,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 17093,
      "deployReadinessDurationMs": 791,
      "deployedWorkerName": "streams-example-app-preview-4",
      "deployedWorkerVersion": "ed2ca664-0f87-4f64-8841-651335a90679",
      "testDurationMs": 156692,
      "testRetries": "1 retried: node-hosted stream processor (e2e) > reconnects and resumes from its snapshot without reprocessing (vitest x1) — WebSocket connection failed.",
      "workerSizeKib": 5262.09,
      "workerGzipKib": 1490.21,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `ac6b362` | [https://auth.iterate-preview-4.com](https://auth.iterate-preview-4.com) | 814.6 KiB | 20.0s | 3.3s |  | 2.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/373384178704138) | 2026-07-29T18:39:06.039Z | Preview app released. |
| Streams Example App | released | `ac6b362` | [https://streams.iterate-preview-4.com](https://streams.iterate-preview-4.com) | 1.46 MiB | 17.9s | 156.7s | 1 retried: node-hosted stream processor (e2e) > reconnects and resumes from its snapshot without reprocessing (vitest x1) — WebSocket connection failed. | 7.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/373384178704138) | 2026-07-29T18:39:10.451Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->