### PR TITLE
Fix main CI: trim default agent prompt back under its 4200-token budget

### DIFF
--- a/apps/os/src/domains/agents/agent-defaults.ts
+++ b/apps/os/src/domains/agents/agent-defaults.ts
@@ -205,7 +205,7 @@ export const DEFAULT_AGENT_SYSTEM_PROMPT = [
   "- Most scripts should fetch data and RETURN it. You cannot see data while writing the script, so code that interprets response shapes you have never seen is guesswork. Get the data in front of your eyes; decide on the next turn.",
   "- YOU are the LLM: don't pipe content through `itx.ai.run` to summarize, draft, or answer — return the data and write it yourself. `ai.run` is for what you cannot do: images, audio, transcription, bulk classification.",
   "- The script body is real TypeScript: `Promise.all` fans out independent calls, `Promise.race` bounds anything that might hang (scripts get minutes, not hours), map/filter/loops handle mechanical iteration.",
-  "- Return only what you need: pick fields, slice arrays. Oversized results render as an inferred type plus a small structural preview, and the FULL result is saved to a workspace file — the notice names the path; read it with `itx.workspace.readFile` and filter it in plain TypeScript instead of re-fetching.",
+  "- Return only what you need: pick fields, slice arrays. Oversized results render as an inferred type plus a preview; the FULL result is saved to a workspace file — the notice names the path; read it with `itx.workspace.readFile` and filter it in TypeScript instead of re-fetching.",
   "- Send as many chat messages per script as helps: an acknowledgement before slow work, one message per result, a final summary.",
   "",
   "OTHER AGENTS — the semantics behind the tour's delegation calls:",
@@ -232,7 +232,10 @@ export const DEFAULT_AGENT_SYSTEM_PROMPT = [
 // (itx.worker.docs.link mints both views; itx.worker.tasks is gone).
 // 7: THE SHAPE OF WORK gains the "YOU are the LLM" bullet — don't pipe
 // content through itx.ai.run to summarize/draft/answer.
-const DEFAULT_AGENT_SYSTEM_PROMPT_REVISION = "7";
+// 8: budget trim — #2399 and #2400 each grew the prompt concurrently and the
+// merge overshot the 4200-token ceiling; the oversized-results bullet loses
+// "small structural"/"plain" wording, no meaning change.
+const DEFAULT_AGENT_SYSTEM_PROMPT_REVISION = "8";
 const AGENT_MODEL_POLICY_REVISION = "2";
 const AGENT_WORKSPACE_POLICY_REVISION = "3";
 const AGENT_BOOT_CONTEXT_REVISION = "3";

--- a/tasks/complete/2026-08-04-fix-default-prompt-budget.md
+++ b/tasks/complete/2026-08-04-fix-default-prompt-budget.md
@@ -1,11 +1,11 @@
 ---
-status: done-pending-ci
+status: done
 size: small
 ---
 
 # Fix main CI: default agent prompt 13 chars over budget
 
-**Status summary:** fix implemented and verified locally (full apps/os suite + typecheck/lint/knip green). Awaiting CI on PR #2406.
+**Status summary:** done — PR #2406 fully green (all Depot checks pass, mergeable CLEAN).
 
 Main has been red since fe7167f6b (#2399). `agent-prompt-budgets.test.ts > the default prompt stays under 4200 tokens` fails: 16813 chars vs the 16800 ceiling (4200 tokens × 4 chars/token).
 

--- a/tasks/fix-default-prompt-budget.md
+++ b/tasks/fix-default-prompt-budget.md
@@ -1,11 +1,11 @@
 ---
-status: in-progress
+status: done-pending-ci
 size: small
 ---
 
 # Fix main CI: default agent prompt 13 chars over budget
 
-**Status summary:** spec committed; fix is a small prompt trim + revision bump. Main red since fe7167f6b.
+**Status summary:** fix implemented and verified locally (full apps/os suite + typecheck/lint/knip green). Awaiting CI on PR #2406.
 
 Main has been red since fe7167f6b (#2399). `agent-prompt-budgets.test.ts > the default prompt stays under 4200 tokens` fails: 16813 chars vs the 16800 ceiling (4200 tokens × 4 chars/token).
 
@@ -18,11 +18,12 @@ Each PR was green alone; the merge is 13 chars over.
 
 ## Plan
 
-- [ ] Trim the #2400 bullet wording in `apps/os/src/domains/agents/agent-defaults.ts` to get comfortably under 16800 without losing meaning (no ceiling raise — the test says raises must be argued in a PR, and this overshoot is accidental, not an ask)
-- [ ] Bump `DEFAULT_AGENT_SYSTEM_PROMPT_REVISION` 7 → 8 (content changed → shipped payload changes; MCP/onboarding revisions derive from it)
-- [ ] `pnpm vitest run agent-prompt-budgets` green in apps/os
-- [ ] typecheck/lint/knip clean
+- [x] Trim the #2400 bullet wording in `apps/os/src/domains/agents/agent-defaults.ts` to get comfortably under 16800 without losing meaning _("a small structural preview" → "a preview", "in plain TypeScript" → "in TypeScript"; prompt now 16786 chars, 14 headroom. Bullet 207 already teaches that the script body is real TypeScript.)_
+- [x] Bump `DEFAULT_AGENT_SYSTEM_PROMPT_REVISION` 7 → 8 _(MCP/onboarding revisions derive from it automatically)_
+- [x] `pnpm vitest run agent-prompt-budgets` green in apps/os _(7/7; full apps/os suite also green: 2547 passed)_
+- [x] typecheck/lint/knip clean _(all green locally)_
 
 ## Implementation notes
 
-(log below as work happens)
+- Kept the ceiling at 4200 — the overshoot is accidental accretion from a concurrent merge, not a product ask, so trimming beats raising.
+- Trim taken from the newer #2400 wording rather than #2399's bullet since it had the most compressible adjectives.

--- a/tasks/fix-default-prompt-budget.md
+++ b/tasks/fix-default-prompt-budget.md
@@ -1,0 +1,28 @@
+---
+status: in-progress
+size: small
+---
+
+# Fix main CI: default agent prompt 13 chars over budget
+
+**Status summary:** spec committed; fix is a small prompt trim + revision bump. Main red since fe7167f6b.
+
+Main has been red since fe7167f6b (#2399). `agent-prompt-budgets.test.ts > the default prompt stays under 4200 tokens` fails: 16813 chars vs the 16800 ceiling (4200 tokens × 4 chars/token).
+
+Cause: semantic conflict between two PRs that both grew `DEFAULT_AGENT_SYSTEM_PROMPT`:
+
+- #2400 (merged 12:59) grew the "Return only what you need" bullet by ~46 chars (inferred type + structural preview wording).
+- #2399 (merged 13:25, branched before #2400 landed) added the "YOU are the LLM" bullet and raised the ceiling 4150 → 4200, leaving ~30 chars of headroom against the main it could see.
+
+Each PR was green alone; the merge is 13 chars over.
+
+## Plan
+
+- [ ] Trim the #2400 bullet wording in `apps/os/src/domains/agents/agent-defaults.ts` to get comfortably under 16800 without losing meaning (no ceiling raise — the test says raises must be argued in a PR, and this overshoot is accidental, not an ask)
+- [ ] Bump `DEFAULT_AGENT_SYSTEM_PROMPT_REVISION` 7 → 8 (content changed → shipped payload changes; MCP/onboarding revisions derive from it)
+- [ ] `pnpm vitest run agent-prompt-budgets` green in apps/os
+- [ ] typecheck/lint/knip clean
+
+## Implementation notes
+
+(log below as work happens)


### PR DESCRIPTION
Main has been red since fe7167f6b: `agent-prompt-budgets.test.ts > the default prompt stays under 4200 tokens` fails with 16813 chars vs the 16800 ceiling.

Semantic conflict, not a bad PR: #2400 (merged 12:59) grew the "Return only what you need" bullet by ~46 chars, and #2399 (merged 13:25, branched before #2400 landed) added the "YOU are the LLM" bullet and raised the ceiling to 4200 with ~30 chars of headroom against the main it could see. Each was green alone; the merge is 13 chars over.

Fix: trim wording in the #2400 bullet (no meaning lost), no ceiling raise — the overshoot is accidental accretion, exactly what the budget test exists to catch. Bumps `DEFAULT_AGENT_SYSTEM_PROMPT_REVISION` 7 → 8 since the shipped payload changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +5 -2 | +2 -2 🟩⬜⬜⬜⬜ |
| Docs | +29 -0 | +19 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+34 -2** | **+21 -2** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 2a271a2 and 71d12ce, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

> [!CAUTION]
> This PR is a draft, so it doesn't claim a preview slot. To get previews: add the `preview` label, mark the PR ready for review, or dispatch the Cloudflare Previews workflow for a one-off run.

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": "This PR is a draft, so it doesn't claim a preview slot. To get previews: add the `preview` label, mark the PR ready for review, or dispatch the Cloudflare Previews workflow for a one-off run."
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->


Session: `3468eef4-5985-40d5-a4e4-3ab937d63833`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only prompt trim plus a revision bump to keep agent setup idempotency correct; no runtime logic or security paths change.
> 
> **Overview**
> Restores **main CI** by shrinking the default agent system prompt so `agent-prompt-budgets` passes again (16813 chars vs the 16800 ceiling after concurrent merges of #2399 and #2400).
> 
> In `agent-defaults.ts`, the **"Return only what you need"** bullet under **THE SHAPE OF WORK** drops redundant wording ("small structural" → "a preview", "in plain TypeScript" → "in TypeScript") with no intended semantic change. **`DEFAULT_AGENT_SYSTEM_PROMPT_REVISION`** is bumped **7 → 8** so shipped system-context payloads match the trimmed text (MCP/onboarding revisions that embed the default prompt follow automatically).
> 
> The 4200-token ceiling is **not** raised; the overshoot is treated as accidental merge accretion rather than a product ask to expand the prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71d12ce289b0414961dd6c841c711b260ccd5aab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->