### PR TITLE
Screenshots collector: spec (grill-you)

### DIFF
--- a/tasks/screenshots-collector.interview.md
+++ b/tasks/screenshots-collector.interview.md
@@ -1,0 +1,92 @@
+# Interview: screenshots-collector
+
+Grilling session: sub-claude runs grill-with-docs against the dossier at /tmp/grillings/iterate/screenshots-collector/dossier.md; the orchestrating agent answers on Misha's behalf. Guesses tagged `[guess: ...]`.
+
+---
+## Q1 — what does "background" mean for capture? — 2026-08-04
+Options: (a) foreground-triggered sync only; (b) BGAppRefreshTask best-effort; (c) both, (a) as contract + (b) contract-free. Sub-claude recommended (a) only for MVP.
+
+## A1
+(c), leaning harder on (b) than recommended — "at whatever cadence is possible" was explicit. Sync protocol is trigger-agnostic; (a)+manual "sync now" are the only contracted triggers; (b) is a contract-free accelerant gated behind an on-device prototype checklist item (lock/reboot/force-quit/low-power). Silent-push-triggered sync named as future lever, not designed. [guess: including (b) in scope now rather than deferring]
+
+---
+
+## Q2 — initial backfill scope — 2026-08-04
+(a) full immediate backfill; (b) forward-only; (c) forward-sync immediately + explicit throttled resumable backfill job. Sub-claude recommends (c), noting high-volume stream concerns and event batching implications.
+
+## A2
+(c) agreed. Riders: newest-first backfill [guess: fits screenshot use case]; events per sync-pass batch not per photo (batch event carries array of asset records + stored paths); simple max-N-per-pass safety cap.
+
+---
+
+## Q3 — iOS Limited Access degraded state — 2026-08-04
+(a) block on limited access, require full; (b) degrade gracefully, sync visible subset + soft banner. Sub-claude recommends (b).
+
+## A3
+(b) agreed. Sync pass agnostic to visible-library size; soft banner; one task-file line about the three-way prompt / accessPrivileges.
+
+---
+
+## Q4 — ingestion path: addFiles into a collector agent vs email-ingress-style door — 2026-08-04
+(a) agent.addFiles into dedicated agent (free chat browsing, but batches live in agent context forever); (b) direct itx.files + bespoke project-level photos-synced event mirroring email ingress. Sub-claude recommends (b), pending verification itx.files is callable from mobile capnweb stub.
+
+## A4
+(b), no hesitation. Path layout follows email ingress (/photos/inbound/<stableKey>-<filename>); dedup key from localIdentifier + content hash, never random. If itx.files not reachable from mobile, fix the seam rather than fall back to (a). Sub-claude verified: itx.files.put and streams.append both client-callable over existing capnweb socket — zero new seam.
+
+---
+
+## Q5 — dedup source of truth (no R2 listing layer) — 2026-08-04
+(a) client-local only; (b) server index only; (c) client cursor as fast path + processor reduced state as durable source of truth with alreadySynced(stableKeys[]) query. Sub-claude recommends (c).
+
+## A5
+(c) agreed. alreadySynced lives on the collector capability surface; client cursor is disposable cache — wiping it and reconciling from server must always be safe.
+
+---
+
+## Q6 — what a rule's action IS — 2026-08-04
+(a) fixed structured action vocabulary; (b) free-text instruction handed to the LLM step after cheap structured match; (c) full user TypeScript validated by itx.docs.typecheck. Sub-claude recommends (b).
+
+## A6
+(b). Riders: rule shape mirrors egress (ordered, ruleKey, description, structured cheap match, wholesale replacement, first-match-wins [guess: over all-matching — simpler; revisit for multi-category]); LLM step returns structured result envelope (category, extractedUrl, extractedText, notes) — instruction controls content not shape; (c) typecheck-validated rule scripts noted as future work.
+
+---
+
+## Q7 — cost gate: when does OCR run? — 2026-08-04
+iOS tags screenshots natively (mediaSubtypes 'screenshot' — free). (a) OCR everything; (b) OCR gated on free isScreenshot flag, one shared OCR pass feeds all rule matching; (c) dynamic two-pass gating per rule set. Sub-claude recommends (b).
+
+## Q7 hiccup
+Sub-claude misread A7 as a background-task notification and held; A7 restated verbatim as an explicit user turn; accepted.
+
+## A7
+(b) confirmed. mediaSubtypes/creationTime/dimensions captured on-device before recompression, carried in per-asset records. Layers: 0 = on-device metadata (free); 1 = shared OCR via ai.run cheap model, screenshots only, cached per asset; 2 = LLM instruction for rule-matched only. (c) future optimization.
+
+---
+
+## Q8 — where results land — 2026-08-04
+(a) event + processor state, queryable via listByCategory/getResult RPCs; (b) also write per-category index files; (c) (a) now, (b) future. Sub-claude recommends (c)/(a)-for-MVP.
+
+## A8
+(c)/(a)-for-MVP. Rider: dogfood read surface is itx scripts — listByCategory/getResult/signed-url must make "this week's interesting-tech-articles with links" a three-line script. Future: per-category markdown digests; gallery lens as fifth lens per tasks/workspace-lenses-consolidation.md.
+
+---
+
+## Q9 — ownership: which device syncs into which project — 2026-08-04
+(a) explicit per-device opt-in, possibly multiple projects; (b) one project per device enforced. Sub-claude recommends (a), noting sync is device-initiated push so no first-phone race.
+
+## A9
+(a). Explicit per-device per-project opt-in; task file must answer the location-reminders comparison head-on (device-initiated push, no first-phone race). Toggle state lives on-device [guess: device-local rather than server registry — device is the actor; server just sees who appends].
+
+Sub-claude finding: egress rules have no settings UI — configured by itx call only; photo rules follow suit for MVP (photos-rules-configured via itx script, no settings screen).
+
+---
+
+## Q10 — MVP cut: horizontal vs vertical slice — 2026-08-04
+(a) horizontal (sync → backfill → rules → bg refresh); (b) vertical thin slice through every layer (no backfill/BG in M1). Sub-claude recommends (b). Also asks: is the X-post rule the right M1 rule, or a simpler "any screenshot → uncategorized + text" first?
+
+## A10
+(b) vertical. Simple rule ("any screenshot → uncategorized + extractedText") is the built-in spec/e2e fixture proving the spine; the X-post rule is pure config (match + instruction string) and serves as M1's dogfood acceptance demo on the real project, allowed to be imperfect (URL recovery via itx.mcp.exa from handle+text). If the X-post rule needs any code beyond config, that's a rule-model design bug.
+
+---
+
+## Termination — 2026-08-04
+Sub-claude ran the stopping-rule checklist across all branches (capture, transport/dedup, storage/index, rules model, pipeline layers, outputs, ownership, MVP cut), found nothing in tension, declared "Ready for Phase 2."

