### PR TITLE
Close empty capability provider Pagers

### DIFF
--- a/apps/os/src/domains/capability-host/capability-provider-pager-relay.test.ts
+++ b/apps/os/src/domains/capability-host/capability-provider-pager-relay.test.ts
@@ -138,6 +138,20 @@ describe("CapabilityProviderPagerRelay", () => {
     expect(pager.closed).toEqual([]);
   });
 
+  it("closes the shared Pager when its final mount retires", async () => {
+    const pager = new FakePager();
+    dialPager.mockResolvedValue(pager);
+    const relay = relayOver(makeDurableObject());
+    const first = await relay.provide({ capability: {}, path: ["first"], type: "live" });
+    const second = await relay.provide({ capability: {}, path: ["second"], type: "live" });
+
+    await first.revoke({ path: first.path, providedAtOffset: first.providedAtOffset });
+    expect(pager.closed).toEqual([]);
+
+    await second.revoke({ path: second.path, providedAtOffset: second.providedAtOffset });
+    expect(pager.closed).toEqual([{ code: 1000, reason: "no live capability mounts" }]);
+  });
+
   it("retires every mount when the shared Pager disconnects", async () => {
     const pager = new FakePager();
     dialPager.mockResolvedValue(pager);

--- a/apps/os/src/domains/capability-host/capability-provider-pager-relay.ts
+++ b/apps/os/src/domains/capability-host/capability-provider-pager-relay.ts
@@ -246,6 +246,15 @@ export class CapabilityProviderPagerRelay {
     } catch (error) {
       console.error("live provider disposal failed", { error, providedAtOffset });
     }
+    const pager = this.#pager;
+    if (this.#mounts.size > 0 || pager === undefined) return;
+    this.#pager = undefined;
+    this.#connectedAtOffset = undefined;
+    try {
+      pager.close(1000, "no live capability mounts");
+    } catch {
+      // Already closed.
+    }
   }
 
   #releaseActiveLeg(mounted: MountedProvider): void {


### PR DESCRIPTION
## Summary

Close a Capability Provider Pager as soon as its final live capability mount retires. Sibling mounts continue sharing the Pager; only the zero-mount transition closes it.

## Root cause

The relay retired providers and call legs but kept an empty Pager open for possible reuse. A 1,000-client production soak made that lifecycle visible: after every mount was revoked, hundreds of empty Pager records remained until their stateless relays were eventually collected.

The relay now clears its Pager identity and closes the WebSocket on the exact final-mount transition, so the Durable Object receives the normal disconnect lifecycle promptly.

## Impact

- Empty provider relays release their hibernatable Pager immediately.
- Relays with one or more live mounts are unchanged.
- A later provide operation dials a fresh Pager through the existing path.
- No migration or compatibility behavior is added.

## Risk map

- Riskiest point: final-mount retirement can race with the Pager close callback. The relay clears the current Pager identity before close, making the callback an idempotent no-op after the mount is already retired.
- On merge: clients that revoke their final live mount create one prompt Pager disconnect event instead of retaining an empty channel. Existing live mounts are unaffected.
- Review order: capability-provider-pager-relay.ts first, then the focused regression test.

## Validation

- pnpm install --frozen-lockfile
- pnpm typecheck
- pnpm lint
- pnpm knip
- pnpm format
- pnpm test
- Thermonuclear maintainability review: no structural findings; 23 net lines across implementation and regression test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches capability-host relay lifecycle and WebSocket teardown; clearing pager identity before `close` limits races with the pager close handler, but final-mount retirement timing still matters for DO disconnect events.
> 
> **Overview**
> **Capability Provider Pager relays** no longer keep a shared hibernatable WebSocket open after every live mount is gone. When `#retireMount` removes the final entry from `#mounts` (revoke, retire page, or failure paths), the relay clears `#pager` and `#connectedAtOffset`, then closes the socket with code `1000` and reason `no live capability mounts`. Sibling mounts on the same Pager are unchanged; only the zero-mount transition triggers close. A later `provide` still dials a fresh Pager via the existing `#ensurePager` path.
> 
> A regression test asserts that revoking one of two mounts leaves the Pager open, and revoking the second produces the expected close record.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c76a0f88c30e50ee2a6674dab26d284ac054721c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-06T17:25:16.648Z",
      "headSha": "c76a0f88c30e50ee2a6674dab26d284ac054721c",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/386629419547380",
      "shortSha": "c76a0f8",
      "cleanupDurationMs": 13754,
      "deployDurationMs": 125184,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 125181,
      "workerSizeKib": 14447.9,
      "workerGzipKib": 3824.99,
      "mainWorkerGzipKib": 5194.21
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-06T17:25:05.817Z",
      "deployedAt": "2026-08-06T16:21:42.329Z",
      "headSha": "c76a0f88c30e50ee2a6674dab26d284ac054721c",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-11.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/386629419547380",
      "shortSha": "c76a0f8",
      "cleanupDurationMs": 2920,
      "deployDurationMs": 13278,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 11649,
      "deployReadinessDurationMs": 1625,
      "deployedWorkerName": "docs-preview-11",
      "deployedWorkerVersion": "6859dd95-38ca-4109-b8c1-43d930184a5c",
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-06T17:25:06.555Z",
      "deployedAt": "2026-08-06T16:21:52.220Z",
      "headSha": "c76a0f88c30e50ee2a6674dab26d284ac054721c",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/386629419547380",
      "shortSha": "c76a0f8",
      "cleanupDurationMs": 3655,
      "deployDurationMs": 21963,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 21538,
      "deployReadinessDurationMs": 420,
      "deployedWorkerName": "auth-preview-11",
      "deployedWorkerVersion": "c84d5ff5-7777-402d-b0d1-5b989ea2f747",
      "workerSizeKib": 3981.29,
      "workerGzipKib": 815.32,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-06T17:25:03.797Z",
      "deployedAt": "2026-08-06T16:21:36.488Z",
      "headSha": "c76a0f88c30e50ee2a6674dab26d284ac054721c",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/386629419547380",
      "shortSha": "c76a0f8",
      "cleanupDurationMs": 896,
      "deployDurationMs": 6039,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 5764,
      "deployReadinessDurationMs": 227,
      "deployedWorkerName": "dummy-petshop-preview-11",
      "deployedWorkerVersion": "95cc5bca-f850-41fb-8d2f-f84bc3e4ac89",
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `c76a0f8` | [https://auth.iterate-preview-11.com](https://auth.iterate-preview-11.com) | 815.3 KiB | 22.0s |  |  | 3.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/386629419547380) | 2026-08-06T17:25:06.555Z | Preview app released. |
| Docs | released | `c76a0f8` | [https://docs-preview-11.iterate-dev-preview.workers.dev](https://docs-preview-11.iterate-dev-preview.workers.dev) | 866.2 KiB | 13.3s |  |  | 2.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/386629419547380) | 2026-08-06T17:25:05.817Z | Preview app released. |
| Dummy Petshop | released | `c76a0f8` | [https://dummy-petshop.iterate-preview-11.com](https://dummy-petshop.iterate-preview-11.com) | 198.3 KiB | 6.0s |  |  | 896ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/386629419547380) | 2026-08-06T17:25:03.797Z | Preview app released. |
| OS | released | `c76a0f8` | [https://os.iterate-preview-11.com](https://os.iterate-preview-11.com) | 3.74 MiB (-1.34 MiB vs main) | 125.2s |  |  | 13.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/386629419547380) | 2026-08-06T17:25:16.648Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +9 -0 | +8 -0 🟩🟩🟩🟩⬜ |
| Tests | +14 -0 | +11 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+23 -0** | **+19 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 20b6b0b and c76a0f8, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->