### PR TITLE
mobile: per-PR preview channels, in-app switcher, QR codes on PR bodies

### DIFF
--- a/.depot/workflows/mobile-pr-preview.yml
+++ b/.depot/workflows/mobile-pr-preview.yml
@@ -1,0 +1,35 @@
+name: Mobile PR Preview
+permissions:
+  contents: write # QR PNGs upload to the gh-attach-assets release
+  pull-requests: write
+concurrency:
+  # Within one PR the newest push wins - cancel stale publishes. Across PRs
+  # channels are independent, so runs proceed in parallel.
+  group: mobile-pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+on:
+  pull_request:
+    paths:
+      - apps/mobile/**
+jobs:
+  publish:
+    runs-on:
+      size: 2x8
+      image: 0p91s0lz49.registry.depot.dev/iterate-preview-ci:node24-pnpm10-worktree
+    timeout-minutes: 30
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          clean: false
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Reconcile dependencies (baked)
+        run: pnpm install --frozen-lockfile --prefer-offline
+      # EXPO_TOKEN lives in the Doppler _shared project and is inherited by
+      # os/prd; eas-cli picks it up from the environment.
+      - name: Publish PR channel and update PR body
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+        run: doppler run --project os --config prd -- pnpm tsx scripts/ci/publish-mobile-pr-preview.ts

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -74,9 +74,23 @@ same merges are the ones that need a manual dev-client rebuild
 `eas update` publishes stamp `src/build-info.json` via
 `scripts/write-build-info.mjs` (EAS native builds run it through the
 `eas-build-pre-install` hook). The checked-in file is an all-empty
-placeholder — don't commit a stamped one. Manual publish, e.g. to push a
-branch's JS to your installed preview app without waiting for a merge:
+placeholder — don't commit a stamped one. Manual publish to the shared
+main channel (rare — see per-PR channels below):
 `pnpm --dir apps/mobile update:preview`.
+
+### Per-PR channels
+
+The `preview` channel is main-only; publishing PR work to it would be
+last-write-wins chaos. PRs touching `apps/mobile/**` get their own channel
+named after the branch: CI (`.depot/workflows/mobile-pr-preview.yml` →
+`scripts/ci/publish-mobile-pr-preview.ts`) publishes on every push and
+maintains a PR-body section with two tappable QR codes — an
+`iterate://preview-channel/<channel>` deep link that switches the installed
+app to the PR's channel (confirm screen, then fetch + reload), and the
+matching build's install page for when the runtime differs or the app isn't
+installed. Whichever the fingerprint heuristic says you need is expanded.
+The switch persists across restarts; get back with **Build info → Reset to
+default channel**.
 
 ## Run and test it in a browser
 

--- a/apps/mobile/fingerprint.config.js
+++ b/apps/mobile/fingerprint.config.js
@@ -1,0 +1,10 @@
+// The expo-updates runtime fingerprint decides which JS updates an installed
+// binary will accept. By default it hashes package.json scripts, so editing
+// e.g. `update:preview` would bump the runtime and strand every installed
+// build on stale JS despite zero native changes (bitten on PR #2410). Scripts
+// never ship in the bundle — skip them. Dependencies still count.
+/** @type {import('@expo/fingerprint').Config} */
+const config = {
+  sourceSkips: ["PackageJsonScriptsAll"],
+};
+module.exports = config;

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -10,7 +10,7 @@
     "build:development:ios": "pnpm dlx eas-cli@21.0.1 build --platform ios --profile development",
     "build:simulator:ios": "pnpm dlx eas-cli@21.0.1 build --platform ios --profile development-simulator",
     "build:preview:ios": "pnpm dlx eas-cli@21.0.1 build --platform ios --profile preview",
-    "update:preview": "node scripts/write-build-info.mjs && pnpm dlx eas-cli@21.0.1 update --channel preview --platform ios; s=$?; git restore src/build-info.json; exit $s",
+    "update:preview": "node scripts/write-build-info.mjs && pnpm dlx eas-cli@21.0.1 update --channel preview --platform ios --clear-cache --message \"$(git log -1 --format=%s)\"; s=$?; git restore src/build-info.json; exit $s",
     "eas-build-pre-install": "node scripts/write-build-info.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --reporter=default --reporter=../../packages/shared/src/test-support/e2e-policy/retry-telemetry-reporter.ts",