--- a/tasks/screenshots-collector.md
+++ b/tasks/screenshots-collector.md
@@ -1,0 +1,11 @@
+---
+status: needs-grilling
+size: large
+tags: [mobile, files, processors, ai]
+---
+
+# Screenshots collector
+
+A photo-library collector built on iterate: the mobile app gains full photo-library access, syncs photos into a project's file storage in the background, and a per-project rules pipeline processes each photo with cheap-first layers (metadata → screenshot heuristics → OCR/small models via `itx.ai.run` → LLM agent only for photos that earn it). Rules are user-configurable, e.g. "screenshot of an X post → find the post URL, capture the text, categorise as 'interesting tech articles'".
+
+Being fleshed out via a grill-you interview; transcript will land alongside this file.

--- a/tasks/screenshots-collector.md
+++ b/tasks/screenshots-collector.md
@@ -1,11 +1,88 @@
 ---
-status: needs-grilling
+state: ready
+priority: medium
 size: large
 tags: [mobile, files, processors, ai]
 ---
 
 # Screenshots collector
 
-A photo-library collector built on iterate: the mobile app gains full photo-library access, syncs photos into a project's file storage in the background, and a per-project rules pipeline processes each photo with cheap-first layers (metadata → screenshot heuristics → OCR/small models via `itx.ai.run` → LLM agent only for photos that earn it). Rules are user-configurable, e.g. "screenshot of an X post → find the post URL, capture the text, categorise as 'interesting tech articles'".
+**Status summary:** specced via grill-you interview ([transcript](screenshots-collector.interview.md)), not started. Every design branch resolved; guesses flagged below. M1 is a thin vertical slice: permission → foreground sync → one rule → OCR → LLM → queryable result.
 
