### PR TITLE
State socket opening: share one in-flight dial, drop it if watchers left

### DIFF
--- a/apps/os/src/domains/streams/stream-connection-relay.ts
+++ b/apps/os/src/domains/streams/stream-connection-relay.ts
@@ -380,41 +380,62 @@ export function openRelayedLiveState(input: {
     }
   };
 
-  const ensureSocket = async () => {
-    if (socket !== undefined) return;
-    try {
-      const upgrade = await input.stub().fetch("https://stream-wake.internal/", {
-        headers: {
-          Upgrade: "websocket",
-          [STREAM_WAKE_SOCKET_HEADER]: STATE_SOCKET_HEADER_BODY,
-        },
-      });
-      const ws = upgrade.webSocket ?? undefined;
-      if (ws === undefined) return;
-      ws.accept();
-      ws.addEventListener("message", (event) => {
-        const frame = parseStateSocketFrame(event.data);
-        if (frame === undefined) return;
-        // The only producer of state frames is this stream DO's pushState,
-        // which sends exactly #readRuntimeState() — the same value the
-        // snapshot read returns typed. The protocol module keeps the payload
-        // `unknown` on purpose (forward-compat across deploy skew), and
-        // liveState consumers are read-only debug surfaces that tolerate
-        // transient shape drift, so a full runtime re-validation here would
-        // buy nothing but a second schema to keep in sync.
-        apply(frame.state as StreamRuntimeDebugState);
-      });
-      ws.addEventListener("close", () => {
-        // Stale-until-next-read: the next subscribe re-opens and re-seeds.
-        if (socket === ws) socket = undefined;
-      });
-      socket = ws;
-    } catch (error) {
-      console.warn("stream state socket unavailable; liveState reads stay snapshot-only", {
-        error,
-      });
-    }
-  };
+  // Memoized while an open is in flight: concurrent subscribes must share
+  // one dial, or each opens its own DO-side socket and only the last keeps a
+  // worker reference — the rest linger as watchers the DO keeps
+  // materializing state for.
+  let socketOpening: Promise<void> | undefined;
+
+  const ensureSocket = (): Promise<void> =>
+    (socketOpening ??= (async () => {
+      if (socket !== undefined) return;
+      try {
+        const upgrade = await input.stub().fetch("https://stream-wake.internal/", {
+          headers: {
+            Upgrade: "websocket",
+            [STREAM_WAKE_SOCKET_HEADER]: STATE_SOCKET_HEADER_BODY,
+          },
+        });
+        const ws = upgrade.webSocket ?? undefined;
+        if (ws === undefined) return;
+        ws.accept();
+        // Subscribers can vanish while the upgrade is in flight — a fast
+        // useLiveState mount/unmount is the common case — and the
+        // unsubscribe-time release no-ops while `socket` is still undefined.
+        // Adopting the fresh socket anyway would orphan it on the DO.
+        if (!engine.observed) {
+          try {
+            ws.close(1000, "no subscribers");
+          } catch {
+            // Already closed.
+          }
+          return;
+        }
+        ws.addEventListener("message", (event) => {
+          const frame = parseStateSocketFrame(event.data);
+          if (frame === undefined) return;
+          // The only producer of state frames is this stream DO's pushState,
+          // which sends exactly #readRuntimeState() — the same value the
+          // snapshot read returns typed. The protocol module keeps the payload
+          // `unknown` on purpose (forward-compat across deploy skew), and
+          // liveState consumers are read-only debug surfaces that tolerate
+          // transient shape drift, so a full runtime re-validation here would
+          // buy nothing but a second schema to keep in sync.
+          apply(frame.state as StreamRuntimeDebugState);
+        });
+        ws.addEventListener("close", () => {
+          // Stale-until-next-read: the next subscribe re-opens and re-seeds.
+          if (socket === ws) socket = undefined;
+        });
+        socket = ws;
+      } catch (error) {
+        console.warn("stream state socket unavailable; liveState reads stay snapshot-only", {
+          error,
+        });
+      } finally {
+        socketOpening = undefined;
+      }
+    })());
 
   const releaseSocketIfUnobserved = () => {
     if (engine.observed || socket === undefined) return;
@@ -434,8 +455,14 @@ export function openRelayedLiveState(input: {
         const subscription = engine.subscribe(sink);
         // Socket lifetime tracks observation: open on first subscriber, and
         // re-seed once attached so a change landing between the pre-read
-        // snapshot and the socket attach still becomes visible.
-        void ensureSocket().then(() => (socket === undefined ? undefined : seed()));
+        // snapshot and the socket attach still becomes visible. Best-effort
+        // end to end — the subscriber already holds a snapshot, so a failed
+        // follow-up seed must log, never surface an unhandled rejection.
+        void ensureSocket()
+          .then(() => (socket === undefined ? undefined : seed()))
+          .catch((error: unknown) => {
+            console.warn("stream state socket post-attach seed failed", { error });
+          });
         return {
           ping: () => subscription.ping(),
           unsubscribe: () => {

--- a/apps/os/src/domains/streams/stream-connection-relay.ts
+++ b/apps/os/src/domains/streams/stream-connection-relay.ts
@@ -386,10 +386,14 @@ export function openRelayedLiveState(input: {
   // materializing state for.
   let socketOpening: Promise<void> | undefined;
 
-  const ensureSocket = (): Promise<void> =>
+  const ensureSocket = () =>
     (socketOpening ??= (async () => {
-      if (socket !== undefined) return;
       try {
+        // Inside the try so EVERY completion clears the memo below — an
+        // early return that skipped the finally would leave a resolved
+        // promise memoized forever, and a later re-dial after the socket
+        // closed would never start (liveState stuck snapshot-only).
+        if (socket !== undefined) return;
         const upgrade = await input.stub().fetch("https://stream-wake.internal/", {
           headers: {
             Upgrade: "websocket",


### PR DESCRIPTION
Fix-forward for two Bugbot findings that landed on #2392's final commit after its review threads had been resolved (the merge should have waited; my gate didn't):

- **Concurrent open race**: two first-subscribers racing `ensureSocket` each dialed a DO-side state socket; only the last kept a worker reference, the rest lingered as watchers the DO keeps materializing state for. The dial is now memoized while in flight.
- **Fast-unsubscribe orphan**: `releaseSocketIfUnobserved` no-ops while the upgrade is still in flight, so a mount/unmount faster than the dial left the fresh socket orphaned. A completed upgrade is now closed instead of adopted when `engine.observed` is already false.
- The post-attach seed chain gains its missing `.catch` (Low): the subscriber already holds a snapshot, so a failed follow-up seed logs instead of surfacing an unhandled rejection.

Verified: typecheck, lint, knip, 454 streams unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches worker–DO WebSocket lifecycle for stream liveState; fixes leaks and races that could pin DOs or leave orphan sockets, but scope is debug live-state relaying, not auth or data paths.
> 
> **Overview**
> Fixes **liveState** state-socket lifecycle races in `openRelayedLiveState` so debug subscribers do not leave extra DO-side watchers or orphaned WebSockets.
> 
> **Concurrent first subscribers** now share a single in-flight upgrade via a memoized `socketOpening` promise; the memo is cleared in `finally` so a later re-dial after the socket closes still works.
> 
> If subscribers unsubscribe before the upgrade finishes, the completed WebSocket is **closed** instead of adopted when `engine.observed` is already false.
> 
> The post-attach **re-seed** after `ensureSocket()` adds a `.catch` so a failed seed logs a warning instead of an unhandled rejection (subscribers already have a snapshot).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a47bc24264ad965a5fde7e9539160324d9fca7c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-03T16:26:12.851Z",
      "deployedAt": "2026-08-03T16:16:48.207Z",
      "headSha": "a47bc24264ad965a5fde7e9539160324d9fca7c7",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/251948800753876",
      "shortSha": "a47bc24",
      "cleanupDurationMs": 11951,
      "deployDurationMs": 52290,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 50676,
      "deployReadinessDurationMs": 1611,
      "deployedWorkerName": "os-preview-2",
      "deployedWorkerVersion": "db6eb1f6-b872-46a7-a19d-3b319e52d7ef",
      "testDurationMs": 292858,
      "testRetries": "6 retried: catalogue example \"repo-edit-file\" runs identically across runtimes (vitest x1) — example \"repo-edit-file\" failed in the project-worker runtime: Repo has no commits yet (unseeded or still seeding): Could not find main. · catalogue example \"workspace-files-transfer\" runs identically across runtimes (vitest x1) — example \"workspace-files-transfer\" failed in the cli runtime: Unexpected end of JSON input · MCP built-in connects directly and mounts as a described capability (vitest x1) — promise rejected \"Error: Internal error in Durable Object s… { itxCallId: '…' }\" instead of resolving · itx expression capabilities mount MCP and OpenAPI built-ins through connect() (vitest x1) — promise rejected \"Error: Network connection lost. { …(1) }\" instead of resolving · concurrent long-running itx scripts all complete (vitest x1) — expected { …(2) } to deeply equal { Object (fulfilled, rejected) } · repo-ide.spec.ts › edit, stage, inspect the Index, and commit through the repo IDE › web (playwright x1) — Error: stream-unavailable: Internal error in Durable Object storage caused object to be reset; reference = c877f7fdfrlsg2feg74habv4",
      "workerSizeKib": 20159.71,
      "workerGzipKib": 5085.38,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5096.79
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-03T16:26:04.429Z",
      "deployedAt": "2026-08-03T16:16:11.097Z",
      "headSha": "a47bc24264ad965a5fde7e9539160324d9fca7c7",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-2.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/251948800753876",
      "shortSha": "a47bc24",
      "cleanupDurationMs": 3523,
      "deployDurationMs": 13819,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 13563,
      "deployReadinessDurationMs": 252,
      "deployedWorkerName": "docs-preview-2",
      "deployedWorkerVersion": "6dd8e826-2e1e-4194-9634-e6d9eb106aa2",
      "testDurationMs": 1871,
      "testRetries": null,
      "workerSizeKib": 3103.42,
      "workerGzipKib": 745.09,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-03T16:26:05.312Z",
      "deployedAt": "2026-08-03T16:16:15.700Z",
      "headSha": "a47bc24264ad965a5fde7e9539160324d9fca7c7",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/251948800753876",
      "shortSha": "a47bc24",
      "cleanupDurationMs": 4405,
      "deployDurationMs": 18201,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 18164,
      "deployReadinessDurationMs": 30,
      "deployedWorkerName": "auth-preview-2",
      "deployedWorkerVersion": "69c7b2d7-92c5-41f1-b995-cf8caeedc327",
      "testDurationMs": 11062,
      "testRetries": null,
      "workerSizeKib": 3979.33,
      "workerGzipKib": 814.81,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-08-03T16:26:09.367Z",
      "deployedAt": "2026-08-03T16:16:10.994Z",
      "headSha": "a47bc24264ad965a5fde7e9539160324d9fca7c7",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/251948800753876",
      "shortSha": "a47bc24",
      "cleanupDurationMs": 8458,
      "deployDurationMs": 36488,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 13457,
      "deployReadinessDurationMs": 23024,
      "deployedWorkerName": "streams-example-app-preview-2",
      "deployedWorkerVersion": "9b3c2978-eca4-4efd-a92e-f56097582814",
      "testDurationMs": 106182,
      "testRetries": null,
      "workerSizeKib": 5315.51,
      "workerGzipKib": 1505.79,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-03T16:26:01.728Z",
      "deployedAt": "2026-08-03T16:16:04.655Z",
      "headSha": "a47bc24264ad965a5fde7e9539160324d9fca7c7",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/251948800753876",
      "shortSha": "a47bc24",
      "cleanupDurationMs": 816,
      "deployDurationMs": 7336,
      "deployConfigDurationMs": 8,
      "deployCommandDurationMs": 7079,
      "deployReadinessDurationMs": 211,
      "deployedWorkerName": "dummy-petshop-preview-2",
      "deployedWorkerVersion": "8dee0fb8-0694-4698-87b3-87627ec8d788",
      "testDurationMs": 48235,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `a47bc24` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 814.8 KiB | 18.2s | 11.1s |  | 4.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/251948800753876) | 2026-08-03T16:26:05.312Z | Preview app released. |
| Docs | released | `a47bc24` | [https://docs-preview-2.iterate-dev-preview.workers.dev](https://docs-preview-2.iterate-dev-preview.workers.dev) | 745.1 KiB | 13.8s | 1.9s |  | 3.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/251948800753876) | 2026-08-03T16:26:04.429Z | Preview app released. |
| Dummy Petshop | released | `a47bc24` | [https://dummy-petshop.iterate-preview-2.com](https://dummy-petshop.iterate-preview-2.com) | 198.3 KiB | 7.3s | 48.2s |  | 816ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/251948800753876) | 2026-08-03T16:26:01.728Z | Preview app released. |
| OS | released | `a47bc24` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 4.97 MiB (-11.4 KiB vs main) | 52.3s | 292.9s | 6 retried: catalogue example "repo-edit-file" runs identically across runtimes (vitest x1) — example "repo-edit-file" failed in the project-worker runtime: Repo has no commits yet (unseeded or still seeding): Could not find main. · catalogue example "workspace-files-transfer" runs identically across runtimes (vitest x1) — example "workspace-files-transfer" failed in the cli runtime: Unexpected end of JSON input · MCP built-in connects directly and mounts as a described capability (vitest x1) — promise rejected "Error: Internal error in Durable Object s… { itxCallId: '…' }" instead of resolving · itx expression capabilities mount MCP and OpenAPI built-ins through connect() (vitest x1) — promise rejected "Error: Network connection lost. { …(1) }" instead of resolving · concurrent long-running itx scripts all complete (vitest x1) — expected { …(2) } to deeply equal { Object (fulfilled, rejected) } · repo-ide.spec.ts › edit, stage, inspect the Index, and commit through the repo IDE › web (playwright x1) — Error: stream-unavailable: Internal error in Durable Object storage caused object to be reset; reference = c877f7fdfrlsg2feg74habv4 | 12.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/251948800753876) | 2026-08-03T16:26:12.851Z | Preview app released. |
| Streams Example App | released | `a47bc24` | [https://streams.iterate-preview-2.com](https://streams.iterate-preview-2.com) | 1.47 MiB | 36.5s | 106.2s |  | 8.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/251948800753876) | 2026-08-03T16:26:09.367Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +68 -37 | +43 -28 🟩🟩🟩🟥🟥 |
| **Total** | **+68 -37** | **+43 -28** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 207913d and a47bc24, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->