### PR TITLE
Close Docs project dials when clients disconnect

### DIFF
--- a/apps/docs/src/rpc-api-lifecycle.test.ts
+++ b/apps/docs/src/rpc-api-lifecycle.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const lifecycle = vi.hoisted(() => ({
+  close: vi.fn(),
+}));
+
+vi.mock("@iterate-com/workspace-documents/server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@iterate-com/workspace-documents/server")>();
+  return {
+    ...actual,
+    ProjectDial: class {
+      close = lifecycle.close;
+
+      withProject<T>(
+        operation: (project: { identity(): Promise<{ projectId: string }> }) => PromiseLike<T>,
+      ): PromiseLike<T> {
+        return operation({
+          identity: async () => ({ projectId: "prj_docs_test" }),
+        });
+      }
+    },
+  };
+});
+
+import { DocsApiRoot } from "./rpc-api.ts";
+
+describe("Docs project lifecycle", () => {
+  beforeEach(() => lifecycle.close.mockClear());
+
+  test("closes the downstream OS connection when the project capability is released", async () => {
+    const root = new DocsApiRoot(
+      { OS_BASE_URL: "https://os.example.com" },
+      new Request("https://docs.example.com/api"),
+    );
+    const project = await root.authenticate({
+      projectId: "prj_docs_test",
+      secret: "test-secret",
+      type: "project-secret",
+    });
+
+    expect(lifecycle.close).not.toHaveBeenCalled();
+
+    (project as Partial<Disposable>)[Symbol.dispose]?.();
+
+    expect(lifecycle.close).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/docs/src/rpc-api.ts
+++ b/apps/docs/src/rpc-api.ts
@@ -102,6 +102,11 @@ class DocsProjectApi extends RpcTarget implements DocsProject {
   workspace(workspacePath: string): DocsWorkspace {
     return new DocsWorkspaceApi(this.#dial, requireWorkspacePath(workspacePath));
   }
+
+  /** Release the downstream OS session when Cap'n Web drops this project capability. */
+  [Symbol.dispose](): void {
+    this.#dial.close();
+  }
 }
 
 class DocsWorkspaceApi extends RpcTarget implements DocsWorkspace {


### PR DESCRIPTION
## What

- release the downstream OS `ProjectDial` when Cap’n Web disposes a Docs project capability
- add a regression test that authenticates the project capability and proves disposal closes the dial exactly once

## Why

Production validation of Docs in the `iterate` project showed a successful `/api` request leaving its downstream OS WebSocket alive after the browser disconnected. Cloudflare eventually cancelled the remaining `waitUntil()` work and emitted a warning for ray `a22e273e4724ef2b`. Tasks already implements this capability lifecycle; Docs needs the same ownership boundary.

## Validation

- `pnpm --dir apps/docs test`
- `pnpm --dir apps/docs typecheck`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test` (all packages; OS: 2,456 passed, 12 expected failures, 1 skipped)

After merge I will repeat the production deep-link/edit/comment/reload proof and audit the new Docs worker version in Cloudflare telemetry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized resource-cleanup change with a regression test; no auth or data-path changes beyond closing connections on capability release.
> 
> **Overview**
> Docs now **closes the downstream OS `ProjectDial`** when Cap'n Web releases the authenticated project capability, matching the lifecycle boundary Tasks already uses.
> 
> `DocsProjectApi` implements **`[Symbol.dispose]`** to call `this.#dial.close()`, so browser disconnects do not leave the OS WebSocket tied to a finished `/api` request.
> 
> A new **`rpc-api-lifecycle` test** mocks `ProjectDial`, authenticates a project capability, and asserts disposal invokes `close` exactly once (and not before).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1f1a51662c1d143901b054d7f9cb9b474adc218. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +5 -0 | +3 -0 🟩⬜⬜⬜⬜ |
| Tests | +47 -0 | +37 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+52 -0** | **+40 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 7dfaa4b and e1f1a51, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T18:48:09.442Z",
      "deployedAt": "2026-07-29T18:42:58.535Z",
      "headSha": "e1f1a51662c1d143901b054d7f9cb9b474adc218",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/256528133581855",
      "shortSha": "e1f1a51",
      "cleanupDurationMs": 11495,
      "deployDurationMs": 66078,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 37129,
      "deployReadinessDurationMs": 28946,
      "deployedWorkerName": "os-preview-17",
      "deployedWorkerVersion": "e421d768-11b3-4d12-9e14-f1ffcae22b64",
      "testDurationMs": 188408,
      "testRetries": null,
      "workerSizeKib": 19953.5,
      "workerGzipKib": 5038.53,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5048.86
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-07-29T18:48:00.547Z",
      "deployedAt": "2026-07-29T18:42:32.795Z",
      "headSha": "e1f1a51662c1d143901b054d7f9cb9b474adc218",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-17.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/256528133581855",
      "shortSha": "e1f1a51",
      "cleanupDurationMs": 2595,
      "deployDurationMs": 12718,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 11386,
      "deployReadinessDurationMs": 1328,
      "deployedWorkerName": "docs-preview-17",
      "deployedWorkerVersion": "a04c8898-4f28-4b1e-ad41-78d8de6b82d9",
      "testDurationMs": 2340,
      "testRetries": null,
      "workerSizeKib": 2636.5,
      "workerGzipKib": 640.5,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T18:48:01.504Z",
      "deployedAt": "2026-07-29T18:42:37.410Z",
      "headSha": "e1f1a51662c1d143901b054d7f9cb9b474adc218",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/256528133581855",
      "shortSha": "e1f1a51",
      "cleanupDurationMs": 3551,
      "deployDurationMs": 16042,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 15999,
      "deployReadinessDurationMs": 37,
      "deployedWorkerName": "auth-preview-17",
      "deployedWorkerVersion": "6a5acb6a-9e99-42f4-804f-624817c1ac5c",
      "testDurationMs": 9751,
      "testRetries": null,
      "workerSizeKib": 3978.65,
      "workerGzipKib": 814.58,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T18:47:58.846Z",
      "deployedAt": "2026-07-29T18:35:57.300Z",
      "headSha": "e1f1a51662c1d143901b054d7f9cb9b474adc218",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/256528133581855",
      "shortSha": "e1f1a51",
      "cleanupDurationMs": 890,
      "deployDurationMs": 273,
      "deployConfigDurationMs": 6,
      "deployReuseProofDurationMs": 231,
      "deployedWorkerName": "dummy-petshop-preview-17",
      "deployedWorkerVersion": "26c0c20f-806f-4d1c-8602-b31bd4d26cd8",
      "testDurationMs": 5264,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+d92ce8ce059a5ebd3b1f149e2a6e385dceb49730",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `e1f1a51` | [https://auth.iterate-preview-17.com](https://auth.iterate-preview-17.com) | 814.6 KiB | 16.0s | 9.8s |  | 3.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/256528133581855) | 2026-07-29T18:48:01.504Z | Preview app released. |
| Docs | released | `e1f1a51` | [https://docs-preview-17.iterate-dev-preview.workers.dev](https://docs-preview-17.iterate-dev-preview.workers.dev) | 640.5 KiB | 12.7s | 2.3s |  | 2.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/256528133581855) | 2026-07-29T18:48:00.547Z | Preview app released. |
| Dummy Petshop | released | `e1f1a51` | [https://dummy-petshop.iterate-preview-17.com](https://dummy-petshop.iterate-preview-17.com) | 198.3 KiB | 273ms | 5.3s |  | 890ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/256528133581855) | 2026-07-29T18:47:58.846Z | Preview app released. |
| OS | released | `e1f1a51` | [https://os.iterate-preview-17.com](https://os.iterate-preview-17.com) | 4.92 MiB (-10.3 KiB vs main) | 66.1s | 188.4s |  | 11.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/256528133581855) | 2026-07-29T18:48:09.442Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->