### PR TITLE
mobile: OTA QR codes encode iterate:// directly, taps keep the https interstitial

### DIFF
--- a/scripts/ci/mobile-preview.test.ts
+++ b/scripts/ci/mobile-preview.test.ts
@@ -11,6 +11,7 @@ test("branch names become valid EAS channel names", () => {
 test("links go through the https interstitial, never a raw iterate:// href", () => {
   const plan = planPreview({
     baseUrl: "https://os.iterate.com",
+    scheme: "iterate",
     channel: "my-feature",
     publishedRuntime: "37fb004ced1120b5d1fc8e57c7dd87e0aee98e8e",
     installedRuntime: "37fb004ced1120b5d1fc8e57c7dd87e0aee98e8e",
@@ -18,7 +19,10 @@ test("links go through the https interstitial, never a raw iterate:// href", () 
   });
   expect(plan).toMatchObject({
     runtimeMatchesInstalled: true,
+    // Tap path: https interstitial (GitHub strips custom-scheme hrefs).
     deepLinkUrl: "https://os.iterate.com/m/preview-channel/my-feature",
+    // Scan path: the camera opens the app scheme directly, no interstitial hop.
+    otaQrContent: "iterate://preview-channel/my-feature",
   });
 
   const section = renderPreviewSection({
@@ -43,6 +47,7 @@ test("links go through the https interstitial, never a raw iterate:// href", () 
 test("a runtime-matching PR renders with the OTA details open and install collapsed", () => {
   const plan = planPreview({
     baseUrl: "https://os.iterate.com",
+    scheme: "iterate",
     channel: "my-feature",
     publishedRuntime: "37fb004ced1120b5d1fc8e57c7dd87e0aee98e8e",
     installedRuntime: "37fb004ced1120b5d1fc8e57c7dd87e0aee98e8e",
@@ -68,6 +73,7 @@ test("a runtime-matching PR renders with the OTA details open and install collap
 test("a native-change PR flips the expanded details to the install QR", () => {
   const plan = planPreview({
     baseUrl: "https://os.iterate.com",
+    scheme: "iterate",
     channel: "add-native-module",
     publishedRuntime: "aaaa000000000000000000000000000000000000",
     installedRuntime: "37fb004ced1120b5d1fc8e57c7dd87e0aee98e8e",
@@ -92,6 +98,7 @@ test("a native-change PR flips the expanded details to the install QR", () => {
 test("the main variant reads as a switch-back, not a PR switch", () => {
   const plan = planPreview({
     baseUrl: "https://os.iterate.com",
+    scheme: "iterate",
     channel: "preview",
     publishedRuntime: "37fb004ced1120b5d1fc8e57c7dd87e0aee98e8e",
     installedRuntime: "37fb004ced1120b5d1fc8e57c7dd87e0aee98e8e",
@@ -116,6 +123,7 @@ test("the main variant reads as a switch-back, not a PR switch", () => {
 test("no finished preview build at all counts as a runtime mismatch", () => {
   const plan = planPreview({
     baseUrl: "https://os.iterate.com",
+    scheme: "iterate",
     channel: "first-ever",
     publishedRuntime: "aaaa000000000000000000000000000000000000",
     installedRuntime: undefined,

--- a/scripts/ci/mobile-preview.ts
+++ b/scripts/ci/mobile-preview.ts
@@ -103,13 +103,19 @@ export type PreviewPlan = {
   /** Does the published JS run on the binary a phone already has installed? */
   runtimeMatchesInstalled: boolean;
   channel: string;
-  /** Https interstitial that bounces to iterate://preview-channel/<channel>. */
+  /** Https interstitial that bounces to iterate://preview-channel/<channel> —
+   * the TAP path (GitHub strips custom-scheme hrefs, so links need https). */
   deepLinkUrl: string;
+  /** Raw app-scheme URL — the SCAN path. The camera opens custom schemes
+   * directly, so QR codes encode this and skip the interstitial hop. */
+  otaQrContent: string;
   installUrl: string;
 };
 
 export const planPreview = (input: {
   baseUrl: string;
+  /** The app's URL scheme (app.json `scheme`, i.e. "iterate"). */
+  scheme: string;
   channel: string;
   publishedRuntime: string;
   /** Runtime of the newest FINISHED preview-profile build — what's installable today. */
@@ -121,6 +127,7 @@ export const planPreview = (input: {
   runtimeMatchesInstalled: input.publishedRuntime === input.installedRuntime,
   channel: input.channel,
   deepLinkUrl: interstitialUrl(input.baseUrl, input.channel),
+  otaQrContent: `${input.scheme}://preview-channel/${input.channel}`,
   installUrl: input.installUrl,
 });
 

--- a/scripts/ci/publish-mobile-pr-preview.ts
+++ b/scripts/ci/publish-mobile-pr-preview.ts
@@ -38,7 +38,7 @@ async function publishMobilePrPreview() {
   }
 
   const appConfig = JSON.parse(readFileSync(path.join(mobileDir, "app.json"), "utf8"));
-  const { owner, slug } = appConfig.expo;
+  const { owner, slug, scheme } = appConfig.expo;
   const channel = channelForBranch(pullRequest.head.ref);
   const headSha = pullRequest.head.sha;
 
@@ -70,6 +70,7 @@ async function publishMobilePrPreview() {
 
   const plan = planPreview({
     baseUrl: prdBaseUrl,
+    scheme,
     channel,
     publishedRuntime,
     installedRuntime,
@@ -78,8 +79,8 @@ async function publishMobilePrPreview() {
 
   const [deepLinkQrUrl, installQrUrl] = await Promise.all([
     uploadQrAsset(
-      `mobile-pr-${pullRequest.number}-${headSha.slice(0, 9)}-ota.png`,
-      plan.deepLinkUrl,
+      `mobile-pr-${pullRequest.number}-${headSha.slice(0, 9)}-ota-scheme.png`,
+      plan.otaQrContent,
     ),
     uploadQrAsset(
       `mobile-pr-${pullRequest.number}-${headSha.slice(0, 9)}-install-${installBuild.id.slice(0, 8)}.png`,

--- a/scripts/ci/publish-mobile-update.ts
+++ b/scripts/ci/publish-mobile-update.ts
@@ -63,16 +63,17 @@ async function publishMobileUpdate() {
 
   const sha = process.env.GITHUB_SHA || run("git", ["rev-parse", "HEAD"], repoRoot).trim();
   const appConfig = JSON.parse(readFileSync(path.join(mobileDir, "app.json"), "utf8"));
-  const { owner, slug } = appConfig.expo;
+  const { owner, slug, scheme } = appConfig.expo;
   const plan = planPreview({
     baseUrl: prdBaseUrl,
+    scheme,
     channel: "preview",
     publishedRuntime: runtimeVersion,
     installedRuntime,
     installUrl: `https://expo.dev/accounts/${owner}/projects/${slug}/builds/${installBuild.id}`,
   });
   const [deepLinkQrUrl, installQrUrl] = await Promise.all([
-    uploadQrAsset(`mobile-main-${sha.slice(0, 9)}-ota.png`, plan.deepLinkUrl),
+    uploadQrAsset(`mobile-main-${sha.slice(0, 9)}-ota-scheme.png`, plan.otaQrContent),
     uploadQrAsset(
       `mobile-main-${sha.slice(0, 9)}-install-${installBuild.id.slice(0, 8)}.png`,
       plan.installUrl,


### PR DESCRIPTION
Scanning a preview QR now opens the app immediately — the camera handles custom schemes natively, so the trip through `os.iterate.com/m/preview-channel/…` only happens on *taps* (where GitHub's href sanitizer makes https unavoidable).

| Path | URL |
| --- | --- |
| QR scan (camera) | `iterate://preview-channel/<channel>` |
| Tap (bold link) | `https://os.iterate.com/m/preview-channel/<channel>` |

QR asset names gain a `-scheme` suffix because the release-asset reuse cache assumes a name fully determines content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session: `5daba6b0-cb79-4137-b08f-5a25efebbafe`

<!-- mobile-pr-preview -->
## 📱 Mobile preview

Channel `mobile-qr-scheme-content` · runtime `1bf9f0fe0` · **JS-only** — the installed app can run it

<details open><summary>OTA — switch the installed app to this PR's channel (`feae99a`)</summary>

**[Switch this phone to the PR channel](https://os.iterate.com/m/preview-channel/mobile-qr-scheme-content)**

<a href="https://os.iterate.com/m/preview-channel/mobile-qr-scheme-content"><img src="https://github.com/iterate/iterate/releases/download/gh-attach-assets/mobile-pr-2419-feae99aff-ota-scheme.png" width="90" alt="QR code" /></a>

</details>
<details><summary>Full install — if the app is uninstalled or the runtime differs (`09cb766`)</summary>

**[Open the EAS build install page](https://expo.dev/accounts/mishanustom/projects/iterate/builds/9623bb11-70cc-4263-9f7e-e0c6b95eb209)**

<a href="https://expo.dev/accounts/mishanustom/projects/iterate/builds/9623bb11-70cc-4263-9f7e-e0c6b95eb209"><img src="https://github.com/iterate/iterate/releases/download/gh-attach-assets/mobile-pr-2419-feae99aff-install-9623bb11.png" width="90" alt="QR code" /></a>

</details>

<sub>Back to main inside the app: Build info → Reset to default channel. Republishes on every push to this PR.</sub>
<!-- /mobile-pr-preview -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +8 -0 | +6 -0 🟩🟩⬜⬜⬜ |
| CI & scripts | +15 -6 | +8 -5 🟩🟩🟩🟥🟥 |
| **Total** | **+23 -6** | **+14 -5** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 1e652fa and feae99a, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->