-Being fleshed out via a grill-you interview; transcript will land alongside this file.
+The mobile app gains full photo-library access, syncs photos into a project's file storage, and a per-project rules pipeline processes each photo cheap-first: free on-device metadata → OCR via `itx.ai.run` (screenshots only) → LLM instruction only for photos whose rule matched. Rules are user-configured, e.g. "screenshot of an X post → find the post URL, capture the text, categorise as 'interesting tech articles'".
+
+## Design decisions (from the interview)
+
+**Sync pass** is the unit of work: diff library → upload deltas → append one batch event. Trigger-agnostic by contract; foreground-open and a manual "sync now" button are the only *contracted* triggers. `BGAppRefreshTask` (expo-background-fetch + expo-task-manager) is a contract-free opportunistic accelerant — nothing durable may depend on it firing — and ships only after an on-device prototype (see checklist). Silent-push-triggered sync is a named future lever, not designed here.
+
+**Backfill** is a separate explicit job: newest-first, throttled, resumable, with a simple max-N-per-pass safety cap. Forward sync starts at grant time; backfill is user-triggered.
+
+**Permissions**: iOS presents a three-way prompt (Full / Limited "Select Photos" / Deny), surfaced by `expo-media-library` as `accessPrivileges: 'all' | 'limited' | 'none'`, and users can downgrade later in Settings. Degrade gracefully — a sync pass doesn't care how big the visible library is; show a soft "Limited access" banner, never a blocking screen.
+
+**Ingestion** mirrors email ingress (`apps/os/src/domains/email/email-ingress.ts`), not `agent.addFiles`: bytes go directly to `itx.files` at `/photos/inbound/<stableKey>-<filename>`, then one project-level `photos-synced` event per sync-pass batch carries an array of per-asset records (stored path, stableKey, metadata). No agent feed involved — coupling a 14k-photo backfill to agent compaction semantics would be a design smell. Verified: `itx.files.get(path).put()` and `itx.streams.get(path).append()` are both callable from the mobile capnweb stub over the existing socket; zero new server seam.
+
+**Dedup**: stable key = iOS asset `localIdentifier` + content hash, never random (email-ingress `messageKey` doctrine). The client keeps a local synced-cursor as *disposable cache*; the collector processor's DO-SQLite reduction of `photos-synced` events is the durable source of truth, exposed as `alreadySynced(stableKeys[]) -> stableKeys[]` on the collector capability surface. Wiping the local cursor and reconciling from the server must always be safe (reinstall, second device).
+
+**Metadata**: `expo-image-picker`-style recompression strips EXIF, so capture `mediaSubtypes` (iOS natively tags screenshots — free `isScreenshot`), `creationTime`, and dimensions on-device *before* recompression and carry them in the per-asset event records. The server never infers screenshot-ness.
+
+**Rules** follow the egress-rules precedent (`project-processor-contract.ts` `egress-rules-configured`): ordered list, `ruleKey`, `description`, wholesale replacement in one `photos-rules-configured` event, first-match-wins. `match` is structured and cheap (`isScreenshot`, `ocrKeywords`, dimensions, …). The *action* is a free-text instruction string handed to the LLM step when a photo matches. The LLM returns a structured result envelope — `category`, `extractedUrl`, `extractedText`, `notes` — the instruction controls the content, not the shape. Configured via itx script (like egress rules — no settings UI for MVP).
+
+**Pipeline layers** (cheap-first):
+- Layer 0 — on-device metadata, free. Non-screenshots short-circuit here for content rules.
+- Layer 1 — one shared OCR pass per screenshot via `itx.ai.run` with a cheap model, cached per asset, feeding match evaluation for every rule.
+- Layer 2 — LLM instruction, only for photos whose rule matched. Follows the obligation pattern (`…-requested` with expiry → `…-settled` with result union).
+
+**Outputs**: terminal per-photo processed event folded into the same processor state; queryable via `listByCategory(category)` / `getResult(stableKey)` plus signed-URL access on the collector capability. The MVP read surface is itx scripts — "this week's interesting-tech-articles with links" must be a three-line script.
+
+**Ownership**: explicit per-device, per-project opt-in toggle (device-local state); a device may feed multiple projects, each deliberately enabled. This answers the location-reminders trap head-on: photo sync is *device-initiated push* — the device the user toggled decides to run a sync pass — not the project reacting to an ambiguous set of candidate devices, so there is no first-phone race to arbitrate.
+
+## Checklist
+
+### M1 — vertical slice (the product, small)
+
+- [ ] Add `expo-media-library`; permission flow with graceful Limited-Access degrade + soft banner (new native module ⇒ new EAS dev-client build)
+- [ ] Sync-pass engine: enumerate assets, compute stable keys, reconcile via local cursor + `alreadySynced`, upload deltas to `itx.files`, append one `photos-synced` batch event with per-asset metadata records (captured pre-recompression)
+- [ ] Per-project "collect photos into this project" toggle + manual "sync now" (foreground-open trigger too); device-local toggle state
+- [ ] Collector processor (contract/implementation split per doctrine): reduce `photos-synced` into synced-state; expose `alreadySynced`
+- [ ] `photos-rules-configured` event + rule schema (egress-shaped; structured match, instruction action)
+- [ ] Layer 1: shared OCR pass via `itx.ai.run` gated on `isScreenshot`, cached per asset
+- [ ] Layer 2: LLM instruction step as an obligation (`…-requested`/`…-settled`), structured result envelope
+- [ ] Read surface: `listByCategory` / `getResult` / signed-URL on the collector capability
+- [ ] Spec/e2e fixture rule: "any screenshot → category `uncategorized` + extractedText" proving the spine end-to-end
+- [ ] Dogfood acceptance demo: configure the X-post rule (pure config — match + instruction; URL recovery may lean on `itx.mcp.exa` from handle+text; imperfect is fine). If it needs *any* code beyond config, treat that as a rule-model design bug
+
+### M2 — backfill
+
+- [ ] Explicit "import existing library" job: newest-first, throttled, resumable across app restarts, max-N-per-pass cap, visible progress
+
+### M3 — background refresh (prototype-gated)
+
+- [ ] Prototype `BGAppRefreshTask` behavior on-device across lock, reboot, force-quit, low-power *before* wiring it to sync (location-reminders lesson)
+- [ ] If the prototype earns it: register the task as a contract-free trigger of the same sync pass
+
+## Guesses and assumptions
+
+- [guess] BGAppRefreshTask is in scope (M3) rather than deferred entirely — "at whatever cadence is possible" was explicit in the original ask.
+- [guess] Newest-first backfill ordering — recent screenshots are the valuable ones.
+- [guess] First-match-wins rule semantics (over all-matching) — simpler, mirrors egress; revisit if one photo should land in two categories.
+- [guess] Device-local toggle state rather than a server-side device registry entry — the device is the actor; server state adds a reconciliation problem for zero benefit.
+
+## Out of scope
+
+- Android; Expo Go restoration.
+- Agent-turn vision content parts (transport is text-only today; vision goes through `ai.run`).
+- Settings UI for rules (itx-script configured, like egress rules).
+- Billing/quotas beyond the max-N safety cap.
+- Silent-push-triggered sync (future lever, uses existing device/notification stack).
+
+## For the next pass
+
+- Typecheck-validated user rule *scripts* (`itx.docs.typecheck`) as a power-user escape hatch beyond instruction strings.
+- Per-category markdown digest files; a gallery/screenshots lens as a natural fifth lens in `tasks/workspace-lenses-consolidation.md`.
+- Dynamic per-rule-set OCR gating (only run OCR if a live rule still needs content signal).
+- Multi-category (all-matching) rule semantics if wanted.
+
+## Notes
+
+- High-volume stream delivery is a known weak point (`tasks/redesign-high-volume-stream-delivery-transport.md`); batch events per sync pass (not per photo) is deliberate mitigation. A 20k backfill will still exercise it — keep the cap conservative at first.
+- Interview transcript: [screenshots-collector.interview.md](screenshots-collector.interview.md)


