### PR TITLE
explain-type-cast: skip e2e dirs and test scaffolding files

### DIFF
--- a/rules/typescript/explain-type-cast.md
+++ b/rules/typescript/explain-type-cast.md
@@ -6,6 +6,8 @@ files:
     "**/*.{ts,tsx,mts,cts}",
     "!**/*.{test,spec}.{js,jsx,mjs,cjs,ts,tsx,mts,cts}",
     "!**/{__tests__,test,tests,spec,specs}/**",
+    "!**/e2e/**",
+    "!**/*test-{helpers,harness,utils}.{ts,tsx,mts,cts}",
   ]
 ---
 

--- a/tasks/complete/2026-08-04-explain-type-cast-test-globs.md
+++ b/tasks/complete/2026-08-04-explain-type-cast-test-globs.md
@@ -1,5 +1,5 @@
 ---
-status: in-review
+status: done
 size: small
 ---
 

--- a/tasks/explain-type-cast-test-globs.md
+++ b/tasks/explain-type-cast-test-globs.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: in-review
 size: small
 ---
 
@@ -29,7 +29,7 @@ place to get fancy about types).
 
 ## Checklist
 
-- [ ] Add `!**/e2e/**` and `!**/*test-{helpers,harness,utils}.{ts,tsx,mts,cts}` to
+- [x] Add `!**/e2e/**` and `!**/*test-{helpers,harness,utils}.{ts,tsx,mts,cts}` to
       `rules/typescript/explain-type-cast.md`'s files globs.
 
 ## Out of scope

--- a/tasks/explain-type-cast-test-globs.md
+++ b/tasks/explain-type-cast-test-globs.md
@@ -1,0 +1,42 @@
+---
+status: in-progress
+size: small
+---
+
+# Iterate Review: stop applying explain-type-cast to test code the globs miss
+
+## Status summary
+
+Spec written; one-file change to follow.
+
+## Ask (from Misha)
+
+Exclude the `typescript/explain-type-cast` rule from ANY test code. The rule's
+frontmatter already excludes `*.{test,spec}.*` files and `__tests__/test/tests/spec/specs`
+directories, but real test code still slips through — most recently the casts in
+`apps/os/e2e/examples/example-cases.ts` on PR #2409. Test code shouldn't need
+cast-justification comments (per the repo's own testing docs, test files are not the
+place to get fancy about types).
+
+## Gaps found in this repo
+
+- `**/e2e/**` — eight e2e directories (apps/os, apps/mobile, apps/auth, …), none
+  matched by the current negatives.
+- Test scaffolding named by convention outside test dirs:
+  `apps/os/src/domains/projects/project-processor-test-harness.ts`,
+  `apps/os/e2e/vitest/test-helpers.ts` (the latter also covered by the e2e glob).
+- Root `specs/` is already covered by the existing directory glob.
+
+## Checklist
+
+- [ ] Add `!**/e2e/**` and `!**/*test-{helpers,harness,utils}.{ts,tsx,mts,cts}` to
+      `rules/typescript/explain-type-cast.md`'s files globs.
+
+## Out of scope
+
+- The identical template copy at
+  `apps/os/config-repo-template/rules/typescript/explain-type-cast.md` — that ships
+  to customer projects' config repos, whose test layouts differ; changing their
+  policy is a separate decision.
+- The other rules (`no-inferable-type-annotation`, structure rules) keep their
+  existing globs — the ask was specifically explain-type-cast.


### PR DESCRIPTION
The rule's frontmatter already excluded `*.{test,spec}.*` files and `__tests__/test/tests/spec/specs` directories, but real test code still slipped through: `**/e2e/**` (eight e2e directories across the apps) and conventionally-named scaffolding like `project-processor-test-harness.ts`. Iterate Review demonstrated the gap live on #2409, flagging unexplained casts in `apps/os/e2e/examples/example-cases.ts` — exactly the kind of test code the repo's own testing docs say shouldn't get fancy about types.

Two new negative globs:

```yaml
"!**/e2e/**",
"!**/*test-{helpers,harness,utils}.{ts,tsx,mts,cts}",
```

Deliberately scoped to this rule only, and only the repo's own `rules/` copy — the identical template at `apps/os/config-repo-template/rules/typescript/explain-type-cast.md` ships to customer projects' config repos, and changing their lint policy is a separate decision.

Task file: [tasks/explain-type-cast-test-globs.md](https://github.com/iterate/iterate/blob/explain-type-cast-test-globs/tasks/complete/2026-08-04-explain-type-cast-test-globs.md)

Session: d2ed786e-506b-447d-bad9-0e751c318659

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Docs | +44 -0 | +33 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+44 -0** | **+33 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 747f43f and b0054dc, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint rule scope change for test/e2e paths only; no runtime or production code paths affected.
> 
> **Overview**
> **Tightens file globs** for the `typescript/explain-type-cast` Iterate Review rule so it no longer runs on e2e trees or conventionally named test helper/harness/utils files that slipped past the existing `*.{test,spec}.*` and `__tests__/test/tests/spec/specs` negatives.
> 
> Adds `!**/e2e/**` and `!**/*test-{helpers,harness,utils}.{ts,tsx,mts,cts}` to `rules/typescript/explain-type-cast.md` only. The customer-facing copy under `apps/os/config-repo-template/` is unchanged.
> 
> A completed task note in `tasks/complete/` records the motivation (e.g. casts flagged in `apps/os/e2e/examples/example-cases.ts`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0054dc7d438ddcd75e9465504a9d42a73906735. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->