### PR TITLE
auth: add getUserGrantsByEmail RPC (directory bridge for Access-walled kernel)

### DIFF
--- a/apps/auth-contract/src/worker.ts
+++ b/apps/auth-contract/src/worker.ts
@@ -95,6 +95,17 @@ export abstract class AuthWorker<Env = unknown> extends WorkerEntrypoint<Env> {
     organizations: IterateAuthOrganizationClaim[];
     projects: IterateAuthProjectClaim[];
   }>;
+  /**
+   * Same grant bundle as {@link getUserGrants}, but keyed on the user's verified
+   * `email` instead of `userId`. For callers that only know the email — e.g. a
+   * kernel behind a Cloudflare Access wall, whose Access JWT carries the IdP-
+   * verified email but a Cloudflare-issued `sub` (not the auth user id). An
+   * unknown email resolves to empty grants, never an error.
+   */
+  abstract getUserGrantsByEmail(input: { email: string }): Promise<{
+    organizations: IterateAuthOrganizationClaim[];
+    projects: IterateAuthProjectClaim[];
+  }>;
   abstract mintProjectAppSession(
     input: MintProjectAppSessionInput,
   ): Promise<{ token: string } | null>;

--- a/apps/auth/src/server/worker.ts
+++ b/apps/auth/src/server/worker.ts
@@ -43,6 +43,7 @@ import {
   userCanAccessProject,
 } from "./project-directory.ts";
 import { buildAccessTokenGrantClaims } from "./oauth-project-selection.ts";
+import { getUserByEmail } from "./db/queries/index.ts";
 
 const app = hono();
 const AUTH_ISSUER_PATH = "/api/auth";