### PR DESCRIPTION
Spec-only PR from a grill-you session: a fleshed-out task file for the screenshots-collector feature, plus the full interview transcript for the decision trail.

## What the feature is

The mobile app gains full photo-library access, syncs photos into a project's files, and a per-project rules pipeline processes each photo cheap-first — free on-device metadata (iOS tags screenshots natively) → one shared OCR pass via `itx.ai.run` → LLM instruction only for rule-matched photos. Rules are egress-shaped config: structured cheap `match` + a free-text instruction, e.g.

```ts
await itx.streams.get("/").append({
  type: "events.iterate.com/photos/rules-configured",
  payload: { rules: [{
    ruleKey: "x-posts",
    description: "Screenshots of X posts",
    match: { isScreenshot: true, ocrKeywords: ["Repost", "Quote", "@"] },
    instruction: "Find the URL for the post (search by handle + text if needed), capture the text, categorise as 'interesting tech articles'",
  }]},
})
```

## Key calls made in the interview

- Sync pass is trigger-agnostic; only foreground-open + manual "sync now" are contracted. `BGAppRefreshTask` is a contract-free accelerant gated behind an on-device prototype (the location-reminders lesson, answered head-on).
- Ingestion copies email ingress, not `agent.addFiles`: bytes to `itx.files` at the door, one `photos-synced` batch event per sync pass. Verified both are callable from the mobile capnweb stub — zero new server seam.
- Dedup: `localIdentifier` + content hash; processor DO-SQLite state is the source of truth (`alreadySynced` query); client cursor is disposable cache.
- Results land in processor state, queryable via `listByCategory`/`getResult` — itx scripts are the MVP read surface.
- M1 is a vertical slice: one screenshot gets categorized and queried end-to-end. Backfill is M2, background refresh M3.

Guesses (vs. facts) are flagged in the task file's **Guesses and assumptions** section; the full decision trail is in [tasks/screenshots-collector.interview.md](https://github.com/iterate/iterate/blob/screenshots-collector/tasks/screenshots-collector.interview.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session: 1ba80473-737e-4184-a6ca-457c21d11eff

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Docs | +180 -0 | +117 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+180 -0** | **+117 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 8232fee and 32c1cca, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->