### PR TITLE
docs: personal vs project agent skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,13 @@ from your machine, and when you need a public callback URL. Doppler/Cloudflare/d
 - [Task grooming](docs/tasks-grooming.md)
 - [Writing agent docs](docs/writing-agent-docs.md)
 
+
+### Personal vs project skills
+
+- **Project skills** live in `.agents/skills/` in this monorepo and are team-owned (OS debug, deploy, shadcn, etc.).
+- **Personal methodology packs** (for example Matt Pocock skills under `~/.agents/skills`) stay user-scope. Do **not** vendor them into this repo.
+- Incomplete skill directories without a `SKILL.md` should not be committed.
+
 ### App-specific
 
 - [OS app](apps/os/AGENTS.md)

--- a/README.md
+++ b/README.md
@@ -196,6 +196,13 @@ from your machine, and when you need a public callback URL. Doppler/Cloudflare/d
 - [Cloudflare trace queries](.agents/skills/cloudflare-traces/SKILL.md) — MCP dataset selection, correlation, and span-tree audits
 - [Debugging the OS worker](.agents/skills/debug-os-worker/SKILL.md) — ITX, agents, scheduler alarms, dynamic workers, and error lookup
 
+
+### Personal vs project skills
+
+- **Project skills** live in `.agents/skills/` in this monorepo and are team-owned (OS debug, deploy, shadcn, etc.).
+- **Personal methodology packs** (for example Matt Pocock skills under `~/.agents/skills`) stay user-scope. Do **not** vendor them into this repo.
+- Incomplete skill directories without a `SKILL.md` should not be committed.
+
 ### App-specific
 
 - [OS app](apps/os/AGENTS.md)


### PR DESCRIPTION
## Summary
- Documents the split between **project** skills (`.agents/skills` in this monorepo) and **personal** methodology packs (user-scope `~/.agents/skills`).
- Explicitly steers agents away from vendoring Matt Pocock / personal packs into iterate.
- Notes that incomplete skill shells without `SKILL.md` should not be committed.

## Context
Personal agent skill cleanup moved Matt Pocock and other user-scope packs fully into the personal agents home fragment. Iterate should only keep team-owned product skills.

## Test plan
- [ ] Skim README / Agents.md documentation section for accuracy
- [ ] Confirm no product skill paths were removed

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Docs | +14 -0 | +8 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+14 -0** | **+8 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 8232fee and 1972931, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->