### PR TITLE
mobile: package.json script edits no longer strand installed builds

### DIFF
--- a/apps/mobile/fingerprint.config.js
+++ b/apps/mobile/fingerprint.config.js
@@ -1,0 +1,10 @@
+// The expo-updates runtime fingerprint decides which JS updates an installed
+// binary will accept. By default it hashes package.json scripts, so editing
+// e.g. `update:preview` would bump the runtime and strand every installed
+// build on stale JS despite zero native changes (bitten on PR #2410). Scripts
+// never ship in the bundle — skip them. Dependencies still count.
+/** @type {import('@expo/fingerprint').Config} */
+const config = {
+  sourceSkips: ["PackageJsonScriptsAll"],
+};
+module.exports = config;

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -10,7 +10,7 @@
     "build:development:ios": "pnpm dlx eas-cli@21.0.1 build --platform ios --profile development",
     "build:simulator:ios": "pnpm dlx eas-cli@21.0.1 build --platform ios --profile development-simulator",
     "build:preview:ios": "pnpm dlx eas-cli@21.0.1 build --platform ios --profile preview",
-    "update:preview": "node scripts/write-build-info.mjs && pnpm dlx eas-cli@21.0.1 update --channel preview --platform ios; s=$?; git restore src/build-info.json; exit $s",
+    "update:preview": "node scripts/write-build-info.mjs && pnpm dlx eas-cli@21.0.1 update --channel preview --platform ios --clear-cache --message \"$(git log -1 --format=%s)\"; s=$?; git restore src/build-info.json; exit $s",
     "eas-build-pre-install": "node scripts/write-build-info.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --reporter=default --reporter=../../packages/shared/src/test-support/e2e-policy/retry-telemetry-reporter.ts",

--- a/tasks/complete/2026-08-04-mobile-fingerprint-sourceskips.md
+++ b/tasks/complete/2026-08-04-mobile-fingerprint-sourceskips.md
@@ -1,0 +1,18 @@
+---
+status: done
+size: small
+---
+
+# Mobile: stop package.json scripts changing the runtime fingerprint
+
+**Status summary:** done and locally verified. One config file plus the re-landed `update:preview` fixes that the fingerprint gotcha forced out of PR #2410.
+
+The expo-updates fingerprint runtime policy hashed `package.json` scripts: editing `update:preview` on PR #2410 moved the fingerprint from `37fb004c` to `f195c3d2`, which would have stranded every installed binary on stale JS despite zero native changes.
+
+- [x] add `apps/mobile/fingerprint.config.js` with `sourceSkips: ["PackageJsonScriptsAll"]` _scripts never ship in the bundle; deps still count_
+- [x] verify a scripts-only edit no longer changes the hash _`expo-updates fingerprint:generate` → `1bf9f0fe` with and without a script edit_
+- [x] re-land the `update:preview` fixes reverted from #2410 _`--message "$(git log -1 --format=%s)"` (eas requires --message when non-interactive) and `--clear-cache` (Metro's shared cache leaks absolute paths across worktrees — see #2410's task notes)_
+
+## Implementation notes
+
+- Landing this changes the fingerprint once (`37fb004c` → `1bf9f0fe`-ish as computed on merge): the merge-to-main workflow will detect no matching preview build and auto-trigger one — Misha reinstalls one more time, then script edits are permanently fingerprint-neutral.


### PR DESCRIPTION
Editing a package.json script — any script, even one that never runs on a phone — currently changes the expo-updates runtime fingerprint, silently stranding every installed binary on stale JS. Discovered on #2410, where a one-line `update:preview` fix moved the fingerprint from `37fb004c` to `f195c3d2` and had to be reverted.

`fingerprint.config.js` now skips package.json scripts (`sourceSkips: ["PackageJsonScriptsAll"]`). Verified with `expo-updates fingerprint:generate`: the hash is identical with and without a script edit. Dependency changes still count, as they should.

With that safe, this also re-lands the reverted `update:preview` fixes: `--message` from the commit subject (eas-cli hard-requires it in non-interactive shells) and `--clear-cache` (Metro's shared cache leaks absolute paths across git worktrees, breaking exports).

**After merge:** the fingerprint changes one final time, so the merge workflow will auto-trigger a fresh preview build — one more manual install, then script edits are permanently fingerprint-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session: `5daba6b0-cb79-4137-b08f-5a25efebbafe`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

> [!CAUTION]
> This PR is a draft, so it doesn't claim a preview slot. To get previews: add the `preview` label, mark the PR ready for review, or dispatch the Cloudflare Previews workflow for a one-off run.

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": "This PR is a draft, so it doesn't claim a preview slot. To get previews: add the `preview` label, mark the PR ready for review, or dispatch the Cloudflare Previews workflow for a one-off run."
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Mobile | +11 -1 | +5 -1 🟩🟩🟩⬜⬜ |
| Docs | +18 -0 | +12 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+29 -1** | **+17 -1** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 7d0b7f2 and 0933970, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how runtime versions are computed (one-time fingerprint bump and preview reinstall) and alters the preview publish script; dependency changes still affect the fingerprint as before.
> 
> **Overview**
> **Expo runtime fingerprint** no longer includes `package.json` scripts, so editing npm scripts (e.g. `update:preview`) won’t bump the runtime version and strand installed preview binaries on stale JS when there are no native changes.
> 
> Adds `apps/mobile/fingerprint.config.js` with `sourceSkips: ["PackageJsonScriptsAll"]` so only dependency-related inputs still affect the fingerprint (`app.json` already uses `runtimeVersion.policy: "fingerprint"`).
> 
> **`update:preview`** is updated with `--clear-cache` (Metro cache path leakage across worktrees) and `--message "$(git log -1 --format=%s)"` so non-interactive EAS update runs satisfy eas-cli’s message requirement—changes that were reverted on PR #2410 because of the fingerprint issue.
> 
> **After merge:** the fingerprint will change once when this config lands; CI should trigger a new preview native build so testers reinstall once, then script-only edits stay fingerprint-neutral.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09339703767940b2d3f01dfa95d0e11c9fbba9dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->