### PR TITLE
Dev server: diagnose and defuse the workerd isolate-accumulation OOM

### DIFF
--- a/apps/os/scripts/dev.ts
+++ b/apps/os/scripts/dev.ts
@@ -53,18 +53,17 @@ export default async function start(options: StartOptions = {}) {
   // Captured before eviction: shutdown removes the discovery file that
   // recordedPort() reads, and the replacement should keep the stable URL.
   let evictedPort: number | undefined;
-  if (live) {
-    if (await evictIfMemoryPressured(live)) {
-      evictedPort = live.port;
-    } else {
-      if (requestedPort !== undefined && live.port !== requestedPort) {
-        throw new Error(
-          `A dev server is already running on port ${live.port} (pid ${live.pid}) but port ` +
-            `${requestedPort} was requested — kill it or use restart.`,
-        );
-      }
-      return { ...formatStatus(live), note: "already running — use restart to replace it" };
+  if (live && (await evictIfMemoryPressured(live))) {
+    evictedPort = live.port;
+  }
+  if (live && evictedPort === undefined) {
+    if (requestedPort !== undefined && live.port !== requestedPort) {
+      throw new Error(
+        `A dev server is already running on port ${live.port} (pid ${live.pid}) but port ` +
+          `${requestedPort} was requested — kill it or use restart.`,
+      );
     }
+    return { ...formatStatus(live), note: "already running — use restart to replace it" };
   }
 
   const port = requestedPort ?? evictedPort ?? (await pickFreePort(recordedPort()));
@@ -209,7 +208,10 @@ async function resolveLocalOsDevServerTarget(
  * Treat a bloated workerd as already dead: kill it so callers start fresh.
  */
 async function evictIfMemoryPressured(live: DevServerInfo) {
-  const limitMb = Number(process.env.ITERATE_DEV_WORKERD_RSS_LIMIT_MB || 2048);
+  // Guard NaN: `rssMb < NaN` is false, so a typo'd env var would otherwise
+  // evict every live server on every start.
+  const configured = Number(process.env.ITERATE_DEV_WORKERD_RSS_LIMIT_MB);
+  const limitMb = Number.isFinite(configured) && configured > 0 ? configured : 2048;
   const rssMb = Math.round(workerdRssKb(live.pid) / 1024);
   if (rssMb < limitMb) return false;
   console.error(

--- a/apps/os/scripts/dev.ts
+++ b/apps/os/scripts/dev.ts
@@ -50,17 +50,24 @@ const DEFAULT_START_TIMEOUT_MS = 60_000;
 export default async function start(options: StartOptions = {}) {
   const requestedPort = options.port ?? (process.env.PORT ? Number(process.env.PORT) : undefined);
   const live = readDevServerInfo(APP_ROOT, { requireLive: true });
-  if (live && !(await evictIfMemoryPressured(live))) {
-    if (requestedPort !== undefined && live.port !== requestedPort) {
-      throw new Error(
-        `A dev server is already running on port ${live.port} (pid ${live.pid}) but port ` +
-          `${requestedPort} was requested — kill it or use restart.`,
-      );
+  // Captured before eviction: shutdown removes the discovery file that
+  // recordedPort() reads, and the replacement should keep the stable URL.
+  let evictedPort: number | undefined;
+  if (live) {
+    if (await evictIfMemoryPressured(live)) {
+      evictedPort = live.port;
+    } else {
+      if (requestedPort !== undefined && live.port !== requestedPort) {
+        throw new Error(
+          `A dev server is already running on port ${live.port} (pid ${live.pid}) but port ` +
+            `${requestedPort} was requested — kill it or use restart.`,
+        );
+      }
+      return { ...formatStatus(live), note: "already running — use restart to replace it" };
     }
-    return { ...formatStatus(live), note: "already running — use restart to replace it" };
   }
 
-  const port = requestedPort ?? (await pickFreePort(recordedPort()));
+  const port = requestedPort ?? evictedPort ?? (await pickFreePort(recordedPort()));
   // Thread the picked port through the environment too: vite.config.ts writes
   // wrangler.jsonc at import time, and the local-dev vars bake
   // APP_CONFIG_BASE_URL from PORT so the worker knows its own origin (signed
@@ -201,7 +208,7 @@ async function resolveLocalOsDevServerTarget(
  * before every spec run" ritual). Details: tasks/miniflare-oom-investigation.md.
  * Treat a bloated workerd as already dead: kill it so callers start fresh.
  */
-async function evictIfMemoryPressured(live: DevServerInfo): Promise<boolean> {
+async function evictIfMemoryPressured(live: DevServerInfo) {
   const limitMb = Number(process.env.ITERATE_DEV_WORKERD_RSS_LIMIT_MB || 2048);
   const rssMb = Math.round(workerdRssKb(live.pid) / 1024);
   if (rssMb < limitMb) return false;
@@ -219,7 +226,7 @@ async function evictIfMemoryPressured(live: DevServerInfo): Promise<boolean> {
  * loader isolates accumulate, so its RSS — not node's heap — is the health
  * signal that predicts the crash.
  */
-function workerdRssKb(rootPid: number): number {
+function workerdRssKb(rootPid: number) {
   const result = spawnSync("ps", ["-axo", "pid=,ppid=,rss=,comm="], { encoding: "utf8" });
   if (result.status !== 0 || !result.stdout) return 0;
   const rows = result.stdout

--- a/apps/os/scripts/dev.ts
+++ b/apps/os/scripts/dev.ts
@@ -50,7 +50,7 @@ const DEFAULT_START_TIMEOUT_MS = 60_000;
 export default async function start(options: StartOptions = {}) {
   const requestedPort = options.port ?? (process.env.PORT ? Number(process.env.PORT) : undefined);
   const live = readDevServerInfo(APP_ROOT, { requireLive: true });
-  if (live) {
+  if (live && !(await evictIfMemoryPressured(live))) {
     if (requestedPort !== undefined && live.port !== requestedPort) {
       throw new Error(
         `A dev server is already running on port ${live.port} (pid ${live.pid}) but port ` +
@@ -181,11 +181,67 @@ async function resolveLocalOsDevServerTarget(
 > {
   const live = readDevServerInfo(APP_ROOT, { requireLive: true });
   if (live) {
+    if (await evictIfMemoryPressured(live)) {
+      // Same port so the caller's webServer machinery boots a fresh server
+      // at the URL it already resolved.
+      return { baseUrl: live.baseUrl.replace(/\/+$/, ""), kind: "start", port: live.port };
+    }
     return { baseUrl: live.baseUrl.replace(/\/+$/, ""), info: live, kind: "live", port: live.port };
   }
   const envPort = env.PORT ? Number(env.PORT) : undefined;
   const port = await pickFreePort(envPort || recordedPort());
   return { baseUrl: `http://localhost:${port}`, kind: "start", port };
+}
+
+/**
+ * Local workerd NEVER evicts worker-loader isolates (upstream: platform
+ * concern), every project worker / script run loads one under a fresh key,
+ * and all isolates share a ~4GB V8 pointer cage — so a long-lived dev
+ * server is a slow-motion SIGABRT (the historical "restart the dev server
+ * before every spec run" ritual). Details: tasks/miniflare-oom-investigation.md.
+ * Treat a bloated workerd as already dead: kill it so callers start fresh.
+ */
+async function evictIfMemoryPressured(live: DevServerInfo): Promise<boolean> {
+  const limitMb = Number(process.env.ITERATE_DEV_WORKERD_RSS_LIMIT_MB || 2048);
+  const rssMb = Math.round(workerdRssKb(live.pid) / 1024);
+  if (rssMb < limitMb) return false;
+  console.error(
+    `[dev] workerd RSS is ${rssMb}MB (limit ${limitMb}MB) — killing pid ${live.pid} for a fresh ` +
+      `start before the V8 pointer cage fills and it SIGABRTs mid-request.`,
+  );
+  await kill();
+  return true;
+}
+
+/**
+ * Sum RSS of the dev server's workerd descendants (vite spawns miniflare
+ * which spawns workerd; RSS in kB as reported by ps). workerd is where
+ * loader isolates accumulate, so its RSS — not node's heap — is the health
+ * signal that predicts the crash.
+ */
+function workerdRssKb(rootPid: number): number {
+  const result = spawnSync("ps", ["-axo", "pid=,ppid=,rss=,comm="], { encoding: "utf8" });
+  if (result.status !== 0 || !result.stdout) return 0;
+  const rows = result.stdout
+    .trim()
+    .split("\n")
+    .map((line) => {
+      const [pid, ppid, rss, ...comm] = line.trim().split(/\s+/);
+      return { pid: Number(pid), ppid: Number(ppid), rss: Number(rss), comm: comm.join(" ") };
+    });
+  const childrenByPpid = new Map<number, typeof rows>();
+  for (const row of rows) {
+    childrenByPpid.set(row.ppid, [...(childrenByPpid.get(row.ppid) || []), row]);
+  }
+  let totalKb = 0;
+  const queue = [rootPid];
+  while (queue.length > 0) {
+    for (const child of childrenByPpid.get(queue.shift()!) || []) {
+      if (child.comm.includes("workerd")) totalKb += child.rss;
+      queue.push(child.pid);
+    }
+  }
+  return totalKb;
 }
 
 /** This worktree's last-used port, so restarts keep stable URLs. */
@@ -271,6 +327,9 @@ function formatStatus(info: DevServerInfo | null) {
     port: info.port,
     baseUrl: info.baseUrl,
     startedAt: info.startedAt,
+    // The crash predictor: worker-loader isolates accumulate here until the
+    // ~4GB pointer cage fills (tasks/miniflare-oom-investigation.md).
+    workerdRssMb: live ? Math.round(workerdRssKb(info.pid) / 1024) : undefined,
     log: LOG_PATH,
   };
 }

--- a/tasks/complete/2026-08-04-miniflare-oom-investigation.md
+++ b/tasks/complete/2026-08-04-miniflare-oom-investigation.md
@@ -1,5 +1,5 @@
 ---
-status: implemented
+status: done
 size: medium
 ---
 

--- a/tasks/miniflare-oom-investigation.md
+++ b/tasks/miniflare-oom-investigation.md
@@ -1,0 +1,68 @@
+---
+status: in-progress
+size: medium
+---
+
+# "Miniflare OOM": diagnose the local dev-server death, stop living like this
+
+## Status
+
+Root cause identified from crash logs + upstream sources; empirical
+reproduction and the dev.ts mitigation are in progress.
+
+## The complaint
+
+The local OS dev server dies after ~2-3 consecutive playwright spec runs
+("Internal server error: fetch failed", health 500/000, playwright webServer
+"exited early"). The working ritual is "restart the dev server before every
+spec run", which is miserable. Figure out:
+
+- [x] Do we have a smoking gun that it's really an OOM? _Yes —
+      `worktrees/iterate/bump-middlewright-15/apps/os/.dev-server/dev-server.log`
+      lines 2458-2459: `*** Received signal #6: Abort trap: 6` +
+      `V8 fatal error; location = CALL_AND_RETRY_LAST; message = : allocation
+      failed: JavaScript heap out of memory`. The `*** Received signal` prefix
+      is workerd's crash handler; the GC trace shows the dying isolate was
+      8ms old with a 1.9MB heap — a brand-new isolate that could not
+      allocate, i.e. process-level exhaustion inside workerd, not a 4GB Node
+      heap filling._
+- [x] Is it an old version / fixed upstream? _No. workerd intentionally has
+      no isolate eviction (maintainer: platform-level concern, "totally
+      possible to implement your own LRU eviction on top of this codebase" —
+      workerd discussion #351). All isolates in one workerd process share a
+      ~4GB V8 pointer cage regardless of system RAM; when it's full, the next
+      isolate creation aborts the process. Bumping wrangler/miniflare
+      (4.107.0/4.20260701.0 → 4.118.0/4.20260730.0) does not change this._
+- [x] Are we doing something wrong? _Sort of — by design.
+      `apps/os/src/domains/workers/worker-loader.ts` keys `env.LOADER.get`
+      with a `loaderInstanceNonce` that is unique per runner incarnation
+      (per REQUEST for stateless ingress runners), because loader isolates
+      capture runner-scoped loopback RPC bindings. Every script run / agent
+      code round / project-worker request therefore mints an isolate under a
+      never-reused key. In production Cloudflare's platform evicts cold
+      isolates; local workerd keeps every one forever, so a long-lived dev
+      server accumulates isolates until the pointer cage fills and workerd
+      SIGABRTs._
+
+## Remaining work
+
+- [ ] Empirical smoking gun: fresh dev server, loop N script runs via the
+      CLI, sample workerd RSS after each — capture the monotonic growth
+      curve into this file
+- [ ] Mitigation: `apps/os/scripts/dev.ts` learns the memory story —
+      `status` reports workerd/node RSS, and resolving a "live" target
+      auto-restarts the server when workerd RSS exceeds a threshold, so
+      spec runs always start against a healthy server and the manual
+      restart ritual dies
+- [ ] Follow-ups documented: reduce isolate churn (reuse within runner
+      lifetime), consider upstream ask (dispose/eviction hook for
+      worker-loader in local workerd)
+
+## Sources
+
+- workerd discussion #351 ("Loading 100s of workers?") — no eviction by
+  design, 4GB pointer cage shared across isolates
+- Cloudflare Dynamic Workflows blog — production DOES evict loader isolates
+  ("when the isolate eventually gets evicted, the next step.do() pulls the
+  code again")
+- Local crash log: `bump-middlewright-15/apps/os/.dev-server/dev-server.log`

--- a/tasks/miniflare-oom-investigation.md
+++ b/tasks/miniflare-oom-investigation.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: implemented
 size: medium
 ---
 
@@ -7,62 +7,84 @@ size: medium
 
 ## Status
 
-Root cause identified from crash logs + upstream sources; empirical
-reproduction and the dev.ts mitigation are in progress.
+Done: root cause pinned with a smoking gun + live reproduction, and dev.ts
+now auto-restarts a memory-pressured server so the manual ritual dies.
+PR: https://github.com/iterate/iterate/pull/2401
 
 ## The complaint
 
-The local OS dev server dies after ~2-3 consecutive playwright spec runs
-("Internal server error: fetch failed", health 500/000, playwright webServer
-"exited early"). The working ritual is "restart the dev server before every
-spec run", which is miserable. Figure out:
+The local OS dev server dies after a few playwright spec runs ("Internal
+server error: fetch failed", health 500/000, playwright webServer "exited
+early"). The working ritual was "restart the dev server before every spec
+run".
 
-- [x] Do we have a smoking gun that it's really an OOM? _Yes —
-      `worktrees/iterate/bump-middlewright-15/apps/os/.dev-server/dev-server.log`
-      lines 2458-2459: `*** Received signal #6: Abort trap: 6` +
-      `V8 fatal error; location = CALL_AND_RETRY_LAST; message = : allocation
-      failed: JavaScript heap out of memory`. The `*** Received signal` prefix
-      is workerd's crash handler; the GC trace shows the dying isolate was
-      8ms old with a 1.9MB heap — a brand-new isolate that could not
-      allocate, i.e. process-level exhaustion inside workerd, not a 4GB Node
-      heap filling._
-- [x] Is it an old version / fixed upstream? _No. workerd intentionally has
-      no isolate eviction (maintainer: platform-level concern, "totally
-      possible to implement your own LRU eviction on top of this codebase" —
-      workerd discussion #351). All isolates in one workerd process share a
-      ~4GB V8 pointer cage regardless of system RAM; when it's full, the next
-      isolate creation aborts the process. Bumping wrangler/miniflare
-      (4.107.0/4.20260701.0 → 4.118.0/4.20260730.0) does not change this._
-- [x] Are we doing something wrong? _Sort of — by design.
-      `apps/os/src/domains/workers/worker-loader.ts` keys `env.LOADER.get`
-      with a `loaderInstanceNonce` that is unique per runner incarnation
-      (per REQUEST for stateless ingress runners), because loader isolates
-      capture runner-scoped loopback RPC bindings. Every script run / agent
-      code round / project-worker request therefore mints an isolate under a
-      never-reused key. In production Cloudflare's platform evicts cold
-      isolates; local workerd keeps every one forever, so a long-lived dev
-      server accumulates isolates until the pointer cage fills and workerd
-      SIGABRTs._
+## Findings
 
-## Remaining work
+- [x] Smoking gun that it's really an OOM _Two of them. (1) Crash log
+      (`bump-middlewright-15/apps/os/.dev-server/dev-server.log:2458`):
+      `*** Received signal #6` (workerd's crash-handler prefix) +
+      `V8 fatal error; CALL_AND_RETRY_LAST; allocation failed: JavaScript
+      heap out of memory`, with a GC trace showing the dying isolate was 8ms
+      old holding 1.9MB — a brand-new isolate that couldn't allocate, i.e.
+      process-level exhaustion inside workerd, not a Node heap filling.
+      (2) Live: the worktree that ran ~7 spec runs that morning had its
+      workerd at 2.88GB RSS while every idle worktree's workerd sat at
+      5-50MB._
+- [x] Old version / fixed upstream? _No. workerd intentionally ships no
+      isolate eviction (maintainer position in workerd discussion #351:
+      platform-level concern; "totally possible to implement your own LRU
+      eviction on top of this codebase"). All isolates in one workerd
+      process share a ~4GB V8 pointer cage regardless of system RAM; when
+      it fills, the next isolate allocation SIGABRTs the process. Cloudflare
+      production evicts cold loader isolates platform-side (Dynamic
+      Workflows blog confirms), so this is a LOCAL-ONLY hazard. Bumping
+      wrangler/miniflare (we're on 4.107.0/4.20260701.0; latest
+      4.118.0/4.20260730.0) doesn't change it._
+- [x] Are we doing something wrong? _Not per-script, per measurement. The
+      loader key in `apps/os/src/domains/workers/worker-loader.ts` includes
+      a per-runner-incarnation nonce, but measured isolate cost is tiny for
+      script runs. The accumulator is PROJECT WORKERS (seeded docs-app
+      bundles etc.): the server's first project cost ~1GB workerd RSS, each
+      further fresh project +66-134MB, and every project-worker rebuild
+      (content change → new cache key) adds a fresh big isolate. Nothing is
+      ever freed, so RSS is monotonic until the cage fills. Spec runs create
+      fresh projects every run — hence death after a handful of runs._
 
-- [ ] Empirical smoking gun: fresh dev server, loop N script runs via the
-      CLI, sample workerd RSS after each — capture the monotonic growth
-      curve into this file
-- [ ] Mitigation: `apps/os/scripts/dev.ts` learns the memory story —
-      `status` reports workerd/node RSS, and resolving a "live" target
-      auto-restarts the server when workerd RSS exceeds a threshold, so
-      spec runs always start against a healthy server and the manual
-      restart ritual dies
-- [ ] Follow-ups documented: reduce isolate churn (reuse within runner
-      lifetime), consider upstream ask (dispose/eviction hook for
-      worker-loader in local workerd)
+### Measurements (fresh dev server, `pnpm cli itx run` loop, workerd RSS)
+
+| probe | result |
+| --- | --- |
+| first-ever script run in a fresh project | 120MB → 1196MB (+~1GB: project worker bootstrap) |
+| 25 identical script runs | +~50KB/run (same loader key → isolate reused) |
+| 15 unique-content script runs | +~53KB/run (script isolates are near-free) |
+| 2 further fresh projects | +66MB, +134MB |
+| idle/any amount of waiting | never shrinks below the ~1.1GB floor |
+
+## Fix (this PR)
+
+- [x] `pnpm dev status` reports `workerdRssMb` — the crash predictor is now
+      visible _formatStatus sums RSS of the vite pid's workerd descendants_
+- [x] Auto-restart on memory pressure: `start` and
+      `localOsDevServer.resolveTarget` (used by playwright's webServer)
+      treat a live server whose workerd RSS exceeds
+      `ITERATE_DEV_WORKERD_RSS_LIMIT_MB` (default 2048) as already dead —
+      kill it and hand back a fresh-start target on the same port. Verified
+      live: with limit 500 a 1360MB server was killed and
+      `{kind: "start", port: same}` returned._
+
+## Follow-ups (not this PR)
+
+- Project-worker isolate reuse/teardown: erasing or aging out dead spec
+  projects' workers locally would flatten the biggest accumulator
+- Upstream ask: an opt-in eviction/dispose hook for worker-loader isolates
+  in local workerd (they explicitly invite building eviction on top)
+- Consider a periodic RSS log line from the vite plugin so growth is visible
+  in dev-server.log without running `pnpm dev status`
 
 ## Sources
 
 - workerd discussion #351 ("Loading 100s of workers?") — no eviction by
-  design, 4GB pointer cage shared across isolates
-- Cloudflare Dynamic Workflows blog — production DOES evict loader isolates
-  ("when the isolate eventually gets evicted, the next step.do() pulls the
-  code again")
-- Local crash log: `bump-middlewright-15/apps/os/.dev-server/dev-server.log`
+  design; ~4GB shared V8 pointer cage
+- Cloudflare Dynamic Workflows blog — production evicts loader isolates
+- Crash log: `bump-middlewright-15/apps/os/.dev-server/dev-server.log:2458`
+- Probe data: 42 CLI script runs against a fresh dev server, 2026-08-04


### PR DESCRIPTION
The recurring local dev-server death ("restart the dev server before every spec run" or it dies with `fetch failed` / health 000) is diagnosed and defused.

## What actually happens

**It's workerd, not Node.** The crash log shows workerd's crash handler (`*** Received signal #6`) with `V8 fatal error; CALL_AND_RETRY_LAST; allocation failed: JavaScript heap out of memory` — and the GC trace shows the dying isolate was **8ms old holding 1.9MB**. A brand-new isolate that can't allocate means the workerd *process* is out of address space, not that some worker's heap filled.

The mechanism, confirmed upstream ([workerd discussion #351](https://github.com/cloudflare/workerd/discussions/351)):

- all isolates in one workerd process share a **~4GB V8 pointer cage**, regardless of system RAM;
- **local workerd never evicts worker-loader isolates** — maintainers consider eviction a platform concern ("totally possible to implement your own LRU eviction on top of this codebase");
- Cloudflare **production does evict** cold loader isolates platform-side ([Dynamic Workflows blog](https://blog.cloudflare.com/dynamic-workflows/)), so deployed workers are unaffected. This is a local-dev-only hazard, and bumping wrangler/miniflare doesn't change it.

## Measured (42 CLI script runs against a fresh dev server)

| probe | workerd RSS |
| --- | --- |
| server just started | 120MB |
| first-ever script run (bootstraps the project's worker) | **+1.07GB** → 1196MB |
| 25 identical script runs | +~50KB/run (same loader key → isolate reused) |
| 15 unique-content script runs | +~53KB/run (script isolates are near-free) |
| 2 further fresh projects | **+66MB, +134MB** |
| any amount of idling | never shrinks |

So: script-run isolates are near-free; **project workers are the accumulator** (seeded app bundles, 66MB–1GB each, plus a fresh big isolate on every rebuild). Spec runs create fresh projects every run — hence death after a handful. Corroborating live datapoint: a worktree that had served ~7 spec runs had its workerd at **2.88GB** while every idle worktree's sat at 5–50MB.

## The fix

- `pnpm dev status` now reports `workerdRssMb` — the crash predictor is visible.
- `pnpm dev start` and `localOsDevServer.resolveTarget` (what playwright's webServer uses) treat a live server whose workerd RSS exceeds `ITERATE_DEV_WORKERD_RSS_LIMIT_MB` (default 2048) as already dead: kill it and return a fresh-start target on the same port. Spec runs now always begin against a server with headroom.

```
[dev] workerd RSS is 1360MB (limit 500MB) — killing pid 22281 for a fresh start
      before the V8 pointer cage fills and it SIGABRTs mid-request.
{"baseUrl":"http://localhost:50552","kind":"start","port":50552}
```

Follow-ups noted in the task file: age out dead spec-projects' workers locally, and the upstream ask for an opt-in eviction hook.

Task file: `tasks/miniflare-oom-investigation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session id: `b0fe444e-c95c-4ab9-85aa-8bfb3d266d2c`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-04T12:44:24.123Z",
      "deployedAt": "2026-08-04T12:21:23.421Z",
      "headSha": "e9ead1679de46f2f5fe99095482353302d21a9b5",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/22102286659040",
      "shortSha": "e9ead16",
      "cleanupDurationMs": 14597,
      "deployDurationMs": 61917,
      "deployConfigDurationMs": 1,
      "deployCommandDurationMs": 55394,
      "deployReadinessDurationMs": 6519,
      "deployedWorkerName": "os-preview-3",
      "deployedWorkerVersion": "8f76c579-343d-4b3b-9a71-84fa2383609b",
      "testDurationMs": 217344,
      "testRetries": null,
      "workerSizeKib": 20159.04,
      "workerGzipKib": 5085.17,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5099.94
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-04T12:44:12.127Z",
      "deployedAt": "2026-08-04T12:20:50.698Z",
      "headSha": "e9ead1679de46f2f5fe99095482353302d21a9b5",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-3.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/22102286659040",
      "shortSha": "e9ead16",
      "cleanupDurationMs": 2599,
      "deployDurationMs": 22966,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 22667,
      "deployReadinessDurationMs": 294,
      "deployedWorkerName": "docs-preview-3",
      "deployedWorkerVersion": "e705b0c2-0929-422d-9496-e279ae4b26aa",
      "testDurationMs": 1896,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-04T12:44:13.319Z",
      "deployedAt": "2026-08-04T12:20:46.683Z",
      "headSha": "e9ead1679de46f2f5fe99095482353302d21a9b5",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/22102286659040",
      "shortSha": "e9ead16",
      "cleanupDurationMs": 3786,
      "deployDurationMs": 19093,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 18651,
      "deployReadinessDurationMs": 437,
      "deployedWorkerName": "auth-preview-3",
      "deployedWorkerVersion": "e579025d-e7c5-407a-8f4e-8ff5be4e884b",
      "testDurationMs": 12717,
      "testRetries": null,
      "workerSizeKib": 3979.33,
      "workerGzipKib": 814.85,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-04T12:44:10.367Z",
      "deployedAt": "2026-08-04T11:42:27.911Z",
      "headSha": "e9ead1679de46f2f5fe99095482353302d21a9b5",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/22102286659040",
      "shortSha": "e9ead16",
      "cleanupDurationMs": 830,
      "deployDurationMs": 62,
      "deployConfigDurationMs": 47,
      "deployReuseProofDurationMs": 11,
      "deployedWorkerName": "dummy-petshop-preview-3",
      "deployedWorkerVersion": "b8d68002-e318-46eb-82b7-0f1fa7a55c00",
      "testDurationMs": 9904,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `e9ead16` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 814.9 KiB | 19.1s | 12.7s |  | 3.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/22102286659040) | 2026-08-04T12:44:13.319Z | Preview app released. |
| Docs | released | `e9ead16` | [https://docs-preview-3.iterate-dev-preview.workers.dev](https://docs-preview-3.iterate-dev-preview.workers.dev) | 866.2 KiB | 23.0s | 1.9s |  | 2.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/22102286659040) | 2026-08-04T12:44:12.127Z | Preview app released. |
| Dummy Petshop | released | `e9ead16` | [https://dummy-petshop.iterate-preview-3.com](https://dummy-petshop.iterate-preview-3.com) | 198.3 KiB | 62ms | 9.9s |  | 830ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/22102286659040) | 2026-08-04T12:44:10.367Z | Preview app released. |
| OS | released | `e9ead16` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 4.97 MiB (-14.8 KiB vs main) | 61.9s | 217.3s |  | 14.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/22102286659040) | 2026-08-04T12:44:24.123Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| CI & scripts | +70 -2 | +46 -2 🟩🟩🟩⬜⬜ |
| Docs | +90 -0 | +75 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+160 -2** | **+121 -2** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 67290ad and e9ead16, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only local dev lifecycle (process kill + port reuse); no production paths, but Playwright/e2e rely on resolveTarget behavior and ps-based RSS can misread on unusual process trees.
> 
> **Overview**
> Addresses local OS dev server crashes after repeated Playwright runs by treating **bloated workerd** (accumulated worker-loader isolates in a ~4GB V8 cage) as unhealthy and recycling the dev server before SIGABRT.
> 
> **`pnpm dev start`** and **`localOsDevServer.resolveTarget`** (Playwright webServer / e2e) now call **`evictIfMemoryPressured`**: when summed **workerd descendant RSS** exceeds **`ITERATE_DEV_WORKERD_RSS_LIMIT_MB`** (default 2048), the wrapper kills the live server and proceeds as a fresh start, **reusing the same port** when eviction happened so URLs stay stable.
> 
> **`pnpm dev status`** adds **`workerdRssMb`** via a **`ps`-based `workerdRssKb`** walk under the vite pid. A completed task doc records root cause and measurements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9ead1679de46f2f5fe99095482353302d21a9b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->