### PR TITLE
The checkout noun retires; one user type

### DIFF
--- a/apps/docs/src/components/app-sidebar.tsx
+++ b/apps/docs/src/components/app-sidebar.tsx
@@ -36,10 +36,10 @@ import {
 import { withDocsProject } from "../lib/docs-client.ts";
 import {
   DEFAULT_REPO_PATH,
-  checkoutWorkspacePath,
-  isCheckoutId,
+  boardWorkspacePath,
+  isBoardId,
   normalizeRepoPath,
-} from "../lib/checkout-shared.ts";
+} from "../lib/board-shared.ts";
 import { CloseMobileSidebarOnNavigate } from "./close-mobile-sidebar-on-navigate.tsx";
 
 /**
@@ -58,18 +58,18 @@ export function AppSidebar() {
   const location = useRouterState({ select: (state) => state.location });
   const search = location.search as { repo?: string; workspace?: string };
   const boardView = location.pathname.startsWith("/w");
-  // An owned board (/w/<checkoutId>) carries no ?workspace= — its workspace
+  // An owned board (/w/<boardId>) carries no ?workspace= — its workspace
   // path is DERIVED from the id + repo, so derive it here too or the
   // switcher (and the Docs view link) would lose the workspace on the
   // board's main route.
-  const checkoutId = decodeURIComponent(/^\/w\/([^/]+)/.exec(location.pathname)?.[1] ?? "");
+  const boardId = decodeURIComponent(/^\/w\/([^/]+)/.exec(location.pathname)?.[1] ?? "");
   // /w's validated search supplies workspace as a STRING ("" on the board
   // home) — empty means unset here, or the switcher would wear a blank
   // label and the Docs link a dangling workspace=.
   const workspacePath =
     (search.workspace === "" ? undefined : search.workspace) ??
-    (isCheckoutId(checkoutId)
-      ? checkoutWorkspacePath(checkoutId, normalizeRepoPath(search.repo) ?? DEFAULT_REPO_PATH)
+    (isBoardId(boardId)
+      ? boardWorkspacePath(boardId, normalizeRepoPath(search.repo) ?? DEFAULT_REPO_PATH)
       : undefined);
 
   return (

--- a/apps/docs/src/components/board-header.tsx
+++ b/apps/docs/src/components/board-header.tsx
@@ -29,7 +29,7 @@ import type { RowField } from "../lib/board-model.ts";
  * workspace always comes first; the project is never a crumb (the app's
  * host already says which project this is).
  */
