### PR TITLE
evals: add headless Codex regression runner

### DIFF
--- a/evals/run.ts
+++ b/evals/run.ts
@@ -1,0 +1,77 @@
+import { spawn } from "node:child_process";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+import dedent from "dedent";
+import { createCli } from "trpc-cli";
+
+export default async function run(
+  slug: string,
+  options?: { agent?: string; environment?: string },
+) {
+  const evalFile = path.join(import.meta.dirname, slug, "eval.md");
+  const agent = options?.agent || "codex";
+  const environment = options?.environment || "production";
+  if (agent !== "codex") throw new Error(`Agent ${agent} not supported yet`);
+
+  await fs.access(evalFile);
+
+  const runDir = path.join(import.meta.dirname, "runs.ignoreme", slug, Date.now().toString());
+  const resultFile = path.join(runDir, "result.md");
+  await fs.mkdir(runDir, { recursive: true });
+  await fs.writeFile(resultFile, "");
+
+  const instructions = dedent`
+    Run the following eval against Iterate in the ${environment} environment.
+
+    When finished, write the result to ${resultFile}. The first line should be either \`<result>success</result>\` or \`<result>failure</result>\`. In either case, write a concise explanation of why you think the result is what it is. If more details, logs, or notes are needed, write them freely to other files in ${runDir} and point to them in ${resultFile}.
+
+    Create a fresh project using the default template unless the eval says otherwise.
+
+    The eval may link to one or more real streams. Inspect them to understand what happened and to source realistic external-system responses. The product evolves constantly, so the latest agent may make requests that do not exactly match historical calls. Use the stream evidence and your judgment to return coherent responses to whatever it asks now.
+
+    When an eval needs an unavailable external integration, create a live capability backed by a request/response broker. Do not hard-code a narrow response table, spawn another Codex session, fork yourself, or call itx.ai.run to decide what the integration should return.
+
+    Each capability invocation must:
+
+    1. Emit a uniquely identified request to a process controlled by this main Codex session.
+    2. Pause until this same session supplies the response.
+    3. Return that response to the product agent.
+
+    Run the product-agent request asynchronously so capability requests yield back to this same main Codex session. Use your full eval context—including referenced historical streams—to construct realistic, coherent responses. Maintain state across calls, support concurrent requests, log every exchange, use bounded timeouts, and keep the live capability connected until the product agent finishes.
+
+    Include in ${resultFile} every agent stream created in the eval project and the total token usage. You can write helper tools in the \`evals/\` directory. Track a helper in git only if it will help future evals; otherwise give it a gitignored filename.
+
+    The eval must state its success criteria. If it does not, immediately mark the run as a failure and recommend suitable criteria in the explanation.
+
+    This session is not a conversation and will usually run headlessly. Do not respond to the eval or ask for clarification. If the user intervenes, treat that as evidence that the eval setup may need improvement. After the eval, make any broadly useful harness or helper improvements and open a pull request.
+
+    A valid failure can be that you lack enough access to investigate or that the eval is unclear.
+
+    Here is the eval: ${evalFile}
+
+    Begin.
+  `;
+
+  const instructionsFile = path.join(runDir, "instructions.md");
+  await fs.writeFile(instructionsFile, instructions);
+
+  const instructionsHandle = await fs.open(instructionsFile, "r");
+  try {
+    const child = spawn("codex", ["exec", "-"], {
+      cwd: path.join(import.meta.dirname, ".."),
+      stdio: [instructionsHandle.fd, "inherit", "inherit"],
+    });
+    const exitCode = await new Promise<number>((resolve, reject) => {
+      child.on("error", reject);
+      child.on("close", (code) => resolve(code === null ? 1 : code));
+    });
+    if (exitCode !== 0) throw new Error(`Codex exited with code ${exitCode}`);
+  } finally {
+    await instructionsHandle.close();
+  }
+
+  return await fs.readFile(resultFile, "utf8");
+}
+
+void createCli(import.meta).run();