@@ -217,6 +218,18 @@ export default class AuthWorker extends AuthWorkerContract<CloudflareEnv> {
     // selection => every organization and project this user can reach.
     const { organizations, projects } = await buildAccessTokenGrantClaims(
       { userId: input.userId, requestedScopes: [], selection: null },
+      db,
+    );
+    return { organizations, projects };
+  }
+
+  async getUserGrantsByEmail(input: { email: string }) {
+    // Resolve the verified email to a user, then the same grant bundle as getUserGrants.
+    // Unknown email => empty grants (a caller behind a wall may present any email).
+    const user = await getUserByEmail(db, { email: input.email.trim().toLowerCase() });
+    if (!user) return { organizations: [], projects: [] };
+    const { organizations, projects } = await buildAccessTokenGrantClaims(
+      { userId: user.id, requestedScopes: [], selection: null },
       db,
     );
     return { organizations, projects };


### PR DESCRIPTION
## What & why

Adds `getUserGrantsByEmail({ email })` to the `AuthWorker` RPC — a sibling to `getUserGrants` keyed on the user's **verified email** instead of `userId`.

This is the directory bridge for **the kernel behind a Cloudflare Access wall** (the clean-room `apps/kernel` POC, now converging hosted onto Access with auth.iterate.com as IdP). A Cloudflare Access JWT carries the IdP-**verified email** but a **Cloudflare-issued `sub`** — not the auth user id. So membership resolution can't key on `sub`; it keys on email. This RPC resolves `email → user → { organizations, projects }` (reusing `buildAccessTokenGrantClaims`, the single source of truth for grants). An unknown email → empty grants, never an error.

It also serves the MCP path (Managed-OAuth tokens are likewise Cloudflare-issued) — one bridge, both surfaces.

## Not breaking apps/os

Purely **additive** to the RPC contract: a new abstract method + its one implementation in `apps/auth`. apps/os references `Service<AuthWorker>` and simply gains a callable method it need not use — **apps/os typecheck is green**. Same shape as the recently-merged `getUserGrants` (#2346). No existing method changes.

## Changes (2 files, +24)

- `apps/auth-contract/src/worker.ts` — the abstract method.
- `apps/auth/src/server/worker.ts` — impl: `getUserByEmail` (normalized) → `buildAccessTokenGrantClaims`.

Gates: typecheck (auth-contract / auth / **os**), oxlint, knip — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive RPC method reusing existing grant and user lookup logic; no changes to auth behavior for existing callers.
> 
> **Overview**
> Adds **`getUserGrantsByEmail({ email })`** to the `AuthWorker` RPC contract and auth worker implementation — the same `{ organizations, projects }` grant bundle as **`getUserGrants`**, but resolved from a verified **email** instead of **`userId`**.
> 
> The implementation trims and lowercases the email, looks up the user via **`getUserByEmail`**, then builds grants through **`buildAccessTokenGrantClaims`** (same path as **`getUserGrants`**). If no user exists, it returns empty organizations and projects rather than failing.
> 
> This is aimed at callers behind Cloudflare Access (and similar) where the JWT has IdP-verified email but not the auth user id in **`sub`**. The change is additive to the RPC surface; existing methods are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5feaae204ea78d8f33d01759d6084041a621d9a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +24 -0 | +10 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+24 -0** | **+10 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between d9ece64 and 5feaae2, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T19:04:01.582Z",
      "deployedAt": "2026-07-29T18:53:31.213Z",
      "headSha": "5feaae204ea78d8f33d01759d6084041a621d9a1",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/520094168377014",
      "shortSha": "5feaae2",
      "cleanupDurationMs": 12895,
      "deployDurationMs": 43739,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 42455,
      "deployReadinessDurationMs": 1281,
      "deployedWorkerName": "os-preview-3",
      "deployedWorkerVersion": "1fce7284-c54c-4b33-be93-a11854da5709",
      "testDurationMs": 447719,
      "testRetries": "1 retried: seeded-apps.spec.ts › review a workspace document in the seeded Docs app › web (playwright x1, still failed) — TimeoutError: locator.waitFor: Timeout 120000ms exceeded. Call log: \u001b[2m - waiting for locator('header').getByRole('heading', { name: 'Docs review walkthrough' }) to be visible\u001b[22m \u001b[2m 4 × waiting for\" https://docs--docs-app-review-ms6g3lbq-8a29cd99.iterate-preview-3.app/?workspace=%2Fworkspace...",
      "workerSizeKib": 19953.5,
      "workerGzipKib": 5038.53,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5048.86
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T19:03:51.549Z",
      "deployedAt": "2026-07-29T18:53:10.059Z",
      "headSha": "5feaae204ea78d8f33d01759d6084041a621d9a1",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/520094168377014",
      "shortSha": "5feaae2",
      "cleanupDurationMs": 2859,
      "deployDurationMs": 21622,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 21298,
      "deployReadinessDurationMs": 320,
      "deployedWorkerName": "auth-preview-3",
      "deployedWorkerVersion": "7dba4b6a-6402-4fd7-97e8-62d8b7e1b753",
      "testDurationMs": 11262,
      "testRetries": null,
      "workerSizeKib": 3979.02,
      "workerGzipKib": 814.76,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T19:03:49.470Z",
      "deployedAt": "2026-07-29T18:42:43.402Z",
      "headSha": "5feaae204ea78d8f33d01759d6084041a621d9a1",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/520094168377014",
      "shortSha": "5feaae2",
      "cleanupDurationMs": 777,
      "deployDurationMs": 299,
      "deployConfigDurationMs": 5,
      "deployReuseProofDurationMs": 246,
      "deployedWorkerName": "dummy-petshop-preview-3",
      "deployedWorkerVersion": "4f1f7e69-7265-4ebf-b39c-90495ec3fd38",
      "testDurationMs": 10189,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+d92ce8ce059a5ebd3b1f149e2a6e385dceb49730",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `5feaae2` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 814.8 KiB | 21.6s | 11.3s |  | 2.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/520094168377014) | 2026-07-29T19:03:51.549Z | Preview app released. |
| Dummy Petshop | released | `5feaae2` | [https://dummy-petshop.iterate-preview-3.com](https://dummy-petshop.iterate-preview-3.com) | 198.3 KiB | 299ms | 10.2s |  | 777ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/520094168377014) | 2026-07-29T19:03:49.470Z | Preview app released. |
| OS | released | `5feaae2` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 4.92 MiB (-10.3 KiB vs main) | 43.7s | 447.7s | 1 retried: seeded-apps.spec.ts › review a workspace document in the seeded Docs app › web (playwright x1, still failed) — TimeoutError: locator.waitFor: Timeout 120000ms exceeded. Call log: [2m - waiting for locator('header').getByRole('heading', { name: 'Docs review walkthrough' }) to be visible[22m [2m 4 × waiting for" https://docs--docs-app-review-ms6g3lbq-8a29cd99.iterate-preview-3.app/?workspace=%2Fworkspace... | 12.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/520094168377014) | 2026-07-29T19:04:01.582Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->