-export function CheckoutBreadcrumbs({
+export function BoardBreadcrumbs({
   workspace,
   rootPath,
 }: {

--- a/apps/docs/src/components/board-home.tsx
+++ b/apps/docs/src/components/board-home.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { ClockIcon, FolderGit2Icon, Loader2Icon, PlusIcon, TelescopeIcon } from "lucide-react";
 import { Button } from "@iterate-com/ui/components/button";
 import { SidebarTrigger } from "@iterate-com/ui/components/sidebar";
-import { newCheckoutId } from "../lib/checkout-shared.ts";
+import { newBoardId } from "../lib/board-shared.ts";
 import { listRepos, listWorkspaces } from "../lib/project-rpc.ts";
 import type { WorkspaceListEntry } from "../lib/tasks-api.ts";
 
@@ -35,8 +35,8 @@ export function BoardHome() {
 
   const openNewBoard = (repoPath: string) => {
     void navigate({
-      to: "/w/$checkoutId",
-      params: { checkoutId: newCheckoutId() },
+      to: "/w/$boardId",
+      params: { boardId: newBoardId() },
       search: { group: "folder", q: "", repo: repoPath, task: "" },
     });
   };
@@ -89,8 +89,8 @@ export function BoardHome() {
                       </Link>
                     ) : (
                       <Link
-                        to="/w/$checkoutId"
-                        params={{ checkoutId: entry.board.checkoutId }}
+                        to="/w/$boardId"
+                        params={{ boardId: entry.board.boardId }}
                         search={{
                           group: "folder",
                           q: "",
@@ -100,7 +100,7 @@ export function BoardHome() {
                         className="flex items-center justify-between gap-3 px-5 py-3 transition-colors hover:bg-muted/50"
                       >
                         <span className="truncate font-mono text-sm">
-                          /workspaces/tasks/{entry.board.checkoutId}
+                          /workspaces/tasks/{entry.board.boardId}
                         </span>
                         <span className="flex shrink-0 items-center gap-3 text-xs text-muted-foreground">
                           <span className="font-mono">{entry.board.repoPath}</span>
@@ -145,14 +145,12 @@ export function BoardHome() {
                     {entries.map((entry) => (
                       <li key={entry.path}>
                         <Link
-                          to="/w/$checkoutId"
-                          params={{ checkoutId: entry.board!.checkoutId }}
+                          to="/w/$boardId"
+                          params={{ boardId: entry.board!.boardId }}
                           search={{ group: "folder", q: "", repo: repoPath, task: "" }}
                           className="flex items-center justify-between gap-3 px-5 py-3 transition-colors hover:bg-muted/50"
                         >
-                          <span className="truncate font-mono text-sm">
-                            {entry.board!.checkoutId}
-                          </span>
+                          <span className="truncate font-mono text-sm">{entry.board!.boardId}</span>
                           <span className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground">
                             <ClockIcon aria-hidden className="size-3.5" />
                             {relativeTimeLong(entry.createdAt)}

--- a/apps/docs/src/components/board-settings.tsx
+++ b/apps/docs/src/components/board-settings.tsx
@@ -3,7 +3,7 @@ import { Button } from "@iterate-com/ui/components/button";
 import { Checkbox } from "@iterate-com/ui/components/checkbox";
 import { Popover, PopoverContent, PopoverTrigger } from "@iterate-com/ui/components/popover";
 import type { RowField } from "../lib/board-model.ts";
-import { WithTooltip } from "./checkout-header.tsx";
+import { WithTooltip } from "./board-header.tsx";
 
 const GROUPINGS: { label: string; value: RowField }[] = [
   { label: "No grouping", value: null },

--- a/apps/docs/src/components/tag-picker.tsx
+++ b/apps/docs/src/components/tag-picker.tsx
@@ -7,7 +7,7 @@ import { cn } from "@iterate-com/ui/lib/utils";
 
 /**
  * The tag combobox: shows the task's tags, proposes every tag that already
- * exists anywhere in the checkout, and creates new ones from the query.
+ * exists anywhere in the board, and creates new ones from the query.
  * Writes go straight to the frontmatter (and the doc syncs them back), so
  * this and the YAML stay in lockstep.
  */

--- a/apps/docs/src/components/workspace-board-page.tsx
+++ b/apps/docs/src/components/workspace-board-page.tsx
@@ -15,7 +15,7 @@ import {
   type BoardTask,
   type RowField,
 } from "../lib/board-model.ts";
-import { isGuestWorkspacePath, type BoardAddress } from "../lib/checkout-shared.ts";
+import { isGuestWorkspacePath, type BoardAddress } from "../lib/board-shared.ts";
 import {
   columnsForTasks,
   fallbackCommitMessage,
@@ -28,12 +28,12 @@ import {
   taskPathForTitle,
 } from "../tasks-model.ts";
 import {
-  CheckoutBreadcrumbs,
+  BoardBreadcrumbs,
   FilterControl,
   MobileOverflow,
   ShareButton,
   WithTooltip,
-} from "./checkout-header.tsx";
+} from "./board-header.tsx";
 import { BoardSettings } from "./board-settings.tsx";
 import { CommitControls, DeletedTasksStrip } from "./commit-controls.tsx";
 import { StreamEventsSheet } from "./stream-events-sheet.tsx";
@@ -526,9 +526,9 @@ export function WorkspaceBoardPage({
     <>
       <header className="flex h-11 shrink-0 items-center gap-2 border-b bg-background px-3">
         <SidebarTrigger className="-ml-1 md:hidden" />
-        <CheckoutBreadcrumbs
+        <BoardBreadcrumbs
           workspace={
-            address.checkoutId !== null ? `/workspaces/tasks/${address.checkoutId}` : workspacePath
+            address.boardId !== null ? `/workspaces/tasks/${address.boardId}` : workspacePath
           }
           rootPath={repoPath}
         />

--- a/apps/docs/src/components/workspace-task-editor.tsx
+++ b/apps/docs/src/components/workspace-task-editor.tsx
@@ -3,7 +3,7 @@ import { WorkspaceDocumentEditor } from "@iterate-com/workspace-documents/editor
 import type { CollabEditorApi } from "@iterate-com/workspace-documents/editor-api";
 import type { WorkspaceDocumentTransport } from "@iterate-com/workspace-documents/types";
 import { withProject, withProjectOnce, workspaceFor } from "../lib/project-rpc.ts";
-import type { BoardAddress } from "../lib/checkout-shared.ts";
+import type { BoardAddress } from "../lib/board-shared.ts";
 
 export function WorkspaceTaskEditor({
   address,
@@ -26,19 +26,19 @@ export function WorkspaceTaskEditor({
   onStatus?: (status: string) => void;
   onRequestClose?: () => void;
 }) {
-  const { checkoutId, workspacePath, repoPath } = address;
+  const { boardId, workspacePath, repoPath } = address;
   const transport = useMemo<WorkspaceDocumentTransport>(
     () => ({
       run: (operation) =>
         withProject((project) =>
-          operation(workspaceFor(project, { checkoutId, workspacePath, repoPath })),
+          operation(workspaceFor(project, { boardId, workspacePath, repoPath })),
         ),
       runOnce: (operation) =>
         withProjectOnce((project) =>
-          operation(workspaceFor(project, { checkoutId, workspacePath, repoPath })),
+          operation(workspaceFor(project, { boardId, workspacePath, repoPath })),
         ),
     }),
-    [checkoutId, workspacePath, repoPath],
+    [boardId, workspacePath, repoPath],
   );
 
   return (

--- a/apps/docs/src/components/workspace-task-sheet.tsx
+++ b/apps/docs/src/components/workspace-task-sheet.tsx
@@ -24,7 +24,7 @@ import {
 } from "@iterate-com/ui/components/alert-dialog";
 import { stateLabel, type BoardTask } from "../lib/board-model.ts";
 import type { TaskChangeStatus } from "../state.ts";
-import type { BoardAddress } from "../lib/checkout-shared.ts";
+import type { BoardAddress } from "../lib/board-shared.ts";
 import { projectSlug } from "../lib/project-label.ts";
 import { TaskStateIcon } from "./board.tsx";
 import { TagPicker } from "./tag-picker.tsx";

--- a/apps/docs/src/lib/board-shared.test.ts
+++ b/apps/docs/src/lib/board-shared.test.ts
@@ -1,25 +1,25 @@
 import { describe, expect, test } from "vitest";
-import { boardAddressFor, checkoutWorkspacePath, isGuestWorkspacePath } from "./checkout-shared.ts";
+import { boardAddressFor, boardWorkspacePath, isGuestWorkspacePath } from "./board-shared.ts";
 
-describe("checkout workspace stream paths", () => {
+describe("board workspace stream paths", () => {
   test("slug collisions stay distinct workspaces", () => {
     // The "--" separator makes the slug alone non-injective: both of these
     // repos slug to "repos--a--b". The hash tail must keep them apart — a
     // shared path would mean shared overlays, collab sessions, and events.
-    const a = checkoutWorkspacePath("20260730-abcd", "/repos/a/b");
-    const b = checkoutWorkspacePath("20260730-abcd", "/repos/a--b");
+    const a = boardWorkspacePath("20260730-abcd", "/repos/a/b");
+    const b = boardWorkspacePath("20260730-abcd", "/repos/a--b");
     expect(a).not.toBe(b);
   });
 
-  test("shape: /workspaces/tasks/<checkoutId>~<slug>-<hash8>", () => {
-    expect(checkoutWorkspacePath("c1", "/repos/config")).toMatch(
+  test("shape: /workspaces/tasks/<boardId>~<slug>-<hash8>", () => {
+    expect(boardWorkspacePath("c1", "/repos/config")).toMatch(
       /^\/workspaces\/tasks\/c1~repos--config-[0-9a-f]{8}$/,
     );
   });
 
   test("deterministic: the same pair always names the same workspace", () => {
-    expect(checkoutWorkspacePath("c1", "/repos/config")).toBe(
-      checkoutWorkspacePath("c1", "/repos/config"),
+    expect(boardWorkspacePath("c1", "/repos/config")).toBe(
+      boardWorkspacePath("c1", "/repos/config"),
     );
   });
 
@@ -28,8 +28,8 @@ describe("checkout workspace stream paths", () => {
     // resolves each to ITS own board, however deep the path nests.
     const repos = ["/repos/a/b", "/repos/a--b", "/repos/deep/a/b/c/d/e/f/g/h", "/repos/config"];
     for (const repoPath of repos) {
-      expect(boardAddressFor(checkoutWorkspacePath("20260731-ab_c", repoPath), repos)).toEqual({
-        checkoutId: "20260731-ab_c",
+      expect(boardAddressFor(boardWorkspacePath("20260731-ab_c", repoPath), repos)).toEqual({
+        boardId: "20260731-ab_c",
         repoPath,
       });
     }
@@ -37,16 +37,16 @@ describe("checkout workspace stream paths", () => {
     // a board on a repo this project does not have.
     expect(boardAddressFor("/workspaces/agents/you", repos)).toBeNull();
     expect(boardAddressFor("/workspaces/tasks/plain-no-separator", repos)).toBeNull();
-    expect(boardAddressFor(checkoutWorkspacePath("c1", "/repos/gone"), repos)).toBeNull();
+    expect(boardAddressFor(boardWorkspacePath("c1", "/repos/gone"), repos)).toBeNull();
   });
 
   test("guest rule: owned = a board path scoped to its own encoded repo", () => {
-    const board = checkoutWorkspacePath("c1", "/repos/config");
+    const board = boardWorkspacePath("c1", "/repos/config");
     expect(isGuestWorkspacePath(board, "/repos/config")).toBe(false);
     // However deeply the repo nests, the app's OWN board stays owned — the
     // check re-mints rather than parsing the ambiguous slug.
     const deep = "/repos/a/b/c/d/e/f/g/h";
-    expect(isGuestWorkspacePath(checkoutWorkspacePath("c1", deep), deep)).toBe(false);
+    expect(isGuestWorkspacePath(boardWorkspacePath("c1", deep), deep)).toBe(false);
     // A board lens pointed at a DIFFERENT mount must not publish it.
     expect(isGuestWorkspacePath(board, "/repos/other")).toBe(true);
     expect(isGuestWorkspacePath("/workspaces/agents/you", "/repos/config")).toBe(true);

--- a/apps/docs/src/lib/board-shared.ts
+++ b/apps/docs/src/lib/board-shared.ts
@@ -1,6 +1,6 @@
 /**
  * Board workspace naming, shared by the vessel (rpc-api.ts) and the browser
- * (routes/use-workspace-board). A board id ("checkout id" historically) has
+ * (routes/use-workspace-board). A board id has
  * exactly one job left: minting a fresh board workspace path under the tasks
  * app's own /workspaces/tasks/ namespace — the workspace mechanism holds all
  * actual state.
@@ -34,9 +34,9 @@ export function normalizeRepoPath(value: string | null | undefined): string | nu
  * the route component builds this path during render, and WebCrypto digests
  * are async-only.
  */
-export function checkoutWorkspacePath(checkoutId: string, repoPath: string): string {
+export function boardWorkspacePath(boardId: string, repoPath: string): string {
   const slug = repoPath.replace(/^\/+/, "").replaceAll("/", "--");
-  return `/workspaces/tasks/${checkoutId}~${slug}-${fnv1a32Hex(repoPath)}`;
+  return `/workspaces/tasks/${boardId}~${slug}-${fnv1a32Hex(repoPath)}`;
 }
 
 /**
@@ -49,29 +49,27 @@ export function checkoutWorkspacePath(checkoutId: string, repoPath: string): str
 export function boardAddressFor(
   path: string,
   repoPaths: readonly string[],
-): { checkoutId: string; repoPath: string } | null {
-  const checkoutId = boardCheckoutId(path);
-  if (checkoutId === null) return null;
-  const repoPath = repoPaths.find(
-    (candidate) => checkoutWorkspacePath(checkoutId, candidate) === path,
-  );
-  return repoPath === undefined ? null : { checkoutId, repoPath };
+): { boardId: string; repoPath: string } | null {
+  const boardId = boardIdOf(path);
+  if (boardId === null) return null;
+  const repoPath = repoPaths.find((candidate) => boardWorkspacePath(boardId, candidate) === path);
+  return repoPath === undefined ? null : { boardId, repoPath };
 }
 
 /** The board id a /workspaces/tasks/ path carries, if it is shaped like one. */
-function boardCheckoutId(path: string): string | null {
+function boardIdOf(path: string): string | null {
   const match = /^\/workspaces\/tasks\/([A-Za-z0-9][A-Za-z0-9_-]{0,63})~/.exec(path);
   return match?.[1] ?? null;
 }
 
 /**
- * How a board addresses its workspace. `checkoutId` is set when the board
+ * How a board addresses its workspace. `boardId` is set when the board
  * uses the tasks app's own naming (the workspace is lazily created on first
  * use); null when the board is a lens on an existing workspace addressed
  * purely by path (plain get). `workspacePath` is always resolved.
  */
 export type BoardAddress = {
-  checkoutId: string | null;
+  boardId: string | null;
   workspacePath: string;
   /** The /repos/** mount whose task files this board shows. */
   repoPath: string;
@@ -87,8 +85,8 @@ export type BoardAddress = {
  * Commit or Discard-all.
  */
 export function isGuestWorkspacePath(workspacePath: string, repoPath: string): boolean {
-  const checkoutId = boardCheckoutId(workspacePath);
-  return checkoutId === null || checkoutWorkspacePath(checkoutId, repoPath) !== workspacePath;
+  const boardId = boardIdOf(workspacePath);
+  return boardId === null || boardWorkspacePath(boardId, repoPath) !== workspacePath;
 }
 
 /** 32-bit FNV-1a as 8 lowercase hex chars. */
@@ -101,13 +99,13 @@ function fnv1a32Hex(value: string): string {
 }
 
 /** Shareable board id: date-time prefix for humans, random tail for uniqueness. */
-export function newCheckoutId(now: Date = new Date()): string {
+export function newBoardId(now: Date = new Date()): string {
   const pad = (value: number) => String(value).padStart(2, "0");
   const stamp = `${now.getUTCFullYear()}${pad(now.getUTCMonth() + 1)}${pad(now.getUTCDate())}-${pad(now.getUTCHours())}${pad(now.getUTCMinutes())}`;
   const tail = Math.random().toString(36).slice(2, 6);
   return `${stamp}-${tail}`;
 }
 
-export function isCheckoutId(value: string): boolean {
+export function isBoardId(value: string): boolean {
   return /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/.test(value);
 }

--- a/apps/docs/src/lib/docs-api.ts
+++ b/apps/docs/src/lib/docs-api.ts
@@ -34,10 +34,10 @@ export interface DocsProject {
   repos(): Promise<string[]>;
   /**
    * A board on the app's own workspace naming: the workspace path derives
-   * from (checkoutId, repoPath) and is lazily created on first use.
+   * from (boardId, repoPath) and is lazily created on first use.
    * Synchronous on purpose so calls pipeline through it.
    */
-  board(checkoutId: string, repoPath?: string): TasksWorkspace;
+  board(boardId: string, repoPath?: string): TasksWorkspace;
   /**
    * The BOARD lens on an existing workspace addressed by its platform path —
    * plain `get`, like workspace(). Outside /workspaces/tasks/ the lens is a

--- a/apps/docs/src/lib/project-rpc.ts
+++ b/apps/docs/src/lib/project-rpc.ts
@@ -1,5 +1,6 @@
-import type { TasksUser, TasksWorkspace, WorkspaceListEntry } from "./tasks-api.ts";
-import type { BoardAddress } from "./checkout-shared.ts";
+import type { TasksWorkspace, WorkspaceListEntry } from "./tasks-api.ts";
+import type { DocsUser } from "./docs-api.ts";
+import type { BoardAddress } from "./board-shared.ts";
 import { withDocsProject, withDocsProjectOnce } from "./docs-client.ts";
 
 /**
@@ -19,12 +20,12 @@ export const withProjectOnce = withDocsProjectOnce;
  */
 export function workspaceFor(project: unknown, address: BoardAddress): TasksWorkspace {
   const doors = project as {
-    board(checkoutId: string, repoPath?: string): unknown;
+    board(boardId: string, repoPath?: string): unknown;
     workspaceAt(workspacePath: string, repoPath?: string): unknown;
   };
   return (
-    address.checkoutId !== null
-      ? doors.board(address.checkoutId, address.repoPath)
+    address.boardId !== null
+      ? doors.board(address.boardId, address.repoPath)
       : doors.workspaceAt(address.workspacePath, address.repoPath)
   ) as TasksWorkspace;
 }
@@ -40,6 +41,6 @@ export function listWorkspaces(): Promise<WorkspaceListEntry[]> {
 }
 
 /** The platform-verified identity behind this browser's session. */
-export function whoami(): Promise<TasksUser> {
+export function whoami(): Promise<DocsUser> {
   return withProject((project) => project.whoami());
 }

--- a/apps/docs/src/lib/tasks-api.ts
+++ b/apps/docs/src/lib/tasks-api.ts
@@ -10,28 +10,14 @@ export type {
 /**
  * One workspace stream in the project, as the picker lists them. `board` is
  * present when the path is a tasks-app board workspace (minted under
- * /workspaces/tasks/), parsed back into its (checkoutId, repoPath) address;
+ * /workspaces/tasks/), parsed back into its (boardId, repoPath) address;
  * null for every other workspace (an agent's, ...) — a lens opens those by
  * path, as a guest.
  */
 export type WorkspaceListEntry = {
   path: string;
   createdAt: string;
-  board: { checkoutId: string; repoPath: string } | null;
-};
-
-/**
- * Who this session is, as far as the platform can prove it. userId comes
- * from the verified project-app-session claims; email/name appear once the
- * auth worker mints them into the token (absent claims stay null). The
- * machine lane (project-secret) has no user at all.
- */
-export type TasksUser = {
-  userId: string | null;
-  email: string | null;
-  name: string | null;
-  /** Avatar URL, once the auth worker mints an `image` claim. */
-  image: string | null;
+  board: { boardId: string; repoPath: string } | null;
 };
 
 /** One event from the workspace's platform stream (the event-sourced spine). */

--- a/apps/docs/src/lib/use-workspace-board.ts
+++ b/apps/docs/src/lib/use-workspace-board.ts
@@ -3,7 +3,7 @@ import type { TaskChangeStatus, TaskChangeSummary } from "../state.ts";
 import { isTaskFilePath, parseTaskCard } from "../tasks-model.ts";
 import { withProject, workspaceFor } from "./project-rpc.ts";
 import type { TasksWorkspace, WorkspaceStreamEvent } from "./tasks-api.ts";
-import type { BoardAddress } from "./checkout-shared.ts";
+import type { BoardAddress } from "./board-shared.ts";
 import { changeAfterDelete, changeAfterWrite, toBoardTask, type BoardTask } from "./board-model.ts";
 
 /**
@@ -48,7 +48,7 @@ export function changeMap(status: unknown, repoPath: string): Map<string, TaskCh
 }
 
 export function useWorkspaceBoard(address: BoardAddress) {
-  const { checkoutId, workspacePath, repoPath } = address;
+  const { boardId, workspacePath, repoPath } = address;
   const [files, setFiles] = useState<Record<string, string> | null>(null);
   const [changes, setChanges] = useState<Map<string, TaskChangeStatus>>(new Map());
   // Fresh caret presence per path — "who has this card open" (clientIds).
@@ -62,9 +62,9 @@ export function useWorkspaceBoard(address: BoardAddress) {
   const lane = useCallback(
     <T>(operation: (ws: TasksWorkspace) => Promise<T>) =>
       withProject((project) =>
-        operation(workspaceFor(project, { checkoutId, workspacePath, repoPath })),
+        operation(workspaceFor(project, { boardId, workspacePath, repoPath })),
       ),
-    [checkoutId, workspacePath, repoPath],
+    [boardId, workspacePath, repoPath],
   );
 
   // Initial seed: the whole task file set + dirty state, in parallel.

--- a/apps/docs/src/routeTree.gen.ts
+++ b/apps/docs/src/routeTree.gen.ts
@@ -17,7 +17,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as WIndexRouteImport } from './routes/w.index'
-import { Route as WCheckoutIdRouteImport } from './routes/w.$checkoutId'
+import { Route as WBoardIdRouteImport } from './routes/w.$boardId'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -29,39 +29,39 @@ const WIndexRoute = WIndexRouteImport.update({
   path: '/w/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const WCheckoutIdRoute = WCheckoutIdRouteImport.update({
-  id: '/w/$checkoutId',
-  path: '/w/$checkoutId',
+const WBoardIdRoute = WBoardIdRouteImport.update({
+  id: '/w/$boardId',
+  path: '/w/$boardId',
   getParentRoute: () => rootRouteImport,
 } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
-  '/w/$checkoutId': typeof WCheckoutIdRoute
+  '/w/$boardId': typeof WBoardIdRoute
   '/w/': typeof WIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
-  '/w/$checkoutId': typeof WCheckoutIdRoute
+  '/w/$boardId': typeof WBoardIdRoute
   '/w': typeof WIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
-  '/w/$checkoutId': typeof WCheckoutIdRoute
+  '/w/$boardId': typeof WBoardIdRoute
   '/w/': typeof WIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/w/$checkoutId' | '/w/'
+  fullPaths: '/' | '/w/$boardId' | '/w/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/w/$checkoutId' | '/w'
-  id: '__root__' | '/' | '/w/$checkoutId' | '/w/'
+  to: '/' | '/w/$boardId' | '/w'
+  id: '__root__' | '/' | '/w/$boardId' | '/w/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
-  WCheckoutIdRoute: typeof WCheckoutIdRoute
+  WBoardIdRoute: typeof WBoardIdRoute
   WIndexRoute: typeof WIndexRoute
 }
 
@@ -81,11 +81,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof WIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/w/$checkoutId': {
-      id: '/w/$checkoutId'
-      path: '/w/$checkoutId'
-      fullPath: '/w/$checkoutId'
-      preLoaderRoute: typeof WCheckoutIdRouteImport
+    '/w/$boardId': {
+      id: '/w/$boardId'
+      path: '/w/$boardId'
+      fullPath: '/w/$boardId'
+      preLoaderRoute: typeof WBoardIdRouteImport
       parentRoute: typeof rootRouteImport
     }
   }
@@ -93,7 +93,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
-  WCheckoutIdRoute: WCheckoutIdRoute,
+  WBoardIdRoute: WBoardIdRoute,
   WIndexRoute: WIndexRoute,
 }
 export const routeTree = rootRouteImport

--- a/apps/docs/src/routes/w.$boardId.tsx
+++ b/apps/docs/src/routes/w.$boardId.tsx
@@ -1,19 +1,15 @@
 import { useCallback } from "react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { WorkspaceBoardPage, type BoardSearch } from "../components/workspace-board-page.tsx";
-import {
-  DEFAULT_REPO_PATH,
-  checkoutWorkspacePath,
-  normalizeRepoPath,
-} from "../lib/checkout-shared.ts";
+import { DEFAULT_REPO_PATH, boardWorkspacePath, normalizeRepoPath } from "../lib/board-shared.ts";
 
 /**
  * A board on the tasks app's own workspace naming: the id in the path plus
  * `?repo=` derive the workspace path, and the workspace is lazily created on
  * first use — opening a fresh id IS how a new board is born.
- *   /w/<checkoutId>?repo=/repos/config&task=<path>&q=<filter>&group=none
+ *   /w/<boardId>?repo=/repos/config&task=<path>&q=<filter>&group=none
  */
-export const Route = createFileRoute("/w/$checkoutId")({
+export const Route = createFileRoute("/w/$boardId")({
   validateSearch: (search: Record<string, unknown>) => ({
     group:
       search.group === "none" || search.group === "label"
@@ -27,7 +23,7 @@ export const Route = createFileRoute("/w/$checkoutId")({
 });
 
 function BoardByIdPage() {
-  const { checkoutId } = Route.useParams();
+  const { boardId } = Route.useParams();
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
   const repoPath = normalizeRepoPath(search.repo) ?? DEFAULT_REPO_PATH;
@@ -39,9 +35,9 @@ function BoardByIdPage() {
   return (
     <WorkspaceBoardPage
       address={{
-        checkoutId,
+        boardId,
         repoPath,
-        workspacePath: checkoutWorkspacePath(checkoutId, repoPath),
+        workspacePath: boardWorkspacePath(boardId, repoPath),
       }}
       search={{ group: search.group, q: search.q, task: search.task }}
       patchSearch={patchSearch}

--- a/apps/docs/src/routes/w.index.tsx
+++ b/apps/docs/src/routes/w.index.tsx
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { BoardHome } from "../components/board-home.tsx";
 import { WorkspaceBoardPage, type BoardSearch } from "../components/workspace-board-page.tsx";
-import { DEFAULT_REPO_PATH, normalizeRepoPath } from "../lib/checkout-shared.ts";
+import { DEFAULT_REPO_PATH, normalizeRepoPath } from "../lib/board-shared.ts";
 
 /**
  * The board as a LENS on an existing workspace, addressed purely by its
@@ -63,7 +63,7 @@ function BoardLensPage() {
   return (
     <WorkspaceBoardPage
       key={`${search.workspace}:${repoPath}`}
-      address={{ checkoutId: null, repoPath, workspacePath: search.workspace }}
+      address={{ boardId: null, repoPath, workspacePath: search.workspace }}
       search={{ group: search.group, q: search.q, task: search.task }}
       patchSearch={patchSearch}
     />

--- a/apps/docs/src/rpc-api.ts
+++ b/apps/docs/src/rpc-api.ts
@@ -20,10 +20,10 @@ import { TasksWorkspaceApi } from "./tasks-rpc-api.ts";
 import {
   DEFAULT_REPO_PATH,
   boardAddressFor,
-  checkoutWorkspacePath,
-  isCheckoutId,
+  boardWorkspacePath,
+  isBoardId,
   normalizeRepoPath,
-} from "./lib/checkout-shared.ts";
+} from "./lib/board-shared.ts";
 import type { TasksWorkspace, WorkspaceListEntry } from "./lib/tasks-api.ts";
 import type {
   DocsApi,
@@ -115,20 +115,17 @@ class DocsProjectApi extends RpcTarget implements DocsProject {
 
   /**
    * A board on the app's own workspace naming: the workspace path is derived
-   * from (checkoutId, repoPath) and lazily created on first use — opening a
+   * from (boardId, repoPath) and lazily created on first use — opening a
    * fresh board id IS how a new board workspace is born.
    */
-  board(checkoutId: string, repoPath: string = DEFAULT_REPO_PATH): TasksWorkspace {
+  board(boardId: string, repoPath: string = DEFAULT_REPO_PATH): TasksWorkspace {
     const normalized = normalizeRepoPath(repoPath);
-    if (!isCheckoutId(checkoutId) || normalized === null) {
-      throw new Error("bad checkout id or repo path");
+    if (!isBoardId(boardId) || normalized === null) {
+      throw new Error("bad board id or repo path");
     }
-    return new TasksWorkspaceApi(
-      this.#dial,
-      checkoutWorkspacePath(checkoutId, normalized),
-      normalized,
-      { lazyCreate: true },
-    );
+    return new TasksWorkspaceApi(this.#dial, boardWorkspacePath(boardId, normalized), normalized, {
+      lazyCreate: true,
+    });
   }
 
   /**

--- a/apps/docs/src/tasks-rpc-api.ts
+++ b/apps/docs/src/tasks-rpc-api.ts
@@ -8,7 +8,7 @@ import type {
   WorkspaceStreamEvent,
   TasksWorkspace,
 } from "./lib/tasks-api.ts";
-import { isGuestWorkspacePath } from "./lib/checkout-shared.ts";
+import { isGuestWorkspacePath } from "./lib/board-shared.ts";
 import {
   parseTaskCard,
   setTaskCardAgent,
@@ -146,7 +146,7 @@ export class TasksWorkspaceApi extends RpcTarget implements TasksWorkspace {
         project as unknown as { workspaces: { get(path: string): WorkspaceStub } }
       ).workspaces;
       // For boards the workspace identity ENCODES the repo (see
-      // checkoutWorkspacePath): the same checkout id against a different
+      // boardWorkspacePath): the same board id against a different
       // repository can never bind to (and edit) the first repository's
       // workspace.
       const ws = workspaces.get(this.#workspacePath);


### PR DESCRIPTION
Follow-up cleanup to #2396, on the no-backwards-compatibility standing order: the **"checkout" noun retires** — it was the last relic of the retired checkout mechanism (#2375 killed the DO; the vocabulary lived on).

- `checkoutId` → `boardId` everywhere in apps/docs: `boardWorkspacePath`, `newBoardId`, `isBoardId`, `BoardBreadcrumbs`, `board-shared.ts`, `board-header.tsx`, and the `/w/$boardId` route param. **URL shapes and existing `/workspaces/tasks/…` workspace paths are unchanged** — this is code vocabulary, not data; existing prd boards keep resolving.
- `TasksUser` folds into `DocsUser` — one session-identity type for the one API.
- Residual "checkout" comments cleaned (`bad board id`, tag-picker docstring, test describe).

The remaining `checkout` mentions in apps/os are the git sense (repo checkout machinery) and deliberately untouched.

## Review order

1. `apps/docs/src/lib/board-shared.ts` (renamed from checkout-shared) — the naming core.
2. The mechanical rename across board components and routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical rename with no auth, data, or URL shape changes; existing board links and workspace paths remain compatible.
> 
> **Overview**
> Retires the legacy **checkout** naming across `apps/docs` and aligns vocabulary with the current board/workspace model. **`checkoutId` → `boardId`**, **`checkout-shared` → `board-shared`**, and helpers like `boardWorkspacePath`, `newBoardId`, and `isBoardId` replace their checkout-named counterparts. UI and routing follow the same rename (`CheckoutBreadcrumbs` → `BoardBreadcrumbs`, route file `w.$checkoutId` → `w.$boardId`, TanStack param `/w/$boardId`).
> 
> **`TasksUser` is removed**; session identity for boards now uses **`DocsUser`** via `whoami()` in `project-rpc.ts`. `WorkspaceListEntry.board` fields use `boardId` instead of `checkoutId`.
> 
> **No URL or workspace path format changes** — existing `/w/<id>` links and `/workspaces/tasks/…` stream paths keep working; this is code and type vocabulary only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ee74de498c8bfa4ff1127ebbcb6a5aa73f52b36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-03T21:04:57.608Z",
      "deployedAt": "2026-08-03T20:58:28.715Z",
      "headSha": "6ee74de498c8bfa4ff1127ebbcb6a5aa73f52b36",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/306735202430279",
      "shortSha": "6ee74de",
      "cleanupDurationMs": 11827,
      "deployDurationMs": 100257,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 99006,
      "deployReadinessDurationMs": 1248,
      "deployedWorkerName": "os-preview-8",
      "deployedWorkerVersion": "06c25b40-fc37-4a9a-9511-c117c5bbf444",
      "testDurationMs": 256339,
      "testRetries": "1 retried: is MITM-intercepted and routed through project egress with secret substitution (vitest x1) — Timed out waiting for ws close frame to reach the fixture",
      "workerSizeKib": 20159.04,
      "workerGzipKib": 5085.17,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5096.34
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-03T21:04:48.751Z",
      "deployedAt": "2026-08-03T20:57:24.379Z",
      "headSha": "6ee74de498c8bfa4ff1127ebbcb6a5aa73f52b36",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-8.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/306735202430279",
      "shortSha": "6ee74de",
      "cleanupDurationMs": 2968,
      "deployDurationMs": 71482,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 34668,
      "deployReadinessDurationMs": 36810,
      "deployedWorkerName": "docs-preview-8",
      "deployedWorkerVersion": "758a6750-7282-4e0b-98aa-f577cc58387e",
      "testDurationMs": 2513,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-03T21:04:49.801Z",
      "deployedAt": "2026-08-03T20:57:28.492Z",
      "headSha": "6ee74de498c8bfa4ff1127ebbcb6a5aa73f52b36",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/306735202430279",
      "shortSha": "6ee74de",
      "cleanupDurationMs": 4017,
      "deployDurationMs": 38840,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 38780,
      "deployReadinessDurationMs": 56,
      "deployedWorkerName": "auth-preview-8",
      "deployedWorkerVersion": "ecc3d480-a2d7-460d-b96a-8994f8112d7e",
      "testDurationMs": 11971,
      "testRetries": null,
      "workerSizeKib": 3979.33,
      "workerGzipKib": 814.89,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-03T21:04:46.678Z",
      "deployedAt": "2026-08-03T20:56:59.004Z",
      "headSha": "6ee74de498c8bfa4ff1127ebbcb6a5aa73f52b36",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/306735202430279",
      "shortSha": "6ee74de",
      "cleanupDurationMs": 892,
      "deployDurationMs": 9553,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 9255,
      "deployReadinessDurationMs": 257,
      "deployedWorkerName": "dummy-petshop-preview-8",
      "deployedWorkerVersion": "ff7cbbea-900d-4eb1-9fae-be6e583ee45c",
      "testDurationMs": 7311,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `6ee74de` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 814.9 KiB | 38.8s | 12.0s |  | 4.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/306735202430279) | 2026-08-03T21:04:49.801Z | Preview app released. |
| Docs | released | `6ee74de` | [https://docs-preview-8.iterate-dev-preview.workers.dev](https://docs-preview-8.iterate-dev-preview.workers.dev) | 866.2 KiB | 71.5s | 2.5s |  | 3.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/306735202430279) | 2026-08-03T21:04:48.751Z | Preview app released. |
| Dummy Petshop | released | `6ee74de` | [https://dummy-petshop.iterate-preview-8.com](https://dummy-petshop.iterate-preview-8.com) | 198.3 KiB | 9.6s | 7.3s |  | 892ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/306735202430279) | 2026-08-03T21:04:46.678Z | Preview app released. |
| OS | released | `6ee74de` | [https://os.iterate-preview-8.com](https://os.iterate-preview-8.com) | 4.97 MiB (-11.2 KiB vs main) | 100.3s | 256.3s | 1 retried: is MITM-intercepted and routed through project egress with secret substitution (vitest x1) — Timed out waiting for ws close frame to reach the fixture | 11.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/306735202430279) | 2026-08-03T21:04:57.608Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +50 -72 | +35 -44 🟩🟩🟥🟥🟥 |
| UI components | +30 -32 | +26 -28 🟩🟥🟥⬜⬜ |
| Tests | +13 -13 | +13 -13 🟩🟥⬜⬜⬜ |
| Generated | +17 -17 | +5 -5 🟩⬜⬜⬜⬜ |
| **Total** | **+110 -134** | **+79 -90** 🟩🟩🟥🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between b3debe5 and 6ee74de, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->