### PR TITLE
Stop teaching agents to save defensive workspace copies of script results

### DIFF
--- a/apps/os/src/domains/agents/agent-defaults.ts
+++ b/apps/os/src/domains/agents/agent-defaults.ts
@@ -205,7 +205,7 @@ export const DEFAULT_AGENT_SYSTEM_PROMPT = [
   "- Most scripts should fetch data and RETURN it. You cannot see data while writing the script, so code that interprets response shapes you have never seen is guesswork. Get the data in front of your eyes; decide on the next turn.",
   "- YOU are the LLM: don't pipe content through `itx.ai.run` to summarize, draft, or answer — return the data and write it yourself. `ai.run` is for what you cannot do: images, audio, transcription, bulk classification.",
   "- The script body is real TypeScript: `Promise.all` fans out independent calls, `Promise.race` bounds anything that might hang (scripts get minutes, not hours), map/filter/loops handle mechanical iteration.",
-  "- Return only what you need: pick fields, slice arrays. Oversized results render as an inferred type plus a preview; the FULL result is saved to a workspace file — the notice names the path; read it with `itx.workspace.readFile` and filter it in TypeScript instead of re-fetching.",
+  "- Return only what you need: pick fields, slice arrays. An oversized result renders as an inferred type plus a preview, and the FULL value stays reachable via `await results[0].load(itx)` — never re-fetch, and never save your own copy to a file: the platform retains every result.",
   "- Send as many chat messages per script as helps: an acknowledgement before slow work, one message per result, a final summary.",
   "",
   "OTHER AGENTS — the semantics behind the tour's delegation calls:",
@@ -237,7 +237,11 @@ export const DEFAULT_AGENT_SYSTEM_PROMPT = [
 // "small structural"/"plain" wording, no meaning change.
 // 9: docs.search now inlines the top hit's full doc in `result` — the docs
 // teach line says search-and-read is one turn, not two.
-const DEFAULT_AGENT_SYSTEM_PROMPT_REVISION = "9";
+// 10: the oversized-results bullet leads with the `results` loader and says
+// never to save defensive copies — a field agent writeFile'd a full API
+// response AND returned the whole body because the old wording taught the
+// workspace spill file + readFile as the retention mechanism.
+const DEFAULT_AGENT_SYSTEM_PROMPT_REVISION = "10";
 const AGENT_MODEL_POLICY_REVISION = "2";
 const AGENT_WORKSPACE_POLICY_REVISION = "3";
 const AGENT_BOOT_CONTEXT_REVISION = "3";

--- a/apps/os/src/domains/agents/agent-prompt-budgets.test.ts
+++ b/apps/os/src/domains/agents/agent-prompt-budgets.test.ts
@@ -87,6 +87,16 @@ test("the default prompt teaches agents to share workspace files through Docs", 
   );
 });
 
