### PR TITLE
Gate email sign-in on preview rollout

### DIFF
--- a/packages/shared/src/test-support/preview-rollout-gate.ts
+++ b/packages/shared/src/test-support/preview-rollout-gate.ts
@@ -29,9 +29,9 @@ export function resolvePreviewRolloutWaitMs(input: {
 }
 
 /**
- * Wait only at the operation that first creates project-backed Durable
- * Objects. Browser startup, authentication, and unrelated tests remain free to
- * overlap Cloudflare's global code propagation window.
+ * Wait at the earliest operation that requires the freshly deployed app to be
+ * settled. Most callers can overlap browser and authentication setup, while a
+ * flow whose first navigation can observe the parked predecessor waits there.
  */
 export async function waitForPreviewRolloutBeforeProjectCreation(input?: {
   beforeWait?: (waitMs: number) => void | Promise<void>;

--- a/specs/create-project.spec.ts
+++ b/specs/create-project.spec.ts
@@ -14,7 +14,7 @@ import { test } from "./test-support/test.ts";
 // up the new project claim the post-create navigation authorizes with.
 test("a new user can create a project through the UI form", async ({ page }, testInfo) => {
   test.skip(
-    !(await startEmailOtpSignIn(page)),
+    !(await startEmailOtpSignIn(page, testInfo)),
     "Email OTP sign-in is disabled for this deployment (APP_CONFIG_EMAIL_OTP_ENABLED on auth / APP_CONFIG_ITERATE_AUTH__EMAIL_OTP_ENABLED on OS).",
   );
   const firstSlug = uniqueFixtureSlug("first-project");

--- a/specs/seeded-apps.spec.ts
+++ b/specs/seeded-apps.spec.ts
@@ -49,7 +49,7 @@ test("the seeded todo app authenticates a real project member", async ({
 }, testInfo) => {
   test.setTimeout(E2E_HEAVY_TEST_TIMEOUT_MS);
   test.skip(
-    !(await startEmailOtpSignIn(page)),
+    !(await startEmailOtpSignIn(page, testInfo)),
     "Email OTP sign-in is disabled for this deployment (APP_CONFIG_EMAIL_OTP_ENABLED on auth / APP_CONFIG_ITERATE_AUTH__EMAIL_OTP_ENABLED on OS).",
   );
 
@@ -128,7 +128,7 @@ test("the seeded todo app authenticates a real project member", async ({
 test("review a workspace document in the seeded Docs app", async ({ baseURL, page }, testInfo) => {
   test.setTimeout(E2E_HEAVY_TEST_TIMEOUT_MS);
   test.skip(
-    !(await startEmailOtpSignIn(page)),
+    !(await startEmailOtpSignIn(page, testInfo)),
     "Email OTP sign-in is disabled for this deployment (APP_CONFIG_EMAIL_OTP_ENABLED on auth / APP_CONFIG_ITERATE_AUTH__EMAIL_OTP_ENABLED on OS).",
   );
 

--- a/specs/signup.spec.ts
+++ b/specs/signup.spec.ts
@@ -13,7 +13,7 @@ import { test } from "./test-support/test.ts";
 // the apps/auth email-OTP lane instead of minting a session.
 test("can sign up with an email one-time passcode", async ({ page }, testInfo) => {
   test.skip(
-    !(await startEmailOtpSignIn(page)),
+    !(await startEmailOtpSignIn(page, testInfo)),
     "Email OTP sign-in is disabled for this deployment (APP_CONFIG_EMAIL_OTP_ENABLED on auth / APP_CONFIG_ITERATE_AUTH__EMAIL_OTP_ENABLED on OS).",
   );
 

--- a/specs/test-support/email-otp-signup.ts
+++ b/specs/test-support/email-otp-signup.ts
@@ -30,7 +30,14 @@ export function uniqueSignupEmail(prefix: string) {
  * Lands on the auth app's login page in email mode. Resolves false when the
  * deployment doesn't offer email OTP sign-in.
  */
-export async function startEmailOtpSignIn(page: Page) {
+export async function startEmailOtpSignIn(page: Page, testInfo: TestInfo) {
+  // Preview teardown leaves a parked OS Worker behind. During a fresh edge
+  // rollout, even the exact-version request can briefly reach that 503
+  // predecessor, so consume the existing rollout boundary before the first
+  // OS navigation rather than waiting later at project creation.
+  await waitForPreviewRolloutBeforeProjectCreation({
+    beforeWait: (waitMs) => testInfo.setTimeout(testInfo.timeout + waitMs),
+  });
   await page.goto("/api/iterate-auth/login?login_hint=email");
   await page.getByText("Sign in to your iterate account").waitFor();
   return await page.getByTestId("email-input").isVisible();


### PR DESCRIPTION
## Summary

- consume the existing absolute preview-rollout boundary before the first OS email-sign-in navigation
- extend each affected test’s budget by exactly the remaining rollout wait, as the same gate already did later in the flow
- keep the project-creation boundary in `signUpWithEmailOtp` for the mobile OAuth entry path, which does not call `startEmailOtpSignIn`

## Root cause

PostHog showed `create-project.spec.ts` recovering on retry 8 times in 270 executions, plus one terminal failure. The failure population is mixed; this PR addresses the three recovered auth-entry failures and one terminal auth-entry failure with the same Middlewright 1 ms/no-progress signature. It does not claim to fix the separate onboarding-composer waits.

PR #2368 produced a fresh, retained reproduction while this branch was being prepared:

- first attempt failed after 2.119s at `getByText("Sign in to your iterate account")`
- the page was not an auth loading skeleton; it was the parked OS worker’s terminal 503: `This environment’s data was erased; the next deploy brings it back.`
- the trace shows the request already carried exact immutable version overrides for OS, Auth, Docs, and Dummy Petshop
- the retry, started 12 seconds later, passed in 100.391s

The signup helper previously consumed the 90-second absolute rollout gate only immediately before clicking `Get started`. That protects project-backed Durable Object creation, but it is too late when the very first request enters through the freshly deployed OS worker. During edge convergence that request can still observe the parked predecessor.

The fix moves the same absolute boundary earlier for OS-started email flows. It is not a new sleep: local runs and settled/reused previews wait zero, and a fresh preview consumes the same one-time deadline it previously consumed later.

## Validation

- `pnpm format`
- `pnpm lint` — 0 warnings, 0 errors
- `pnpm typecheck`
- `pnpm test` — all workspaces green; OS 242 files / 2,456 passing tests
- shared rollout-gate package tests — 69/69
- focused create-project Playwright run with retries disabled — passed in 11.5s
- focused create-project Playwright run with an injected future rollout deadline — logged an 8.808s bounded wait before navigation and passed in 17.1s, with retries disabled

## Scope and risk

Five files, 15 additions / 8 removals. No product behavior, retry policy, rollout duration, or broad timeout changes. The only timing change is where existing signup flows consume their existing absolute preview boundary.

## Explicitly not addressed

The separate failures where signup completes but the onboarding composer never appears need their own product-state evidence. They are intentionally not folded into this small, proven auth-entry fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timing and helper signature changes in Playwright specs and shared test-support; no production auth or deploy logic.
> 
> **Overview**
> Moves the **preview rollout wait** earlier in email-OTP E2E flows so the first OS navigation does not hit the parked predecessor worker’s 503 during edge convergence.
> 
> `startEmailOtpSignIn` now accepts `testInfo`, calls `waitForPreviewRolloutBeforeProjectCreation` **before** `page.goto("/api/iterate-auth/login?login_hint=email")`, and extends the test timeout by the wait duration—the same boundary `signUpWithEmailOtp` still applies before **Get started** for paths that skip this helper (e.g. mobile OAuth).
> 
> Call sites in `create-project`, `seeded-apps`, and `signup` specs pass `testInfo` into `startEmailOtpSignIn`. The shared gate comment is updated to describe waiting at the earliest operation that needs a settled deploy, not only project-backed Durable Object creation.
> 
> No product behavior, rollout duration, or retry policy changes; local and settled previews still wait zero.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e4f64a9a93c64e7897740bbb5781b683775669f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +3 -3 | +0 -0 ⬜⬜⬜⬜⬜ |
| Tests | +4 -4 | +4 -4 🟩🟩🟩🟥🟥 |
| Other | +8 -1 | +4 -1 🟩🟩🟥⬜⬜ |
| **Total** | **+15 -8** | **+8 -5** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 710f44f and 8e4f64a, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-07-29T21:04:55.144Z",
      "deployedAt": "2026-07-29T20:59:29.624Z",
      "headSha": "8e4f64a9a93c64e7897740bbb5781b683775669f",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/193734232139522",
      "shortSha": "8e4f64a",
      "cleanupDurationMs": 11152,
      "deployDurationMs": 91967,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 89995,
      "deployReadinessDurationMs": 1969,
      "deployedWorkerName": "os-preview-2",
      "deployedWorkerVersion": "523ae856-3d94-4f34-a7dd-491f40c14713",
      "testDurationMs": 221722,
      "testRetries": null,
      "workerSizeKib": 19953.5,
      "workerGzipKib": 5038.53,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5048.85
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-07-29T21:04:47.628Z",
      "deployedAt": "2026-07-29T20:58:23.033Z",
      "headSha": "8e4f64a9a93c64e7897740bbb5781b683775669f",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-2.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/193734232139522",
      "shortSha": "8e4f64a",
      "cleanupDurationMs": 3633,
      "deployDurationMs": 23680,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 23401,
      "deployReadinessDurationMs": 274,
      "deployedWorkerName": "docs-preview-2",
      "deployedWorkerVersion": "5ec47f05-4dd9-453a-8865-c6d5a9fe4d36",
      "testDurationMs": 1965,
      "testRetries": null,
      "workerSizeKib": 2636.5,
      "workerGzipKib": 640.5,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-07-29T21:04:44.714Z",
      "deployedAt": "2026-07-29T20:58:14.277Z",
      "headSha": "8e4f64a9a93c64e7897740bbb5781b683775669f",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/193734232139522",
      "shortSha": "8e4f64a",
      "cleanupDurationMs": 715,
      "deployDurationMs": 14832,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 14643,
      "deployReadinessDurationMs": 182,
      "deployedWorkerName": "semaphore-preview-2",
      "deployedWorkerVersion": "9a0d8864-d8d1-455e-85e7-5f03d169adde",
      "testDurationMs": 32863,
      "testRetries": null,
      "workerSizeKib": 1915.51,
      "workerGzipKib": 441.11,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-07-29T21:04:48.551Z",
      "deployedAt": "2026-07-29T20:58:20.301Z",
      "headSha": "8e4f64a9a93c64e7897740bbb5781b683775669f",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/193734232139522",
      "shortSha": "8e4f64a",
      "cleanupDurationMs": 4550,
      "deployDurationMs": 20989,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 20667,
      "deployReadinessDurationMs": 316,
      "deployedWorkerName": "auth-preview-2",
      "deployedWorkerVersion": "089abf6d-55da-4a8a-9bf0-3b134b3500e1",
      "testDurationMs": 10515,
      "testRetries": null,
      "workerSizeKib": 3979.02,
      "workerGzipKib": 814.6,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-07-29T21:04:51.900Z",
      "deployedAt": "2026-07-29T20:58:19.002Z",
      "headSha": "8e4f64a9a93c64e7897740bbb5781b683775669f",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/193734232139522",
      "shortSha": "8e4f64a",
      "cleanupDurationMs": 7897,
      "deployDurationMs": 49248,
      "deployConfigDurationMs": 7,
      "deployCommandDurationMs": 19366,
      "deployReadinessDurationMs": 29875,
      "deployedWorkerName": "streams-example-app-preview-2",
      "deployedWorkerVersion": "b214b6a9-8256-443a-92b5-7b67472c3770",
      "testDurationMs": 70008,
      "testRetries": null,
      "workerSizeKib": 5262.09,
      "workerGzipKib": 1490.21,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-07-29T21:04:45.883Z",
      "deployedAt": "2026-07-29T20:58:19.659Z",
      "headSha": "8e4f64a9a93c64e7897740bbb5781b683775669f",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/193734232139522",
      "shortSha": "8e4f64a",
      "cleanupDurationMs": 1169,
      "deployDurationMs": 5391,
      "deployConfigDurationMs": 1,
      "deployCommandDurationMs": 5194,
      "deployReadinessDurationMs": 193,
      "deployedWorkerName": "dummy-petshop-preview-2",
      "deployedWorkerVersion": "0f28eed6-8ac1-47a3-9724-e065bc1ebac6",
      "testDurationMs": 21455,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+d92ce8ce059a5ebd3b1f149e2a6e385dceb49730",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `8e4f64a` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 814.6 KiB | 21.0s | 10.5s |  | 4.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/193734232139522) | 2026-07-29T21:04:48.551Z | Preview app released. |
| Docs | released | `8e4f64a` | [https://docs-preview-2.iterate-dev-preview.workers.dev](https://docs-preview-2.iterate-dev-preview.workers.dev) | 640.5 KiB | 23.7s | 2.0s |  | 3.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/193734232139522) | 2026-07-29T21:04:47.628Z | Preview app released. |
| Dummy Petshop | released | `8e4f64a` | [https://dummy-petshop.iterate-preview-2.com](https://dummy-petshop.iterate-preview-2.com) | 198.3 KiB | 5.4s | 21.5s |  | 1.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/193734232139522) | 2026-07-29T21:04:45.883Z | Preview app released. |
| OS | released | `8e4f64a` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 4.92 MiB (-10.3 KiB vs main) | 92.0s | 221.7s |  | 11.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/193734232139522) | 2026-07-29T21:04:55.144Z | Preview app released. |
| Semaphore | released | `8e4f64a` | [https://semaphore.iterate-preview-2.com](https://semaphore.iterate-preview-2.com) | 441.1 KiB | 14.8s | 32.9s |  | 715ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/193734232139522) | 2026-07-29T21:04:44.714Z | Preview app released. |
| Streams Example App | released | `8e4f64a` | [https://streams.iterate-preview-2.com](https://streams.iterate-preview-2.com) | 1.46 MiB | 49.2s | 70.0s |  | 7.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/193734232139522) | 2026-07-29T21:04:51.900Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->