### PR TITLE
Oversized script results: inferred type + inspect-style preview

### DIFF
--- a/apps/os/src/domains/agents/agent-defaults.ts
+++ b/apps/os/src/domains/agents/agent-defaults.ts
@@ -204,7 +204,7 @@ export const DEFAULT_AGENT_SYSTEM_PROMPT = [
   "THE SHAPE OF WORK — scripts are tool calls, not programs:",
   "- Most scripts should fetch data and RETURN it. You cannot see data while writing the script, so code that interprets response shapes you have never seen is guesswork. Get the data in front of your eyes; decide on the next turn.",
   "- The script body is real TypeScript: `Promise.all` fans out independent calls, `Promise.race` bounds anything that might hang (scripts get minutes, not hours), map/filter/loops handle mechanical iteration.",
-  "- Return only what you need: pick fields, slice arrays. Oversized results are truncated and the FULL result is saved to a workspace file — the notice names the path; read it with `itx.workspace.readFile` and filter it in plain TypeScript instead of re-fetching.",
+  "- Return only what you need: pick fields, slice arrays. Oversized results render as an inferred type plus a small structural preview, and the FULL result is saved to a workspace file — the notice names the path; read it with `itx.workspace.readFile` and filter it in plain TypeScript instead of re-fetching.",
   "- Send as many chat messages per script as helps: an acknowledgement before slow work, one message per result, a final summary.",
   "",
   "OTHER AGENTS — the semantics behind the tour's delegation calls:",

--- a/apps/os/src/domains/agents/agent-processor-implementation.ts
+++ b/apps/os/src/domains/agents/agent-processor-implementation.ts
@@ -1963,8 +1963,6 @@ function renderOversizedJsonResult(input: {
     console.error("[agent] failed to build preview for oversized script result", { error });
     previewText = `${input.text.slice(0, Math.min(OVERSIZED_JSON_PREVIEW_MAX_BYTES, input.historyLimit))}\n… (cut mid-document)`;
   }
-  const dataBinding = typeText === null ? "const data" : "const data: Result";
-  const typeComment = typeText === null ? "" : " // matches the inferred type above";
   return [
     `Your script returned ${input.text.length.toLocaleString("en-US")} chars of JSON — too big to show in full.${typeText === null ? "" : " Inferred type:"}`,
     ...(typeText === null ? [] : ["```ts", `type Result = ${typeText}`, "```"]),
@@ -1975,8 +1973,8 @@ function renderOversizedJsonResult(input: {
     `The full result is saved in your workspace at ${JSON.stringify(input.path)} — don't re-fetch; read and filter it with plain TypeScript in your next script, e.g.:`,
     "```ts",
     "async (itx) => {",
-    `  ${dataBinding} = JSON.parse(await itx.workspace.readFile(${JSON.stringify(input.path)}));${typeComment}`,
-    "  return Object.keys(data); // then slice/filter/regex to return only what you need",
+    `  const data = JSON.parse(await itx.workspace.readFile(${JSON.stringify(input.path)}));`,
+    "  // you can now do whatever you see fit with `data`",
     "}",
     "```",
   ].join("\n");

--- a/apps/os/src/domains/agents/agent-processor-implementation.ts
+++ b/apps/os/src/domains/agents/agent-processor-implementation.ts
@@ -11,6 +11,8 @@ import {
   StreamProcessor,
 } from "iterate/processors";
 import type { EmittedInput, ProcessEventArgs, ReduceArgs, StreamEvent } from "iterate/processors";
+import { inferJsonType } from "../../lib/infer-json-type.ts";
+import { previewJson } from "../../lib/truncate-json.ts";
 import {
   AgentProcessorContract,
   type AgentContextAddedPayload,
@@ -1848,13 +1850,25 @@ async function renderScriptSettlement(input: {
         text,
         writeWorkspaceFile,
       });
-      return [
-        "Your script returned:",
-        fence,
-        text.slice(0, historyLimit),
-        "```",
-        spillNotice({ isRawText, path: spilledPath, totalChars: text.length, historyLimit }),
-      ].join("\n");
+      // Once the full result is safely on disk, the inline copy stops trying
+      // to be the data and becomes a map of it: shrink hard (well under
+      // historyLimit) and spend the space on shape instead of payload.
+      if (isRawText) {
+        const shownChars = Math.min(OVERSIZED_RAW_TEXT_PREVIEW_CHARS, historyLimit);
+        return [
+          "Your script returned:",
+          "```",
+          text.slice(0, shownChars),
+          "```",
+          rawTextSpillNotice({ path: spilledPath, shownChars, totalChars: text.length }),
+        ].join("\n");
+      }
+      return renderOversizedJsonResult({
+        historyLimit,
+        path: spilledPath,
+        result: settlement.result,
+        text,
+      });
     } catch (error) {
       // Spilling is best effort: a workspace that cannot clone or write must
       // not lose the result entirely — fall through to inline truncation.
@@ -1908,31 +1922,83 @@ async function spillScriptResult(input: {
   return written.absolutePath;
 }
 
+/** Inline budgets for an oversized result once the full copy is spilled: the
+ * inferred type and shape-preserving preview replace raw payload — the model
+ * reads the spill file when it needs actual data, so keep history lean. */
+const OVERSIZED_RAW_TEXT_PREVIEW_CHARS = 10_000;
+const OVERSIZED_TYPE_MAX_CHARS = 3_000;
+const OVERSIZED_JSON_PREVIEW_MAX_BYTES = 8_000;
+
 /**
- * The model-facing text after a truncated preview: where the full result
- * lives and a concrete next-script recipe for paging it, so the model reads
- * the file with plain TypeScript instead of re-running the expensive fetch.
+ * Oversized JSON result, spilled successfully: render an inferred TypeScript
+ * type (the whole shape, cheap) plus an aggressively elided preview (a few
+ * items per array, capped strings/depth) plus the read-it-back recipe. Both
+ * smart parts degrade independently — a value that defeats inference or
+ * previewing still renders the other, or falls back to a plain slice.
  */
-function spillNotice(input: {
-  isRawText: boolean;
-  path: string;
-  totalChars: number;
+function renderOversizedJsonResult(input: {
   historyLimit: number;
+  path: string;
+  result: unknown;
+  text: string;
 }): string {
-  const readRecipe = input.isRawText
-    ? [
-        `  const text = await itx.workspace.readFile(${JSON.stringify(input.path)});`,
-        "  return text.slice(30_000, 60_000); // page/regex to return only what you need",
-      ]
-    : [
-        `  const data = JSON.parse(await itx.workspace.readFile(${JSON.stringify(input.path)}));`,
-        "  return Object.keys(data); // then slice/filter/regex to return only what you need",
-      ];
+  let typeText: string | null = null;
+  try {
+    typeText = inferJsonType(input.result, {
+      maxChars: Math.min(OVERSIZED_TYPE_MAX_CHARS, input.historyLimit),
+    });
+  } catch (error) {
+    console.error("[agent] failed to infer type for oversized script result", { error });
+  }
+  let previewText: string;
+  try {
+    const preview = previewJson(input.result, {
+      maxArrayItems: 3,
+      maxBytes: Math.min(OVERSIZED_JSON_PREVIEW_MAX_BYTES, input.historyLimit),
+      maxDepth: 5,
+      maxStringChars: 500,
+    });
+    previewText = JSON.stringify(preview.value, null, 2);
+  } catch (error) {
+    console.error("[agent] failed to build preview for oversized script result", { error });
+    previewText = `${input.text.slice(0, Math.min(OVERSIZED_JSON_PREVIEW_MAX_BYTES, input.historyLimit))}\n… (cut mid-document)`;
+  }
+  const dataBinding = typeText === null ? "const data" : "const data: Result";
+  const typeComment = typeText === null ? "" : " // matches the inferred type above";
   return [
-    `…truncated: showing the first ${input.historyLimit.toLocaleString("en-US")} of ${input.totalChars.toLocaleString("en-US")} chars. The full result is saved in your workspace at ${JSON.stringify(input.path)} — don't re-fetch; read and filter it with plain TypeScript in your next script, e.g.:`,
+    `Your script returned ${input.text.length.toLocaleString("en-US")} chars of JSON — too big to show in full.${typeText === null ? "" : " Inferred type:"}`,
+    ...(typeText === null ? [] : ["```ts", `type Result = ${typeText}`, "```"]),
+    "Preview (long arrays/strings elided):",
+    "```json",
+    previewText,
+    "```",
+    `The full result is saved in your workspace at ${JSON.stringify(input.path)} — don't re-fetch; read and filter it with plain TypeScript in your next script, e.g.:`,
     "```ts",
     "async (itx) => {",
-    ...readRecipe,
+    `  ${dataBinding} = JSON.parse(await itx.workspace.readFile(${JSON.stringify(input.path)}));${typeComment}`,
+    "  return Object.keys(data); // then slice/filter/regex to return only what you need",
+    "}",
+    "```",
+  ].join("\n");
+}
+
+/**
+ * The model-facing text after a truncated raw-text preview: where the full
+ * result lives and a concrete next-script recipe for paging it, so the model
+ * reads the file with plain TypeScript instead of re-running the expensive
+ * fetch.
+ */
+function rawTextSpillNotice(input: {
+  path: string;
+  shownChars: number;
+  totalChars: number;
+}): string {
+  return [
+    `…truncated: showing the first ${input.shownChars.toLocaleString("en-US")} of ${input.totalChars.toLocaleString("en-US")} chars. The full result is saved in your workspace at ${JSON.stringify(input.path)} — don't re-fetch; read and filter it with plain TypeScript in your next script, e.g.:`,
+    "```ts",
+    "async (itx) => {",
+    `  const text = await itx.workspace.readFile(${JSON.stringify(input.path)});`,
+    `  return text.slice(${input.shownChars}, ${input.shownChars * 4}); // page/regex to return only what you need`,
     "}",
     "```",
   ].join("\n");

--- a/apps/os/src/domains/agents/agent-processor.test.ts
+++ b/apps/os/src/domains/agents/agent-processor.test.ts
@@ -1278,7 +1278,7 @@ describe("AgentProcessor script execution", () => {
     expect(rendered!.payload.content).toContain("Inferred type:");
     expect(rendered!.payload.content).toContain("type Result = {");
     expect(rendered!.payload.content).toContain("items: string");
-    expect(rendered!.payload.content).toContain("const data: Result = JSON.parse(");
+    expect(rendered!.payload.content).toContain("const data = JSON.parse(");
     expect(rendered!.payload.content).not.toContain("x".repeat(200)); // preview stays bounded
   });
 

--- a/apps/os/src/domains/agents/agent-processor.test.ts
+++ b/apps/os/src/domains/agents/agent-processor.test.ts
@@ -1272,9 +1272,69 @@ describe("AgentProcessor script execution", () => {
       'JSON.parse(await itx.workspace.readFile("/workspaces/agents/main/script-results/',
     );
     expect(rendered!.payload.content).toContain(
-      `showing the first 100 of ${spilled.length.toLocaleString("en-US")} chars`,
+      `Your script returned ${spilled.length.toLocaleString("en-US")} chars of JSON — too big to show in full.`,
     );
+    // The inferred type block tells the model the shape it cannot see.
+    expect(rendered!.payload.content).toContain("Inferred type:");
+    expect(rendered!.payload.content).toContain("type Result = {");
+    expect(rendered!.payload.content).toContain("items: string");
+    expect(rendered!.payload.content).toContain("const data: Result = JSON.parse(");
     expect(rendered!.payload.content).not.toContain("x".repeat(200)); // preview stays bounded
+  });
+
+  it("an oversized structured result renders an inferred type and an array-eliding preview", async () => {
+    const written: { path: string; content: string }[] = [];
+    const h = makeAgentHarness(undefined, {
+      writeWorkspaceFile: async (input) => {
+        written.push(input);
+        return { absolutePath: `/workspaces/agents/main/${input.path}` };
+      },
+    });
+    await h.play(
+      [
+        "append",
+        ...NEW_AGENT_EVENTS,
+        {
+          type: "events.iterate.com/agent/configured",
+          payload: { config: { scriptResultHistoryLimit: 5_000 } },
+        },
+        userMessage("fetch the rows"),
+      ],
+      ["advanceTime", 10_000],
+      () => h.llm.respond("```ts\nasync (itx) => itx.rows()\n```"),
+    );
+    const executionId = h.events("events.iterate.com/capability-host/script-run-requested")[0]!
+      .payload.executionId;
+
+    const result = {
+      rows: Array.from({ length: 400 }, (_, index) => ({
+        id: index,
+        status: index % 2 === 0 ? "open" : "closed",
+        note: `note ${index}`,
+      })),
+    };
+    await h.play([
+      "append",
+      {
+        type: "events.iterate.com/capability-host/script-run-settled",
+        payload: { executionId, settlement: { status: "succeeded", result } },
+      },
+    ]);
+
+    const rendered = h
+      .state()
+      .contextItems.find((item) => item.payload.content.startsWith("Your script returned"));
+    const content = rendered!.payload.content;
+    // Type: element shapes merged across all 400 rows, cardinality annotated.
+    expect(content).toContain('status: "open" | "closed"');
+    expect(content).toContain("/* 400 items */");
+    // Preview: a few rows plus a marker, NOT 5_000 chars of leading rows.
+    expect(content).toContain('"id": 0');
+    expect(content).not.toContain('"id": 10');
+    expect(content).toMatch(/\[truncated 397 items; from \d+ JSON bytes\]/);
+    // History stays lean: the whole rendered item is far below the old
+    // slice-to-historyLimit behavior's floor.
+    expect(content.length).toBeLessThan(5_000);
   });
 
   it("a markdown fence inside a string literal does not truncate script extraction", async () => {

--- a/apps/os/src/domains/integrations/posthog.ts
+++ b/apps/os/src/domains/integrations/posthog.ts
@@ -5,7 +5,7 @@ import type { StreamDeliveryBatch } from "iterate/processors";
 import type { StreamEvent } from "iterate/processors";
 import type { SubscriptionConfiguredPayload } from "../streams/core-processor-contract.ts";
 import { internalStreamId } from "../streams/stream-delivery-utils.ts";
-import { truncateJsonToBytes } from "./truncate-json.ts";
+import { truncateJsonToBytes } from "../../lib/truncate-json.ts";
 
 export const POSTHOG_STREAM_EVENT_MAX_JSON_BYTES = 100 * 1_024;
 const POSTHOG_STREAM_FEED_WORKER_NAME = "os-prd";

--- a/apps/os/src/lib/infer-json-type.test.ts
+++ b/apps/os/src/lib/infer-json-type.test.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "vitest";
+import { inferJsonType } from "./infer-json-type.ts";
+
+test("primitives and simple objects", () => {
+  expect(inferJsonType({ ok: true, count: 3, name: "hi", missing: null }, { maxChars: 1_000 }))
+    .toMatchInlineSnapshot(`
+      "{
+        ok: boolean;
+        count: number;
+        name: "hi";
+        missing: null;
+      }"
+    `);
+});
+
+test("array elements merge structurally, with optional fields and cardinality", () => {
+  const rows = [
+    { id: 1, name: "a", tags: ["x", "y"] },
+    { id: 2, name: "b", tags: [] },
+    { id: 3, name: "c", tags: ["z"], deleted: true },
+  ];
+  expect(inferJsonType(rows, { maxChars: 1_000 })).toMatchInlineSnapshot(`
+    "Array<{
+      id: number;
+      name: "a" | "b" | "c";
+      tags: Array<"x" | "y" | "z"> /* 0–2 items each */;
+      deleted?: boolean;
+    }> /* 3 items */"
+  `);
+});
+
+test("more than 5 distinct strings widen to string", () => {
+  const rows = Array.from({ length: 10 }, (_, index) => ({ word: `word-${index}` }));
+  expect(inferJsonType(rows, { maxChars: 1_000 })).toContain("word: string;");
+});
+
+test("mixed-kind fields become unions; too many kinds become unknown", () => {
+  const union = [{ v: 1 }, { v: "s" }];
+  expect(inferJsonType(union, { maxChars: 1_000 })).toContain(`v: number | "s";`);
+  const chaos = [{ v: 1 }, { v: "s" }, { v: true }, { v: [] }];
+  expect(inferJsonType(chaos, { maxChars: 1_000 })).toContain("v: unknown;");
+});
+
+test("null merges into unions", () => {
+  const rows = [{ v: 1 }, { v: null }];
+  expect(inferJsonType(rows, { maxChars: 1_000 })).toContain("v: number | null;");
+});
+
+test("long strings get an approximate length comment", () => {
+  expect(inferJsonType({ body: "x".repeat(45_000) }, { maxChars: 1_000 })).toContain(
+    "body: string /* up to ~45k chars */;",
+  );
+});
+
+test("wide keyed objects render as Record", () => {
+  const map = Object.fromEntries(
+    Array.from({ length: 100 }, (_, index) => [
+      `user-${index}`,
+      { score: index, active: index % 2 === 0 },
+    ]),
+  );
+  const rendered = inferJsonType(map, { maxChars: 1_000 });
+  expect(rendered).toMatch(/^Record<string, \{/);
+  expect(rendered).toContain("/* 100 keys */");
+  expect(rendered).toContain("score: number;");
+});
+
+test("non-identifier keys are quoted", () => {
+  expect(inferJsonType({ "content-type": "a" }, { maxChars: 1_000 })).toContain(
+    '"content-type": "a";',
+  );
+});
+
+test("maxChars is enforced by collapsing depth", () => {
+  // Deeply nested and wide: full render is far over budget.
+  const deep = Array.from({ length: 20 }, (_, index) => ({
+    [`key${index}`]: { nested: { further: { evenMore: { value: index } } } },
+  }));
+  const rendered = inferJsonType(deep, { maxChars: 500 });
+  expect(rendered.length).toBeLessThanOrEqual(500);
+  expect(rendered).toContain("unknown /* nested object */");
+});
+
+test("handles empty containers", () => {
+  expect(inferJsonType([], { maxChars: 100 })).toBe("unknown[] /* 0 items */");
+  expect(inferJsonType({}, { maxChars: 100 })).toBe("{}");
+});
+
+test("undefined-valued keys become optional fields, matching JSON.stringify output", () => {
+  const rows = [
+    { id: 1, extra: "x" },
+    { id: 2, extra: undefined },
+  ];
+  const rendered = inferJsonType(rows, { maxChars: 1_000 });
+  expect(rendered).toContain('extra?: "x";');
+  expect(rendered).not.toContain("null");
+});

--- a/apps/os/src/lib/infer-json-type.ts
+++ b/apps/os/src/lib/infer-json-type.ts
@@ -1,0 +1,237 @@
+/**
+ * Infer a TypeScript type *text* from a JSON value, for LLM eyes — shown next
+ * to a truncated preview of an oversized script result so the model knows the
+ * full shape without seeing the full payload. The output reads like a .d.ts
+ * but is not required to compile (cardinality comments ride along inline).
+ *
+ * Deliberately hand-rolled rather than quicktype: synchronous, zero deps,
+ * Workers-safe, and tuned for this one job (aggressive merging, size budget).
+ */
+
+// Internal shape lattice. Object field counts track optionality: a field seen
+// in 3 of 5 merged samples renders as `key?: T`.
+type Shape =
+  | { kind: "null" }
+  | { kind: "boolean" }
+  | { kind: "number" }
+  | { kind: "string"; distinct: Set<string> | null; maxLength: number }
+  | { kind: "array"; element: Shape | null; minLength: number; maxLength: number }
+  | { kind: "object"; fields: Map<string, { shape: Shape; seen: number }>; samples: number }
+  | { kind: "record"; value: Shape; keys: number }
+  | { kind: "union"; branches: Shape[] }
+  | { kind: "unknown" };
+
+const MAX_UNION_BRANCHES = 3;
+const MAX_TRACKED_STRINGS = 5;
+const LITERAL_STRING_MAX_LENGTH = 40;
+const LONG_STRING_COMMENT_THRESHOLD = 1_000;
+const RECORD_KEY_THRESHOLD = 32;
+const MAX_INFER_DEPTH = 32;
+
+function inferShape(value: unknown, depth: number): Shape {
+  if (depth >= MAX_INFER_DEPTH) return { kind: "unknown" };
+  if (value === null || value === undefined) return { kind: "null" };
+  if (typeof value === "boolean") return { kind: "boolean" };
+  if (typeof value === "number") return { kind: "number" };
+  if (typeof value === "string") {
+    return {
+      kind: "string",
+      distinct: value.length <= LITERAL_STRING_MAX_LENGTH ? new Set([value]) : null,
+      maxLength: value.length,
+    };
+  }
+  if (Array.isArray(value)) {
+    let element: Shape | null = null;
+    for (const item of value) {
+      const itemShape = inferShape(item, depth + 1);
+      element = element === null ? itemShape : mergeShapes(element, itemShape);
+    }
+    return { kind: "array", element, minLength: value.length, maxLength: value.length };
+  }
+  if (typeof value === "object") {
+    // undefined-valued keys are dropped, matching what JSON.stringify writes
+    // to the spill file — they surface as optional fields after merging, not
+    // as `| null` branches that the file would contradict.
+    const entries = Object.entries(value as Record<string, unknown>).filter(
+      ([, child]) => child !== undefined,
+    );
+    const fields = new Map(
+      entries.map(([key, child]) => [key, { shape: inferShape(child, depth + 1), seen: 1 }]),
+    );
+    const shape: Shape = { kind: "object", fields, samples: 1 };
+    return maybeRecord(shape, entries.length);
+  }
+  // Functions, symbols, bigints — JSON.stringify would have dropped or thrown
+  // on these anyway; be honest that we don't know.
+  return { kind: "unknown" };
+}
+
+/** A wide object whose values all merge into one shape is a keyed map, not a
+ * struct: render `Record<string, T>` instead of hundreds of fields. */
+function maybeRecord(shape: Extract<Shape, { kind: "object" }>, keyCount: number): Shape {
+  if (keyCount < RECORD_KEY_THRESHOLD) return shape;
+  let merged: Shape | null = null;
+  for (const field of shape.fields.values()) {
+    merged = merged === null ? field.shape : mergeShapes(merged, field.shape);
+    if (merged.kind === "unknown") return shape;
+    // A union of struct-ish shapes means the values genuinely differ — keep
+    // the object rendering (the char budget will trim it if oversized).
+    if (merged.kind === "union" && merged.branches.length >= MAX_UNION_BRANCHES) return shape;
+  }
+  if (merged === null) return shape;
+  return { kind: "record", value: merged, keys: keyCount };
+}
+
+function mergeShapes(a: Shape, b: Shape): Shape {
+  if (a.kind === "unknown" || b.kind === "unknown") return { kind: "unknown" };
+  if (a.kind === b.kind) {
+    if (a.kind === "string" && b.kind === "string") {
+      let distinct: Set<string> | null = null;
+      if (a.distinct !== null && b.distinct !== null) {
+        distinct = new Set([...a.distinct, ...b.distinct]);
+        // Stop tracking once clearly not an enum-ish field; keeps memory flat.
+        if (distinct.size > MAX_TRACKED_STRINGS) distinct = null;
+      }
+      return { kind: "string", distinct, maxLength: Math.max(a.maxLength, b.maxLength) };
+    }
+    if (a.kind === "array" && b.kind === "array") {
+      const element =
+        a.element === null
+          ? b.element
+          : b.element === null
+            ? a.element
+            : mergeShapes(a.element, b.element);
+      return {
+        kind: "array",
+        element,
+        minLength: Math.min(a.minLength, b.minLength),
+        maxLength: Math.max(a.maxLength, b.maxLength),
+      };
+    }
+    if (a.kind === "object" && b.kind === "object") {
+      const fields = new Map(a.fields);
+      for (const [key, incoming] of b.fields) {
+        const existing = fields.get(key);
+        fields.set(
+          key,
+          existing === undefined
+            ? incoming
+            : {
+                shape: mergeShapes(existing.shape, incoming.shape),
+                seen: existing.seen + incoming.seen,
+              },
+        );
+      }
+      return { kind: "object", fields, samples: a.samples + b.samples };
+    }
+    if (a.kind === "record" && b.kind === "record") {
+      return {
+        kind: "record",
+        value: mergeShapes(a.value, b.value),
+        keys: Math.max(a.keys, b.keys),
+      };
+    }
+    if (a.kind === "union" || b.kind === "union") {
+      // handled below via the generic union path
+    } else {
+      return a; // null/boolean/number: identical kinds carry no extra data
+    }
+  }
+  const branches: Shape[] = [];
+  for (const shape of [...unionBranches(a), ...unionBranches(b)]) {
+    const mergeableAt = branches.findIndex((existing) => existing.kind === shape.kind);
+    if (mergeableAt === -1) branches.push(shape);
+    else branches[mergeableAt] = mergeShapes(branches[mergeableAt]!, shape);
+  }
+  if (branches.length === 1) return branches[0]!;
+  if (branches.length > MAX_UNION_BRANCHES) return { kind: "unknown" };
+  return { kind: "union", branches };
+}
+
+function unionBranches(shape: Shape): Shape[] {
+  return shape.kind === "union" ? shape.branches : [shape];
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+
+const INDENT = "  ";
+
+type RenderOptions = { maxDepth: number };
+
+function renderShape(shape: Shape, indent: string, options: RenderOptions, depth: number): string {
+  if (depth >= options.maxDepth && (shape.kind === "object" || shape.kind === "record")) {
+    return "unknown /* nested object */";
+  }
+  switch (shape.kind) {
+    case "null":
+      return "null";
+    case "boolean":
+      return "boolean";
+    case "number":
+      return "number";
+    case "unknown":
+      return "unknown";
+    case "string": {
+      if (shape.distinct !== null && shape.distinct.size <= MAX_TRACKED_STRINGS) {
+        return [...shape.distinct].map((value) => JSON.stringify(value)).join(" | ");
+      }
+      if (shape.maxLength >= LONG_STRING_COMMENT_THRESHOLD) {
+        return `string /* up to ~${approximate(shape.maxLength)} chars */`;
+      }
+      return "string";
+    }
+    case "array": {
+      const lengthComment =
+        shape.minLength === shape.maxLength
+          ? `/* ${shape.minLength} item${shape.minLength === 1 ? "" : "s"} */`
+          : `/* ${shape.minLength}–${shape.maxLength} items each */`;
+      if (shape.element === null) return `unknown[] ${lengthComment}`;
+      const element = renderShape(shape.element, indent, options, depth + 1);
+      const rendered =
+        element.includes("\n") || element.includes(" | ") ? `Array<${element}>` : `${element}[]`;
+      return `${rendered} ${lengthComment}`;
+    }
+    case "record": {
+      const value = renderShape(shape.value, indent, options, depth + 1);
+      return `Record<string, ${value}> /* ${shape.keys} keys */`;
+    }
+    case "union":
+      return shape.branches
+        .map((branch) => renderShape(branch, indent, options, depth + 1))
+        .join(" | ");
+    case "object": {
+      if (shape.fields.size === 0) return "{}";
+      const inner = indent + INDENT;
+      const lines = [...shape.fields].map(([key, field]) => {
+        const optional = field.seen < shape.samples ? "?" : "";
+        const rendered = renderShape(field.shape, inner, options, depth + 1);
+        const renderedKey = IDENTIFIER_KEY.test(key) ? key : JSON.stringify(key);
+        return `${inner}${renderedKey}${optional}: ${rendered};`;
+      });
+      return `{\n${lines.join("\n")}\n${indent}}`;
+    }
+  }
+}
+
+const IDENTIFIER_KEY = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+function approximate(length: number): string {
+  if (length >= 1_000) return `${Math.round(length / 1_000)}k`;
+  return String(length);
+}
+
+/**
+ * Infer a TypeScript type text (the right-hand side of a `type Result = …`)
+ * for a JSON value. Never exceeds `maxChars`: rendering retries at shrinking
+ * depths (deep subtrees collapse to `unknown`), and as a last resort returns
+ * a one-line summary.
+ */
+export function inferJsonType(value: unknown, options: { maxChars: number }): string {
+  const shape = inferShape(value, 0);
+  for (let maxDepth = 8; maxDepth >= 1; maxDepth--) {
+    const rendered = renderShape(shape, "", { maxDepth }, 0);
+    if (rendered.length <= options.maxChars) return rendered;
+  }
+  return "unknown".slice(0, Math.max(0, options.maxChars));
+}

--- a/apps/os/src/lib/infer-json-type.ts
+++ b/apps/os/src/lib/infer-json-type.ts
@@ -52,9 +52,7 @@ function inferShape(value: unknown, depth: number): Shape {
     // undefined-valued keys are dropped, matching what JSON.stringify writes
     // to the spill file — they surface as optional fields after merging, not
     // as `| null` branches that the file would contradict.
-    const entries = Object.entries(value as Record<string, unknown>).filter(
-      ([, child]) => child !== undefined,
-    );
+    const entries = Object.entries(value).filter(([, child]) => child !== undefined);
     const fields = new Map(
       entries.map(([key, child]) => [key, { shape: inferShape(child, depth + 1), seen: 1 }]),
     );

--- a/apps/os/src/lib/truncate-json.test.ts
+++ b/apps/os/src/lib/truncate-json.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { truncateJsonToBytes } from "./truncate-json.ts";
+import { previewJson, truncateJsonToBytes } from "./truncate-json.ts";
 
 const jsonBytes = (value: unknown) => new TextEncoder().encode(JSON.stringify(value)).byteLength;
 
@@ -149,5 +149,92 @@ describe("truncateJsonToBytes", () => {
     expect(compacted.field_0).toBe(0);
     expect(compacted.field_999).toBeUndefined();
     expect(compacted.$iterate_truncated).toMatch(/properties/);
+  });
+});
+
+describe("previewJson", () => {
+  it("elides long arrays everywhere, not just the largest child", () => {
+    const value = {
+      users: Array.from({ length: 500 }, (_, index) => ({ id: index, name: `user-${index}` })),
+      events: Array.from({ length: 200 }, (_, index) => ({ at: index })),
+    };
+
+    const result = previewJson(value, {
+      maxArrayItems: 3,
+      maxStringChars: 500,
+      maxDepth: 5,
+      maxBytes: 8_000,
+    });
+    const preview = result.value as any;
+
+    expect(result.truncated).toBe(true);
+    expect(preview.users).toHaveLength(4); // 3 items + marker
+    expect(preview.users[3]).toMatch(/^\[truncated 497 items; from \d+ JSON bytes\]$/);
+    expect(preview.events).toHaveLength(4);
+    expect(preview.events[0]).toMatchObject({ at: 0 });
+  });
+
+  it("caps long strings with a marker", () => {
+    const result = previewJson(
+      { body: "x".repeat(50_000) },
+      {
+        maxArrayItems: 3,
+        maxStringChars: 100,
+        maxDepth: 5,
+        maxBytes: 8_000,
+      },
+    );
+    expect((result.value as any).body).toMatch(/^x{100}… \[truncated from \d+ JSON bytes\]$/);
+  });
+
+  it("collapses containers past maxDepth to summaries, keeping tiny leaves intact", () => {
+    const wide = {
+      deep: { deeper: { wide: Array.from({ length: 100 }, (_, index) => ({ index })) } },
+    };
+    const result = previewJson(wide, {
+      maxArrayItems: 3,
+      maxStringChars: 500,
+      maxDepth: 2,
+      maxBytes: 8_000,
+    });
+    expect((result.value as any).deep.deeper).toMatch(
+      /^\[object with 1 properties; \d+ JSON bytes\]$/,
+    );
+
+    const tiny = { deep: { deeper: { evenDeeper: { ok: true } } } };
+    const untouched = previewJson(tiny, {
+      maxArrayItems: 3,
+      maxStringChars: 500,
+      maxDepth: 2,
+      maxBytes: 8_000,
+    });
+    expect(untouched.truncated).toBe(false);
+    expect(untouched.value).toEqual(tiny);
+  });
+
+  it("still guarantees the byte ceiling after the policy pass", () => {
+    // Wide object of medium strings: policy alone leaves it over budget.
+    const value = Object.fromEntries(
+      Array.from({ length: 200 }, (_, index) => [`key_${index}`, "v".repeat(200)]),
+    );
+    const result = previewJson(value, {
+      maxArrayItems: 3,
+      maxStringChars: 500,
+      maxDepth: 5,
+      maxBytes: 2_000,
+    });
+    expect(result.truncated).toBe(true);
+    expect(jsonBytes(result.value)).toBeLessThanOrEqual(2_000);
+  });
+
+  it("returns small values unchanged", () => {
+    const value = { ok: true, items: [1, 2, 3] };
+    const result = previewJson(value, {
+      maxArrayItems: 3,
+      maxStringChars: 500,
+      maxDepth: 5,
+      maxBytes: 8_000,
+    });
+    expect(result).toMatchObject({ truncated: false, value });
   });
 });

--- a/apps/os/src/lib/truncate-json.test.ts
+++ b/apps/os/src/lib/truncate-json.test.ts
@@ -238,3 +238,19 @@ describe("previewJson", () => {
     expect(result).toMatchObject({ truncated: false, value });
   });
 });
+
+describe("previewJson surrogate safety", () => {
+  it("does not split a surrogate pair at the maxStringChars boundary", () => {
+    // 99 ascii chars then an emoji: the cap of 100 lands between the pair.
+    const value = { body: `${"x".repeat(99)}😀${"y".repeat(500)}` };
+    const result = previewJson(value, {
+      maxArrayItems: 3,
+      maxStringChars: 100,
+      maxDepth: 5,
+      maxBytes: 8_000,
+    });
+    const body = (result.value as any).body as string;
+    expect(body).toMatch(/^x{99}… \[truncated from \d+ JSON bytes\]$/);
+    expect(JSON.stringify(body)).not.toMatch(/\\ud83d(?!\\)/i); // no lone surrogate escape
+  });
+});

--- a/apps/os/src/lib/truncate-json.ts
+++ b/apps/os/src/lib/truncate-json.ts
@@ -307,9 +307,14 @@ function applyPreviewPolicy(
   if (node.kind === "primitive") return { changed: false, value: node.value };
   if (node.kind === "string") {
     if (node.value.length <= options.maxStringChars) return { changed: false, value: node.value };
+    // Back off one unit if the cut lands mid-surrogate-pair — a lone high
+    // surrogate would render as a \udxxx escape in the pretty-printed preview.
+    let end = options.maxStringChars;
+    const lastUnit = node.value.charCodeAt(end - 1);
+    if (lastUnit >= 0xd800 && lastUnit <= 0xdbff) end -= 1;
     return {
       changed: true,
-      value: `${node.value.slice(0, options.maxStringChars)}… [truncated from ${node.bytes} JSON bytes]`,
+      value: `${node.value.slice(0, end)}… [truncated from ${node.bytes} JSON bytes]`,
     };
   }
   if (node.kind === "array") {

--- a/apps/os/src/lib/truncate-json.ts
+++ b/apps/os/src/lib/truncate-json.ts
@@ -287,6 +287,9 @@ const PREVIEW_KEEP_INTACT_BYTES = 100;
  * The result still serializes within `maxBytes`.
  */
 export function previewJson(value: unknown, options: PreviewOptions): TruncatedJson {
+  // serialize() round-trips through JSON.stringify (throwing on undefined), so
+  // parsing its output can only yield JSON-shaped data — the cast just names
+  // what JSON.parse's `any` already guarantees here.
   const measured = measureJson(JSON.parse(serialize(value)) as JsonValue);
   const policied = applyPreviewPolicy(measured, options, 0);
   const bounded = truncateJsonToBytes(policied.value, options.maxBytes);

--- a/apps/os/src/lib/truncate-json.ts
+++ b/apps/os/src/lib/truncate-json.ts
@@ -264,6 +264,89 @@ type TruncatedJson = {
   value: unknown;
 };
 
+type PreviewOptions = {
+  /** Arrays keep only their first N items (a truncation marker replaces the rest). */
+  maxArrayItems: number;
+  /** Strings longer than this keep a prefix plus a truncation marker. */
+  maxStringChars: number;
+  /** Containers nested at or below this depth collapse to a one-line summary string. */
+  maxDepth: number;
+  /** Hard ceiling on the serialized preview, enforced by truncateJsonToBytes. */
+  maxBytes: number;
+};
+
+/** Small subtrees survive the depth/policy cuts untouched — replacing a tiny
+ * leaf tuple with a "[truncated …]" marker would cost bytes to lose data. */
+const PREVIEW_KEEP_INTACT_BYTES = 100;
+
+/**
+ * util.inspect-flavored preview: unlike truncateJsonToBytes (which keeps as
+ * much as fits), this aggressively elides *everywhere* — a few items per
+ * array, capped strings, bounded depth — so a bounded preview shows the
+ * overall shape of a huge value instead of the start of its largest child.
+ * The result still serializes within `maxBytes`.
+ */
+export function previewJson(value: unknown, options: PreviewOptions): TruncatedJson {
+  const measured = measureJson(JSON.parse(serialize(value)) as JsonValue);
+  const policied = applyPreviewPolicy(measured, options, 0);
+  const bounded = truncateJsonToBytes(policied.value, options.maxBytes);
+  return {
+    bytes: bounded.bytes,
+    originalBytes: measured.bytes,
+    truncated: policied.changed || bounded.truncated,
+    value: bounded.value,
+  };
+}
+
+function applyPreviewPolicy(
+  node: MeasuredJson,
+  options: PreviewOptions,
+  depth: number,
+): { changed: boolean; value: JsonValue } {
+  if (node.bytes <= PREVIEW_KEEP_INTACT_BYTES) return { changed: false, value: node.value };
+  if (node.kind === "primitive") return { changed: false, value: node.value };
+  if (node.kind === "string") {
+    if (node.value.length <= options.maxStringChars) return { changed: false, value: node.value };
+    return {
+      changed: true,
+      value: `${node.value.slice(0, options.maxStringChars)}… [truncated from ${node.bytes} JSON bytes]`,
+    };
+  }
+  if (node.kind === "array") {
+    if (depth >= options.maxDepth) {
+      return {
+        changed: true,
+        value: `[array of ${node.items.length} items; ${node.bytes} JSON bytes]`,
+      };
+    }
+    const kept = node.items
+      .slice(0, options.maxArrayItems)
+      .map((item) => applyPreviewPolicy(item, options, depth + 1));
+    const dropped = node.items.length - kept.length;
+    return {
+      changed: dropped > 0 || kept.some((item) => item.changed),
+      value: [
+        ...kept.map((item) => item.value),
+        ...(dropped > 0 ? [`[truncated ${dropped} items; from ${node.bytes} JSON bytes]`] : []),
+      ],
+    };
+  }
+  if (depth >= options.maxDepth) {
+    return {
+      changed: true,
+      value: `[object with ${node.entries.length} properties; ${node.bytes} JSON bytes]`,
+    };
+  }
+  const entries = node.entries.map((entry) => ({
+    key: entry.key,
+    result: applyPreviewPolicy(entry.value, options, depth + 1),
+  }));
+  return {
+    changed: entries.some((entry) => entry.result.changed),
+    value: Object.fromEntries(entries.map((entry) => [entry.key, entry.result.value])),
+  };
+}
+
 /**
  * Keep JSON intact until it crosses a byte boundary, then deterministically
  * chop the tail of its largest useful nested value. The input is never mutated

--- a/tasks/complete/2026-08-04-script-result-truncation.md
+++ b/tasks/complete/2026-08-04-script-result-truncation.md
@@ -1,11 +1,11 @@
 ---
-status: in-progress
+status: done
 size: medium
 ---
 
 # Smarter truncation for oversized script results
 
-**Status summary:** implemented; unit tests green (typecheck/lint/knip/format clean). Remaining: CI + review. Followup task filed for typed `Results<...>` handles.
+**Status summary:** implemented; unit tests green (typecheck/lint/knip/format clean). CI green on PR #2400. Followup task filed for typed `Results<...>` handles.
 
 When an agent script returns a big result, `renderScriptSettlement` slices the pretty-printed JSON at `scriptResultHistoryLimit` (30k chars) — bisecting JSON mid-key and showing only the start of the payload (often one giant array's first entries). The model learns nothing about overall shape; in [this chat](https://os.iterate.com/projects/misha/agents/streams/agents/mobile/2026-08-03t16-27-32-701z) the agent had to guess a prior result's structure and got it wrong.
 

--- a/tasks/script-result-truncation.md
+++ b/tasks/script-result-truncation.md
@@ -5,7 +5,7 @@ size: medium
 
 # Smarter truncation for oversized script results
 
-**Status summary:** spec committed, implementation starting. Nothing built yet.
+**Status summary:** implemented; unit tests green (typecheck/lint/knip/format clean). Remaining: CI + review. Followup task filed for typed `Results<...>` handles.
 
 When an agent script returns a big result, `renderScriptSettlement` slices the pretty-printed JSON at `scriptResultHistoryLimit` (30k chars) — bisecting JSON mid-key and showing only the start of the payload (often one giant array's first entries). The model learns nothing about overall shape; in [this chat](https://os.iterate.com/projects/misha/agents/streams/agents/mobile/2026-08-03t16-27-32-701z) the agent had to guess a prior result's structure and got it wrong.
 
@@ -20,13 +20,15 @@ Decisions (grilled with Misha 2026-08-04):
 
 ## Checklist
 
-- [ ] `apps/os/src/lib/infer-json-type.ts` — `inferJsonType(value, {maxChars})` → TS type text: structural merge of array elements (union cap ~3), cardinality comments (`// 1234 items`, `// ~45k chars`), small literal unions for repeated short strings, budget enforced by collapsing deepest subtrees to `unknown`
-- [ ] unit tests `apps/os/src/lib/infer-json-type.test.ts`
-- [ ] move `apps/os/src/domains/integrations/truncate-json.ts` (+ test) → `apps/os/src/lib/`, update posthog import; no behavior change
-- [ ] add `previewJson(value, {maxArrayItems, maxStringChars, maxDepth, maxBytes})` to truncate-json — policy pre-pass reusing existing marker idiom, then byte-budget guarantee
-- [ ] rewire `renderScriptSettlement` JSON overflow branch: type block + preview block + spill notice (recipe now `const data: Result = JSON.parse(...)`); raw-text results keep slice path with ~10k preview; failure branch unchanged; `inferJsonType` failure degrades to no type block
-- [ ] update system-prompt one-liner in `agent-defaults.ts` (~line 207)
-- [ ] update render expectations in `agent-processor.test.ts` (~1040–1140); e2e spill test should pass as-is
-- [ ] file followup `tasks/typed-script-result-handles.md`
+- [x] `apps/os/src/lib/infer-json-type.ts` — `inferJsonType(value, {maxChars})` → TS type text: structural merge of array elements (union cap ~3), cardinality comments (`// 1234 items`, `// ~45k chars`), small literal unions for repeated short strings, budget enforced by collapsing deepest subtrees to `unknown` _shape lattice + merge + depth-shrinking renderer; also renders wide keyed maps as `Record<string, T>` and drops undefined-valued keys to match the spilled JSON_
+- [x] unit tests `apps/os/src/lib/infer-json-type.test.ts` _11 tests incl. optionality-from-undefined and budget enforcement_
+- [x] move `apps/os/src/domains/integrations/truncate-json.ts` (+ test) → `apps/os/src/lib/`, update posthog import; no behavior change _git mv; only importer was posthog.ts_
+- [x] add `previewJson(value, {maxArrayItems, maxStringChars, maxDepth, maxBytes})` to truncate-json — policy pre-pass reusing existing marker idiom, then byte-budget guarantee _policy pass over the MeasuredJson tree (tiny ≤100-byte subtrees survive untouched), then truncateJsonToBytes for the ceiling_
+- [x] rewire `renderScriptSettlement` JSON overflow branch: type block + preview block + spill notice (recipe now `const data: Result = JSON.parse(...)`); raw-text results keep slice path with ~10k preview; failure branch unchanged; `inferJsonType` failure degrades to no type block _`renderOversizedJsonResult` in agent-processor-implementation.ts; budgets 3k type / 8k preview / 10k raw-text, each clamped to historyLimit_
+- [x] update system-prompt one-liner in `agent-defaults.ts` (~line 207)
+- [x] update render expectations in `agent-processor.test.ts` (~1040–1140); e2e spill test should pass as-is _JSON spill test asserts type block + typed recipe; new test covers array-eliding preview with 400 rows_
+- [x] file followup `tasks/typed-script-result-handles.md`
 
 ## Implementation log
+
+- 2026-08-04: implemented as specced. Full os unit lane green (2545 passed). Demo render on a Slack-history-shaped 270KB payload: type block ~20 lines with `thread_ts?: string` optionality and literal unions, preview 3 messages + `[truncated 797 items; from 271814 JSON bytes]` marker — total rendered item ~2.5KB vs 30KB before.

--- a/tasks/script-result-truncation.md
+++ b/tasks/script-result-truncation.md
@@ -1,0 +1,32 @@
+---
+status: in-progress
+size: medium
+---
+
+# Smarter truncation for oversized script results
+
+**Status summary:** spec committed, implementation starting. Nothing built yet.
+
+When an agent script returns a big result, `renderScriptSettlement` slices the pretty-printed JSON at `scriptResultHistoryLimit` (30k chars) — bisecting JSON mid-key and showing only the start of the payload (often one giant array's first entries). The model learns nothing about overall shape; in [this chat](https://os.iterate.com/projects/misha/agents/streams/agents/mobile/2026-08-03t16-27-32-701z) the agent had to guess a prior result's structure and got it wrong.
+
+Fix: on overflow, render (1) an inferred TypeScript type of the whole value, (2) a small inspect-style preview (a few items per array, capped strings/depth, valid JSON with truncation markers), (3) the existing spill notice. The full result already spills to `script-results/<id>.json`; the type tells the agent how to write the follow-up `readFile` script.
+
+Decisions (grilled with Misha 2026-08-04):
+
+- Drill-in stays the spill-file + `itx.workspace.readFile` recipe. Typed `Results<"agent-output-400">` cast is a followup (see `tasks/typed-script-result-handles.md`).
+- Type inference is hand-rolled (sync, zero deps, Workers-safe) — not quicktype (Workers compat scar tissue: the `quicktype-core>readable-stream` pnpm override).
+- Preview builds on the existing `truncateJsonToBytes` (was PostHog-only) with an aggressive arrays/strings/depth policy pre-pass.
+- Budget shrinks on overflow: type ~3k chars + preview ~10k bytes + notice. 30k stays the passthrough threshold, per-agent patchable as before.
+
+## Checklist
+
+- [ ] `apps/os/src/lib/infer-json-type.ts` — `inferJsonType(value, {maxChars})` → TS type text: structural merge of array elements (union cap ~3), cardinality comments (`// 1234 items`, `// ~45k chars`), small literal unions for repeated short strings, budget enforced by collapsing deepest subtrees to `unknown`
+- [ ] unit tests `apps/os/src/lib/infer-json-type.test.ts`
+- [ ] move `apps/os/src/domains/integrations/truncate-json.ts` (+ test) → `apps/os/src/lib/`, update posthog import; no behavior change
+- [ ] add `previewJson(value, {maxArrayItems, maxStringChars, maxDepth, maxBytes})` to truncate-json — policy pre-pass reusing existing marker idiom, then byte-budget guarantee
+- [ ] rewire `renderScriptSettlement` JSON overflow branch: type block + preview block + spill notice (recipe now `const data: Result = JSON.parse(...)`); raw-text results keep slice path with ~10k preview; failure branch unchanged; `inferJsonType` failure degrades to no type block
+- [ ] update system-prompt one-liner in `agent-defaults.ts` (~line 207)
+- [ ] update render expectations in `agent-processor.test.ts` (~1040–1140); e2e spill test should pass as-is
+- [ ] file followup `tasks/typed-script-result-handles.md`
+
+## Implementation log

--- a/tasks/typed-script-result-handles.md
+++ b/tasks/typed-script-result-handles.md
@@ -1,0 +1,20 @@
+---
+status: ready
+size: medium
+---
+
+# Typed script-result handles: `Results<"agent-output-400">`
+
+Followup to `tasks/script-result-truncation.md` (which renders an inferred TS type for oversized script results). Bonus round: make that type *usable* in later scripts, not just readable.
+
+Goal:
+
+```ts
+const data: Results<"agent-output-400"> = JSON.parse(
+  await itx.workspace.readFile(".../script-results/agent-output-400.json"),
+);
+```
+
+- [ ] register each spilled result's inferred type in the typecheck virtual project (`apps/os/src/domains/typecheck/virtual-project.ts`) under a `Results<Id>` lookup type, so `itx.docs.typecheck` validates drill-in scripts against the real shape
+- [ ] decide lifetime/scope: types for results of the current agent stream only? persisted where? (probably regenerate on demand from the spill file rather than storing type text)
+- [ ] surface it in the spill notice recipe once it actually typechecks


### PR DESCRIPTION
When an agent script returns a big result, today's render is a raw `text.slice(0, 30_000)` of the pretty-printed JSON — cut mid-key, showing only the start of the payload (often one giant array's leading rows). The model learns nothing about overall shape and has to guess ([sample chat](https://os.iterate.com/projects/misha/agents/streams/agents/mobile/2026-08-03t16-27-32-701z) where an agent guessed wrong at a prior turn's structure).

After this PR, an oversized JSON result renders as a *map* of the data instead of its first 30k chars. Real output for a 270KB Slack-history-shaped payload (the whole rendered item is ~2.5KB):

````
Your script returned 271,814 chars of JSON — too big to show in full. Inferred type:
```ts
type Result = {
  ok: boolean;
  channel: "C0123456789";
  messages: Array<{
    type: "message";
    user: string;
    text: string;
    ts: string;
    thread_ts?: string;
    reactions?: Array<{
      name: "thumbsup";
      count: number;
      users: string[] /* 1 item */;
    }> /* 1 item */;
  }> /* 800 items */;
  response_metadata: {
    next_cursor: "dGVhbTpDMDEyMzQ1Njc4OQ==";
  };
}
```
Preview (long arrays/strings elided):
```json
{
  "ok": true,
  "channel": "C0123456789",
  "messages": [
    { "type": "message", "user": "U000000000", "text": "message body number 0 ", ... },
    { ... },
    { ... },
    "[truncated 797 items; from 271814 JSON bytes]"
  ],
  "response_metadata": { "next_cursor": "dGVhbTpDMDEyMzQ1Njc4OQ==" }
}
```
The full result is saved in your workspace at ".../script-results/agent-output-400.json" — don't re-fetch; read and filter it with plain TypeScript in your next script, e.g.:
```ts
async (itx) => {
  const data: Result = JSON.parse(await itx.workspace.readFile(".../agent-output-400.json")); // matches the inferred type above
  return Object.keys(data); // then slice/filter/regex to return only what you need
}
```
````

How:

- **`apps/os/src/lib/infer-json-type.ts`** (new): hand-rolled sync value→TS-text inferrer — structural merge of array elements (union cap 3), literal unions for small string sets, optionality from `undefined`/missing keys (matching what `JSON.stringify` writes to the spill file), `Record<string, T>` for wide keyed maps, cardinality comments, char budget enforced by collapsing depth. Deliberately not quicktype: sync, zero deps, Workers-safe (the `quicktype-core>readable-stream` pnpm override is the scar tissue from last time).
- **`truncate-json.ts` moves** `domains/integrations` → `src/lib` (it was PostHog-only; now shared, unchanged for existing callers) and gains **`previewJson`**: an inspect-flavored policy pass (first 3 items per array, 500-char strings, depth 5, tiny subtrees untouched) followed by the existing `truncateJsonToBytes` byte-ceiling guarantee.
- **`renderScriptSettlement`**: JSON overflow renders type (≤3k) + preview (≤8k bytes) + typed recipe; raw-text results keep the slice path shrunk to 10k. Type inference and preview degrade independently; spill-failure fallback unchanged. `scriptResultHistoryLimit` (30k, per-agent patchable) remains the passthrough threshold — small results are untouched.

Followup filed in-branch (`tasks/typed-script-result-handles.md`): make `Results<"agent-output-400">` actually typecheck via the virtual project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session: 95c7978d-5f85-40b6-9454-d17aa4d1432f

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-04T12:00:16.290Z",
      "deployedAt": "2026-08-04T11:27:11.376Z",
      "headSha": "322d2e8ab23176a4478a6b9e30e76fc03490e4c6",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/53794549031125",
      "shortSha": "322d2e8",
      "cleanupDurationMs": 23752,
      "deployDurationMs": 46596,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 45304,
      "deployReadinessDurationMs": 1289,
      "deployedWorkerName": "os-preview-1",
      "deployedWorkerVersion": "496dc0d4-20e5-443b-9787-bbf15a267230",
      "testDurationMs": 257929,
      "testRetries": null,
      "workerSizeKib": 20170.25,
      "workerGzipKib": 5088.71,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5096.34
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-04T11:59:55.106Z",
      "deployedAt": "2026-08-04T11:26:53.708Z",
      "headSha": "322d2e8ab23176a4478a6b9e30e76fc03490e4c6",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-1.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/53794549031125",
      "shortSha": "322d2e8",
      "cleanupDurationMs": 2565,
      "deployDurationMs": 27937,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 27632,
      "deployReadinessDurationMs": 300,
      "deployedWorkerName": "docs-preview-1",
      "deployedWorkerVersion": "3b154a5d-4e46-4eb1-af57-313fee224179",
      "testDurationMs": 2312,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-04T11:59:55.908Z",
      "deployedAt": "2026-08-04T11:26:54.099Z",
      "headSha": "322d2e8ab23176a4478a6b9e30e76fc03490e4c6",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/53794549031125",
      "shortSha": "322d2e8",
      "cleanupDurationMs": 3365,
      "deployDurationMs": 28345,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 28022,
      "deployReadinessDurationMs": 318,
      "deployedWorkerName": "auth-preview-1",
      "deployedWorkerVersion": "2ee7a557-b862-4e16-a778-58283f92d37c",
      "testDurationMs": 3500,
      "testRetries": null,
      "workerSizeKib": 3979.33,
      "workerGzipKib": 814.78,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-04T11:59:53.271Z",
      "deployedAt": "2026-08-04T11:26:35.521Z",
      "headSha": "322d2e8ab23176a4478a6b9e30e76fc03490e4c6",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/53794549031125",
      "shortSha": "322d2e8",
      "cleanupDurationMs": 726,
      "deployDurationMs": 9641,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 9397,
      "deployReadinessDurationMs": 191,
      "deployedWorkerName": "dummy-petshop-preview-1",
      "deployedWorkerVersion": "dbc1a8b3-4584-46bf-ab62-473114a77598",
      "testDurationMs": 56401,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `322d2e8` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 814.8 KiB | 28.3s | 3.5s |  | 3.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/53794549031125) | 2026-08-04T11:59:55.908Z | Preview app released. |
| Docs | released | `322d2e8` | [https://docs-preview-1.iterate-dev-preview.workers.dev](https://docs-preview-1.iterate-dev-preview.workers.dev) | 866.2 KiB | 27.9s | 2.3s |  | 2.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/53794549031125) | 2026-08-04T11:59:55.106Z | Preview app released. |
| Dummy Petshop | released | `322d2e8` | [https://dummy-petshop.iterate-preview-1.com](https://dummy-petshop.iterate-preview-1.com) | 198.3 KiB | 9.6s | 56.4s |  | 726ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/53794549031125) | 2026-08-04T11:59:53.271Z | Preview app released. |
| OS | released | `322d2e8` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 4.97 MiB (-7.6 KiB vs main) | 46.6s | 257.9s |  | 23.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/53794549031125) | 2026-08-04T12:00:16.290Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +416 -26 | +309 -21 🟩🟩🟩🟩🟩 |
| Tests | +262 -2 | +219 -2 🟩🟩🟩⬜⬜ |
| Docs | +54 -0 | +39 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+732 -28** | **+567 -23** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 67290ad and 322d2e8, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how large script results enter agent context (core codemode loop) but keeps spill semantics, independent degradation paths, and the same passthrough threshold; risk is mainly behavioral—agents may rely on the new type/preview format.
> 
> **Overview**
> When a codemode script returns JSON larger than `scriptResultHistoryLimit`, the agent no longer gets a ~30k-char slice of pretty-printed JSON (often cut mid-key). After a successful workspace spill, **JSON** results now show a compact **inferred TypeScript type**, an **elided JSON preview**, and the existing spill + `readFile` recipe; **raw text** spills shrink the inline preview to ~10k chars with an updated paging notice.
> 
> **New `inferJsonType`** (`apps/os/src/lib/infer-json-type.ts`) synthesizes TS-like type text from the full value (merged array elements, optional fields, cardinality comments, `Record` for wide maps), bounded by a char budget.
> 
> **`previewJson`** on moved **`truncate-json`** (`domains/integrations` → `src/lib`) applies array/string/depth limits then `truncateJsonToBytes` so previews show shape across the whole tree, not just the largest child.
> 
> **`renderScriptSettlement`** wires the JSON overflow path through `renderOversizedJsonResult`; type inference and preview fail independently with fallbacks. Default agent prompt text and processor tests match the new messaging. A follow-up task tracks typed `Results<...>` handles for virtual typecheck.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 322d2e8ab23176a4478a6b9e30e76fc03490e4c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->