--- a/evals/run.ts
+++ b/evals/run.ts
@@ -30,6 +30,8 @@ export default async function run(
 
     The eval may link to one or more real streams. Inspect them to understand what happened and to source realistic external-system responses. The product evolves constantly, so the latest agent may make requests that do not exactly match historical calls. Use the stream evidence and your judgment to return coherent responses to whatever it asks now.
 
+    Referenced streams are read-only evidence. Read their journaled events; never invoke the referenced project's integrations or spend its secrets — that hits real external services and can trip production egress approvals, paging a human. Anything you invoke live belongs in the fresh eval project, behind your broker.
+
     When an eval needs an unavailable external integration, create a live capability backed by a request/response broker. Do not hard-code a narrow response table, spawn another Codex session, fork yourself, or call itx.ai.run to decide what the integration should return.
 
     Each capability invocation must:

--- a/evals/summarise-emails/eval.md
+++ b/evals/summarise-emails/eval.md
@@ -1,0 +1,12 @@
+https://os.iterate.com/projects/misha/agents/streams/agents/mobile/2026-08-03t16-27-32-701z
+
+This chat did not go very well.
+
+Problems:
+
+- It took eight rounds to complete the request.
+- It used `itx.ai.run(...)` instead of returning results and letting the agent's own model process them.
+- It parsed HTML manually with regular expressions instead of using a suitable conversion capability such as `toMarkdown(...)`.
+- Truncation left the agent guessing how to use prior results.
+
+Success criteria: the new run should clearly improve on the historical stream without any of the problems above.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev-all": "sh -c 'export APP_CONFIG_AUTH_APP_ORIGIN=http://localhost:7101; export APP_CONFIG_PUBLIC_URL=http://localhost:7101; export APP_CONFIG_ITERATE_AUTH__ISSUER=http://localhost:7101/api/auth; export APP_CONFIG_ITERATE_AUTH__RESOURCE=http://localhost; (cd apps/auth && doppler run --preserve-env=APP_CONFIG_AUTH_APP_ORIGIN,APP_CONFIG_PUBLIC_URL -- pnpm dev:local) & (cd apps/os && doppler run --preserve-env=APP_CONFIG_ITERATE_AUTH__ISSUER,APP_CONFIG_ITERATE_AUTH__RESOURCE -- pnpm dev start --skip-doppler true); wait'",
     "dev": "pnpm os dev",
+    "eval": "node evals/run.ts",
     "build": "pnpm -r --parallel build",
     "typecheck": "pnpm -r --parallel typecheck",
     "format": "oxfmt",


### PR DESCRIPTION
## Summary

Adds a headless eval harness that:

- creates isolated, ignored artifacts for each run
- starts Codex from a generated instruction file while streaming the normal session output
- requires a structured result with the agent streams and total token usage
- tells the main evaluator to simulate unavailable integrations with a live request/response capability routed back to that same Codex session, so it can use the eval and historical stream context to make realistic responses

The first regression eval targets the FirstFT email-summary stream. It guards against excessive rounds, nested AI summarization, regex-based HTML conversion, and guessing after truncated results.

```sh
pnpm eval summarise-emails
pnpm eval summarise-emails --environment preview_3
```

## Verification

- `pnpm install`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm format`
- `pnpm test`
- `pnpm eval --help`
- focused eval formatting, lint, and TypeScript checks

## Risk map

- Highest-attention area: `evals/run.ts` process lifecycle and evaluator instructions. Correctness depends on inherited stdio and the same-session broker contract being clear enough for Codex to implement.
- Merge impact: developer tooling only; no deployed runtime changes. Running an eval defaults to production and asks Codex to create a throwaway project.
- Suggested review order: `evals/run.ts`, then `evals/summarise-emails/eval.md`, then the package script.

Coding agent session: `019fd0fe-5974-7a43-a17c-1d2b08c994fb`

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Config | +1 -0 | +1 -0 🟩⬜⬜⬜⬜ |
| Docs | +12 -0 | +8 -0 🟩⬜⬜⬜⬜ |
| Other | +79 -0 | +42 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+92 -0** | **+51 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 2a868fc and 2a0e343, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-only tooling with no deployed runtime changes; risk is mainly operational (default production target, Codex creating throwaway projects) rather than product code correctness.
> 
> **Overview**
> Adds a **headless eval harness** (`evals/run.ts`) invoked via `pnpm eval <slug>`, with optional `--environment` and `--agent` (Codex only for now). Each run writes artifacts under gitignored `evals/runs.ignoreme/`, spawns `codex exec` with generated instructions, and expects a structured `result.md` (`success`/`failure`, stream URLs, token usage).
> 
> The harness directs the evaluator to run against a fresh Iterate project, treat linked historical streams as **read-only evidence** (no live calls on referenced projects), and simulate missing integrations through a **same-session request/response broker**—explicitly avoiding nested `itx.ai.run`, hard-coded response tables, or extra Codex sessions.
> 
> The first regression eval, **`summarise-emails`**, targets a bad FirstFT email-summary stream and requires fewer rounds, no nested AI summarization, proper HTML conversion (e.g. `toMarkdown`), and no guessing after truncated results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a0e34342a81bc7ac809d8e53c97ce3db23b4b8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->