### PR TITLE
Recreate preview slot 5 + 19 resources; fix DNS ensure pagination

### DIFF
--- a/envs.ts
+++ b/envs.ts
@@ -187,9 +187,9 @@ export const envs = {
     authDbId: "bd115332-9515-4bbf-96d5-f041e628bcf9",
   }),
   preview_5: previewSlot(5, {
-    projectDirectoryKvId: "a0f87dc67b39465bb9c00bd05587eadc",
-    workerBuildCacheKvId: "34f27e888b6243189e42a0ea5a93291f",
-    authDbId: "f8542574-48e3-4374-910f-3186293137f0",
+    projectDirectoryKvId: "3757821220854587ae92231688119d86",
+    workerBuildCacheKvId: "d006c8418cd14779957cd63db8c9063b",
+    authDbId: "c3ecc175-3bc2-4d78-ae89-733de3863563",
   }),
   preview_6: previewSlot(6, {
     projectDirectoryKvId: "e414e68c13e1471a8a3c41f5e50136e4",
@@ -257,8 +257,8 @@ export const envs = {
     authDbId: "2f61f8f0-b16a-4d53-89ef-b75b2982452c",
   }),
   preview_19: previewSlot(19, {
-    projectDirectoryKvId: "916fa97c2ec84067997012702f242646",
-    workerBuildCacheKvId: "a22450ba186a40549cfe2cff29079aca",
+    projectDirectoryKvId: "7d77673aae074ee593e308a4fcb01f07",
+    workerBuildCacheKvId: "75c6150b88a346f9a5f582b5b9943be8",
     authDbId: "42efe1e4-194f-4c61-8e62-810ec35fbf43",
   }),
 } satisfies Record<string, DeployedEnv>;
@@ -382,7 +382,7 @@ export const semaphoreEnvs = {
   preview_2: semaphorePreviewSlot(2, "711994bd-4faa-42f0-80ac-fc292d68569d"),
   preview_3: semaphorePreviewSlot(3, "17493958-1589-4a2c-a280-0a55bc11a92c"),
   preview_4: semaphorePreviewSlot(4, "f61083ef-23b5-4201-8731-8d3d46ebfeaa"),
-  preview_5: semaphorePreviewSlot(5, "eea19312-34e2-4e5c-be19-fe6929636544"),
+  preview_5: semaphorePreviewSlot(5, "25c934d2-cf2e-41b2-be33-3e8348d96365"),
   preview_6: semaphorePreviewSlot(6, "eff27a10-2f52-4077-9372-05dcf1c77ccd"),
   preview_7: semaphorePreviewSlot(7, "f4b1b641-71bd-4952-8726-3c2c543383fe"),
   preview_8: semaphorePreviewSlot(8, "77af433e-c870-43a6-be8e-1d2452feb23d"),
@@ -396,7 +396,7 @@ export const semaphoreEnvs = {
   preview_16: semaphorePreviewSlot(16, "69bd6563-c889-484e-ada3-d0e3f94021b9"),
   preview_17: semaphorePreviewSlot(17, "8fc3a6ff-f42b-4215-b6e5-aaacba27b82c"),
   preview_18: semaphorePreviewSlot(18, "c8762bd2-f4d0-4207-b038-0c03a83aabed"),
-  preview_19: semaphorePreviewSlot(19, "d1eab1d5-8a03-46b7-9c43-73b10f6133e0"),
+  preview_19: semaphorePreviewSlot(19, "84bc6ce0-ef76-43b6-8fc0-19cc4e0a6db0"),
 } satisfies Record<EnvName, SemaphoreEnv>;
 
 /**

--- a/scripts/lib/deploy-helpers.ts
+++ b/scripts/lib/deploy-helpers.ts
@@ -478,8 +478,10 @@ export async function ensureProxiedDnsRecord(
     console.warn(`⚠ no zone for ${host} in this account — create the zone first, then re-run`);
     return;
   }
+  // per_page must exceed the records a routed apex accumulates (A plus Email
+  // Routing MX/TXT can pass 5, which trips the paginate guard in cfV4).
   const existing = await ctx.cfV4<unknown[]>(
-    `/zones/${zone.id}/dns_records?name=${encodeURIComponent(host)}&per_page=5`,
+    `/zones/${zone.id}/dns_records?name=${encodeURIComponent(host)}&per_page=50`,
   );
   if (existing.length > 0) {
     console.log(`DNS record for ${host} exists`);


### PR DESCRIPTION
Preview slots 5 and 19 were missing their Cloudflare resources — both slots' OS KV namespaces, slot 5's R2 buckets + auth D1, and both slots' semaphore D1s were gone from the preview account. Any PR landing on those slots failed its preview deploy with `KV namespace not found` / `database could not be found` (#2339 hit slot 19 exactly this way). Because acquire hands out the least-recently-released slot first, a poisoned slot keeps boomeranging onto new PRs.

This runs the documented `ensure-resources` bring-up for both slots (os + semaphore) and commits the reconciled IDs into `envs.ts`. Slot 19's auth D1 survived, so its ID is unchanged.

Also fixes a bring-up blocker found on the way: the DNS-record existence check queried with `per_page=5`, but a routed apex like `iterate-preview-5.app` accumulates more than 5 records (A + Email Routing MX/TXT), tripping cfV4's paginate guard and aborting ensure-resources.

**Worth investigating separately: what deleted these resources?** Nothing in `erase-data`/GC deletes KV namespaces or D1 databases — lifecycle rules + erase handle data, resources are meant to be permanent. Slots 5 and 19 specifically suggests a manual or scripted cleanup hit them.

## Risk map

- The riskiest part is the envs.ts ID swap itself: a typo'd ID fails the next preview deploy on those slots. The IDs are pasted verbatim from the ensure-resources reconcile output, and the next deploy to either slot is the real verification.
- The per_page bump only affects an existence check; worst case is an unnecessary create attempt that Cloudflare rejects as a duplicate name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session: `4a701c88-5931-49e1-a0a5-970ccedfdd2a`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

> [!CAUTION]
> This PR is a draft, so it doesn't claim a preview slot. To get previews: add the `preview` label, mark the PR ready for review, or dispatch the Cloudflare Previews workflow for a one-off run.

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": "This PR is a draft, so it doesn't claim a preview slot. To get previews: add the `preview` label, mark the PR ready for review, or dispatch the Cloudflare Previews workflow for a one-off run."
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| CI & scripts | +3 -1 | +1 -1 🟩⬜⬜⬜⬜ |
| Other | +7 -7 | +7 -7 🟩🟩🟩🟥🟥 |
| **Total** | **+10 -8** | **+8 -8** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 4cde13b and 6b3ee83, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->