### PR TITLE
Add Parallel Search MCP example

### DIFF
--- a/apps/os/e2e/examples/example-cases.ts
+++ b/apps/os/e2e/examples/example-cases.ts
@@ -35,6 +35,9 @@
 //   exa-web-search  calls Exa's public MCP server (external service, rate
 //                   limited); interactive reading material, same rationale as
 //                   ai-models.
+//   parallel-web-research
+//                   calls Parallel's public MCP server (external service,
+//                   rate limited); interactive reading material.
 //   ai-generate-text
 //                   depends on remote Workers AI model availability and
 //                   billing; interactive reading material.

--- a/apps/os/src/itx/examples-source.ts
+++ b/apps/os/src/itx/examples-source.ts
@@ -1052,6 +1052,64 @@ return await itx.projects.get(pid).__describe();
       return { pages, search };
     },
   }),
+  projectExample<{
+    parallelSearch: {
+      web_search(input: {
+        objective: string;
+        search_queries: string[];
+        session_id?: string;
+      }): Promise<unknown>;
+      web_fetch(input: {
+        urls: string[];
+        objective?: string | null;
+        search_queries?: string[] | null;
+        full_content?: boolean;
+        session_id?: string;
+      }): Promise<unknown>;
+    };
+  }>({
+    id: "parallel-web-research",
+    e2eProven: false,
+    title: "Search and fetch with Parallel Search MCP",
+    description:
+      "Mounts Parallel's public MCP endpoint as a durable project capability, then uses web_search for current web results and web_fetch for focused content from a specific URL. The default endpoint needs no account or API key. External service — interactive-only.",
+    runtimes: ALL_RUNTIMES,
+    fn: async (
+      itx,
+      vars: {
+        fetchObjective?: string;
+        objective?: string;
+        searchQueries?: string[];
+        url?: string;
+      },
+    ) => {
+      await itx.provideCapability({
+        expression: ["mcp", ["connect", { url: "https://search.parallel.ai/mcp" }]],
+        instructions:
+          "Parallel Search MCP. Call itx.parallelSearch.web_search({ objective, search_queries, session_id }) for current web results and itx.parallelSearch.web_fetch({ urls, objective, session_id }) for focused page content.",
+        path: ["parallelSearch"],
+        type: "itx-call",
+      });
+
+      const sessionId = crypto.randomUUID();
+      const [search, page] = await Promise.all([
+        itx.parallelSearch.web_search({
+          objective:
+            vars.objective ?? "Find current documentation about Cloudflare Durable Objects",
+          search_queries: vars.searchQueries ?? ["Cloudflare Durable Objects documentation"],
+          session_id: sessionId,
+        }),
+        itx.parallelSearch.web_fetch({
+          urls: [vars.url ?? "https://developers.cloudflare.com/durable-objects/"],
+          objective:
+            vars.fetchObjective ?? "Extract how Durable Objects coordinate stateful applications",
+          session_id: sessionId,
+        }),
+      ]);
+
+      return { page, search };
+    },
+  }),
   // String-authored: connect() returns Promise<McpClientRpc> and the first
   // call pipelines a dynamically-named tool onto the un-awaited promise —
   // untypeable in the published surface (tool names come from the server),

--- a/apps/os/src/itx/examples-typecheck.test.ts
+++ b/apps/os/src/itx/examples-typecheck.test.ts
@@ -126,6 +126,12 @@ const EXAMPLE_MOUNTS: Record<string, CapabilityDescription[]> = {
       "export type ExaTools = { web_search_exa(input: { query: string; numResults?: number }): Promise<unknown>; web_fetch_exa(input: { urls: string[]; maxCharacters?: number }): Promise<unknown> };",
     ),
   ],
+  "parallel-web-research": [
+    mount(
+      ["parallelSearch"],
+      "export type ParallelSearchTools = { web_search(input: { objective: string; search_queries: string[]; session_id?: string }): Promise<unknown>; web_fetch(input: { urls: string[]; objective?: string | null; search_queries?: string[] | null; full_content?: boolean; session_id?: string }): Promise<unknown> };",
+    ),
+  ],
 };
 
 /**

--- a/apps/os/src/itx/examples.generated.ts
+++ b/apps/os/src/itx/examples.generated.ts
@@ -983,6 +983,42 @@ return { pages, search };
 `.trim(),
   },
   {
+    id: "parallel-web-research",
+    e2eProven: false,
+    title: "Search and fetch with Parallel Search MCP",
+    description:
+      "Mounts Parallel's public MCP endpoint as a durable project capability, then uses web_search for current web results and web_fetch for focused content from a specific URL. The default endpoint needs no account or API key. External service — interactive-only.",
+    context: "project",
+    runtimes: ["browser", "node", "cli", "run-script", "project-worker"],
+    code: `
+await itx.provideCapability({
+  expression: ["mcp", ["connect", { url: "https://search.parallel.ai/mcp" }]],
+  instructions:
+    "Parallel Search MCP. Call itx.parallelSearch.web_search({ objective, search_queries, session_id }) for current web results and itx.parallelSearch.web_fetch({ urls, objective, session_id }) for focused page content.",
+  path: ["parallelSearch"],
+  type: "itx-call",
+});
+
+const sessionId = crypto.randomUUID();
+const [search, page] = await Promise.all([
+  itx.parallelSearch.web_search({
+    objective:
+      vars.objective ?? "Find current documentation about Cloudflare Durable Objects",
+    search_queries: vars.searchQueries ?? ["Cloudflare Durable Objects documentation"],
+    session_id: sessionId,
+  }),
+  itx.parallelSearch.web_fetch({
+    urls: [vars.url ?? "https://developers.cloudflare.com/durable-objects/"],
+    objective:
+      vars.fetchObjective ?? "Extract how Durable Objects coordinate stateful applications",
+    session_id: sessionId,
+  }),
+]);
+
+return { page, search };
+`.trim(),
+  },
+  {
     id: "connect-public-mcp",
     e2eProven: false,
     title: "Connect a public MCP server, then mount it",


### PR DESCRIPTION
This adds a copyable catalogue example for mounting a public MCP endpoint as a durable project capability and using it for current web search and focused URL fetching.

## What changed

- Added an interactive `parallel-web-research` example that mounts `https://search.parallel.ai/mcp` and calls `web_search` and `web_fetch` with one shared session ID.
- Declared the generated example's dynamic mount shape and regenerated the checked-in catalogue.
- Marked the example as interactive-only because it calls an external rate-limited service.

## Validation

- Catalogue generation and 63 focused generation/typecheck tests
- Formatting and lint checks on the changed files
- Iterate OS typecheck
- Full test suite: 244 files passed, 2,492 tests passed, 12 expected failures, 1 skipped

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Catalogue and typecheck wiring only; no runtime platform changes. External MCP calls are interactive-only and excluded from unattended e2e matrix runs.
> 
> **Overview**
> Adds a new **interactive-only** itx examples catalogue entry, `parallel-web-research`, alongside the existing Exa MCP documentation pattern.
> 
> The example **durably mounts** Parallel’s public MCP endpoint (`https://search.parallel.ai/mcp`) via `provideCapability` at `itx.parallelSearch`, then runs **`web_search`** and **`web_fetch`** in parallel with one shared **`session_id`**. It is marked **`e2eProven: false`** and documented in e2e example cases as matrix-excluded because it hits an external, rate-limited service.
> 
> Supporting updates wire the dynamic mount into **`examples-typecheck.test.ts`** (`ParallelSearchTools`) and regenerate **`examples.generated.ts`** from `examples-source.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34ba86622b91cccf79adf7c30afcd0061383baa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->