### PR TITLE
Quiet streams actually sleep: delete the alarm when nothing needs a turn

### DIFF
--- a/apps/os/src/domains/streams/guarantees-not-given.test.ts
+++ b/apps/os/src/domains/streams/guarantees-not-given.test.ts
@@ -72,6 +72,7 @@ function durableObjectContext(name: string) {
   const values = new Map<string, unknown>();
   const backgroundWork: Promise<unknown>[] = [];
   const alarms: number[] = [];
+  const alarmDeletes: number[] = [];
   let latestInitialization: Promise<unknown> | undefined;
   const storage = {
     sql: wrapSqlStorage(db),
@@ -89,6 +90,10 @@ function durableObjectContext(name: string) {
     },
     setAlarm(atMs: number): Promise<void> {
       alarms.push(atMs);
+      return Promise.resolve();
+    },
+    deleteAlarm(): Promise<void> {
+      alarmDeletes.push(alarms.length);
       return Promise.resolve();
     },
     sync(): Promise<void> {
@@ -442,6 +447,7 @@ describe("guarantees the subscription rewrite deliberately does not give", () =>
         now: () => now,
         random: () => 0.5,
         armAlarm: () => undefined,
+        clearAlarm: () => undefined,
         runDurable: (work) => kept.push(work()),
         keepAlive: (promise) => kept.push(promise),
         wakeChannelKeys: () => new Set<string>(),

--- a/apps/os/src/domains/streams/stream-durable-object-background-work.test.ts
+++ b/apps/os/src/domains/streams/stream-durable-object-background-work.test.ts
@@ -124,10 +124,36 @@ describe("StreamDeliveryAlarmBoundary", () => {
   });
 });
 
+describe("StreamDeliveryAlarmBoundary scheduled-work marker", () => {
+  it("marks an append-armed wake as owed until the alarm turn runs", () => {
+    const boundary = new StreamDeliveryAlarmBoundary({
+      armAlarm: () => undefined,
+      now: () => 123,
+      waitUntil: () => undefined,
+    });
+    expect(boundary.hasScheduledWork).toBe(false);
+
+    // Append turn: work is scheduled, not started — nothing else (no cursor
+    // row, no in-flight flag) betrays that a wake is owed, so the quiet-alarm
+    // deletion must see this marker or it deletes the just-armed alarm and
+    // strands every durable send (the exact e2e-caught regression).
+    boundary.scheduleOrRun(() => Promise.resolve());
+    expect(boundary.hasScheduledWork).toBe(true);
+
+    boundary.runAlarmTurn(() => undefined);
+    expect(boundary.hasScheduledWork).toBe(false);
+
+    // Scheduling from within an alarm turn starts the work directly and owes
+    // no future wake.
+    boundary.runAlarmTurn(() => boundary.scheduleOrRun(() => Promise.resolve()));
+    expect(boundary.hasScheduledWork).toBe(false);
+  });
+});
+
 describe("StreamAlarmArmer", () => {
   it("writes synchronously, never moves an alarm later, and can re-arm after it fires", () => {
     const setAlarm = vi.fn(async () => undefined);
-    const armer = new StreamAlarmArmer({ setAlarm });
+    const armer = new StreamAlarmArmer({ setAlarm, deleteAlarm: vi.fn(async () => undefined) });
 
     armer.armNoLaterThan(200);
     expect(setAlarm).toHaveBeenLastCalledWith(200);
@@ -152,7 +178,7 @@ describe("StreamAlarmArmer", () => {
         throw failure;
       })
       .mockResolvedValue(undefined);
-    const armer = new StreamAlarmArmer({ setAlarm });
+    const armer = new StreamAlarmArmer({ setAlarm, deleteAlarm: vi.fn(async () => undefined) });
 
     expect(() => armer.armNoLaterThan(100)).toThrow("stream alarm arming failed");
     armer.armNoLaterThan(100);

--- a/apps/os/src/domains/streams/stream-durable-object-copy-recovery.test.ts
+++ b/apps/os/src/domains/streams/stream-durable-object-copy-recovery.test.ts
@@ -66,6 +66,7 @@ function durableObjectContext(name: string) {
   const values = new Map<string, unknown>();
   const backgroundWork: Promise<unknown>[] = [];
   const alarms: number[] = [];
+  const alarmDeletes: number[] = [];
   let storageSyncCount = 0;
   let latestInitialization: Promise<unknown> | undefined;
   let kvPutFailure: { error: Error; key?: string } | undefined;
@@ -91,6 +92,10 @@ function durableObjectContext(name: string) {
     },
     setAlarm(atMs: number): Promise<void> {
       alarms.push(atMs);
+      return Promise.resolve();
+    },
+    deleteAlarm(): Promise<void> {
+      alarmDeletes.push(alarms.length);
       return Promise.resolve();
     },
     sync(): Promise<void> {

--- a/apps/os/src/domains/streams/stream-durable-object.ts
+++ b/apps/os/src/domains/streams/stream-durable-object.ts
@@ -143,6 +143,7 @@ type StreamDeliveryAlarmBoundaryHooks = {
 
 type StreamAlarmStorage = {
   setAlarm(atMs: number): Promise<void>;
+  deleteAlarm(): Promise<void>;
 };
 
 /**
@@ -185,6 +186,23 @@ export class StreamAlarmArmer {
   markFired(): void {
     this.#armedForMs = null;
   }
+
+  /**
+   * Delete the pending native alarm because the caller proved nothing needs
+   * a future turn. Safe by construction: durable obligations are visible to
+   * that recomputation (cursor rows, in-flight sets, the idle deadline), and
+   * new work only arises through an append or wake — both of which reconcile
+   * and re-arm. Without this, the in-flight watchdog armed before every
+   * successful send outlives its delivery, fires on the hibernated stream,
+   * boots it, appends `woken`, whose delivery arms the next watchdog — a
+   * perpetual ~21-second boot loop on quiet streams with subscriptions.
+   * A later armNoLaterThan in the same turn simply re-arms after the delete.
+   */
+  clearWhenQuiet(): void {
+    this.#armedForMs = null;
+    // Same posture as setAlarm: not awaited or caught; the output gate owns it.
+    void this.#storage.deleteAlarm();
+  }
 }
 
 export class StreamDeliveryAlarmBoundary {
@@ -195,6 +213,20 @@ export class StreamDeliveryAlarmBoundary {
     this.#hooks = hooks;
   }
 
+  /**
+   * True between an append turn arming its immediate work alarm and the
+   * alarm turn that runs the re-derived work. In that gap NOTHING else
+   * betrays that a wake is owed — no cursor row is due yet, no in-flight
+   * flag is set (the closure never started) — so the quiet-alarm deletion
+   * must treat this as pending work or it deletes the very alarm that was
+   * just armed to start delivery, stranding every durable send.
+   */
+  #scheduledWorkPending = false;
+
+  get hasScheduledWork(): boolean {
+    return this.#scheduledWorkPending;
+  }
+
   scheduleOrRun(work: () => Promise<unknown>): void {
     if (this.#inAlarmTurn) {
       this.#hooks.waitUntil(settleStreamCoreBackgroundWork(work));
@@ -203,12 +235,17 @@ export class StreamDeliveryAlarmBoundary {
     // setAlarm is itself an output-gated storage write. Issue it directly in
     // this append turn: wrapping it in a settling waitUntil would cross the
     // implicit-transaction boundary and could acknowledge lag without a wake.
+    this.#scheduledWorkPending = true;
     this.#hooks.armAlarm(this.#hooks.now());
   }
 
   runAlarmTurn(work: () => void): void {
     const wasInAlarmTurn = this.#inAlarmTurn;
     this.#inAlarmTurn = true;
+    // The fired alarm turn re-derives ALL owed work from durable cursors
+    // (the scheduled closure was deliberately discarded), so the owed-wake
+    // marker is satisfied the moment this turn starts.
+    this.#scheduledWorkPending = false;
     try {
       work();
     } finally {
@@ -468,6 +505,13 @@ export class StreamDurableObject extends DurableObject<Env> {
       now: () => Date.now(),
       random: () => Math.random(),
       armAlarm: (atMs) => this.#alarmArmer.armNoLaterThan(atMs),
+      clearAlarm: () => {
+        // An append turn may have armed an immediate alarm for scheduled
+        // durable work that has not started yet; that owed wake is invisible
+        // to the sender's recomputation and must veto the deletion.
+        if (this.#deliveryAlarmBoundary.hasScheduledWork) return;
+        this.#alarmArmer.clearWhenQuiet();
+      },
       runDurable: (work) => this.#deliveryAlarmBoundary.scheduleOrRun(work),
       keepAlive: (promise) => this.#runInBackground(() => promise),
       wakeChannelKeys: () => this.#wakeSockets.channelKeys(),

--- a/apps/os/src/domains/streams/stream-event-sender.test.ts
+++ b/apps/os/src/domains/streams/stream-event-sender.test.ts
@@ -126,6 +126,7 @@ function harness(args: {
     args.store ?? new SqliteSubscriptionCursorStore(wrapSqlStorage(new DatabaseSync(":memory:")));
   store.ensure(PROCESSOR_KEY, 0, 1);
   const alarms: number[] = [];
+  const alarmClears: number[] = [];
   const kept: Promise<unknown>[] = [];
   const wakeCalls: Parameters<SubscriptionReceiverCalls["wakeStreamProcessor"]>[] = [];
   const receiverCalls: SubscriptionReceiverCalls = {
@@ -154,6 +155,7 @@ function harness(args: {
       now: () => now,
       random: () => 0.5,
       armAlarm: (atMs) => alarms.push(atMs),
+      clearAlarm: () => alarmClears.push(now),
       runDurable: (work) => kept.push(work()),
       keepAlive: (promise) => kept.push(promise),
       wakeChannelKeys: () => new Set<string>(),
@@ -175,6 +177,7 @@ function harness(args: {
   return {
     wakeCalls,
     alarms,
+    alarmClears,
     state,
     store,
     eventSender,
@@ -636,6 +639,50 @@ describe("StreamEventSender stream delivery", () => {
       failingEventOffset: null,
       failingEventAttempt: 0,
     });
+  });
+
+  it("deletes the alarm once the last send settles with nothing due, and never while a retry is pending", async () => {
+    const itxConfig = {
+      subscriptionKey: PROCESSOR_KEY,
+      receiver: {
+        action: "itx-call",
+        expression: ["worker", "processEventBatch"],
+        delivery: { start: "beginning", onFailingEvent: "halt" },
+      },
+    } satisfies SubscriptionConfiguredPayload;
+
+    // Success: the send's pre-armed in-flight watchdog would otherwise
+    // outlive this delivery and boot the hibernated stream forever (each
+    // boot appends `woken`, whose delivery arms the next watchdog).
+    const ok = harness({
+      events: [event(2, "example.com/issue-created", { issue: 1 })],
+      configuration: itxConfig,
+      deliverToItx: async () => undefined,
+      wakeProcessor: async () => {
+        throw new Error("an ITX receiver must not wake a hosted processor");
+      },
+    });
+    ok.eventSender.sendDue();
+    await ok.settle();
+    expect(ok.store.get(PROCESSOR_KEY)?.acknowledgedOffset).toBe(2);
+    expect(ok.alarmClears.length).toBeGreaterThan(0);
+
+    // Failure: a pending retry row must keep the alarm armed — the quiet
+    // check may never delete a wake a durable obligation depends on.
+    const failing = harness({
+      events: [event(2, "example.com/issue-created", { issue: 1 })],
+      configuration: itxConfig,
+      deliverToItx: async () => {
+        throw new Error("receiver down");
+      },
+      wakeProcessor: async () => {
+        throw new Error("an ITX receiver must not wake a hosted processor");
+      },
+    });
+    failing.eventSender.sendDue();
+    await failing.settle();
+    expect(failing.store.get(PROCESSOR_KEY)?.nextAttemptAt).not.toBeNull();
+    expect(failing.alarmClears).toEqual([]);
   });
 
   it("an ITX transform shapes each delivered event while the batch keeps the source coordinates", async () => {
@@ -1823,6 +1870,7 @@ function connectionsHarness(
         sessionsIdleClosed.push([...keys]);
         options.onSessionsIdleClosed?.(keys);
       },
+      reconcileAlarm: () => undefined,
       hostedDeliveryStillMatches: (_subscriptionKey, candidate) =>
         candidate.configuredAtOffset === expectedDelivery.configuredAtOffset &&
         candidate.cursorChangedAtOffset === expectedDelivery.cursorChangedAtOffset &&

--- a/apps/os/src/domains/streams/stream-event-sender.test.ts
+++ b/apps/os/src/domains/streams/stream-event-sender.test.ts
@@ -2552,9 +2552,14 @@ describe("StreamConnections hosted delivery watchdog", () => {
       connectionKey: "session",
       processEventBatch: () => undefined,
     });
+    // Publication itself arms the deadline: the opened-fact reconcile runs
+    // before the connection is in the map, and with quiet-alarm deletion no
+    // stray later fire exists to paper over a missed arming (Bugbot 3705177939).
+    const armedAtPublication = h.alarmTimes.at(-1);
+    expect(armedAtPublication).toBeDefined();
     h.connections.armOrClearIdleAlarm();
     const firstDeadline = h.alarmTimes.at(-1);
-    expect(firstDeadline).toBeDefined();
+    expect(firstDeadline).toBe(armedAtPublication);
 
     // Re-running the check with no new delivery activity must keep the SAME
     // deadline: the old now+window reset slid it forward on the idle alarm's

--- a/apps/os/src/domains/streams/stream-event-sender.test.ts
+++ b/apps/os/src/domains/streams/stream-event-sender.test.ts
@@ -685,6 +685,41 @@ describe("StreamEventSender stream delivery", () => {
     expect(failing.alarmClears).toEqual([]);
   });
 
+  it("never clears the alarm while un-acked lag has no scheduled retry (lifecycle-retry state)", async () => {
+    // Model the lifecycle-retry state directly: a non-halted row lagging the
+    // head with nothing scheduled (an interrupted audit append leaves the
+    // cursor untouched and arms only a bare short-delay alarm). The quiet
+    // deletion must see that lag as pending work.
+    const h = harness({
+      events: [event(2, "example.com/issue-created", { issue: 1 })],
+      configuration: {
+        subscriptionKey: PROCESSOR_KEY,
+        filter: { jsonataCondition: "$notAFunction(payload)" },
+        receiver: {
+          action: "itx-call",
+          expression: ["worker", "processEventBatch"],
+          delivery: { start: "beginning", onFailingEvent: "halt" },
+        },
+      },
+      // The audit append for the filter failure is interrupted (false): the
+      // loop arms the lifecycle retry, leaves the row un-acked, and returns.
+      appendDeliveryEvent: (entry) =>
+        entry.type === "events.iterate.com/stream/error-occurred" ? false : true,
+      deliverToItx: async () => undefined,
+      wakeProcessor: async () => {
+        throw new Error("an ITX receiver must not wake a hosted processor");
+      },
+    });
+    h.eventSender.sendDue();
+    await h.settle();
+
+    const row = h.store.get(PROCESSOR_KEY)!;
+    expect(row.acknowledgedOffset).toBeLessThan(h.state.maxOffset);
+    expect(row.nextAttemptAt).toBeNull();
+    // The bare lifecycle retry was armed and, critically, never cleared.
+    expect(h.alarmClears).toEqual([]);
+  });
+
   it("an ITX transform shapes each delivered event while the batch keeps the source coordinates", async () => {
     const batches: StreamDeliveryBatch[] = [];
     const deliverToItx = vi.fn<SubscriptionReceiverCalls["deliverToItx"]>(

--- a/apps/os/src/domains/streams/stream-event-sender.ts
+++ b/apps/os/src/domains/streams/stream-event-sender.ts
@@ -1400,6 +1400,12 @@ export class StreamEventSender {
   /** Recompute (and possibly clear) the alarm after an asynchronous settlement. */
   reconcileAlarmAfterSettlement(): void {
     try {
+      // Re-derive idle eligibility from the CURRENT connection map first: a
+      // settlement may be the first reconciliation that can see a connection
+      // published after its opened-fact reconcile, and the quiet deletion
+      // below must observe that pending idle deadline, not clear the alarm
+      // out from under it.
+      this.connections.armOrClearIdleAlarm();
       this.#armAlarmFromStore();
     } catch (error) {
       console.error("post-settlement alarm reconciliation failed", error);
@@ -2369,6 +2375,13 @@ export class StreamConnections {
     // wake path records the processor's reported checkpoint.
     this.#connections.set(connectionKey, connection);
     this.#hooks.runtimeChanged();
+    // Idle eligibility changed exactly here, so (re)derive the deadline here.
+    // The connection-opened append's nested reconcile ran BEFORE this
+    // publication and could not see the connection; on main the stray
+    // in-flight watchdog alarm papered over that gap by re-running the
+    // reconcile later, but with quiet-alarm deletion there may be no later
+    // fire — an unarmmed idle deadline would pin this connection forever.
+    this.armOrClearIdleAlarm();
     processEventBatch.onRpcBroken?.((error) => {
       if (kind === "hosted" && args.expectedHostedDelivery !== undefined) {
         this.onHostedDeliveryError(connectionKey, error, args.expectedHostedDelivery, "rpc-broken");

--- a/apps/os/src/domains/streams/stream-event-sender.ts
+++ b/apps/os/src/domains/streams/stream-event-sender.ts
@@ -1344,6 +1344,7 @@ export class StreamEventSender {
     // from either spins the alarm at zero delay.
     const state = this.#hooks.coreState();
     let next: number | null = null;
+    let lagWithoutSchedule = false;
     for (const row of this.#hooks.store.list()) {
       const key = row.subscriptionKey;
       const configured = state.subscriptions.outbound.byKey[key];
@@ -1365,7 +1366,15 @@ export class StreamEventSender {
         if (next === null || watchdogAt < next) next = watchdogAt;
         continue;
       }
-      if (row.nextAttemptAt === null) continue;
+      if (row.nextAttemptAt === null) {
+        // A non-halted row lagging the head with NOTHING scheduled is the
+        // lifecycle-retry state: an interrupted audit/settlement append armed
+        // a bare short-delay alarm without touching the row (deliberately —
+        // the cursor must not move past unexplained work). That armed wake is
+        // this row's only future, so it must veto the quiet deletion below.
+        if (row.acknowledgedOffset < state.maxOffset) lagWithoutSchedule = true;
+        continue;
+      }
       if (next === null || row.nextAttemptAt < next) next = row.nextAttemptAt;
     }
     if (next !== null) this.#hooks.armAlarm(next);
@@ -1379,6 +1388,7 @@ export class StreamEventSender {
     // the same turn re-arms after the delete.
     if (
       next === null &&
+      !lagWithoutSchedule &&
       !this.connections.hasPendingIdleDeadline &&
       this.#sourceOwnedSendsInFlight.size === 0 &&
       this.#hostedWakesInFlight.size === 0

--- a/apps/os/src/domains/streams/stream-event-sender.ts
+++ b/apps/os/src/domains/streams/stream-event-sender.ts
@@ -290,6 +290,13 @@ type StreamEventSenderHooks = {
   /** Arm the Durable Object alarm for the earliest pending retry. */
   armAlarm(atMs: number): void;
   /**
+   * Delete the pending Durable Object alarm; called only when the full
+   * recomputation found NOTHING needing a future turn (no due or in-flight
+   * cursor rows, no idle deadline). Lets a quiet stream sleep until a real
+   * touch instead of being booted forever by its last send's watchdog.
+   */
+  clearAlarm(): void;
+  /**
    * Run durable delivery in its alarm-owned invocation. The production Stream
    * DO schedules an immediate alarm when called from an append and runs the
    * closure only when delivery is already running inside that alarm turn.
@@ -371,6 +378,7 @@ export class StreamEventSender {
         onHostedDeliveryFailure: (subscriptionKey, error) =>
           this.#onDeliveryFailure(subscriptionKey, error),
         sendDueSubscriptions: () => this.sendDue(),
+        reconcileAlarm: () => this.reconcileAlarmAfterSettlement(),
       },
     });
   }
@@ -691,6 +699,7 @@ export class StreamEventSender {
         }
       } finally {
         this.#hostedWakesInFlight.delete(subscriptionKey);
+        this.reconcileAlarmAfterSettlement();
       }
     });
   }
@@ -1005,6 +1014,7 @@ export class StreamEventSender {
         }
       } finally {
         this.#sourceOwnedSendsInFlight.delete(subscriptionKey);
+        this.reconcileAlarmAfterSettlement();
       }
     });
   }
@@ -1360,6 +1370,30 @@ export class StreamEventSender {
     }
     if (next !== null) this.#hooks.armAlarm(next);
     this.connections.rearmIdleAlarm();
+    // Nothing durable needs a future turn and no idle deadline is pending:
+    // delete the alarm outright, or the last send's in-flight watchdog
+    // outlives its successful delivery and boots the hibernated stream every
+    // ~21s forever (each boot appends `woken`, whose delivery re-arms the
+    // next watchdog). Settlement paths re-run this method so the LAST
+    // completion is what finds the quiet state. A later armNoLaterThan in
+    // the same turn re-arms after the delete.
+    if (
+      next === null &&
+      !this.connections.hasPendingIdleDeadline &&
+      this.#sourceOwnedSendsInFlight.size === 0 &&
+      this.#hostedWakesInFlight.size === 0
+    ) {
+      this.#hooks.clearAlarm();
+    }
+  }
+
+  /** Recompute (and possibly clear) the alarm after an asynchronous settlement. */
+  reconcileAlarmAfterSettlement(): void {
+    try {
+      this.#armAlarmFromStore();
+    } catch (error) {
+      console.error("post-settlement alarm reconciliation failed", error);
+    }
   }
 
   /**
@@ -1575,6 +1609,8 @@ type StreamConnectionsHooks = Pick<
   ): boolean;
   onHostedDeliveryFailure(connectionKey: string, error: unknown): void;
   sendDueSubscriptions(): void;
+  /** Recompute (and possibly clear) the alarm after a hosted batch settles. */
+  reconcileAlarm(): void;
 };
 
 const PING_ROUND_MIN_INTERVAL_MS = 5_000;
@@ -1700,6 +1736,11 @@ export class StreamConnections {
 
   rearmIdleAlarm(): void {
     if (this.#idleTeardownAtMs !== null) this.#hooks.armAlarm(this.#idleTeardownAtMs);
+  }
+
+  /** Whether an idle-teardown deadline is pending (the alarm must stay armed for it). */
+  get hasPendingIdleDeadline(): boolean {
+    return this.#idleTeardownAtMs !== null;
   }
 
   openSession(args: {
@@ -2209,6 +2250,9 @@ export class StreamConnections {
                     connectionGeneration: expectedDelivery.connectionGeneration,
                     cursorChangedAtOffset: expectedDelivery.cursorChangedAtOffset,
                   });
+                  // The batch's pre-armed watchdog is now moot; let the full
+                  // recomputation decide whether anything still needs a turn.
+                  this.#hooks.reconcileAlarm();
                   if (newestCreatedAtMs !== undefined && Number.isFinite(newestCreatedAtMs)) {
                     const completedAtMs = this.#hooks.now();
                     connection.completionLatency.record(


### PR DESCRIPTION
During PR #2386's real-clock proofs (preview and production), the event log showed a quiet stream re-booting every ~21 seconds forever: four `stream/woken` events per idle window, each a fresh-incarnation boot. The cause is pre-existing: the in-flight delivery watchdog armed before every send (a #1518-era safety net) survives successful completion — the alarm armer deliberately only lowers — so the leftover alarm fires on the hibernated DO, boots it, appends `woken`, whose delivery to the birth-configured feeds (project worker, PostHog) arms the next watchdog. Each boot is milliseconds of billed duration, but quiet streams never fully sleep, and with #2386 making session-idle streams hibernate at all, the tax is now the dominant residual cost.

## The change

Settlement paths (source-owned send completion, hosted wake completion, hosted batch acknowledgement) re-run the sender's alarm recomputation. When that full recomputation finds **nothing needing a future turn** — no due or in-flight cursor rows, no in-flight sends, no idle-teardown deadline — the native alarm is deleted (`StreamAlarmArmer.clearWhenQuiet`). Deletion is safe by construction: every durable obligation is visible to the recomputation, and new work only arises through an append or a wake, both of which reconcile and re-arm.

One state is invisible to that recomputation, and the local e2e caught it before this PR left the machine: an **append turn** arms an immediate alarm for scheduled durable work whose closure deliberately never starts in that turn (the alarm turn re-derives it from cursors). No cursor row is due yet, no in-flight flag is set — so the quiet check would delete the very alarm just armed to start delivery, stranding every durable send including project-creation barriers. `StreamDeliveryAlarmBoundary` now tracks that owed wake (`hasScheduledWork`), and the DO's `clearAlarm` hook vetoes deletion until the alarm turn runs.

## Risk map

1. **The deletion condition** (`stream-event-sender.ts`, `#armAlarmFromStore` tail): the invariant is that every future-turn need is either a visible row/in-flight/idle-deadline or covered by the scheduled-work veto. If a future obligation type is added without surfacing in this recomputation, a quiet stream could strand it until the next touch — the exact class the watchdog existed to prevent. The unit test pins both directions (clear on quiet, never while a retry row is pending).
2. **The scheduled-work veto** (`stream-durable-object.ts`, `StreamDeliveryAlarmBoundary`): the marker must clear exactly when the alarm turn starts (work is re-derived there) — unit-tested, plus three e2e canaries (session wake cycle, hosted idle/wake cycle, ITX project-worker delivery) that all failed against the un-vetoed version and pass now.
3. Everything else is plumbing (a `clearAlarm` hook, `deleteAlarm` on test fakes).

On merge: quiet streams with subscriptions stop waking every ~21s — `stream/woken` counts on idle streams drop to zero between real touches. Verifiable by re-running the #2386 real-clock proof and counting `woken` events during the dormant window (expected: exactly one, at the post-idle append, instead of four).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core stream DO alarm lifecycle and deletion conditions; a missed obligation in recomputation or a wrong scheduled-work veto could strand delivery or delete alarms that still owe work.
> 
> **Overview**
> Fixes quiet streams **re-booting every ~21s** after delivery settles: the in-flight watchdog alarm outlived successful sends and kept waking hibernated Durable Objects (each boot appends `woken`, which re-arms delivery).
> 
> **Alarm deletion when truly quiet:** After async settlement (source-owned sends, hosted wakes, hosted batch acks), `reconcileAlarmAfterSettlement` re-runs idle-deadline and cursor recomputation. When nothing needs a future turn—no due retries, no in-flight sends, no lag without a scheduled retry, no idle teardown deadline—it calls **`deleteAlarm`** via `StreamAlarmArmer.clearWhenQuiet` and a new `clearAlarm` hook.
> 
> **Scheduled-work veto:** Append turns that only **arm** an immediate alarm (durable work not started yet) set `StreamDeliveryAlarmBoundary.hasScheduledWork` until the alarm turn runs. `clearAlarm` skips deletion in that gap so delivery is not stranded.
> 
> **Connection idle:** `openSession` now runs `armOrClearIdleAlarm` after publishing the connection so idle deadlines are armed even when quiet-alarm deletion removed stray watchdog fires.
> 
> Tests cover scheduled-work marking, clear-on-success vs never-clear-on-retry/lifecycle-retry lag, and idle deadline at publication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59367c8b715c8cf1df8397c6393802eee28a6cd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-03T15:52:35.484Z",
      "deployedAt": "2026-08-03T15:11:54.246Z",
      "headSha": "59367c8b715c8cf1df8397c6393802eee28a6cd9",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/441474083842060",
      "shortSha": "59367c8",
      "cleanupDurationMs": 19086,
      "deployDurationMs": 51400,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 49149,
      "deployReadinessDurationMs": 2247,
      "deployedWorkerName": "os-preview-11",
      "deployedWorkerVersion": "d195d9cd-6f59-4bd1-aa48-6b66b3880fd9",
      "testDurationMs": 253041,
      "testRetries": "3 retried: concurrent long-running itx scripts all complete (vitest x1) — expected { fulfilled: [ { …(2) }, …(2) ], …(1) } to deeply equal { Object (fulfilled, rejected) } · the packaged Todo adopts rows from the config-owned worker (vitest x1) — Too many dynamic workers are starting concurrently. · mobile/approvals.spec.ts › approve and reject script bursts from inside the chat thread › mobile (playwright x1) — TimeoutError: locator.waitFor: Timeout 1ms exceeded. Call log: \u001b[2m - waiting for getByTestId(/^notification-row-/).nth(1) to be visible\u001b[22m \u001b[33m If this is a slow operation, update the product code to add a spinner while it's running. This will improve the user experience and buy you more time...",
      "workerSizeKib": 20154.4,
      "workerGzipKib": 5083.79,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5094.52
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-03T15:52:20.012Z",
      "deployedAt": "2026-08-03T15:11:17.004Z",
      "headSha": "59367c8b715c8cf1df8397c6393802eee28a6cd9",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-11.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/441474083842060",
      "shortSha": "59367c8",
      "cleanupDurationMs": 3611,
      "deployDurationMs": 64732,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 11904,
      "deployReadinessDurationMs": 52824,
      "deployedWorkerName": "docs-preview-11",
      "deployedWorkerVersion": "2ead8be4-a37f-46e1-8314-f0418103db8f",
      "testDurationMs": 1846,
      "testRetries": null,
      "workerSizeKib": 3103.42,
      "workerGzipKib": 745.09,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-03T15:52:21.368Z",
      "deployedAt": "2026-08-03T15:11:21.403Z",
      "headSha": "59367c8b715c8cf1df8397c6393802eee28a6cd9",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/441474083842060",
      "shortSha": "59367c8",
      "cleanupDurationMs": 4965,
      "deployDurationMs": 16836,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 16302,
      "deployReadinessDurationMs": 528,
      "deployedWorkerName": "auth-preview-11",
      "deployedWorkerVersion": "1457f2ec-f663-4254-9ec1-d6a835e167fc",
      "testDurationMs": 11852,
      "testRetries": null,
      "workerSizeKib": 3979.33,
      "workerGzipKib": 814.97,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-08-03T15:52:25.027Z",
      "deployedAt": "2026-08-03T15:11:18.794Z",
      "headSha": "59367c8b715c8cf1df8397c6393802eee28a6cd9",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/441474083842060",
      "shortSha": "59367c8",
      "cleanupDurationMs": 8622,
      "deployDurationMs": 67062,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 13692,
      "deployReadinessDurationMs": 53363,
      "deployedWorkerName": "streams-example-app-preview-11",
      "deployedWorkerVersion": "548e60b6-bca9-4011-85cd-e890d14ce854",
      "testDurationMs": 88384,
      "testRetries": null,
      "workerSizeKib": 5308.96,
      "workerGzipKib": 1503.89,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-03T15:52:17.206Z",
      "deployedAt": "2026-08-03T15:11:10.627Z",
      "headSha": "59367c8b715c8cf1df8397c6393802eee28a6cd9",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/441474083842060",
      "shortSha": "59367c8",
      "cleanupDurationMs": 799,
      "deployDurationMs": 5565,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 5479,
      "deployReadinessDurationMs": 34,
      "deployedWorkerName": "dummy-petshop-preview-11",
      "deployedWorkerVersion": "4fe2641e-5d0d-4d00-8942-522f79a3c21c",
      "testDurationMs": 32524,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `59367c8` | [https://auth.iterate-preview-11.com](https://auth.iterate-preview-11.com) | 815.0 KiB | 16.8s | 11.9s |  | 5.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/441474083842060) | 2026-08-03T15:52:21.368Z | Preview app released. |
| Docs | released | `59367c8` | [https://docs-preview-11.iterate-dev-preview.workers.dev](https://docs-preview-11.iterate-dev-preview.workers.dev) | 745.1 KiB | 64.7s | 1.8s |  | 3.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/441474083842060) | 2026-08-03T15:52:20.012Z | Preview app released. |
| Dummy Petshop | released | `59367c8` | [https://dummy-petshop.iterate-preview-11.com](https://dummy-petshop.iterate-preview-11.com) | 198.3 KiB | 5.6s | 32.5s |  | 799ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/441474083842060) | 2026-08-03T15:52:17.206Z | Preview app released. |
| OS | released | `59367c8` | [https://os.iterate-preview-11.com](https://os.iterate-preview-11.com) | 4.96 MiB (-10.7 KiB vs main) | 51.4s | 253.0s | 3 retried: concurrent long-running itx scripts all complete (vitest x1) — expected { fulfilled: [ { …(2) }, …(2) ], …(1) } to deeply equal { Object (fulfilled, rejected) } · the packaged Todo adopts rows from the config-owned worker (vitest x1) — Too many dynamic workers are starting concurrently. · mobile/approvals.spec.ts › approve and reject script bursts from inside the chat thread › mobile (playwright x1) — TimeoutError: locator.waitFor: Timeout 1ms exceeded. Call log: [2m - waiting for getByTestId(/^notification-row-/).nth(1) to be visible[22m [33m If this is a slow operation, update the product code to add a spinner while it's running. This will improve the user experience and buy you more time... | 19.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/441474083842060) | 2026-08-03T15:52:35.484Z | Preview app released. |
| Streams Example App | released | `59367c8` | [https://streams.iterate-preview-11.com](https://streams.iterate-preview-11.com) | 1.47 MiB | 67.1s | 88.4s |  | 8.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/441474083842060) | 2026-08-03T15:52:25.027Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +112 -1 | +44 -1 🟩🟩⬜⬜⬜ |
| Tests | +128 -3 | +98 -3 🟩🟩🟩🟩🟩 |
| **Total** | **+240 -4** | **+142 -4** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between e9df500 and 59367c8, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->