+test("the default prompt teaches results retention, not defensive file copies", () => {
+  // A field agent writeFile'd a full API response AND returned the whole
+  // body because the old oversized-results bullet taught the workspace
+  // spill file + readFile as the retention mechanism. The prompt must lead
+  // with the `results` loader and draw the implication explicitly.
+  expect(DEFAULT_AGENT_SYSTEM_PROMPT).toContain("await results[0].load(itx)");
+  expect(DEFAULT_AGENT_SYSTEM_PROMPT).toContain("never save your own copy to a file");
+  expect(DEFAULT_AGENT_SYSTEM_PROMPT).not.toContain("itx.workspace.readFile");
+});
+
 test("the default prompt teaches agents to share task boards through Tasks", () => {
   expect(DEFAULT_AGENT_SYSTEM_PROMPT).toContain(
     'itx.worker.docs.link({ workspace: "/workspaces/agents/you", repo: "/repos/config" })',

--- a/apps/os/src/itx/examples-source.ts
+++ b/apps/os/src/itx/examples-source.ts
@@ -709,7 +709,7 @@ return await itx.projects.get(pid).__describe();
     e2eProven: false,
     title: "Make a plain HTTP request through project egress",
     description:
-      "itx.egress.fetch(request) is the raw outbound HTTP door: call an external API, download a file, GET or POST anything — every request project-attributed. It takes ONE argument, a Request (build headers/method/body onto it). Choosing a door: egress.fetch is the plain request; itx.browser.quickAction renders a JS-heavy page and can return markdown; itx.ai.toMarkdown converts documents. Secret placeholders in headers and URL paths substitute at egress; exact JSON string values also substitute when x-iterate-secret-template: json is set (see secret-postman-echo). External service — interactive-only.",
+      "itx.egress.fetch(request) is the raw outbound HTTP door: call an external API, download a file, GET or POST anything — every request project-attributed. It takes ONE argument, a Request (build headers/method/body onto it). Choosing a door: egress.fetch is the plain request; itx.browser.quickAction renders a JS-heavy page and can return markdown; itx.ai.toMarkdown converts documents. RETURN the response data (or just the fields you need) — never save a copy to a file first: script results are retained, and your next script reads them via the `results` preamble. Secret placeholders in headers and URL paths substitute at egress; exact JSON string values also substitute when x-iterate-secret-template: json is set (see secret-postman-echo). External service — interactive-only.",
     runtimes: ALL_RUNTIMES,
     fn: async (itx, vars: { url?: string }) => {
       const url = vars.url ?? "https://example.com/";
@@ -1009,7 +1009,7 @@ return await itx.projects.get(pid).__describe();
     id: "files-roundtrip",
     title: "Store, read, and share a project file",
     description:
-      "itx.files.get(path) is project file storage (R2-backed, mutable paths): put({ data, contentType }) stores bytes — base64 strings (what itx.ai.run image models return), Uint8Array, Blob, or a stream — bytes() reads them back, url() mints a signed public link any HTTP client can fetch (default expiry 7 days), delete() removes the file. Use it to save, keep, or persist data for later and remember state between runs (files hold bytes; streams hold structured events). On agent scopes prefer itx.agent.addFiles: one call that stores AND attaches files to the conversation.",
+      "itx.files.get(path) is project file storage (R2-backed, mutable paths): put({ data, contentType }) stores bytes — base64 strings (what itx.ai.run image models return), Uint8Array, Blob, or a stream — bytes() reads them back, url() mints a signed public link any HTTP client can fetch (default expiry 7 days), delete() removes the file. Use it to save, keep, or persist data for later and remember state between runs (files hold bytes; streams hold structured events) — but NOT for script results: those are retained automatically and reachable from later scripts via the `results` preamble, no copy needed. On agent scopes prefer itx.agent.addFiles: one call that stores AND attaches files to the conversation.",
     runtimes: ALL_RUNTIMES,
     fn: async (itx, vars: { path?: string; note?: string }) => {
       const path = vars.path ?? "/repl/files-demo.txt";
@@ -1508,7 +1508,7 @@ return {
     e2eProven: false,
     title: "Search the inbox and read message bodies through the built-in Gmail integration",
     description:
-      "itx.integrations.gmail.get().request({ path, query, method, headers, body }) proxies the Gmail REST API — paths relative to https://gmail.googleapis.com/gmail/v1. get() selects the first connected account; pass a slug only for a specific account. Do it in ONE script: list matching ids, fan out format: 'full' fetches, decode and convert every body, return the lot — don't spread list/read across turns, and don't pre-trim out of caution: an oversized return comes back as a typed preview plus a spill file you read next turn. Bodies arrive as base64url-encoded MIME parts: walk payload.parts for text/html, decode the bytes, and convert with itx.ai.toMarkdown using conversionOptions.output.format 'text' (never regex-strip HTML by hand) — email HTML is mostly tracking links and giant base64 images, and text output strips link/image URLs for ~10x smaller content. Reads real mail — interactive-only.",
+      "itx.integrations.gmail.get().request({ path, query, method, headers, body }) proxies the Gmail REST API — paths relative to https://gmail.googleapis.com/gmail/v1. get() selects the first connected account; pass a slug only for a specific account. Do it in ONE script: list matching ids, fan out format: 'full' fetches, decode and convert every body, return the lot — don't spread list/read across turns, and don't pre-trim out of caution: an oversized return comes back as a typed preview, with the full value available to your next script as `await results[0].load(itx)`. Bodies arrive as base64url-encoded MIME parts: walk payload.parts for text/html, decode the bytes, and convert with itx.ai.toMarkdown using conversionOptions.output.format 'text' (never regex-strip HTML by hand) — email HTML is mostly tracking links and giant base64 images, and text output strips link/image URLs for ~10x smaller content. Reads real mail — interactive-only.",
     runtimes: ALL_RUNTIMES,
     fn: async (itx, vars: { q?: string }) => {
       const gmail = itx.integrations.gmail.get();
@@ -1519,7 +1519,7 @@ return {
 
       // One script, one return: fetch every hit in full and read all the
       // bodies now — splitting list/read across turns wastes rounds, and an
-      // oversized return degrades safely (typed preview + spill file).
+      // oversized return degrades safely (typed preview + results loader).
       const messages = await Promise.all(
         (inbox.data.messages ?? []).map(async (message) => {
           const full = await gmail.request({

--- a/apps/os/src/itx/examples.generated.ts
+++ b/apps/os/src/itx/examples.generated.ts
@@ -630,7 +630,7 @@ return await secret.__describe();
     e2eProven: false,
     title: "Make a plain HTTP request through project egress",
     description:
-      "itx.egress.fetch(request) is the raw outbound HTTP door: call an external API, download a file, GET or POST anything — every request project-attributed. It takes ONE argument, a Request (build headers/method/body onto it). Choosing a door: egress.fetch is the plain request; itx.browser.quickAction renders a JS-heavy page and can return markdown; itx.ai.toMarkdown converts documents. Secret placeholders in headers and URL paths substitute at egress; exact JSON string values also substitute when x-iterate-secret-template: json is set (see secret-postman-echo). External service — interactive-only.",
+      "itx.egress.fetch(request) is the raw outbound HTTP door: call an external API, download a file, GET or POST anything — every request project-attributed. It takes ONE argument, a Request (build headers/method/body onto it). Choosing a door: egress.fetch is the plain request; itx.browser.quickAction renders a JS-heavy page and can return markdown; itx.ai.toMarkdown converts documents. RETURN the response data (or just the fields you need) — never save a copy to a file first: script results are retained, and your next script reads them via the `results` preamble. Secret placeholders in headers and URL paths substitute at egress; exact JSON string values also substitute when x-iterate-secret-template: json is set (see secret-postman-echo). External service — interactive-only.",
     context: "project",
     runtimes: ["browser", "node", "cli", "run-script", "project-worker"],
     code: `
@@ -936,7 +936,7 @@ return { offset: sent.offset, type: sent.type };
     id: "files-roundtrip",
     title: "Store, read, and share a project file",
     description:
-      "itx.files.get(path) is project file storage (R2-backed, mutable paths): put({ data, contentType }) stores bytes — base64 strings (what itx.ai.run image models return), Uint8Array, Blob, or a stream — bytes() reads them back, url() mints a signed public link any HTTP client can fetch (default expiry 7 days), delete() removes the file. Use it to save, keep, or persist data for later and remember state between runs (files hold bytes; streams hold structured events). On agent scopes prefer itx.agent.addFiles: one call that stores AND attaches files to the conversation.",
+      "itx.files.get(path) is project file storage (R2-backed, mutable paths): put({ data, contentType }) stores bytes — base64 strings (what itx.ai.run image models return), Uint8Array, Blob, or a stream — bytes() reads them back, url() mints a signed public link any HTTP client can fetch (default expiry 7 days), delete() removes the file. Use it to save, keep, or persist data for later and remember state between runs (files hold bytes; streams hold structured events) — but NOT for script results: those are retained automatically and reachable from later scripts via the `results` preamble, no copy needed. On agent scopes prefer itx.agent.addFiles: one call that stores AND attaches files to the conversation.",
     context: "project",
     runtimes: ["browser", "node", "cli", "run-script", "project-worker"],
     code: `
@@ -1396,7 +1396,7 @@ return { copied: copied.payload, copiedFrom: copied.source?.copiedFrom };
     e2eProven: false,
     title: "Search the inbox and read message bodies through the built-in Gmail integration",
     description:
-      "itx.integrations.gmail.get().request({ path, query, method, headers, body }) proxies the Gmail REST API — paths relative to https://gmail.googleapis.com/gmail/v1. get() selects the first connected account; pass a slug only for a specific account. Do it in ONE script: list matching ids, fan out format: 'full' fetches, decode and convert every body, return the lot — don't spread list/read across turns, and don't pre-trim out of caution: an oversized return comes back as a typed preview plus a spill file you read next turn. Bodies arrive as base64url-encoded MIME parts: walk payload.parts for text/html, decode the bytes, and convert with itx.ai.toMarkdown using conversionOptions.output.format 'text' (never regex-strip HTML by hand) — email HTML is mostly tracking links and giant base64 images, and text output strips link/image URLs for ~10x smaller content. Reads real mail — interactive-only.",
+      "itx.integrations.gmail.get().request({ path, query, method, headers, body }) proxies the Gmail REST API — paths relative to https://gmail.googleapis.com/gmail/v1. get() selects the first connected account; pass a slug only for a specific account. Do it in ONE script: list matching ids, fan out format: 'full' fetches, decode and convert every body, return the lot — don't spread list/read across turns, and don't pre-trim out of caution: an oversized return comes back as a typed preview, with the full value available to your next script as `await results[0].load(itx)`. Bodies arrive as base64url-encoded MIME parts: walk payload.parts for text/html, decode the bytes, and convert with itx.ai.toMarkdown using conversionOptions.output.format 'text' (never regex-strip HTML by hand) — email HTML is mostly tracking links and giant base64 images, and text output strips link/image URLs for ~10x smaller content. Reads real mail — interactive-only.",
     context: "project",
     runtimes: ["browser", "node", "cli", "run-script", "project-worker"],
     code: `
@@ -1408,7 +1408,7 @@ const inbox = await gmail.request({
 
 // One script, one return: fetch every hit in full and read all the
 // bodies now — splitting list/read across turns wastes rounds, and an
-// oversized return degrades safely (typed preview + spill file).
+// oversized return degrades safely (typed preview + results loader).
 const messages = await Promise.all(
   (inbox.data.messages ?? []).map(async (message) => {
     const full = await gmail.request({

--- a/tasks/preamble-defensive-saves-audit.md
+++ b/tasks/preamble-defensive-saves-audit.md
@@ -1,0 +1,99 @@
+---
+status: in-progress
+size: small
+branch: preamble-defensive-saves-audit
+---
+
+# Preamble follow-up: stop teaching defensive workspace saves
+
+Third checklist item from `tasks/codemode-script-preamble-followups.md`. After
+#2431 (scripts see a typed `results` array; large results get loaders), a
+field-tested agent still did this:
+
+```ts
+const text = await response.text();
+await itx.workspace.writeFile("sopranos-tvmaze-full.json", text);
+return { status: response.status, bytes: text.length, body: JSON.parse(text) };
+```
+
+Neither the file nor the full-body return was needed. Audit what still teaches
+save-then-read, fix the teaching.
+
+## Assumptions (made while fleshing out, Misha AFK)
+
+- The fix is teaching-only: prompt wording, example descriptions, tests. No
+  runtime behavior changes.
+- Prompt edits stay within the 4200-token ceiling budget
+  (`agent-prompt-budgets.test.ts`); aim token-neutral by rewording the
+  existing oversized-results bullet rather than adding one.
+- The eval belongs to the sibling branch `preamble-results-eval` — none here.
+- The workspace spill file keeps existing as a mechanism (a different
+  follow-up item questions it); we only stop *teaching* it as the primary
+  retention story.
+
+## Audit findings
+
+The proactive save wasn't taught by the settlement render (that text only
+arrives AFTER an oversized result, and post-#2431 it already leads with
+`results[0].load`). It was taught by three static surfaces that still tell a
+file-centric retention story:
+
+1. **`apps/os/src/domains/agents/agent-defaults.ts:208`** — the SHAPE OF WORK
+   oversized-results bullet (pre-#2431 wording, not updated by that PR):
+   "the FULL result is saved to a workspace file — the notice names the path;
+   read it with `itx.workspace.readFile`". The system prompt itself teaches
+   write-a-file-read-it-back as how big data survives turns, and never draws
+   the implication of `results`: "so don't save copies". An agent expecting a
+   big response mimics the platform: writes its own copy with a name it
+   controls, and returns the full body in case the preview loses data.
+   (#2431 rewrote only the fresh-scripts bullet at line 90 — which previously
+   said "Carry state by returning it, messaging it, **or writing a file**".)
+2. **`apps/os/src/itx/examples-source.ts` gmail example (~line 1511, 1522)** —
+   docs corpus served by `itx.docs.search`: "an oversized return comes back as
+   a typed preview **plus a spill file you read next turn**" — retrieval
+   channel = file, loaders unmentioned.
+3. **`apps/os/src/itx/examples-source.ts` files example (~line 1012)** — "Use
+   it to save, keep, or persist data for later and remember state between
+   runs" with no carve-out for script results: the top docs hit for
+   save/keep/persist tells the agent saving is the way to keep data.
+
+Also: nothing in the docs corpus mentions `results` at all — a docs.search
+for how to reuse a previous result finds only file-based answers.
+
+## Checklist
+
+- [x] Audit the four suspect surfaces; write findings here with file:line refs
+      _above — headline: the system prompt's own oversized-results bullet
+      (agent-defaults.ts:208) still taught workspace-file+readFile as the
+      retention mechanism and never said "don't save copies"_
+- [ ] Reword the oversized-results bullet in `agent-defaults.ts` to lead with
+      `results` retention + the no-defensive-copies implication; drop the
+      readFile recipe; bump `DEFAULT_AGENT_SYSTEM_PROMPT_REVISION`
+- [ ] Update the gmail example description + comment to name the loader, not
+      the spill file
+- [ ] Add the script-results carve-out to the files example description
+- [ ] Teach the anti-pattern at the point of temptation: egress-fetch example
+      description says return the data, never save a copy first
+- [ ] Regenerate `examples.generated.ts` via `pnpm generate:itx-examples`
+- [ ] Prompt-content test: default prompt teaches results retention and no
+      longer contains the `itx.workspace.readFile` recipe
+- [ ] `pnpm typecheck && pnpm lint && pnpm knip && pnpm format && pnpm test`
+
+## Status summary
+
+Audit complete (findings above); fixes not yet applied. Headline: the system
+prompt itself (agent-defaults.ts:208) still taught the spill-file+readFile
+retention story and never drew the "don't save copies" implication.
+
+## Implementation log
+
+- Worktree/branch `preamble-defensive-saves-audit` off origin/main
+  (34c7de98a, the #2431 merge).
+- Confirmed #2431 changed exactly one prompt line (the fresh-scripts bullet)
+  and did NOT touch the oversized-results bullet — and did not bump
+  `DEFAULT_AGENT_SYSTEM_PROMPT_REVISION` (stayed "9"); this branch bumps it
+  to "10" alongside the wording change.
+- Settlement render (`agent-processor-implementation.ts`
+  renderScriptSettlement/renderOversizedJsonResult/rawTextSpillNotice) audited
+  clean: post-#2431 it leads with the `results` recipe and mentions the spill
+  path only parenthetically. No change needed there.

--- a/tasks/preamble-defensive-saves-audit.md
+++ b/tasks/preamble-defensive-saves-audit.md
@@ -66,24 +66,34 @@ for how to reuse a previous result finds only file-based answers.
       _above — headline: the system prompt's own oversized-results bullet
       (agent-defaults.ts:208) still taught workspace-file+readFile as the
       retention mechanism and never said "don't save copies"_
-- [ ] Reword the oversized-results bullet in `agent-defaults.ts` to lead with
+- [x] Reword the oversized-results bullet in `agent-defaults.ts` to lead with
       `results` retention + the no-defensive-copies implication; drop the
       readFile recipe; bump `DEFAULT_AGENT_SYSTEM_PROMPT_REVISION`
-- [ ] Update the gmail example description + comment to name the loader, not
-      the spill file
-- [ ] Add the script-results carve-out to the files example description
-- [ ] Teach the anti-pattern at the point of temptation: egress-fetch example
+      _SHAPE OF WORK bullet now says "never save your own copy to a file: the
+      platform retains every result"; revision "10"; slightly token-negative_
+- [x] Update the gmail example description + comment to name the loader, not
+      the spill file _both now say typed preview + `results[0].load(itx)`_
+- [x] Add the script-results carve-out to the files example description
+      _"but NOT for script results: those are retained automatically"_
+- [x] Teach the anti-pattern at the point of temptation: egress-fetch example
       description says return the data, never save a copy first
-- [ ] Regenerate `examples.generated.ts` via `pnpm generate:itx-examples`
-- [ ] Prompt-content test: default prompt teaches results retention and no
+      _one sentence in the egress-fetch description_
+- [x] Regenerate `examples.generated.ts` via `pnpm generate:itx-examples`
+      _ran in apps/os; freshness test green_
+- [x] Prompt-content test: default prompt teaches results retention and no
       longer contains the `itx.workspace.readFile` recipe
-- [ ] `pnpm typecheck && pnpm lint && pnpm knip && pnpm format && pnpm test`
+      _new test in agent-prompt-budgets.test.ts, next to the other
+      prompt-content pins_
+- [x] `pnpm typecheck && pnpm lint && pnpm knip && pnpm format && pnpm test`
+      _all green locally_
 
 ## Status summary
 
-Audit complete (findings above); fixes not yet applied. Headline: the system
-prompt itself (agent-defaults.ts:208) still taught the spill-file+readFile
-retention story and never drew the "don't save copies" implication.
+Done, pending review (PR #2441). Audit findings above — headline: the system
+prompt itself (agent-defaults.ts:208) taught the spill-file+readFile
+retention story and never drew the "don't save copies" implication. All three
+teaching surfaces reworded, prompt revision bumped, catalogue regenerated,
+prompt-content test added.
 
 ## Implementation log
 


### PR DESCRIPTION
## Audit conclusion

After #2431 a field-tested agent still wrote an API response to a workspace file AND returned the full body defensively. The audit (details in `tasks/preamble-defensive-saves-audit.md`) found the settlement render innocent — post-#2431 it already leads with the `results[0].load` recipe. What still taught the file-centric story:

1. **The default system prompt itself** (`agent-defaults.ts`, SHAPE OF WORK): "the FULL result is saved to a workspace file — the notice names the path; read it with `itx.workspace.readFile`". Pre-#2431 wording, never updated: the prompt taught write-a-file-read-it-back as how big data survives turns, and never drew the implication of `results` — *so don't save copies*. (#2431 rewrote only the fresh-scripts bullet, which previously said "Carry state by returning it, messaging it, **or writing a file**".)
2. **The docs corpus** (`itx.docs.search`): the gmail example said an oversized return comes back as "a typed preview plus a spill file you read next turn"; the files example teaches "save, keep, or persist data for later" with no script-results carve-out. Nothing in the corpus mentioned `results` at all.

## Fix (teaching-only, no runtime changes)

Worst offender, before/after (system prompt bullet):

```diff
-- Return only what you need: pick fields, slice arrays. Oversized results render as an
-  inferred type plus a preview; the FULL result is saved to a workspace file — the notice
-  names the path; read it with `itx.workspace.readFile` and filter it in TypeScript
-  instead of re-fetching.
+- Return only what you need: pick fields, slice arrays. An oversized result renders as an
+  inferred type plus a preview, and the FULL value stays reachable via
+  `await results[0].load(itx)` — never re-fetch, and never save your own copy to a file:
+  the platform retains every result.
```

Plus:
- gmail example: oversized return degrades to "typed preview + `await results[0].load(itx)`", not "spill file you read next turn"
- files example: "save, keep, or persist data for later … but NOT for script results: those are retained automatically"
- egress-fetch example (the exact point of temptation): "RETURN the response data — never save a copy to a file first"
- `DEFAULT_AGENT_SYSTEM_PROMPT_REVISION` 9 → 10 (note: #2431 changed the prompt without bumping it); token-negative net change, well under the 4250 ceiling
- new prompt-content test in `agent-prompt-budgets.test.ts` pinning the loader recipe + no-`itx.workspace.readFile`
- catalogue regenerated via `pnpm generate:itx-examples`

Local gate green: typecheck, lint, knip, format, test (2708 passed).

Deliberately left out: the eval (sibling branch `preamble-results-eval` owns it), any change to the spill mechanism itself (a separate follow-up item questions its existence — this PR only stops teaching it as the primary retention story), and edits to the shared `tasks/codemode-script-preamble-followups.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session id: `e89f2eb5-b303-47df-9e5d-5033942f37d8` (subagent)

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +10 -6 | +5 -5 🟩⬜⬜⬜⬜ |
| Tests | +10 -0 | +5 -0 🟩⬜⬜⬜⬜ |
| Docs | +109 -0 | +93 -0 🟩🟩🟩🟩🟩 |
| Generated | +4 -4 | +3 -3 🟩⬜⬜⬜⬜ |
| **Total** | **+133 -10** | **+106 -8** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 34c7de9 and f612417, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Teaching-only prompt and example description changes with a revision bump; no auth, data handling, or runtime behavior changes.
> 
> **Overview**
> After #2431, agents still **writeFile'd full API responses** because static teaching pointed at workspace spill files + `readFile`, not the `results` loader. This PR **rewords teaching only**—no runtime changes.
> 
> **Default system prompt** (`agent-defaults.ts`): the SHAPE OF WORK oversized-results bullet now leads with `await results[0].load(itx)`, says **never save your own copy to a file**, and drops the `itx.workspace.readFile` recipe. `DEFAULT_AGENT_SYSTEM_PROMPT_REVISION` bumps **9 → 10**.
> 
> **Docs corpus** (`itx.docs.search` examples): **egress-fetch**, **files-roundtrip**, and **gmail-search-inbox** descriptions/comments now say return data (or use the results preamble) instead of spill-file retention; **files** explicitly carves out script results from “save/persist” guidance.
> 
> **Tests**: new pin in `agent-prompt-budgets.test.ts` for loader teaching and absence of `readFile`; catalogue regenerated from `examples-source.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f61241724f253c334708207d676ae90ffd83753f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->