--- a/apps/mobile/scripts/write-build-info.mjs
+++ b/apps/mobile/scripts/write-build-info.mjs
@@ -25,7 +25,9 @@ const git = (args) => {
 const env = process.env;
 const info = {
   commit: env.EAS_BUILD_GIT_COMMIT_HASH || git("rev-parse HEAD"),
-  branch: env.GITHUB_REF_NAME || git("rev-parse --abbrev-ref HEAD"),
+  // GITHUB_HEAD_REF is the PR head branch (pull_request runs); GITHUB_REF_NAME
+  // is "<n>/merge" there, so it only wins on push runs where it's the real branch.
+  branch: env.GITHUB_HEAD_REF || env.GITHUB_REF_NAME || git("rev-parse --abbrev-ref HEAD"),
   builtBy: env.EAS_BUILD_USERNAME || env.GITHUB_ACTOR || userInfo().username,
   machine: env.EAS_BUILD ? "eas-build" : env.CI ? "ci" : hostname(),
   builtAt: new Date().toISOString(),

--- a/apps/mobile/src/app/build-info.tsx
+++ b/apps/mobile/src/app/build-info.tsx
@@ -12,6 +12,7 @@ import { Stack } from "expo-router";
 import * as Updates from "expo-updates";
 import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 import { buildInfo } from "../lib/build-info.ts";
+import { getPreviewChannelOverride, switchChannelAndReload } from "../lib/preview-channel.ts";
 import { colors, radius, spacing } from "../lib/theme.ts";
 
 export default function BuildInfoScreen() {
@@ -20,6 +21,19 @@ export default function BuildInfoScreen() {
     // Unavailable on web; the row shows "—" there.
     queryFn: () => Application.getInstallationTimeAsync().catch(() => null),
     staleTime: Infinity,
+  });
+  const channelOverride = useQuery({
+    queryKey: ["preview-channel-override"],
+    queryFn: getPreviewChannelOverride,
+  });
+  const resetChannel = useMutation({
+    mutationFn: async () => {
+      const result = await switchChannelAndReload(null);
+      await channelOverride.refetch();
+      return result === "no-update"
+        ? "Override cleared — no newer update on the default channel"
+        : "Restarting…";
+    },
   });
   const check = useMutation({
     mutationFn: async () => {
@@ -54,10 +68,27 @@ export default function BuildInfoScreen() {
       </Section>
       <Section title="Updates">
         <Row label="Channel" value={Updates.channel} />
+        <Row label="Channel override" value={channelOverride.data} />
         <Row label="Runtime version" value={Updates.runtimeVersion} />
         <Row label="Update id" value={Updates.updateId} />
         <Row label="Update published" value={formatTime(Updates.createdAt?.toISOString())} />
       </Section>
+      {channelOverride.data ? (
+        <Pressable
+          accessibilityRole="button"
+          disabled={resetChannel.isPending}
+          onPress={() => resetChannel.mutate()}
+          style={[styles.button, resetChannel.isPending && styles.buttonDisabled]}
+        >
+          <Text style={styles.buttonLabel}>
+            {resetChannel.isPending ? "Resetting…" : "Reset to default channel"}
+          </Text>
+        </Pressable>
+      ) : null}
+      {resetChannel.data ? <Text style={styles.note}>{resetChannel.data}</Text> : null}
+      {resetChannel.error ? (
+        <Text style={styles.errorNote}>{String(resetChannel.error)}</Text>
+      ) : null}
       <Section title="App">
         <Row label="Version" value={Constants.expoConfig?.version} />
         <Row label="Native build" value={Application.nativeBuildVersion} />

--- a/apps/mobile/src/app/preview-channel/[channel].tsx
+++ b/apps/mobile/src/app/preview-channel/[channel].tsx
@@ -1,8 +1,8 @@
 // Deep-link target for PR preview QRs: iterate://preview-channel/<channel>.
 // Deliberately a confirm screen, not an auto-switch — a stray link tap
 // shouldn't silently repoint the app at another PR's JS.
-import { useMutation, useQuery } from "@tanstack/react-query";
-import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Redirect, Stack, useLocalSearchParams, useRouter } from "expo-router";
 import * as Updates from "expo-updates";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 import { buildInfo } from "../../lib/build-info.ts";
@@ -12,13 +12,23 @@ import { colors, radius, spacing } from "../../lib/theme.ts";
 export default function PreviewChannelScreen() {
   const { channel } = useLocalSearchParams<{ channel: string }>();
   const router = useRouter();
+  const queryClient = useQueryClient();
   const current = useQuery({
     queryKey: ["preview-channel-override"],
     queryFn: getPreviewChannelOverride,
   });
   const switchChannel = useMutation({
     mutationFn: () => switchChannelAndReload(channel),
+    // Only reaches onSuccess without a reload ("no-update"); the invalidate
+    // flips `current` and the Redirect below takes over.
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["preview-channel-override"] }),
   });
+
+  // Already on the target channel — including the relaunch after a successful
+  // switch, where the deep link URL re-opens this screen. Nothing to confirm.
+  if (current.isSuccess && current.data === channel) {
+    return <Redirect href="/build-info" />;
+  }
 
   const currentChannel = current.data || Updates.channel || "preview";
 
@@ -61,7 +71,12 @@ export default function PreviewChannelScreen() {
       {switchChannel.error ? (
         <Text style={styles.errorNote}>{String(switchChannel.error)}</Text>
       ) : null}
-      <Pressable accessibilityRole="button" onPress={() => router.back()} style={styles.linkButton}>
+      <Pressable
+        accessibilityRole="button"
+        // Deep links open this screen with no back stack.
+        onPress={() => (router.canGoBack() ? router.back() : router.replace("/"))}
+        style={styles.linkButton}
+      >
         <Text style={styles.linkLabel}>Cancel</Text>
       </Pressable>
     </View>

--- a/apps/mobile/src/app/preview-channel/[channel].tsx
+++ b/apps/mobile/src/app/preview-channel/[channel].tsx
@@ -1,0 +1,123 @@
+// Deep-link target for PR preview QRs: iterate://preview-channel/<channel>.
+// Deliberately a confirm screen, not an auto-switch — a stray link tap
+// shouldn't silently repoint the app at another PR's JS.
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import * as Updates from "expo-updates";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { buildInfo } from "../../lib/build-info.ts";
+import { getPreviewChannelOverride, switchChannelAndReload } from "../../lib/preview-channel.ts";
+import { colors, radius, spacing } from "../../lib/theme.ts";
+
+export default function PreviewChannelScreen() {
+  const { channel } = useLocalSearchParams<{ channel: string }>();
+  const router = useRouter();
+  const current = useQuery({
+    queryKey: ["preview-channel-override"],
+    queryFn: getPreviewChannelOverride,
+  });
+  const switchChannel = useMutation({
+    mutationFn: () => switchChannelAndReload(channel),
+  });
+
+  const currentChannel = current.data || Updates.channel || "preview";
+
+  return (
+    <View style={styles.container}>
+      <Stack.Screen options={{ title: "Switch preview channel" }} />
+      <Text style={styles.heading}>Point this app at another channel?</Text>
+      <View style={styles.card}>
+        <Row label="Current" value={currentChannel} />
+        <Row label="Target" value={channel} />
+        <Row
+          label="Running"
+          value={`${buildInfo.branch || "?"} @ ${buildInfo.commit.slice(0, 9) || "?"}`}
+        />
+      </View>
+      {!Updates.isEnabled ? (
+        <Text style={styles.note}>
+          OTA updates are off in this bundle (Metro dev server) — channel switching only works in
+          installed builds.
+        </Text>
+      ) : (
+        <Pressable
+          accessibilityRole="button"
+          disabled={switchChannel.isPending}
+          onPress={() => switchChannel.mutate()}
+          style={[styles.button, switchChannel.isPending && styles.buttonDisabled]}
+        >
+          <Text style={styles.buttonLabel}>
+            {switchChannel.isPending ? "Switching…" : `Switch to ${channel}`}
+          </Text>
+        </Pressable>
+      )}
+      {switchChannel.data === "no-update" ? (
+        <Text style={styles.note}>
+          Switched, but the channel has nothing this binary can run — either nothing is published
+          yet, or the PR has native changes (install its build instead). The override sticks; the
+          app will pick updates up once compatible ones are published.
+        </Text>
+      ) : null}
+      {switchChannel.error ? (
+        <Text style={styles.errorNote}>{String(switchChannel.error)}</Text>
+      ) : null}
+      <Pressable accessibilityRole="button" onPress={() => router.back()} style={styles.linkButton}>
+        <Text style={styles.linkLabel}>Cancel</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string | null | undefined }) {
+  return (
+    <View style={styles.row}>
+      <Text style={styles.rowLabel}>{label}</Text>
+      <Text selectable style={styles.rowValue}>
+        {value || "—"}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { gap: spacing.lg, padding: spacing.lg },
+  heading: { color: colors.text, fontSize: 18, fontWeight: "600" },
+  card: {
+    backgroundColor: colors.surface,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    paddingHorizontal: spacing.md,
+  },
+  row: {
+    alignItems: "center",
+    borderBottomColor: colors.border,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    flexDirection: "row",
+    gap: spacing.md,
+    justifyContent: "space-between",
+    paddingVertical: 12,
+  },
+  rowLabel: { color: colors.textMuted, fontSize: 14 },
+  rowValue: {
+    color: colors.text,
+    flexShrink: 1,
+    fontSize: 14,
+    fontVariant: ["tabular-nums"],
+    textAlign: "right",
+  },
+  button: {
+    alignItems: "center",
+    backgroundColor: colors.surfaceRaised,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    paddingVertical: 14,
+  },
+  buttonDisabled: { opacity: 0.6 },
+  buttonLabel: { color: colors.text, fontSize: 16, fontWeight: "600" },
+  linkButton: { alignItems: "center", paddingVertical: 8 },
+  linkLabel: { color: colors.textMuted, fontSize: 14 },
+  note: { color: colors.textMuted, fontSize: 13, textAlign: "center" },
+  errorNote: { color: colors.danger, fontSize: 13, textAlign: "center" },
+});

--- a/apps/mobile/src/build-info.json
+++ b/apps/mobile/src/build-info.json
@@ -1,7 +1,7 @@
 {
-  "commit": "",
-  "branch": "",
-  "builtBy": "",
-  "machine": "",
-  "builtAt": ""
+  "commit": "09cb766babcdddc62d1458c7a0ec2115d5c9a634",
+  "branch": "mobile-per-pr-preview-channels",
+  "builtBy": "mmkal",
+  "machine": "Mishas-MacBook-Pro.local",
+  "builtAt": "2026-08-04T16:13:33.437Z"
 }

--- a/apps/mobile/src/lib/preview-channel.ts
+++ b/apps/mobile/src/lib/preview-channel.ts
@@ -1,0 +1,37 @@
+// Per-PR preview channels: the installed binary defaults to the channel baked
+// in at build time (`preview` = latest main), and this override points it at a
+// PR's channel instead. Uses the headers-only override, which expo-updates
+// allows without `disableAntiBrickingMeasures` because the override keys must
+// already exist in the embedded request headers (EAS embeds expo-channel-name).
+// The override persists natively (UserDefaults) across restarts; expo-updates
+// exposes no getter, so we mirror the active value in AsyncStorage ourselves.
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as Updates from "expo-updates";
+
+const STORAGE_KEY = "preview-channel-override";
+
+export async function setPreviewChannelOverride(channel: string | null) {
+  Updates.setUpdateRequestHeadersOverride(channel ? { "expo-channel-name": channel } : null);
+  if (channel) {
+    await AsyncStorage.setItem(STORAGE_KEY, channel);
+  } else {
+    await AsyncStorage.removeItem(STORAGE_KEY);
+  }
+}
+
+export async function getPreviewChannelOverride() {
+  return AsyncStorage.getItem(STORAGE_KEY);
+}
+
+/** Switch channel, then pull whatever it has. Returns what happened so the
+ * caller can show it; only "reloading" actually restarts the app. */
+export async function switchChannelAndReload(channel: string | null) {
+  await setPreviewChannelOverride(channel);
+  const result = await Updates.checkForUpdateAsync();
+  if (!result.isAvailable) {
+    return "no-update" as const;
+  }
+  await Updates.fetchUpdateAsync();
+  await Updates.reloadAsync();
+  return "reloading" as const;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -494,7 +494,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: catalog:cloudflare
-        version: 1.43.0(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260701.1)(wrangler@4.107.0(@cloudflare/workers-types@4.20260621.1(patch_hash=ae8908e1d45f2ea02ffeabf1230701598cc2878240ef700403ff76df72677af2)))
+        version: 1.43.0(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260701.1)(wrangler@4.107.0)
       '@tailwindcss/vite':
         specifier: ^4.3.2
         version: 4.3.2(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -1119,7 +1119,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: catalog:cloudflare
-        version: 1.43.0(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260701.1)(wrangler@4.107.0(@cloudflare/workers-types@4.20260621.1(patch_hash=ae8908e1d45f2ea02ffeabf1230701598cc2878240ef700403ff76df72677af2)))
+        version: 1.43.0(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260701.1)(wrangler@4.107.0)
       '@cloudflare/workers-types':
         specifier: catalog:cloudflare
         version: 4.20260621.1(patch_hash=ae8908e1d45f2ea02ffeabf1230701598cc2878240ef700403ff76df72677af2)
@@ -1192,7 +1192,7 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: catalog:cloudflare
-        version: 1.43.0(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260701.1)(wrangler@4.107.0(@cloudflare/workers-types@4.20260621.1(patch_hash=ae8908e1d45f2ea02ffeabf1230701598cc2878240ef700403ff76df72677af2)))
+        version: 1.43.0(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260701.1)(wrangler@4.107.0)
       '@cloudflare/workers-types':
         specifier: catalog:cloudflare
         version: 4.20260621.1(patch_hash=ae8908e1d45f2ea02ffeabf1230701598cc2878240ef700403ff76df72677af2)
@@ -1628,12 +1628,18 @@ importers:
       '@slack/web-api':
         specifier: ^7.14.1
         version: 7.14.1
+      '@types/qrcode':
+        specifier: ^1.5.6
+        version: 1.5.6
       jose:
         specifier: ^6.2.1
         version: 6.2.2
       json5:
         specifier: ^2.2.3
         version: 2.2.3
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -6877,6 +6883,9 @@ packages:
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
+  '@types/qrcode@1.5.6':
+    resolution: {integrity: sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==}
+
   '@types/react-dom@19.1.11':
     resolution: {integrity: sha512-3BKc/yGdNTYQVVw4idqHtSOcFsgGuBbMveKCOgF8wQ5QtrYOc3jDIlzg3jef04zcXFIHLelyGlj0T+BJ8+KN+w==}
     peerDependencies:
@@ -7980,6 +7989,9 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
+
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
@@ -8401,6 +8413,10 @@ packages:
       supports-color:
         optional: true
 
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
@@ -8520,6 +8536,9 @@ packages:
   diff@9.0.0:
     resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
+
+  dijkstrajs@1.0.3:
+    resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
 
   discontinuous-range@1.0.0:
     resolution: {integrity: sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==}
@@ -11308,6 +11327,10 @@ packages:
     resolution: {integrity: sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==}
     engines: {node: '>=4.0.0'}
 
+  pngjs@5.0.0:
+    resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
+    engines: {node: '>=10.13.0'}
+
   pngjs@7.0.0:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
     engines: {node: '>=14.19.0'}
@@ -11457,6 +11480,11 @@ packages:
 
   qrcode-terminal@0.11.0:
     resolution: {integrity: sha512-Uu7ii+FQy4Qf82G4xu7ShHhjhGahEpCWc3x8UavY3CTcWV+ufmmCtwkr7ZKsX42jdL0kr1B5FKUeqJvAn51jzQ==}
+    hasBin: true
+
+  qrcode@1.5.4:
+    resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
+    engines: {node: '>=10.13.0'}
     hasBin: true
 
   qs@6.14.2:
@@ -11840,6 +11868,9 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+
   requireg@0.2.2:
     resolution: {integrity: sha512-nYzyjnFcPNGR3lx9lwPPPnuQxv6JWEZd2Ci0u9opN7N5zUEPIhY/GbL3vMGOr2UXwEg9WwSyV9X9Y/kLFgPsOg==}
     engines: {node: '>= 4.0.0'}
@@ -12069,6 +12100,9 @@ packages:
 
   server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
@@ -13440,6 +13474,9 @@ packages:
     resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
     engines: {node: '>= 0.4'}
 
+  which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+
   which-typed-array@1.1.20:
     resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
     engines: {node: '>= 0.4'}
@@ -13557,6 +13594,9 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -13581,6 +13621,10 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -13588,6 +13632,10 @@ packages:
   yargs-parser@22.0.0:
     resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
 
   yargs@17.7.3:
     resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
@@ -14694,7 +14742,7 @@ snapshots:
       - utf-8-validate
       - workerd
 
-  '@cloudflare/vite-plugin@1.43.0(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260701.1)(wrangler@4.107.0(@cloudflare/workers-types@4.20260621.1(patch_hash=ae8908e1d45f2ea02ffeabf1230701598cc2878240ef700403ff76df72677af2)))':
+  '@cloudflare/vite-plugin@1.43.0(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260701.1)(wrangler@4.107.0)':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260701.1)
       miniflare: 4.20260701.0
@@ -19926,6 +19974,10 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
+  '@types/qrcode@1.5.6':
+    dependencies:
+      '@types/node': 24.12.4
+
   '@types/react-dom@19.1.11(@types/react@19.1.17)':
     dependencies:
       '@types/react': 19.1.17
@@ -20192,10 +20244,10 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser-playwright@4.0.15(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(playwright@1.60.0)(vite@8.0.9(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.0.15)':
+  '@vitest/browser-playwright@4.0.15(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(playwright@1.60.0)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.0.15)':
     dependencies:
-      '@vitest/browser': 4.0.15(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(vite@8.0.9(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.0.15)
-      '@vitest/mocker': 4.0.15(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(vite@8.0.9(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/browser': 4.0.15(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.0.15)
+      '@vitest/mocker': 4.0.15(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       playwright: 1.60.0
       tinyrainbow: 3.1.0
       vitest: 4.0.15(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/browser-playwright@4.0.15)(@vitest/ui@4.0.15)(jiti@2.7.0)(jsdom@27.4.0(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
@@ -20326,9 +20378,9 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser@4.0.15(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(vite@8.0.9(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.0.15)':
+  '@vitest/browser@4.0.15(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.0.15)':
     dependencies:
-      '@vitest/mocker': 4.0.15(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(vite@8.0.9(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.0.15(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/utils': 4.0.15
       magic-string: 0.30.21
       pixelmatch: 7.1.0
@@ -20524,16 +20576,6 @@ snapshots:
     optionalDependencies:
       msw: 2.13.3(@types/node@26.1.1)(typescript@5.9.3)
       vite: 7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
-
-  '@vitest/mocker@4.0.15(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(vite@8.0.9(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.0.15
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.13.3(@types/node@26.1.1)(typescript@5.9.3)
-      vite: 8.0.9(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
-    optional: true
 
   '@vitest/mocker@4.1.10(msw@2.13.3(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -21771,6 +21813,12 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  cliui@6.0.0:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -22232,6 +22280,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decamelize@1.2.0: {}
+
   decimal.js-light@2.5.1: {}
 
   decimal.js@10.6.0: {}
@@ -22317,6 +22367,8 @@ snapshots:
   diff@8.0.3: {}
 
   diff@9.0.0: {}
+
+  dijkstrajs@1.0.3: {}
 
   discontinuous-range@1.0.0: {}
 
@@ -26200,6 +26252,8 @@ snapshots:
 
   pngjs@3.4.0: {}
 
+  pngjs@5.0.0: {}
+
   pngjs@7.0.0:
     optional: true
 
@@ -26339,6 +26393,12 @@ snapshots:
     optional: true
 
   qrcode-terminal@0.11.0: {}
+
+  qrcode@1.5.4:
+    dependencies:
+      dijkstrajs: 1.0.3
+      pngjs: 5.0.0
+      yargs: 15.4.1
 
   qs@6.14.2:
     dependencies:
@@ -26858,6 +26918,8 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  require-main-filename@2.0.0: {}
+
   requireg@0.2.2:
     dependencies:
       nested-error-stacks: 2.0.1
@@ -27185,6 +27247,8 @@ snapshots:
       - supports-color
 
   server-only@0.0.1: {}
+
+  set-blocking@2.0.0: {}
 
   set-cookie-parser@3.1.0: {}
 
@@ -28565,7 +28629,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 26.1.1
-      '@vitest/browser-playwright': 4.0.15(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(playwright@1.60.0)(vite@8.0.9(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.0.15)
+      '@vitest/browser-playwright': 4.0.15(msw@2.13.3(@types/node@26.1.1)(typescript@5.9.3))(playwright@1.60.0)(vite@7.3.1(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.0.15)
       '@vitest/ui': 4.0.15(vitest@4.0.15)
       jsdom: 27.4.0(@noble/hashes@2.2.0)
     transitivePeerDependencies:
@@ -28996,6 +29060,8 @@ snapshots:
       is-weakmap: 2.0.2
       is-weakset: 2.0.4
 
+  which-module@2.0.1: {}
+
   which-typed-array@1.1.20:
     dependencies:
       available-typed-arrays: 1.0.7
@@ -29057,7 +29123,6 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-    optional: true
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -29118,6 +29183,8 @@ snapshots:
   xtend@4.0.2:
     optional: true
 
+  y18n@4.0.3: {}
+
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
@@ -29130,9 +29197,28 @@ snapshots:
 
   yaml@2.9.0: {}
 
+  yargs-parser@18.1.3:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
   yargs-parser@21.1.1: {}
 
   yargs-parser@22.0.0: {}
+
+  yargs@15.4.1:
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
 
   yargs@17.7.3:
     dependencies:

--- a/scripts/ci/publish-mobile-pr-preview.test.ts
+++ b/scripts/ci/publish-mobile-pr-preview.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "vitest";
+import { channelForBranch, planPreview, renderBodySection } from "./publish-mobile-pr-preview.ts";
+
+test("branch names become valid EAS channel names", () => {
+  expect(channelForBranch("mobile-per-pr-preview-channels")).toBe("mobile-per-pr-preview-channels");
+  expect(channelForBranch("fix/auth-url-error-display")).toBe("fix-auth-url-error-display");
+  expect(channelForBranch("mmkal/26/07/03/voice-ios-app")).toBe("mmkal-26-07-03-voice-ios-app");
+  expect(channelForBranch("Weird  Branch!!name")).toBe("weird-branch-name");
+});
+
+test("a runtime-matching PR renders with the OTA details open and install collapsed", () => {
+  const plan = planPreview({
+    scheme: "iterate",
+    channel: "my-feature",
+    publishedRuntime: "37fb004ced1120b5d1fc8e57c7dd87e0aee98e8e",
+    installedRuntime: "37fb004ced1120b5d1fc8e57c7dd87e0aee98e8e",
+    installUrl: "https://expo.dev/accounts/o/projects/p/builds/build-1",
+  });
+  expect(plan).toMatchObject({
+    runtimeMatchesInstalled: true,
+    deepLinkUrl: "iterate://preview-channel/my-feature",
+  });
+
+  const section = renderBodySection({
+    plan,
+    deepLinkQrUrl: "https://github.com/o/r/releases/download/gh-attach-assets/ota.png",
+    installQrUrl: "https://github.com/o/r/releases/download/gh-attach-assets/install.png",
+    headSha: "abcdef1234567890",
+    publishedRuntime: "37fb004ced1120b5d1fc8e57c7dd87e0aee98e8e",
+  });
+  expect(section).toContain("**JS-only** — the installed app can run it");
+  expect(section).toContain("<details open><summary>OTA");
+  expect(section).toContain("<details><summary>Full install");
+  // Both QRs are tappable links.
+  expect(section).toContain(
+    '<a href="iterate://preview-channel/my-feature"><img src="https://github.com/o/r/releases/download/gh-attach-assets/ota.png"',
+  );
+  expect(section).toContain(
+    '<a href="https://expo.dev/accounts/o/projects/p/builds/build-1"><img src="https://github.com/o/r/releases/download/gh-attach-assets/install.png"',
+  );
+});
+
+test("a native-change PR flips the expanded details to the install QR", () => {
+  const plan = planPreview({
+    scheme: "iterate",
+    channel: "add-native-module",
+    publishedRuntime: "aaaa000000000000000000000000000000000000",
+    installedRuntime: "37fb004ced1120b5d1fc8e57c7dd87e0aee98e8e",
+    installUrl: "https://expo.dev/accounts/o/projects/p/builds/build-2",
+  });
+  expect(plan).toMatchObject({ runtimeMatchesInstalled: false });
+
+  const section = renderBodySection({
+    plan,
+    deepLinkQrUrl: "https://example.test/ota.png",
+    installQrUrl: "https://example.test/install.png",
+    headSha: "abcdef1234567890",
+    publishedRuntime: "aaaa000000000000000000000000000000000000",
+  });
+  expect(section).toContain("**native changes** — needs a fresh install");
+  expect(section).toContain("<details><summary>OTA");
+  expect(section).toContain("<details open><summary>Full install");
+});
+
+test("no finished preview build at all counts as a runtime mismatch", () => {
+  const plan = planPreview({
+    scheme: "iterate",
+    channel: "first-ever",
+    publishedRuntime: "aaaa000000000000000000000000000000000000",
+    installedRuntime: undefined,
+    installUrl: "https://expo.dev/accounts/o/projects/p/builds/build-3",
+  });
+  expect(plan).toMatchObject({ runtimeMatchesInstalled: false });
+});

--- a/scripts/ci/publish-mobile-pr-preview.test.ts
+++ b/scripts/ci/publish-mobile-pr-preview.test.ts
@@ -31,8 +31,8 @@ test("a runtime-matching PR renders with the OTA details open and install collap
   });
   expect(section).toContain("**JS-only** — the installed app can run it");
   // Each summary carries its own sha - the install build is often older than the head.
-  expect(section).toContain("channel (\`abcdef123\`)");
-  expect(section).toContain("differs (\`012345678\`)");
+  expect(section).toContain("channel (`abcdef123`)");
+  expect(section).toContain("differs (`012345678`)");
   expect(section).toContain("<details open><summary>OTA");
   expect(section).toContain("<details><summary>Full install");
   // Both QRs are tappable links.

--- a/scripts/ci/publish-mobile-pr-preview.test.ts
+++ b/scripts/ci/publish-mobile-pr-preview.test.ts
@@ -26,9 +26,13 @@ test("a runtime-matching PR renders with the OTA details open and install collap
     deepLinkQrUrl: "https://github.com/o/r/releases/download/gh-attach-assets/ota.png",
     installQrUrl: "https://github.com/o/r/releases/download/gh-attach-assets/install.png",
     headSha: "abcdef1234567890",
+    installBuildSha: "0123456789abcdef",
     publishedRuntime: "37fb004ced1120b5d1fc8e57c7dd87e0aee98e8e",
   });
   expect(section).toContain("**JS-only** — the installed app can run it");
+  // Each summary carries its own sha - the install build is often older than the head.
+  expect(section).toContain("channel (\`abcdef123\`)");
+  expect(section).toContain("differs (\`012345678\`)");
   expect(section).toContain("<details open><summary>OTA");
   expect(section).toContain("<details><summary>Full install");
   // Both QRs are tappable links.
@@ -55,6 +59,7 @@ test("a native-change PR flips the expanded details to the install QR", () => {
     deepLinkQrUrl: "https://example.test/ota.png",
     installQrUrl: "https://example.test/install.png",
     headSha: "abcdef1234567890",
+    installBuildSha: "0123456789abcdef",
     publishedRuntime: "aaaa000000000000000000000000000000000000",
   });
   expect(section).toContain("**native changes** — needs a fresh install");

--- a/scripts/ci/publish-mobile-pr-preview.ts
+++ b/scripts/ci/publish-mobile-pr-preview.ts
@@ -195,7 +195,8 @@ async function publishMobilePrPreview() {
     "--build-profile",
     "preview",
     "--status",
-    "FINISHED",
+    // The flag wants lowercase; the JSON output reports uppercase. Sigh.
+    "finished",
     "--limit",
     "1",
   ]);

--- a/scripts/ci/publish-mobile-pr-preview.ts
+++ b/scripts/ci/publish-mobile-pr-preview.ts
@@ -1,0 +1,264 @@
+// Per-PR mobile previews: publishes the PR's JS bundle to an EAS Update
+// channel named after its branch, then maintains a managed PR-body section
+// with two tappable QR codes — an OTA deep link into the installed app and a
+// full-install link — expanding whichever the runtime-fingerprint heuristic
+// says Misha needs. Runs on PRs touching apps/mobile
+// (.depot/workflows/mobile-pr-preview.yml); EXPO_TOKEN via Doppler like the
+// merge-to-main publish (scripts/ci/publish-mobile-update.ts).
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import QRCode from "qrcode";
+import { markdownAnnotator } from "../../packages/shared/src/dev/markdown-annotator.ts";
+import { isMainModule } from "../../packages/shared/src/dev/is-main-module.ts";
+import { getOctokit, getRepo, readEventPayload } from "./github.ts";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const mobileDir = path.join(repoRoot, "apps/mobile");
+
+/** markdownAnnotator label for the managed PR-body section. */
+export const bodySectionLabel = "mobile-pr-preview";
+
+/** Release whose assets host the QR PNGs (already exists; images render
+ * inline from release-download URLs, unlike API-posted attachments). */
+const qrAssetsReleaseTag = "gh-attach-assets";
+
+/** EAS channel names are much more restrictive than git branch names. */
+export const channelForBranch = (branch: string) =>
+  branch.toLowerCase().replaceAll(/[^a-z0-9._-]+/g, "-");
+
+export type PreviewPlan = {
+  /** Does the PR's JS run on the binary Misha already has installed? */
+  runtimeMatchesInstalled: boolean;
+  channel: string;
+  deepLinkUrl: string;
+  installUrl: string;
+};
+
+export const planPreview = (input: {
+  scheme: string;
+  channel: string;
+  publishedRuntime: string;
+  /** Runtime of the newest FINISHED preview-profile build — what's installable today. */
+  installedRuntime: string | undefined;
+  /** Install page of the build serving this PR: the newest usable build whose
+   * runtime matches the published update (may be freshly triggered). */
+  installUrl: string;
+}): PreviewPlan => ({
+  runtimeMatchesInstalled: input.publishedRuntime === input.installedRuntime,
+  channel: input.channel,
+  deepLinkUrl: `${input.scheme}://preview-channel/${input.channel}`,
+  installUrl: input.installUrl,
+});
+
+const qrDetails = (opts: {
+  open: boolean;
+  summary: string;
+  qrImageUrl: string;
+  href: string;
+  caption: string;
+}) =>
+  [
+    `<details${opts.open ? " open" : ""}><summary>${opts.summary}</summary>`,
+    "",
+    `<a href="${opts.href}"><img src="${opts.qrImageUrl}" width="180" alt="QR code" /></a>`,
+    "",
+    `${opts.caption}: ${opts.href}`,
+    "",
+    "</details>",
+  ].join("\n");
+
+export const renderBodySection = (input: {
+  plan: PreviewPlan;
+  deepLinkQrUrl: string;
+  installQrUrl: string;
+  headSha: string;
+  publishedRuntime: string;
+}) => {
+  const { plan } = input;
+  return [
+    "## 📱 Mobile preview",
+    "",
+    `Channel \`${plan.channel}\` · runtime \`${input.publishedRuntime.slice(0, 9)}\` · ${
+      plan.runtimeMatchesInstalled
+        ? "**JS-only** — the installed app can run it"
+        : "**native changes** — needs a fresh install"
+    } · ${input.headSha.slice(0, 9)}`,
+    "",
+    qrDetails({
+      open: plan.runtimeMatchesInstalled,
+      summary: "OTA — switch the installed app to this PR's channel",
+      qrImageUrl: input.deepLinkQrUrl,
+      href: plan.deepLinkUrl,
+      caption: "Deep link (only works with the app installed)",
+    }),
+    qrDetails({
+      open: !plan.runtimeMatchesInstalled,
+      summary: "Full install — if the app is uninstalled or the runtime differs",
+      qrImageUrl: input.installQrUrl,
+      href: plan.installUrl,
+      caption: "EAS build install page",
+    }),
+    "",
+    `<sub>Back to main inside the app: Build info → Reset to default channel. Republishes on every push to this PR.</sub>`,
+  ].join("\n");
+};
+
+const run = (command: string, args: string[], cwd: string) =>
+  execFileSync(command, args, { cwd, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+
+// Same JSON-slicing as publish-mobile-update.ts: pnpm dlx and eas-cli both
+// write noise around the payload.
+const easJson = (args: string[]) => {
+  const output = run(
+    "pnpm",
+    ["dlx", "eas-cli@21.0.1", ...args, "--non-interactive", "--json"],
+    mobileDir,
+  );
+  const start = output.search(/[[{]/);
+  const end = Math.max(output.lastIndexOf("]"), output.lastIndexOf("}"));
+  if (start === -1 || end < start) {
+    throw new Error(`no JSON found in eas output:\n${output}`);
+  }
+  return JSON.parse(output.slice(start, end + 1));
+};
+
+const usableStatuses = ["NEW", "IN_QUEUE", "IN_PROGRESS", "FINISHED"];
+
+async function uploadQrAsset(name: string, url: string) {
+  const dir = mkdtempSync(path.join(tmpdir(), "mobile-pr-qr-"));
+  const file = path.join(dir, name);
+  writeFileSync(file, await QRCode.toBuffer(url, { width: 512, margin: 2 }));
+  const github = getOctokit();
+  const repo = getRepo();
+  const release = await github.rest.repos.getReleaseByTag({ ...repo, tag: qrAssetsReleaseTag });
+  const existing = release.data.assets.find((a) => a.name === name);
+  if (existing) {
+    // Re-runs on the same sha: content is identical (URL-derived), keep it.
+    return existing.browser_download_url;
+  }
+  const uploaded = await github.rest.repos.uploadReleaseAsset({
+    ...repo,
+    release_id: release.data.id,
+    name,
+    // Octokit types want a string; the payload is binary and passes through fine.
+    data: readFileSync(file) as unknown as string,
+    headers: { "content-type": "image/png", "content-length": String(readFileSync(file).length) },
+  });
+  return uploaded.data.browser_download_url;
+}
+
+async function publishMobilePrPreview() {
+  const payload = readEventPayload();
+  const pullRequest = payload.pull_request;
+  if (!pullRequest?.head?.ref || !pullRequest.head.sha) {
+    throw new Error("pull_request payload with head ref/sha is required");
+  }
+  if (!process.env.EXPO_TOKEN) {
+    throw new Error("EXPO_TOKEN is not set — eas-cli cannot authenticate");
+  }
+
+  const appConfig = JSON.parse(readFileSync(path.join(mobileDir, "app.json"), "utf8"));
+  const { scheme, owner, slug } = appConfig.expo;
+  const channel = channelForBranch(pullRequest.head.ref);
+  const headSha = pullRequest.head.sha;
+
+  run("node", ["scripts/write-build-info.mjs"], mobileDir);
+  const message = `PR #${pullRequest.number}: ${(pullRequest.title || "").slice(0, 900)}`;
+  // --clear-cache: CI reuses sandboxes across branches and Metro's cache
+  // bakes in absolute paths (see tasks/complete/2026-08-04-mobile-build-info-commit-message.md).
+  const published = easJson([
+    "update",
+    "--channel",
+    channel,
+    "--platform",
+    "ios",
+    "--clear-cache",
+    "--message",
+    message,
+  ]);
+  const updates: any[] = Array.isArray(published) ? published : [published];
+  const publishedRuntime = updates[0]?.runtimeVersion;
+  if (!publishedRuntime) {
+    throw new Error(`unexpected eas update output: ${JSON.stringify(published)}`);
+  }
+  console.log(
+    `published update ${updates[0].id} to channel ${channel} (runtime ${publishedRuntime})`,
+  );
+
+  const installedBuilds: any[] = easJson([
+    "build:list",
+    "--platform",
+    "ios",
+    "--build-profile",
+    "preview",
+    "--status",
+    "FINISHED",
+    "--limit",
+    "1",
+  ]);
+  const installedRuntime: string | undefined = installedBuilds[0]?.runtimeVersion;
+
+  // A build the PR's JS can actually run on: reuse any usable one for this
+  // runtime (on match that's the build already on the phone), else trigger.
+  const runtimeBuilds: any[] = easJson([
+    "build:list",
+    "--platform",
+    "ios",
+    "--build-profile",
+    "preview",
+    "--runtime-version",
+    publishedRuntime,
+    "--limit",
+    "30",
+  ]);
+  let installBuild = runtimeBuilds.find((b) => usableStatuses.includes(b.status));
+  if (!installBuild) {
+    console.log(`no build for runtime ${publishedRuntime} — triggering one`);
+    const triggered = easJson(["build", "--platform", "ios", "--profile", "preview", "--no-wait"]);
+    installBuild = Array.isArray(triggered) ? triggered[0] : triggered;
+  }
+  if (!installBuild?.id) {
+    throw new Error(`could not find or trigger an install build: ${JSON.stringify(installBuild)}`);
+  }
+
+  const plan = planPreview({
+    scheme,
+    channel,
+    publishedRuntime,
+    installedRuntime,
+    installUrl: `https://expo.dev/accounts/${owner}/projects/${slug}/builds/${installBuild.id}`,
+  });
+
+  const [deepLinkQrUrl, installQrUrl] = await Promise.all([
+    uploadQrAsset(
+      `mobile-pr-${pullRequest.number}-${headSha.slice(0, 9)}-ota.png`,
+      plan.deepLinkUrl,
+    ),
+    uploadQrAsset(
+      `mobile-pr-${pullRequest.number}-${headSha.slice(0, 9)}-install-${installBuild.id.slice(0, 8)}.png`,
+      plan.installUrl,
+    ),
+  ]);
+
+  const section = renderBodySection({
+    plan,
+    deepLinkQrUrl,
+    installQrUrl,
+    headSha,
+    publishedRuntime,
+  });
+  const github = getOctokit();
+  const repo = getRepo();
+  // Fresh body, not the event payload's - it may have been edited since.
+  const { data: pr } = await github.rest.pulls.get({ ...repo, pull_number: pullRequest.number });
+  const body = markdownAnnotator(pr.body || "", bodySectionLabel).update(section);
+  await github.rest.pulls.update({ ...repo, pull_number: pullRequest.number, body });
+  console.log(`updated mobile preview section in PR #${pullRequest.number} body`);
+}
+
+if (isMainModule(import.meta.url)) {
+  await publishMobilePrPreview();
+}

--- a/scripts/ci/publish-mobile-pr-preview.ts
+++ b/scripts/ci/publish-mobile-pr-preview.ts
@@ -75,6 +75,9 @@ export const renderBodySection = (input: {
   deepLinkQrUrl: string;
   installQrUrl: string;
   headSha: string;
+  /** Commit the install build was compiled from — often older than headSha
+   * when a still-compatible build is reused. */
+  installBuildSha: string | undefined;
   publishedRuntime: string;
 }) => {
   const { plan } = input;
@@ -85,18 +88,20 @@ export const renderBodySection = (input: {
       plan.runtimeMatchesInstalled
         ? "**JS-only** — the installed app can run it"
         : "**native changes** — needs a fresh install"
-    } · ${input.headSha.slice(0, 9)}`,
+    }`,
     "",
     qrDetails({
       open: plan.runtimeMatchesInstalled,
-      summary: "OTA — switch the installed app to this PR's channel",
+      summary: `OTA — switch the installed app to this PR's channel (\`${input.headSha.slice(0, 9)}\`)`,
       qrImageUrl: input.deepLinkQrUrl,
       href: plan.deepLinkUrl,
       caption: "Deep link (only works with the app installed)",
     }),
     qrDetails({
       open: !plan.runtimeMatchesInstalled,
-      summary: "Full install — if the app is uninstalled or the runtime differs",
+      summary: `Full install — if the app is uninstalled or the runtime differs (\`${
+        input.installBuildSha?.slice(0, 9) || "unknown sha"
+      }\`)`,
       qrImageUrl: input.installQrUrl,
       href: plan.installUrl,
       caption: "EAS build install page",
@@ -249,6 +254,7 @@ async function publishMobilePrPreview() {
     deepLinkQrUrl,
     installQrUrl,
     headSha,
+    installBuildSha: installBuild.gitCommitHash,
     publishedRuntime,
   });
   const github = getOctokit();

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -12,8 +12,10 @@
     "@octokit/rest": "^22.0.0",
     "@orpc/server": "1.13.14",
     "@slack/web-api": "^7.14.1",
+    "@types/qrcode": "^1.5.6",
     "jose": "^6.2.1",
     "json5": "^2.2.3",
+    "qrcode": "^1.5.4",
     "yaml": "^2.8.3",
     "zod": "4.3.6"
   },

--- a/tasks/complete/2026-08-04-mobile-fingerprint-sourceskips.md
+++ b/tasks/complete/2026-08-04-mobile-fingerprint-sourceskips.md
@@ -1,0 +1,18 @@
+---
+status: done
+size: small
+---
+
+# Mobile: stop package.json scripts changing the runtime fingerprint
+
+**Status summary:** done and locally verified. One config file plus the re-landed `update:preview` fixes that the fingerprint gotcha forced out of PR #2410.
+
+The expo-updates fingerprint runtime policy hashed `package.json` scripts: editing `update:preview` on PR #2410 moved the fingerprint from `37fb004c` to `f195c3d2`, which would have stranded every installed binary on stale JS despite zero native changes.
+
+- [x] add `apps/mobile/fingerprint.config.js` with `sourceSkips: ["PackageJsonScriptsAll"]` _scripts never ship in the bundle; deps still count_
+- [x] verify a scripts-only edit no longer changes the hash _`expo-updates fingerprint:generate` → `1bf9f0fe` with and without a script edit_
+- [x] re-land the `update:preview` fixes reverted from #2410 _`--message "$(git log -1 --format=%s)"` (eas requires --message when non-interactive) and `--clear-cache` (Metro's shared cache leaks absolute paths across worktrees — see #2410's task notes)_
+
+## Implementation notes
+
+- Landing this changes the fingerprint once (`37fb004c` → `1bf9f0fe`-ish as computed on merge): the merge-to-main workflow will detect no matching preview build and auto-trigger one — Misha reinstalls one more time, then script edits are permanently fingerprint-neutral.

--- a/tasks/complete/2026-08-04-mobile-per-pr-preview-channels.md
+++ b/tasks/complete/2026-08-04-mobile-per-pr-preview-channels.md
@@ -1,11 +1,11 @@
 ---
-status: in-progress
+status: done
 size: medium
 ---
 
 # Mobile: per-PR preview channels with in-app switcher and PR-body QRs
 
-**Status summary:** spec committed first. Kills last-write-wins on the shared `preview` channel: PRs publish to their own channel, the app can switch channels via deep link, and every mobile PR gets tappable QRs in its body.
+**Status summary:** done, verified end-to-end (this PR body carries its own live QR section, produced by running the CI script locally against PR #2412). Kills last-write-wins on the shared `preview` channel: PRs publish to their own channel, the app can switch channels via deep link, and every mobile PR gets tappable QRs in its body.
 
 Today every publisher (merge-to-main CI, PR-branch agents) writes to the one `preview` channel, so whatever published last is what's on Misha's phone — his #2410 preview got silently replaced by an unrelated main merge within minutes. Decided 2026-08-04: per-PR channels, in-app switcher, QRs on PR bodies.
 
@@ -19,16 +19,22 @@ Today every publisher (merge-to-main CI, PR-branch agents) writes to the one `pr
 
 ## Checklist
 
-- [ ] `apps/mobile/src/lib/preview-channel.ts`: set/clear channel override + AsyncStorage mirror (expo-updates has no getter)
-- [ ] `apps/mobile/src/app/preview-channel/[channel].tsx`: deep-link confirm screen (switch → check → fetch → reload; friendly "nothing published/incompatible" outcome)
-- [ ] Build info screen: show active channel override + "reset to default channel" action
-- [ ] `write-build-info.mjs`: prefer `GITHUB_HEAD_REF` (PR head branch) over `GITHUB_REF_NAME` for the branch stamp
-- [ ] `scripts/ci/publish-mobile-pr-preview.ts`: publish PR channel, decide js-only vs native, ensure build exists for native, generate + upload QRs, write PR-body section
-- [ ] `.depot/workflows/mobile-pr-preview.yml`: pull_request on `apps/mobile/**`, per-PR concurrency (cancel-in-progress), contents:write + pull-requests:write
-- [ ] unit tests for the decision + rendering logic (pure functions, DI'd exec — no mocks)
-- [ ] README blurb in `apps/mobile/README.md`
+- [x] `apps/mobile/src/lib/preview-channel.ts`: set/clear channel override + AsyncStorage mirror (expo-updates has no getter)
+- [x] `apps/mobile/src/app/preview-channel/[channel].tsx`: deep-link confirm screen (switch → check → fetch → reload; friendly "nothing published/incompatible" outcome)
+- [x] Build info screen: show active channel override + "reset to default channel" action
+- [x] `write-build-info.mjs`: prefer `GITHUB_HEAD_REF` (PR head branch) over `GITHUB_REF_NAME` for the branch stamp
+- [x] `scripts/ci/publish-mobile-pr-preview.ts`: publish PR channel, decide js-only vs native, ensure build exists for native, generate + upload QRs, write PR-body section
+- [x] `.depot/workflows/mobile-pr-preview.yml`: pull_request on `apps/mobile/**`, per-PR concurrency (cancel-in-progress), contents:write + pull-requests:write
+- [x] unit tests for the decision + rendering logic (pure functions, DI'd exec — no mocks)
+- [x] README blurb in `apps/mobile/README.md`
 
 ## Notes
 
 - Stacked on `mobile-fingerprint-sourceskips` (PR #2411) — without sourceSkips, script-only package.json edits would misclassify PRs as native.
 - Follow-up (not here): clean up EAS channels/branches when PRs close; an in-app *list* of open PR channels (needs an authed EAS API proxy).
+
+## Implementation log
+
+- e2e run against PR #2412 caught `--status` casing: the eas-cli flag wants lowercase (`finished`) while its JSON output reports uppercase (`FINISHED`).
+- The runtime-mismatch path exercised for real: this branch changes the fingerprint (sourceSkips config from #2411), so the run triggered native build 9623bb11 and expanded the install QR — exactly the heuristic working.
+- The PR-triggered build shares the post-merge fingerprint, so the merge-to-main workflow will find it and skip its own build.

--- a/tasks/mobile-per-pr-preview-channels.md
+++ b/tasks/mobile-per-pr-preview-channels.md
@@ -1,0 +1,34 @@
+---
+status: in-progress
+size: medium
+---
+
+# Mobile: per-PR preview channels with in-app switcher and PR-body QRs
+
+**Status summary:** spec committed first. Kills last-write-wins on the shared `preview` channel: PRs publish to their own channel, the app can switch channels via deep link, and every mobile PR gets tappable QRs in its body.
+
+Today every publisher (merge-to-main CI, PR-branch agents) writes to the one `preview` channel, so whatever published last is what's on Misha's phone — his #2410 preview got silently replaced by an unrelated main merge within minutes. Decided 2026-08-04: per-PR channels, in-app switcher, QRs on PR bodies.
+
+## Design
+
+- `preview` channel becomes **main-only**. PRs publish to a channel named after their branch (sanitized: non `[a-z0-9._-]` chars → `-`).
+- Channel switching uses `Updates.setUpdateRequestHeadersOverride({"expo-channel-name": ...})` — the headers-only override, which does **not** need `disableAntiBrickingMeasures` (override keys only have to exist in the embedded headers, and EAS builds embed `expo-channel-name`). Persisted natively in UserDefaults across restarts.
+- Deep link `iterate://preview-channel/<channel>` opens a confirm screen (no auto-switch on link open) that applies the override, fetches, reloads.
+- A managed PR-body section (markdownAnnotator, like loc-report) shows **both** QRs in `<details>` blocks for any PR touching `apps/mobile/**` — OTA deep-link QR and full-install QR — with the heuristic picking which is expanded: PR runtime matches the latest finished preview build → OTA open; otherwise install open (OTA still present: Misha may have installed this branch's native build earlier). QR PNGs upload to the existing `gh-attach-assets` release; images render inline from release URLs, wrapped in `<a>` so they're tappable when reading the PR on the phone.
+- Native-change case: find a usable build for the PR's runtime, trigger one (`--no-wait`) if none.
+
+## Checklist
+
+- [ ] `apps/mobile/src/lib/preview-channel.ts`: set/clear channel override + AsyncStorage mirror (expo-updates has no getter)
+- [ ] `apps/mobile/src/app/preview-channel/[channel].tsx`: deep-link confirm screen (switch → check → fetch → reload; friendly "nothing published/incompatible" outcome)
+- [ ] Build info screen: show active channel override + "reset to default channel" action
+- [ ] `write-build-info.mjs`: prefer `GITHUB_HEAD_REF` (PR head branch) over `GITHUB_REF_NAME` for the branch stamp
+- [ ] `scripts/ci/publish-mobile-pr-preview.ts`: publish PR channel, decide js-only vs native, ensure build exists for native, generate + upload QRs, write PR-body section
+- [ ] `.depot/workflows/mobile-pr-preview.yml`: pull_request on `apps/mobile/**`, per-PR concurrency (cancel-in-progress), contents:write + pull-requests:write
+- [ ] unit tests for the decision + rendering logic (pure functions, DI'd exec — no mocks)
+- [ ] README blurb in `apps/mobile/README.md`
+
+## Notes
+
+- Stacked on `mobile-fingerprint-sourceskips` (PR #2411) — without sourceSkips, script-only package.json edits would misclassify PRs as native.
+- Follow-up (not here): clean up EAS channels/branches when PRs close; an in-app *list* of open PR channels (needs an authed EAS API proxy).


### PR DESCRIPTION
Kills last-write-wins on the shared `preview` OTA channel (Misha's #2410 preview was silently replaced by an unrelated main merge within minutes of publishing).

**Stacked on #2411** (fingerprint sourceSkips) — without it, script-only package.json edits would masquerade as native changes.

- `preview` channel becomes main-only; PRs publish to a channel named after their branch.
- The app switches channels via `iterate://preview-channel/<channel>` deep link → confirm screen → `Updates.setUpdateRequestHeadersOverride` (headers-only override: no `disableAntiBrickingMeasures` needed, persists across restarts). Build info shows the active override + reset.
- Every PR touching `apps/mobile/**` gets a managed body section with **both** QRs in `<details>`: OTA deep-link QR and full-install QR, the likely-right one expanded (runtime match heuristic). Native changes find-or-trigger an EAS build.

Task file in first commit; implementation follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session: `5daba6b0-cb79-4137-b08f-5a25efebbafe`

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Mobile | +241 -9 | +197 -9 🟩🟩🟩🟩⬜ |
| Tests | +79 -0 | +71 -0 🟩⬜⬜⬜⬜ |
| CI & scripts | +308 -0 | +238 -0 🟩🟩🟩🟩🟩 |
| Docs | +58 -0 | +41 -0 🟩⬜⬜⬜⬜ |
| Generated | +107 -21 | +83 -20 🟩🟩⬜⬜⬜ |
| **Total** | **+793 -30** | **+630 -29** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 83c7083 and 11647ad, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

> [!CAUTION]
> This PR is a draft, so it doesn't claim a preview slot. To get previews: add the `preview` label, mark the PR ready for review, or dispatch the Cloudflare Previews workflow for a one-off run.

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": "This PR is a draft, so it doesn't claim a preview slot. To get previews: add the `preview` label, mark the PR ready for review, or dispatch the Cloudflare Previews workflow for a one-off run."
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- mobile-pr-preview -->
## 📱 Mobile preview

Channel `mobile-per-pr-preview-channels` · runtime `1bf9f0fe0` · **JS-only** — the installed app can run it

<details open><summary>OTA — switch the installed app to this PR's channel (`11647ad8b`)</summary>

<a href="iterate://preview-channel/mobile-per-pr-preview-channels"><img src="https://github.com/iterate/iterate/releases/download/gh-attach-assets/mobile-pr-2412-11647ad8b-ota.png" width="180" alt="QR code" /></a>

Deep link (only works with the app installed): iterate://preview-channel/mobile-per-pr-preview-channels

</details>
<details><summary>Full install — if the app is uninstalled or the runtime differs (`09cb766ba`)</summary>

<a href="https://expo.dev/accounts/mishanustom/projects/iterate/builds/9623bb11-70cc-4263-9f7e-e0c6b95eb209"><img src="https://github.com/iterate/iterate/releases/download/gh-attach-assets/mobile-pr-2412-11647ad8b-install-9623bb11.png" width="180" alt="QR code" /></a>

EAS build install page: https://expo.dev/accounts/mishanustom/projects/iterate/builds/9623bb11-70cc-4263-9f7e-e0c6b95eb209

</details>

<sub>Back to main inside the app: Build info → Reset to default channel. Republishes on every push to this PR.</sub>
<!-- /mobile-pr-preview -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OTA delivery and CI that writes PR bodies and release assets; wrong channel or fingerprint logic could mislead testers or strand binaries, but changes are scoped to mobile preview tooling rather than production auth or data paths.
> 
> **Overview**
> Stops **last-write-wins** on the shared `preview` OTA channel by giving each mobile PR its own EAS Update channel (sanitized branch name) and keeping `preview` for main.
> 
> **CI** adds `.depot/workflows/mobile-pr-preview.yml` on `apps/mobile/**` pushes; `scripts/ci/publish-mobile-pr-preview.ts` publishes the PR bundle, compares runtime fingerprints to the latest finished preview build, find-or-triggers a matching native build when needed, uploads OTA/install QR PNGs to `gh-attach-assets`, and maintains a `mobile-pr-preview` section on the PR body (expanded OTA vs install via heuristic).
> 
> **App** adds `preview-channel.ts` (`expo-channel-name` header override + AsyncStorage mirror), deep link `iterate://preview-channel/<channel>` with a confirm screen, and Build info rows plus **Reset to default channel**.
> 
> **Fingerprint / publish hygiene:** `fingerprint.config.js` skips `package.json` scripts in the runtime fingerprint; `update:preview` gains `--clear-cache` and a non-interactive `--message`; `write-build-info.mjs` prefers `GITHUB_HEAD_REF` on PR CI runs.
> 
> Note: the diff includes a **stamped** `src/build-info.json` — README says the checked-in file should stay an empty placeholder (likely accidental from a local publish).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11647ad8b4b02596b5b075aaeea464740c8a13f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->