### PR TITLE
Agent feed Result tab: show what the agent actually saw

### DIFF
--- a/apps/os/src/components/agent-activity-rounds.test.tsx
+++ b/apps/os/src/components/agent-activity-rounds.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { expect, test } from "vitest";
+import { AgentActivityRounds } from "./agent-activity-rounds.tsx";
+import type { StreamBrowserDatabase } from "~/domains/streams/client-libraries/browser/stream-browser-db.ts";
+
+test("the Result tab defaults to the settlement text the agent was shown", async () => {
+  const agentRender =
+    'Your script returned:\n```json\n{\n  "ok": true\n}\n```\n' +
+    "This result is available to your next script as `results[0].data` (the preamble `results` array, newest first).";
+  await using mounted = await renderRounds(
+    databaseWithRenderEvent("agent-output:53", agentRender),
+    codeStep({ result: { ok: true } }),
+  );
+  const { host } = mounted;
+  await clickResultTab(host);
+
+  const agentView = host.querySelector('[data-testid="script-result-agent-view"]');
+  expect(agentView?.textContent).toContain("Your script returned");
+  expect(agentView?.textContent).toContain("results[0].data");
+  // The client-side YAML re-serialization is NOT the default any more…
+  expect(host.querySelector('[data-testid="script-result-raw"]')).toBeNull();
+  // …but stays one toggle away.
+  const toggle = host.querySelector<HTMLButtonElement>('[data-testid="script-result-view-toggle"]');
+  expect(toggle?.textContent).toBe("Show raw result");
+  await act(async () => toggle!.click());
+  expect(host.querySelector('[data-testid="script-result-agent-view"]')).toBeNull();
+  // SourceCodeBlock is a lazy client-only chunk, so assert the raw container
+  // rather than the highlighted YAML text (it never paints in jsdom).
+  expect(host.querySelector('[data-testid="script-result-raw"]')).not.toBeNull();
+  expect(host.querySelector('[data-testid="script-result-view-toggle"]')?.textContent).toBe(
+    "Show agent view",
+  );
+});
+
+test("a stream with no agent-facing render falls back to the raw result view", async () => {
+  await using mounted = await renderRounds(
+    databaseWithRenderEvent(null, ""),
+    codeStep({ result: [1, 2] }),
+  );
+  const { host } = mounted;
+  await clickResultTab(host);
+
+  expect(host.querySelector('[data-testid="script-result-agent-view"]')).toBeNull();
+  expect(host.querySelector('[data-testid="script-result-view-toggle"]')).toBeNull();
+  expect(host.querySelector('[data-testid="script-result-raw"]')).not.toBeNull();
+});
+
+test("without a raw-event mirror the raw result view renders alone, as before", async () => {
+  await using mounted = await renderRounds(undefined, codeStep({ result: { plain: "raw" } }));
+  const { host } = mounted;
+  await clickResultTab(host);
+
+  expect(host.querySelector('[data-testid="script-result-agent-view"]')).toBeNull();
+  expect(host.querySelector('[data-testid="script-result-view-toggle"]')).toBeNull();
+  expect(host.querySelector('[data-testid="script-result-raw"]')).not.toBeNull();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function codeStep(overrides: Record<string, unknown>) {
+  const startedAtMs = Date.UTC(2026, 6, 15, 22, 6, 0);
+  return {
+    kind: "code",
+    id: "code:53",
+    executionId: "agent-output:53",
+    status: "done",
+    code: "return { ok: true }",
+    success: true,
+    startedAtMs,
+    durationMs: 2_000,
+    expiresAtMs: startedAtMs + 60_000,
+    ...overrides,
+  } as any;
+}
+
+/**
+ * The narrow seam `useStreamQuery` actually uses: `db.query(sql, params)`
+ * returning a stable subscribe/getSnapshot handle. When `executionId` is
+ * null the mirror has no script render event.
+ */
+function databaseWithRenderEvent(
+  executionId: string | null,
+  content: string,
+): StreamBrowserDatabase {
+  const rows =
+    executionId == null
+      ? []
+      : [
+          {
+            raw_json: JSON.stringify({
+              type: "events.iterate.com/agents/context-added",
+              payload: { role: "developer", content, actor: { type: "script", executionId } },
+            }),
+          },
+        ];
+  const snapshot = { data: rows, status: "ok", error: undefined };
+  const handle = { getSnapshot: () => snapshot, subscribe: () => () => {} };
+  return { query: () => handle } as any;
+}
+
+async function renderRounds(database: StreamBrowserDatabase | undefined, code: any) {
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+  const root = createRoot(host);
+  await act(async () => {
+    root.render(<AgentActivityRounds rounds={[{ llm: null, code }]} database={database} />);
+  });
+  return {
+    host,
+    async [Symbol.asyncDispose]() {
+      await act(async () => root.unmount());
+      host.remove();
+    },
+  };
+}
+
+async function clickResultTab(host: HTMLElement) {
+  const resultTab = [
+    ...host.querySelectorAll<HTMLButtonElement>('[data-slot="tabs-trigger"]'),
+  ].find((tab) => tab.textContent === "Result");
+  expect(resultTab).toBeDefined();
+  await act(async () => resultTab!.click());
+}

--- a/apps/os/src/components/agent-activity-rounds.test.tsx
+++ b/apps/os/src/components/agent-activity-rounds.test.tsx
@@ -5,7 +5,9 @@ import { expect, test } from "vitest";
 import { AgentActivityRounds } from "./agent-activity-rounds.tsx";
 import type { StreamBrowserDatabase } from "~/domains/streams/client-libraries/browser/stream-browser-db.ts";
 
-test("the Result tab defaults to the settlement text the agent was shown", async () => {
+test("a result the agent saw in full keeps the raw view as the default", async () => {
+  // The untransformed render embeds the exact stringified result, so the
+  // agent saw everything — the raw view is nicer to read and stays default.
   const agentRender =
     'Your script returned:\n```json\n{\n  "ok": true\n}\n```\n' +
     "This result is available to your next script as `results[0].data` (the preamble `results` array, newest first).";
@@ -16,22 +18,49 @@ test("the Result tab defaults to the settlement text the agent was shown", async
   const { host } = mounted;
   await clickResultTab(host);
 
+  // SourceCodeBlock is a lazy client-only chunk, so assert the raw container
+  // rather than the highlighted YAML text (it never paints in jsdom).
+  expect(host.querySelector('[data-testid="script-result-raw"]')).not.toBeNull();
+  expect(host.querySelector('[data-testid="script-result-agent-view"]')).toBeNull();
+  // The agent's view is still one toggle away.
+  const toggle = host.querySelector<HTMLButtonElement>('[data-testid="script-result-view-toggle"]');
+  expect(toggle?.textContent).toBe("Show agent view");
+  await act(async () => toggle!.click());
   const agentView = host.querySelector('[data-testid="script-result-agent-view"]');
   expect(agentView?.textContent).toContain("Your script returned");
   expect(agentView?.textContent).toContain("results[0].data");
-  // The client-side YAML re-serialization is NOT the default any more…
   expect(host.querySelector('[data-testid="script-result-raw"]')).toBeNull();
-  // …but stays one toggle away.
+  expect(host.querySelector('[data-testid="script-result-view-toggle"]')?.textContent).toBe(
+    "Show raw result",
+  );
+});
+
+test("a truncated render defaults to the agent view — the raw view would misrepresent it", async () => {
+  // Inline truncation: the render carries only a slice of the stringified
+  // result plus the truncation notice, so containment fails.
+  const result = { items: "item ".repeat(50).trim() };
+  const truncatedRender =
+    "Your script returned:\n```json\n" +
+    JSON.stringify(result, null, 2).slice(0, 80) +
+    "\n… truncated (262 chars total; up to 80 render inline — return less: slice arrays, pick fields)\n```\n" +
+    "This result is available to your next script as `results[0].data` (the preamble `results` array, newest first).";
+  await using mounted = await renderRounds(
+    databaseWithRenderEvent("agent-output:53", truncatedRender),
+    codeStep({ result }),
+  );
+  const { host } = mounted;
+  await clickResultTab(host);
+
+  const agentView = host.querySelector('[data-testid="script-result-agent-view"]');
+  expect(agentView?.textContent).toContain("Your script returned");
+  expect(agentView?.textContent).toContain("truncated (262 chars total");
+  expect(host.querySelector('[data-testid="script-result-raw"]')).toBeNull();
+  // The full raw result stays one toggle away.
   const toggle = host.querySelector<HTMLButtonElement>('[data-testid="script-result-view-toggle"]');
   expect(toggle?.textContent).toBe("Show raw result");
   await act(async () => toggle!.click());
   expect(host.querySelector('[data-testid="script-result-agent-view"]')).toBeNull();
-  // SourceCodeBlock is a lazy client-only chunk, so assert the raw container
-  // rather than the highlighted YAML text (it never paints in jsdom).
   expect(host.querySelector('[data-testid="script-result-raw"]')).not.toBeNull();
-  expect(host.querySelector('[data-testid="script-result-view-toggle"]')?.textContent).toBe(
-    "Show agent view",
-  );
 });
 
 test("a stream with no agent-facing render falls back to the raw result view", async () => {

--- a/apps/os/src/components/agent-activity-rounds.test.tsx
+++ b/apps/os/src/components/agent-activity-rounds.test.tsx
@@ -4,16 +4,21 @@ import { createRoot } from "react-dom/client";
 import { expect, test } from "vitest";
 import { AgentActivityRounds } from "./agent-activity-rounds.tsx";
 import type { StreamBrowserDatabase } from "~/domains/streams/client-libraries/browser/stream-browser-db.ts";
+import { stringifyScriptResult, truncateScriptResult } from "~/lib/script-result-render.ts";
 
 test("a result the agent saw in full keeps the raw view as the default", async () => {
-  // The untransformed render embeds the exact stringified result, so the
-  // agent saw everything — the raw view is nicer to read and stays default.
+  // The untransformed render embeds the exact stringified result — built
+  // here through the same shared stringifyScriptResult the server render and
+  // the component's containment check both use, proving the round-trip.
+  const result = { ok: true };
   const agentRender =
-    'Your script returned:\n```json\n{\n  "ok": true\n}\n```\n' +
+    "Your script returned:\n```json\n" +
+    stringifyScriptResult(result) +
+    "\n```\n" +
     "This result is available to your next script as `results[0].data` (the preamble `results` array, newest first).";
   await using mounted = await renderRounds(
     databaseWithRenderEvent("agent-output:53", agentRender),
-    codeStep({ result: { ok: true } }),
+    codeStep({ result }),
   );
   const { host } = mounted;
   await clickResultTab(host);
@@ -36,13 +41,14 @@ test("a result the agent saw in full keeps the raw view as the default", async (
 });
 
 test("a truncated render defaults to the agent view — the raw view would misrepresent it", async () => {
-  // Inline truncation: the render carries only a slice of the stringified
-  // result plus the truncation notice, so containment fails.
+  // Inline truncation, built through the server's own shared helpers: the
+  // render carries only a slice of the stringified result plus the truncation
+  // notice, so containment fails.
   const result = { items: "item ".repeat(50).trim() };
   const truncatedRender =
     "Your script returned:\n```json\n" +
-    JSON.stringify(result, null, 2).slice(0, 80) +
-    "\n… truncated (262 chars total; up to 80 render inline — return less: slice arrays, pick fields)\n```\n" +
+    truncateScriptResult(stringifyScriptResult(result), 80) +
+    "\n```\n" +
     "This result is available to your next script as `results[0].data` (the preamble `results` array, newest first).";
   await using mounted = await renderRounds(
     databaseWithRenderEvent("agent-output:53", truncatedRender),
@@ -53,7 +59,7 @@ test("a truncated render defaults to the agent view — the raw view would misre
 
   const agentView = host.querySelector('[data-testid="script-result-agent-view"]');
   expect(agentView?.textContent).toContain("Your script returned");
-  expect(agentView?.textContent).toContain("truncated (262 chars total");
+  expect(agentView?.textContent).toContain("truncated (");
   expect(host.querySelector('[data-testid="script-result-raw"]')).toBeNull();
   // The full raw result stays one toggle away.
   const toggle = host.querySelector<HTMLButtonElement>('[data-testid="script-result-view-toggle"]');

--- a/apps/os/src/components/agent-activity-rounds.tsx
+++ b/apps/os/src/components/agent-activity-rounds.tsx
@@ -35,10 +35,11 @@ const SCRIPT_RENDER_EVENT_TYPE = "events.iterate.com/agents/context-added";
 // Script and Result (approval batches derived from root-stream events, which
 // this feed doesn't have wired in yet) and streams thinking text inline. If
 // you change the round/tab/Meta structure on one surface, ask whether the
-// other should follow. Known divergence: this feed's Result tab defaults to
-// the AGENT-VISIBLE settlement render (queried from the raw-event mirror,
-// which mobile doesn't have wired in) with the raw view behind a toggle;
-// mobile still shows only the raw result.
+// other should follow. Known divergence: this feed's Result tab can show the
+// AGENT-VISIBLE settlement render (queried from the raw-event mirror, which
+// mobile doesn't have wired in) — the default whenever that render was
+// truncated/transformed, a toggle away otherwise; mobile still shows only
+// the raw result.
 
 /**
  * The rounds rail of one settled (or fully-grouped live) activity. A single
@@ -326,12 +327,15 @@ function RoundTabs({
 }
 
 /**
- * The Result tab body. When the raw-event mirror is available, the DEFAULT
- * view is the agent's: the exact settlement text `renderScriptSettlement`
- * appended for the model (truncated at the configured history limit,
- * oversized results as an inferred type + bounded preview + loader recipe),
- * with the client-side raw view one toggle away. Without a mirror the raw
- * view stands alone, exactly as before.
+ * The Result tab body. When the raw-event mirror is available, the agent's
+ * view — the exact settlement text `renderScriptSettlement` appended for the
+ * model — is one toggle away, and becomes the DEFAULT precisely when that
+ * text is a transformed representation (inline truncation at the history
+ * limit, or an oversized result replaced by an inferred type + bounded
+ * preview + loader recipe): in that case the raw view would misrepresent
+ * what the agent could actually see. When the agent saw the full result, the
+ * raw view is strictly nicer to read and stays the default. Without a mirror
+ * the raw view stands alone, exactly as before.
  */
 function RoundResult({
   code,
@@ -360,7 +364,7 @@ function AgentRenderedRoundResult({
   code: AgentUiCodeStep;
   database: StreamBrowserDatabase;
 }) {
-  const [showRaw, setShowRaw] = useState(false);
+  const [toggled, setToggled] = useState<boolean | null>(null);
   const eventsResult = useStreamQuery(
     database,
     `SELECT json(raw_jsonb) AS raw_json FROM events
@@ -386,6 +390,7 @@ function AgentRenderedRoundResult({
   // view and swapping it out from under the reader.
   if (eventsResult.status === "pending") return null;
   if (agentText == null) return <RawRoundResult code={code} />;
+  const showRaw = toggled ?? !renderIsTransformed(code, agentText);
   return (
     <>
       {showRaw ? (
@@ -410,13 +415,45 @@ function AgentRenderedRoundResult({
         variant="ghost"
         size="xs"
         data-testid="script-result-view-toggle"
-        onClick={() => setShowRaw(!showRaw)}
+        onClick={() => setToggled(!showRaw)}
         className="-ml-2 self-start font-normal text-muted-foreground"
       >
         {showRaw ? "Show agent view" : "Show raw result"}
       </Button>
     </>
   );
+}
+
+/**
+ * Did the agent see a TRANSFORMED representation of this settlement, rather
+ * than the full thing? Detected structurally, coupled to the server-side
+ * render (`renderScriptSettlement` in
+ * apps/os/src/domains/agents/agent-processor-implementation.ts): the
+ * untransformed render always embeds the exact stringified settlement
+ * verbatim inside its fence — a returned string as itself, any other value
+ * as `JSON.stringify(value, null, 2)` (the server's
+ * `stringifyScriptResult`), a failure as its error text — while every
+ * transforming path (inline truncation at the history limit, oversized
+ * spills replaced by an inferred type + elided preview) necessarily drops
+ * part of it. So a simple containment check distinguishes the cases without
+ * matching on notice strings. The check degrades SAFELY: if the server's
+ * stringification ever changes shape, containment fails and the tab defaults
+ * to the agent view — which never misrepresents — rather than to a raw view
+ * claiming the agent saw everything.
+ */
+function renderIsTransformed(code: AgentUiCodeStep, agentText: string): boolean {
+  let full: string | null = null;
+  if (code.result !== undefined) {
+    try {
+      full = typeof code.result === "string" ? code.result : JSON.stringify(code.result, null, 2);
+    } catch {
+      full = null;
+    }
+  } else if (code.errorMessage != null) {
+    full = code.errorMessage;
+  }
+  if (full == null) return true;
+  return !agentText.includes(full);
 }
 
 function RawRoundResult({ code }: { code: AgentUiCodeStep }) {

--- a/apps/os/src/components/agent-activity-rounds.tsx
+++ b/apps/os/src/components/agent-activity-rounds.tsx
@@ -5,6 +5,7 @@ import type {
   AgentUiCodeStep,
   AgentUiLlmStep,
 } from "@iterate-com/ui/components/events/agent-ui-reducer";
+import { MessageResponse } from "@iterate-com/ui/components/ai-elements/message";
 import { Button } from "@iterate-com/ui/components/button";
 import { SourceCodeBlock } from "@iterate-com/ui/components/source-code-block";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@iterate-com/ui/components/tabs";
@@ -15,6 +16,10 @@ import { buildRoundMetaYaml, resultYaml } from "~/lib/agent-round-meta-yaml.ts";
 import { formatClockTime, formatSeconds, formatTokens, looksLikeCode } from "~/lib/feed-format.ts";
 import { LLM_REPLAY_EVENT_TYPES, replayLlmRequest } from "~/lib/llm-request-replay.ts";
 import { MAX_HIGHLIGHTED_SCRIPT_RESULT_CHARACTERS } from "~/lib/script-result-preview.ts";
+
+/** The canonical model-visible context event; script-actor instances carry the
+ * settlement text `renderScriptSettlement` produced for the agent. */
+const SCRIPT_RENDER_EVENT_TYPE = "events.iterate.com/agents/context-added";
 
 // The web feed's ROUND rendering: an expanded "Ran code N×" activity is a list
 // of rounds (the llm step that writes a script and the code step that runs
@@ -30,7 +35,10 @@ import { MAX_HIGHLIGHTED_SCRIPT_RESULT_CHARACTERS } from "~/lib/script-result-pr
 // Script and Result (approval batches derived from root-stream events, which
 // this feed doesn't have wired in yet) and streams thinking text inline. If
 // you change the round/tab/Meta structure on one surface, ask whether the
-// other should follow.
+// other should follow. Known divergence: this feed's Result tab defaults to
+// the AGENT-VISIBLE settlement render (queried from the raw-event mirror,
+// which mobile doesn't have wired in) with the raw view behind a toggle;
+// mobile still shows only the raw result.
 
 /**
  * The rounds rail of one settled (or fully-grouped live) activity. A single
@@ -295,7 +303,7 @@ function RoundTabs({
         )}
       </TabsContent>
       <TabsContent value="result" className="flex flex-col gap-2">
-        <RoundResult code={code} />
+        <RoundResult code={code} database={database} />
       </TabsContent>
       <TabsContent value="meta" className="flex flex-col gap-1.5">
         <RoundMeta llm={llm} code={code} database={database} />
@@ -317,7 +325,101 @@ function RoundTabs({
   );
 }
 
-function RoundResult({ code }: { code: AgentUiCodeStep }) {
+/**
+ * The Result tab body. When the raw-event mirror is available, the DEFAULT
+ * view is the agent's: the exact settlement text `renderScriptSettlement`
+ * appended for the model (truncated at the configured history limit,
+ * oversized results as an inferred type + bounded preview + loader recipe),
+ * with the client-side raw view one toggle away. Without a mirror the raw
+ * view stands alone, exactly as before.
+ */
+function RoundResult({
+  code,
+  database,
+}: {
+  code: AgentUiCodeStep;
+  database?: StreamBrowserDatabase;
+}) {
+  if (database == null) return <RawRoundResult code={code} />;
+  return <AgentRenderedRoundResult code={code} database={database} />;
+}
+
+/**
+ * The agent-visible settlement render lives ON THE STREAM: a developer
+ * `agents/context-added` event stamped `actor: {type: "script", executionId}`
+ * — queried from the mirror the same way the Meta tab replays its prompt
+ * (only while this tab is mounted; inactive base-ui tab panels unmount). The
+ * query is live, so a render event that lands moments after the settlement
+ * fills in when it arrives; streams with no render event (predating the
+ * server-side render, or non-agent executions) keep the raw view.
+ */
+function AgentRenderedRoundResult({
+  code,
+  database,
+}: {
+  code: AgentUiCodeStep;
+  database: StreamBrowserDatabase;
+}) {
+  const [showRaw, setShowRaw] = useState(false);
+  const eventsResult = useStreamQuery(
+    database,
+    `SELECT json(raw_jsonb) AS raw_json FROM events
+     WHERE type = ?
+       AND json_extract(raw_jsonb, '$.payload.actor.type') = 'script'
+       AND json_extract(raw_jsonb, '$.payload.actor.executionId') = ?
+     ORDER BY offset ASC
+     LIMIT 1`,
+    [SCRIPT_RENDER_EVENT_TYPE, code.executionId],
+  );
+  const agentText = useMemo(() => {
+    const row = eventsResult.data[0];
+    if (eventsResult.status !== "ok" || row == null) return null;
+    try {
+      const parsed = JSON.parse(String(row.raw_json)) as { payload?: { content?: unknown } };
+      const content = parsed.payload?.content;
+      return typeof content === "string" ? content : null;
+    } catch {
+      return null;
+    }
+  }, [eventsResult.status, eventsResult.data]);
+  // Wait for the local mirror (it answers in ms) instead of painting the raw
+  // view and swapping it out from under the reader.
+  if (eventsResult.status === "pending") return null;
+  if (agentText == null) return <RawRoundResult code={code} />;
+  return (
+    <>
+      {showRaw ? (
+        <RawRoundResult code={code} />
+      ) : (
+        <div
+          className="max-h-80 overflow-y-auto rounded-lg bg-muted/20 px-3 py-2 text-sm"
+          data-testid="script-result-agent-view"
+        >
+          {/* Same settled-markdown path as assistant messages: static mode,
+              no unpaired-marker balancing (see agent-feed.tsx). */}
+          <MessageResponse
+            className="min-w-0 max-w-full overflow-hidden"
+            mode="static"
+            parseIncompleteMarkdown={false}
+          >
+            {agentText}
+          </MessageResponse>
+        </div>
+      )}
+      <Button
+        variant="ghost"
+        size="xs"
+        data-testid="script-result-view-toggle"
+        onClick={() => setShowRaw(!showRaw)}
+        className="-ml-2 self-start font-normal text-muted-foreground"
+      >
+        {showRaw ? "Show agent view" : "Show raw result"}
+      </Button>
+    </>
+  );
+}
+
+function RawRoundResult({ code }: { code: AgentUiCodeStep }) {
   // One YAML fold for every size; only the RENDERER is bounded — CodeMirror
   // is expensive near the stream event-size ceiling, so oversized results get
   // a plain-text preview of the same YAML instead of falling back to JSON.
@@ -333,7 +435,7 @@ function RoundResult({ code }: { code: AgentUiCodeStep }) {
         </pre>
       )}
       {yaml == null ? null : yaml.length <= MAX_HIGHLIGHTED_SCRIPT_RESULT_CHARACTERS ? (
-        <div className="max-h-80 overflow-y-auto rounded-lg">
+        <div className="max-h-80 overflow-y-auto rounded-lg" data-testid="script-result-raw">
           <SourceCodeBlock code={yaml} language="yaml" showLineNumbers={false} />
         </div>
       ) : (

--- a/apps/os/src/components/agent-activity-rounds.tsx
+++ b/apps/os/src/components/agent-activity-rounds.tsx
@@ -16,6 +16,7 @@ import { buildRoundMetaYaml, resultYaml } from "~/lib/agent-round-meta-yaml.ts";
 import { formatClockTime, formatSeconds, formatTokens, looksLikeCode } from "~/lib/feed-format.ts";
 import { LLM_REPLAY_EVENT_TYPES, replayLlmRequest } from "~/lib/llm-request-replay.ts";
 import { MAX_HIGHLIGHTED_SCRIPT_RESULT_CHARACTERS } from "~/lib/script-result-preview.ts";
+import { stringifyScriptResult } from "~/lib/script-result-render.ts";
 
 /** The canonical model-visible context event; script-actor instances carry the
  * settlement text `renderScriptSettlement` produced for the agent. */
@@ -426,32 +427,23 @@ function AgentRenderedRoundResult({
 
 /**
  * Did the agent see a TRANSFORMED representation of this settlement, rather
- * than the full thing? Detected structurally, coupled to the server-side
- * render (`renderScriptSettlement` in
- * apps/os/src/domains/agents/agent-processor-implementation.ts): the
- * untransformed render always embeds the exact stringified settlement
- * verbatim inside its fence — a returned string as itself, any other value
- * as `JSON.stringify(value, null, 2)` (the server's
- * `stringifyScriptResult`), a failure as its error text — while every
- * transforming path (inline truncation at the history limit, oversized
- * spills replaced by an inferred type + elided preview) necessarily drops
- * part of it. So a simple containment check distinguishes the cases without
- * matching on notice strings. The check degrades SAFELY: if the server's
- * stringification ever changes shape, containment fails and the tab defaults
+ * than the full thing? Detected structurally: the untransformed render
+ * (`renderScriptSettlement` in
+ * apps/os/src/domains/agents/agent-processor-implementation.ts) embeds the
+ * exact stringified settlement verbatim inside its fence — computed by the
+ * SAME `stringifyScriptResult` this check imports (lib/script-result-render),
+ * so the coupling is enforced by sharing the implementation, not by
+ * convention — while every transforming path (inline truncation at the
+ * history limit, oversized spills replaced by an inferred type + elided
+ * preview) necessarily drops part of it. So a containment check
+ * distinguishes the cases without matching on notice strings. Fail-safe
+ * either way: if containment breaks for any other reason, the tab defaults
  * to the agent view — which never misrepresents — rather than to a raw view
  * claiming the agent saw everything.
  */
 function renderIsTransformed(code: AgentUiCodeStep, agentText: string): boolean {
-  let full: string | null = null;
-  if (code.result !== undefined) {
-    try {
-      full = typeof code.result === "string" ? code.result : JSON.stringify(code.result, null, 2);
-    } catch {
-      full = null;
-    }
-  } else if (code.errorMessage != null) {
-    full = code.errorMessage;
-  }
+  const full =
+    code.result !== undefined ? stringifyScriptResult(code.result) : (code.errorMessage ?? null);
   if (full == null) return true;
   return !agentText.includes(full);
 }

--- a/apps/os/src/domains/agents/agent-processor-implementation.ts
+++ b/apps/os/src/domains/agents/agent-processor-implementation.ts
@@ -1,6 +1,7 @@
 import { isIdempotencyConflict, StreamProcessor } from "iterate/processors";
 import type { EmittedInput, ProcessEventArgs, ReduceArgs, StreamEvent } from "iterate/processors";
 import { inferJsonType } from "../../lib/infer-json-type.ts";
+import { stringifyScriptResult, truncateScriptResult } from "../../lib/script-result-render.ts";
 import { previewJson } from "../../lib/truncate-json.ts";
 import { INLINE_RESULT_PREAMBLE_LIMIT } from "../capability-host/capability-host-preamble.ts";
 import {
@@ -1354,25 +1355,6 @@ async function renderScriptSettlement(input: {
     }
   }
   return `Your script returned:\n${fence}\n${truncateScriptResult(text, historyLimit)}\n\`\`\`${preambleNote}`;
-}
-
-function stringifyScriptResult(result: unknown): string {
-  // A returned string renders as itself: JSON.stringify would escape every
-  // newline and quote, turning a fetched page or file into one unreadable
-  // escaped line the model pays to mentally unescape (seen live: an 8.8KB
-  // worker.ts as a single escape-riddled JSON string). Non-strings keep the
-  // pretty-printed JSON shape.
-  if (typeof result === "string") return result;
-  try {
-    return JSON.stringify(result, null, 2) ?? String(result);
-  } catch {
-    return String(result);
-  }
-}
-
-function truncateScriptResult(text: string, historyLimit: number): string {
-  if (text.length <= historyLimit) return text;
-  return `${text.slice(0, historyLimit)}\n… truncated (${text.length} chars total; up to ${historyLimit} render inline — return less: slice arrays, pick fields)`;
 }
 
 /**

--- a/apps/os/src/lib/script-result-render.ts
+++ b/apps/os/src/lib/script-result-render.ts
@@ -1,0 +1,30 @@
+// The ONE stringification a script settlement gets on its way into the
+// agent's context (`renderScriptSettlement` in
+// domains/agents/agent-processor-implementation.ts), extracted here so the
+// feed's Result tab can compute the SAME text and check the rendered event
+// for verbatim containment (agent-activity-rounds.tsx `renderIsTransformed`).
+// Pure by design — importable from the client bundle, so keep processor and
+// contract imports out of this module.
+
+/**
+ * A returned string renders as itself: JSON.stringify would escape every
+ * newline and quote, turning a fetched page or file into one unreadable
+ * escaped line the model pays to mentally unescape (seen live: an 8.8KB
+ * worker.ts as a single escape-riddled JSON string). Non-strings keep the
+ * pretty-printed JSON shape.
+ */
+export function stringifyScriptResult(result: unknown): string {
+  if (typeof result === "string") return result;
+  try {
+    return JSON.stringify(result, null, 2) ?? String(result);
+  } catch {
+    return String(result);
+  }
+}
+
+/** Inline truncation at the configured history limit, with the advice notice
+ * the agent sees appended past the cut. */
+export function truncateScriptResult(text: string, historyLimit: number): string {
+  if (text.length <= historyLimit) return text;
+  return `${text.slice(0, historyLimit)}\n… truncated (${text.length} chars total; up to ${historyLimit} render inline — return less: slice arrays, pick fields)`;
+}

--- a/tasks/result-tab-agent-view.md
+++ b/tasks/result-tab-agent-view.md
@@ -97,6 +97,16 @@ shown.** Keep the raw view reachable, but the agent's view is the default.
 - [x] Screenshot for the PR body (local dev or spec tooling); if too painful, say so in
       the PR body _live capture: local dev + minted session (`pnpm getin`), real agent
       conversation running a fibonacci script; uploaded via gh image_
+- [x] Review follow-up: agent view is the default ONLY when the render was
+      truncated/transformed; full-result settlements keep the raw default
+      _`renderIsTransformed` in agent-activity-rounds.tsx: containment of the exact
+      stringified settlement in the render content; falls toward the agent view on
+      any mismatch_
+- [x] Review follow-up 2: share the actual server stringification instead of relying
+      on convention _`stringifyScriptResult`/`truncateScriptResult` extracted to
+      apps/os/src/lib/script-result-render.ts (pure, client-safe); processor and
+      `renderIsTransformed` import the ONE implementation; component tests build
+      their fixture renders through the same helpers, proving the round-trip_
 
 ## Implementation log
 
@@ -123,3 +133,7 @@ shown.** Keep the raw view reachable, but the agent's view is the default.
   the agent view (never claims the agent saw everything when it didn't).
 - Tests updated: full-result render → raw default with agent view a toggle away;
   truncated render → agent view default with raw a toggle away; fallbacks unchanged.
+- Hardening round (approved by Misha): extracted the stringification into
+  `lib/script-result-render.ts` so processor and client share one implementation —
+  drift now breaks a type/test rather than silently degrading the containment
+  heuristic. Doc comment updated: coupling enforced by sharing, fail-safe note kept.

--- a/tasks/result-tab-agent-view.md
+++ b/tasks/result-tab-agent-view.md
@@ -9,7 +9,11 @@ Follow-up from `tasks/codemode-script-preamble-followups.md` (second checklist i
 
 ## Status summary
 
-Spec committed; implementation not started yet.
+Done, pending review. The feed's Result tab now defaults to the exact settlement
+text the agent was shown (rendered markdown from the stream's script-actor
+context-added event), with the old raw YAML view one toggle away and as the
+fallback. Component tests + live screenshots in the PR. Not done here: mobile's
+twin activity card still shows only the raw result (possible follow-up).
 
 ## Problem
 
@@ -71,16 +75,23 @@ shown.** Keep the raw view reachable, but the agent's view is the default.
 
 ## Checklist
 
-- [ ] Pass `database` down to `RoundResult`; query the mirror for the script's
-      `agents/context-added` render event
-- [ ] Render the agent-visible markdown via `MessageResponse` as the DEFAULT Result
-      view
-- [ ] Keep the raw YAML/error view behind a toggle, and as the fallback when no render
-      event exists
-- [ ] Component test following `agent-feed.test.tsx` patterns (fake
+- [x] Pass `database` down to `RoundResult`; query the mirror for the script's
+      `agents/context-added` render event _`AgentRenderedRoundResult` in
+      apps/os/src/components/agent-activity-rounds.tsx, same `useStreamQuery` pattern
+      as the Meta tab_
+- [x] Render the agent-visible markdown via `MessageResponse` as the DEFAULT Result
+      view _data-testid="script-result-agent-view"; MessageResponse mode="static",
+      like settled assistant messages_
+- [x] Keep the raw YAML/error view behind a toggle, and as the fallback when no render
+      event exists _"Show raw result" / "Show agent view" ghost button; raw body
+      extracted unchanged into `RawRoundResult` (+ data-testid="script-result-raw")_
+- [x] Component test following `agent-feed.test.tsx` patterns (fake
       `StreamBrowserDatabase` with a canned query handle)
-- [ ] Screenshot for the PR body (local dev or spec tooling); if too painful, say so in
-      the PR body
+      _apps/os/src/components/agent-activity-rounds.test.tsx — createRoot + act +
+      disposable mount fixture; the fake db is just `{ query: () => handle }`_
+- [x] Screenshot for the PR body (local dev or spec tooling); if too painful, say so in
+      the PR body _live capture: local dev + minted session (`pnpm getin`), real agent
+      conversation running a fibonacci script; uploaded via gh image_
 
 ## Implementation log
 
@@ -91,3 +102,9 @@ shown.** Keep the raw view reachable, but the agent's view is the default.
 - Confirmed the reducer (`packages/ui/src/components/events/agent-ui-reducer.ts`) drops
   script-actor context-added events ("model input, not another bubble") — so the mirror
   query approach avoids growing always-in-memory reducer state with big rendered text.
+- Verified live on local dev: agent ran a script, Result tab showed
+  "Your script returned:" + fenced JSON + preamble note, toggle flipped to the raw
+  YAML view and back.
+- Note for jsdom tests: `SourceCodeBlock`/CodeMirror is a lazy client-only chunk that
+  never paints in jsdom, so raw-view assertions target `script-result-raw` rather than
+  highlighted YAML text.

--- a/tasks/result-tab-agent-view.md
+++ b/tasks/result-tab-agent-view.md
@@ -9,11 +9,16 @@ Follow-up from `tasks/codemode-script-preamble-followups.md` (second checklist i
 
 ## Status summary
 
-Done, pending review. The feed's Result tab now defaults to the exact settlement
-text the agent was shown (rendered markdown from the stream's script-actor
-context-added event), with the old raw YAML view one toggle away and as the
-fallback. Component tests + live screenshots in the PR. Not done here: mobile's
-twin activity card still shows only the raw result (possible follow-up).
+Done, pending re-review. Per Misha's feedback on the first cut ("only show it
+this way when it's truncated"): the Result tab defaults to the agent-visible
+render ONLY when that render is a transformed/truncated representation
+(inline truncation, oversized spill with inferred type + preview). When the
+agent saw the full result, the raw YAML view stays the default and the agent
+view is one toggle away. Detection is structural (the untransformed render
+embeds the exact stringified settlement verbatim; containment check), no
+string-marker matching, degrades safely toward the agent view. Component
+tests + live screenshots in the PR. Not done here: mobile's twin activity
+card still shows only the raw result (possible follow-up).
 
 ## Problem
 
@@ -108,3 +113,13 @@ shown.** Keep the raw view reachable, but the agent's view is the default.
 - Note for jsdom tests: `SourceCodeBlock`/CodeMirror is a lazy client-only chunk that
   never paints in jsdom, so raw-view assertions target `script-result-raw` rather than
   highlighted YAML text.
+- Review feedback round (Misha): "I don't love either, let's only show it this way
+  when it's truncated." → conditional default via `renderIsTransformed`: containment
+  of the exact stringified settlement (string result as-is, else
+  `JSON.stringify(value, null, 2)`, failure error text) in the render content.
+  Chose structural containment over the marker strings emitted by
+  `truncateScriptResult`/`renderOversizedJsonResult`/`rawTextSpillNotice` — no
+  coupling to notice wording, and a server stringification change degrades toward
+  the agent view (never claims the agent saw everything when it didn't).
+- Tests updated: full-result render → raw default with agent view a toggle away;
+  truncated render → agent view default with raw a toggle away; fallbacks unchanged.

--- a/tasks/result-tab-agent-view.md
+++ b/tasks/result-tab-agent-view.md
@@ -1,0 +1,93 @@
+---
+status: in-progress
+size: small
+---
+
+# Result tab: show what the agent actually saw
+
+Follow-up from `tasks/codemode-script-preamble-followups.md` (second checklist item).
+
+## Status summary
+
+Spec committed; implementation not started yet.
+
+## Problem
+
+The agent feed's expanded activity rounds have a `Script | Result | Meta` tab bar
+(`apps/os/src/components/agent-activity-rounds.tsx`). The Result tab renders its own
+client-side view of the raw settlement: the result value re-serialized as YAML with its
+own truncation ("This result is 81,313 characters as YAML. Showing the first 64 KB
+without syntax highlighting.").
+
+That view is unrelated to what the AGENT was shown. The agent-facing render is produced
+server-side by `renderScriptSettlement`
+(`apps/os/src/domains/agents/agent-processor-implementation.ts`): truncation at
+`scriptResultHistoryLimit`, oversized results replaced by an inferred TS type + bounded
+JSON preview + a `results[0].load(itx)` recipe, spill-file pointers, failure text with
+recovery-tool hints. It is appended to the stream as a developer
+`events.iterate.com/agents/context-added` event with
+`payload.actor = { type: "script", executionId }` and content starting
+"Your script returned" / "Your script failed".
+
+Direction: **the Result tab should be a representation of what the agent is actually
+shown.** Keep the raw view reachable, but the agent's view is the default.
+
+## Design
+
+- The render already exists on the stream, so don't re-implement it client-side: query
+  the local raw-event mirror (`useStreamQuery`, same pattern as the Meta tab's
+  `RoundMetaWithPrompt`) for the `agents/context-added` event whose
+  `payload.actor.type = 'script'` and `payload.actor.executionId` matches the round's
+  code step. The query only runs while the Result tab is mounted (inactive base-ui tab
+  panels unmount), and it's live — if the render event lands after the settlement (it's
+  appended in a blocked async section), the tab picks it up when it arrives.
+- Render the event's `payload.content` through `MessageResponse`
+  (`packages/ui/src/components/ai-elements/message.tsx`, streamdown) with
+  `mode="static"` / `parseIncompleteMarkdown={false}` — the same markdown+fenced-code
+  renderer settled assistant messages use. The text is bounded server-side, so no
+  client-side truncation mechanism is needed on this path.
+- Keep the raw view: a small toggle inside the Result tab switches between the agent
+  view (default) and the existing raw YAML/error rendering. The full raw settlement
+  also stays one click away via the existing "Execution trace" sheet.
+- Fallbacks to the current raw view: no `database` prop, mirror query errored, or no
+  render event found (old streams predating `renderScriptSettlement`, renders for
+  non-agent executions, or a succeeded run with `result === undefined` which produces
+  no render event — though that case doesn't offer a Result tab anyway).
+
+## Assumptions (made while fleshing out, Misha AFK)
+
+- Scope is the FEED Result tab (`agent-activity-rounds.tsx`) — the string observed live
+  is from there. The execution-trace sheet
+  (`script-execution-inspector-panel.tsx`) keeps its raw Result tab as-is: it *is* the
+  raw capability the feed links to.
+- Mobile's structural twin (`apps/mobile/src/components/activity-card.tsx`) is NOT
+  updated in this PR — noted as a possible follow-up so the surfaces don't silently
+  diverge.
+- Correlation by `payload.actor.executionId` (exact match) is sufficient; no offset
+  proximity heuristics needed.
+- `useState` for the in-tab agent/raw toggle matches the file's existing tab-selection
+  pattern (CLAUDE.md's "almost never useState" yields to local UI toggle convention
+  already established in this file).
+
+## Checklist
+
+- [ ] Pass `database` down to `RoundResult`; query the mirror for the script's
+      `agents/context-added` render event
+- [ ] Render the agent-visible markdown via `MessageResponse` as the DEFAULT Result
+      view
+- [ ] Keep the raw YAML/error view behind a toggle, and as the fallback when no render
+      event exists
+- [ ] Component test following `agent-feed.test.tsx` patterns (fake
+      `StreamBrowserDatabase` with a canned query handle)
+- [ ] Screenshot for the PR body (local dev or spec tooling); if too painful, say so in
+      the PR body
+
+## Implementation log
+
+- Worktree `result-tab-agent-view` off origin/main (34c7de98a).
+- Located current truncation code: `RoundResult` in
+  `apps/os/src/components/agent-activity-rounds.tsx` (feed) — the inspector panel has a
+  separate, deliberately-raw equivalent.
+- Confirmed the reducer (`packages/ui/src/components/events/agent-ui-reducer.ts`) drops
+  script-actor context-added events ("model input, not another bubble") — so the mirror
+  query approach avoids growing always-in-memory reducer state with big rendered text.


### PR DESCRIPTION
## What

The agent feed's `Script | Result | Meta` round tabs gain an "agent view" of a script's settlement: the exact text the model was shown. It becomes the Result tab's **default only when that text is a truncated/transformed representation** of the result; when the agent saw the full result, the raw view stays the default. Both views are always one toggle away from each other.

## Why

The Result tab used to re-render the raw settlement as YAML with its own truncation ("This result is 81,313 characters as YAML. Showing the first 64 KB without syntax highlighting."). That mechanism is unrelated to what the agent actually received — the server-side `renderScriptSettlement` render: truncation at `scriptResultHistoryLimit`, oversized results replaced by an inferred TS type + bounded preview + `results[0].load(itx)` recipe, spill-file pointers, failure text with recovery hints. For a small result those two views carry the same information and the raw view reads better — so it stays the default. For a truncated one, the raw view misrepresents what the model could see, so the agent view takes over as the default.

## How

The agent-visible render already exists on the stream as a developer `agents/context-added` event (`actor: { type: "script", executionId }`). The Result tab queries the local raw-event mirror for it (same `useStreamQuery` pattern as the Meta tab's replayed prompt) and renders its markdown through `MessageResponse`, the renderer settled assistant messages use.

Truncation detection is structural, not string-marker matching: the untransformed render always embeds the exact stringified settlement verbatim, while every transforming path necessarily drops part of it — so a containment check distinguishes the cases. The stringification is ONE shared implementation (`apps/os/src/lib/script-result-render.ts` — pure, client-safe): `renderScriptSettlement` and the Result tab's `renderIsTransformed` both import `stringifyScriptResult`, so drift breaks a type/test instead of silently degrading the heuristic, and the component tests build their fixture renders through the same helpers to prove the round-trip. Fail-safe either way: any containment break defaults to the agent view (which never misrepresents), not to a raw view claiming the agent saw everything.

Fallbacks unchanged: no local mirror or no render event (old streams, non-agent executions) → raw view alone, exactly as before. The "Execution trace" sheet is untouched.

## Live on local dev

A 190k-char result, truncated to 30k inline for the agent — the Result tab defaults to the agent view, truncation notice and `results[0].load(itx)` recipe included, raw view one toggle away:

![shot-truncated.png](https://github.com/user-attachments/assets/71d7c308-03d8-4d6f-b1ad-883444615745)

A small result the agent saw in full — raw YAML stays the default, the agent view a toggle away:

![result-raw-view.png](https://github.com/user-attachments/assets/3b4368b2-e84f-4fb0-8ba6-257bf2bc07e8)

## Notes for review

- Component tests: `apps/os/src/components/agent-activity-rounds.test.tsx` — full-result render → raw default with agent view a toggle away; truncated render → agent view default; no-render-event and no-mirror fallbacks. The fake database is the `{ query: () => handle }` seam `useStreamQuery` uses — no mocks.
- Mobile's structural twin (`apps/mobile/src/components/activity-card.tsx`) still shows only the raw result; noted as a known divergence in the twin comment. Possible follow-up once mobile has a raw-event mirror.
- Spec + implementation log: `tasks/result-tab-agent-view.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session id: `e89f2eb5-b303-47df-9e5d-5033942f37d8` (subagent)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Feed UI and shared stringification helpers only; no auth, settlement, or processor behavior changes beyond moving helpers to a shared module.
> 
> **Overview**
> The agent feed **Result** tab can show the **exact settlement text** the model received (`renderScriptSettlement`), not only a client-side YAML re-render with separate truncation.
> 
> When the raw-event mirror is available, the tab queries stream `agents/context-added` events for the script actor’s `executionId` (same pattern as Meta’s prompt replay) and renders that markdown via `MessageResponse`. **Truncated or transformed** renders (inline cut, spill/type preview paths) **default to the agent view**; when the full stringified result is embedded verbatim, **raw YAML stays the default**. A toggle switches views; missing mirror or render event keeps the previous raw-only behavior.
> 
> **`stringifyScriptResult`** and **`truncateScriptResult`** move to shared **`lib/script-result-render.ts`** so the processor and UI **`renderIsTransformed`** containment check use one implementation. Component tests cover defaults, toggles, and fallbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e977a2c8376a8b48cc892f4ae98780a167fa70f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +31 -19 | +13 -12 🟩⬜⬜⬜⬜ |
| UI components | +135 -4 | +73 -3 🟩🟩🟩⬜⬜ |
| Tests | +164 -0 | +129 -0 🟩🟩🟩🟩🟩 |
| Docs | +139 -0 | +123 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+469 -23** | **+338 -15** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 34c7de9 and 9e977a2, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-07T17:31:51.689Z",
      "deployedAt": "2026-08-07T15:01:24.416Z",
      "headSha": "9e977a2c8376a8b48cc892f4ae98780a167fa70f",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/244520314918657",
      "shortSha": "9e977a2",
      "cleanupDurationMs": 11419,
      "deployDurationMs": 93971,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 92598,
      "deployReadinessDurationMs": 1370,
      "deployedWorkerName": "os-preview-4",
      "deployedWorkerVersion": "79855aa5-c17e-4f43-afa0-beca97eb7d62",
      "testDurationMs": 263248,
      "testRetries": "2 retried: reactivity.spec.ts › reactivity page appends a batch and renders every delivered marker › web (playwright x1) — TimeoutError: locator.waitFor: Timeout 30000ms exceeded. Call log: \u001b[2m - waiting for getByTestId('reactivity-stream-status').getByText('live') to be visible\u001b[22m \u001b[33m Spinner was still visible after 30000ms, the UI is likely stuck.\u001b[0m · repo-ide-json-schema.spec.ts › flags a package.json schema violation with a red squiggle › web (playwright x1) — \u001b[31mTest timeout of 90000ms exceeded.\u001b[39m",
      "workerSizeKib": 20611.22,
      "workerGzipKib": 5191.44,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5224.04
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-07T17:31:42.923Z",
      "deployedAt": "2026-08-07T15:00:18.716Z",
      "headSha": "9e977a2c8376a8b48cc892f4ae98780a167fa70f",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-4.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/244520314918657",
      "shortSha": "9e977a2",
      "cleanupDurationMs": 2651,
      "deployDurationMs": 27148,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 26895,
      "deployReadinessDurationMs": 248,
      "deployedWorkerName": "docs-preview-4",
      "deployedWorkerVersion": "ce03fc0d-bb2a-43c8-8c14-7d9abb71cc2b",
      "testDurationMs": 2675,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-07T17:31:44.112Z",
      "deployedAt": "2026-08-07T15:00:21.230Z",
      "headSha": "9e977a2c8376a8b48cc892f4ae98780a167fa70f",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/244520314918657",
      "shortSha": "9e977a2",
      "cleanupDurationMs": 3838,
      "deployDurationMs": 29833,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 29409,
      "deployReadinessDurationMs": 420,
      "deployedWorkerName": "auth-preview-4",
      "deployedWorkerVersion": "8b40f943-cce2-4268-85f0-c9f3ce742f0c",
      "testDurationMs": 4708,
      "testRetries": null,
      "workerSizeKib": 3981.29,
      "workerGzipKib": 815.29,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-07T17:31:40.965Z",
      "deployedAt": "2026-08-07T14:59:57.860Z",
      "headSha": "9e977a2c8376a8b48cc892f4ae98780a167fa70f",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/244520314918657",
      "shortSha": "9e977a2",
      "cleanupDurationMs": 689,
      "deployDurationMs": 6088,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 6002,
      "deployReadinessDurationMs": 44,
      "deployedWorkerName": "dummy-petshop-preview-4",
      "deployedWorkerVersion": "31c3c7fb-9648-4848-bfac-0aaf959c8458",
      "testDurationMs": 7242,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `9e977a2` | [https://auth.iterate-preview-4.com](https://auth.iterate-preview-4.com) | 815.3 KiB | 29.8s | 4.7s |  | 3.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/244520314918657) | 2026-08-07T17:31:44.112Z | Preview app released. |
| Docs | released | `9e977a2` | [https://docs-preview-4.iterate-dev-preview.workers.dev](https://docs-preview-4.iterate-dev-preview.workers.dev) | 866.2 KiB | 27.1s | 2.7s |  | 2.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/244520314918657) | 2026-08-07T17:31:42.923Z | Preview app released. |
| Dummy Petshop | released | `9e977a2` | [https://dummy-petshop.iterate-preview-4.com](https://dummy-petshop.iterate-preview-4.com) | 198.3 KiB | 6.1s | 7.2s |  | 689ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/244520314918657) | 2026-08-07T17:31:40.965Z | Preview app released. |
| OS | released | `9e977a2` | [https://os.iterate-preview-4.com](https://os.iterate-preview-4.com) | 5.07 MiB (-32.6 KiB vs main) | 94.0s | 263.2s | 2 retried: reactivity.spec.ts › reactivity page appends a batch and renders every delivered marker › web (playwright x1) — TimeoutError: locator.waitFor: Timeout 30000ms exceeded. Call log: [2m - waiting for getByTestId('reactivity-stream-status').getByText('live') to be visible[22m [33m Spinner was still visible after 30000ms, the UI is likely stuck.[0m · repo-ide-json-schema.spec.ts › flags a package.json schema violation with a red squiggle › web (playwright x1) — [31mTest timeout of 90000ms exceeded.[39m | 11.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/244520314918657) | 2026-08-07T17:31:51.689Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->