### PR TITLE
Wait for exact agent script settlement

### DIFF
--- a/apps/os/e2e/vitest/agent-tools.itx.e2e.test.ts
+++ b/apps/os/e2e/vitest/agent-tools.itx.e2e.test.ts
@@ -2,7 +2,7 @@
  * Goal coverage: an agent uses itx tools. Deterministic version of the
  * Playwright chat spec — drive an agent over itx, instruct it to run a script
  * that appends a proof event, and assert the full codemode loop on the stream:
- * llm request → output → capability-host/script-run-requested/completed → proof
+ * llm request → output → capability-host/script-run-requested/settled → proof
  * event on the target stream → visible web reply.
  */
 import { test } from "vitest";
@@ -25,7 +25,7 @@ test(
     const marker = crypto.randomUUID().slice(0, 8);
     // Full codemode loop (LLM → script → reply) routinely exceeds the 45s ask
     // default under preview load; wait with the same ceiling as the test.
-    await agent.ask({
+    const reply = await agent.ask({
       message: [
         `Run a script that appends one event of type ${PROOF_TYPE} with payload`,
         `{ "marker": "${marker}" } to the stream ${PROOF_STREAM} via`,
@@ -58,11 +58,29 @@ test(
       },
     );
 
-    const agentEvents = await agent.stream.getEvents({ limit: 500 });
-    const types = agentEvents.map((event) => event.type.replace("events.iterate.com/", ""));
-    expect(types).toContain("capability-host/script-run-requested");
-    expect(types).toContain("capability-host/script-run-settled");
-    expect(types).toContain("agents/web-message-sent");
+    const requested = await agent.stream.waitForEvent({
+      afterOffset: 0,
+      eventTypes: ["events.iterate.com/capability-host/script-run-requested"],
+      predicate: (event) =>
+        typeof event.payload?.code === "string" && event.payload.code.includes(marker),
+      timeoutMs: 30_000,
+    });
+    expect(requested.payload?.executionId).toEqual(expect.any(String));
+
+    // The script's target-stream append can become visible before the agent
+    // stream records its settlement. Synchronize on this execution rather
+    // than treating an immediate stream snapshot as the completion boundary.
+    const settled = await agent.stream.waitForEvent({
+      afterOffset: requested.offset,
+      eventTypes: ["events.iterate.com/capability-host/script-run-settled"],
+      predicate: (event) => event.payload?.executionId === requested.payload?.executionId,
+      timeoutMs: 30_000,
+    });
+    expect(settled.payload).toMatchObject({
+      executionId: requested.payload?.executionId,
+      settlement: { status: "succeeded" },
+    });
+    expect(reply).toMatchObject({ type: "events.iterate.com/agents/web-message-sent" });
   },
 );
 


### PR DESCRIPTION
## Summary

- identify the exact script execution by matching the unique proof marker in its `script-run-requested` event
- wait boundedly for that execution’s `script-run-settled` event and require a successful settlement
- assert the actual `agent.ask` result is the visible web reply instead of looking for three event types in an immediate stream snapshot

## Why

PostHog showed this test recovering on retry 12 times in 270 executions (4.44%), with eight isolated recoveries and one terminal failure. Every inspected failure had already observed the proof event on the target stream, while an immediate snapshot of the source agent stream did not yet contain `script-run-settled`.

Those writes happen on different streams, so the target proof may legitimately become visible just before the source agent stream records settlement. Treating the immediate snapshot as a completion boundary is an observation race, not a product invariant.

This keeps the meaningful contract strict: the marker-matched execution must settle successfully within 30 seconds. Failed, lost, or missing settlements still fail the test.

## Reliability evidence

The focused E2E passed four consecutive local runs with Vitest retries disabled by the local lane:

- 16.245s
- 5.420s
- 5.553s
- 5.689s

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm format`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (242 files, 2,456 passing tests)
- `doppler run --project os --config dev -- pnpm --dir apps/os e2e e2e/vitest/agent-tools.itx.e2e.test.ts -t "agent runs an itx script that appends a proof event, then replies"` ×4

## Scope and risk

Test-only, one file. This does not broaden the test timeout or add a retry; it replaces a racy snapshot assertion with an execution-specific, bounded synchronization point.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single E2E test file only; no production code or harness timeout changes.
> 
> **Overview**
> Fixes a flaky **agent-tools** E2E by stopping after the proof event on the target stream and then synchronizing on the **exact** script run tied to the proof marker, instead of asserting three event types from an immediate agent-stream snapshot.
> 
> The test now **`waitForEvent`s** for `capability-host/script-run-requested` whose code includes the marker, then waits for the matching `script-run-settled` (same `executionId`, `settlement.status: succeeded`) with a 30s bound. It also keeps the **`agent.ask`** return value and asserts it is a `agents/web-message-sent` event.
> 
> The file header comment is updated to say **settled** instead of **completed** for the codemode loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a59486e011a7d5ab41b5489c175be75e541104a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +25 -7 | +20 -6 🟩🟩🟩🟩🟥 |
| **Total** | **+25 -7** | **+20 -6** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 6b1f276 and 3a59486, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T20:49:47.189Z",
      "deployedAt": "2026-07-29T20:44:16.087Z",
      "headSha": "3a59486e011a7d5ab41b5489c175be75e541104a",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-14.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/291465350730173",
      "shortSha": "3a59486",
      "cleanupDurationMs": 9561,
      "deployDurationMs": 70747,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 69525,
      "deployReadinessDurationMs": 1220,
      "deployedWorkerName": "os-preview-14",
      "deployedWorkerVersion": "c671fe83-d922-4ee4-a84f-50af238bd88e",
      "testDurationMs": 224378,
      "testRetries": "1 retried: create-project.spec.ts › a new user can create a project through the UI form › web (playwright x1) — TimeoutError: locator.waitFor: Timeout 1ms exceeded. Call log: \u001b[2m - waiting for getByText('Sign in to your iterate account') to be visible\u001b[22m \u001b[33m If this is a slow operation, update the product code to add a spinner while it's running. This will improve the user experience and buy you more ...",
      "workerSizeKib": 19953.5,
      "workerGzipKib": 5038.53,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5048.81
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-07-29T20:49:40.378Z",
      "deployedAt": "2026-07-29T20:43:53.582Z",
      "headSha": "3a59486e011a7d5ab41b5489c175be75e541104a",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-14.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/291465350730173",
      "shortSha": "3a59486",
      "cleanupDurationMs": 2748,
      "deployDurationMs": 47238,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 47017,
      "deployReadinessDurationMs": 217,
      "deployedWorkerName": "docs-preview-14",
      "deployedWorkerVersion": "48d18a95-db3a-4784-9ef8-48f5991aa295",
      "testDurationMs": 3114,
      "testRetries": null,
      "workerSizeKib": 2636.5,
      "workerGzipKib": 640.5,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T20:49:41.677Z",
      "deployedAt": "2026-07-29T20:44:03.489Z",
      "headSha": "3a59486e011a7d5ab41b5489c175be75e541104a",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-14.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/291465350730173",
      "shortSha": "3a59486",
      "cleanupDurationMs": 4044,
      "deployDurationMs": 57257,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 56923,
      "deployReadinessDurationMs": 329,
      "deployedWorkerName": "auth-preview-14",
      "deployedWorkerVersion": "b606cadc-15ae-450b-8578-bc0f70854941",
      "testDurationMs": 11062,
      "testRetries": null,
      "workerSizeKib": 3979.02,
      "workerGzipKib": 814.68,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T20:49:38.366Z",
      "deployedAt": "2026-07-29T20:43:15.456Z",
      "headSha": "3a59486e011a7d5ab41b5489c175be75e541104a",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-14.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/291465350730173",
      "shortSha": "3a59486",
      "cleanupDurationMs": 731,
      "deployDurationMs": 9138,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 8841,
      "deployReadinessDurationMs": 243,
      "deployedWorkerName": "dummy-petshop-preview-14",
      "deployedWorkerVersion": "2ab30fe8-7bd7-4071-ac42-c62f322c0c9d",
      "testDurationMs": 31465,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+d92ce8ce059a5ebd3b1f149e2a6e385dceb49730",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `3a59486` | [https://auth.iterate-preview-14.com](https://auth.iterate-preview-14.com) | 814.7 KiB | 57.3s | 11.1s |  | 4.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/291465350730173) | 2026-07-29T20:49:41.677Z | Preview app released. |
| Docs | released | `3a59486` | [https://docs-preview-14.iterate-dev-preview.workers.dev](https://docs-preview-14.iterate-dev-preview.workers.dev) | 640.5 KiB | 47.2s | 3.1s |  | 2.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/291465350730173) | 2026-07-29T20:49:40.378Z | Preview app released. |
| Dummy Petshop | released | `3a59486` | [https://dummy-petshop.iterate-preview-14.com](https://dummy-petshop.iterate-preview-14.com) | 198.3 KiB | 9.1s | 31.5s |  | 731ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/291465350730173) | 2026-07-29T20:49:38.366Z | Preview app released. |
| OS | released | `3a59486` | [https://os.iterate-preview-14.com](https://os.iterate-preview-14.com) | 4.92 MiB (-10.3 KiB vs main) | 70.7s | 224.4s | 1 retried: create-project.spec.ts › a new user can create a project through the UI form › web (playwright x1) — TimeoutError: locator.waitFor: Timeout 1ms exceeded. Call log: [2m - waiting for getByText('Sign in to your iterate account') to be visible[22m [33m If this is a slow operation, update the product code to add a spinner while it's running. This will improve the user experience and buy you more ... | 9.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/291465350730173) | 2026-07-29T20:49:47.189Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->