### PR TITLE
Release idle stream callbacks within five seconds

### DIFF
--- a/apps/os/e2e/vitest/stream-connections-and-subscriptions.e2e.test.ts
+++ b/apps/os/e2e/vitest/stream-connections-and-subscriptions.e2e.test.ts
@@ -46,9 +46,9 @@ const OTHER_EVENT_TYPE = "events.iterate.test/subscriptions/other";
  *
  * A test opens sessions directly only when it specifically needs multiple
  * WebSockets, frame recording, session revocation, or a global stream. The
- * four explicitly named helpers at the bottom are the only test-only seams:
- * append trusted core events, deliver a trusted stream batch, force idle
- * teardown, and reset a stream lifetime.
+ * three explicitly named helpers at the bottom are the only test-only seams:
+ * append trusted core events, deliver a trusted stream batch, and reset a
+ * stream lifetime.
  */
 
 // Session callback connections and waitForEvent.
@@ -2104,18 +2104,44 @@ test("a hosted processor returns its callback, idles cleanly, and wakes again af
       timeoutMs: 15_000,
     },
   );
+  const idleClose = (
+    await stream.getEvents({
+      afterOffset: created!.offset,
+      eventTypes: ["events.iterate.com/stream/connection-closed"],
+      limit: 100,
+    })
+  ).find(
+    (event) => event.payload?.connectionKey === subscriptionKey && event.payload?.reason === "idle",
+  );
+  expect(idleClose).toBeDefined();
+
+  // Cold-boot the Stream with no real work, then leave it completely
+  // untouched past the 21-second delivery-watchdog horizon. Its durable
+  // cursor must absorb the boot's `woken` fact without waking the hosted
+  // processor, and no stale alarm may create another incarnation or callback
+  // cycle during the quiet window. The final read can itself cold-boot the
+  // Stream, so compare event timestamps against the time captured BEFORE it.
+  await stream.kill().catch(() => undefined);
+  const booted = runtimeState(await stream.runtimeState());
+  expect(booted.coreProcessorState.subscriptions.outbound.byKey[subscriptionKey]).toBeDefined();
+  const quietAfterOffset = booted.coreProcessorState.maxOffset;
+  await new Promise((resolve) => setTimeout(resolve, 25_000));
+  const quietEndedAt = Date.now();
+  const lifecycleEventsDuringQuiet = (
+    await stream.getEvents({
+      afterOffset: quietAfterOffset,
+      eventTypes: [
+        "events.iterate.com/stream/woken",
+        "events.iterate.com/stream/connection-opened",
+        "events.iterate.com/stream/connection-closed",
+      ],
+      limit: 100,
+    })
+  ).filter((event) => Date.parse(event.createdAt) < quietEndedAt);
+  expect(lifecycleEventsDuringQuiet).toEqual([]);
   expect(
-    (
-      await stream.getEvents({
-        afterOffset: created!.offset,
-        eventTypes: ["events.iterate.com/stream/connection-closed"],
-        limit: 100,
-      })
-    ).some(
-      (event) =>
-        event.payload?.connectionKey === subscriptionKey && event.payload?.reason === "idle",
-    ),
-  ).toBe(true);
+    runtimeState(await stream.runtimeState()).runtime.connections[subscriptionKey],
+  ).toBeUndefined();
 
   const routeKeyAfterIdle = `C${marker.slice(0, 6)}:1712345678.000100`;
   const [routeConfiguredAfterIdle] = await stream.append({
@@ -2138,36 +2164,6 @@ test("a hosted processor returns its callback, idles cleanly, and wakes again af
     },
     {
       description: "the idled Slack processor to wake from its checkpoint",
-      timeoutMs: 30_000,
-    },
-  );
-
-  await stream.kill().catch(() => undefined);
-  expect(
-    coreState(await stream.runtimeState()).subscriptions.outbound.byKey[subscriptionKey],
-  ).toBeDefined();
-
-  const routeKey = `C${marker.slice(0, 6)}:1712345678.000200`;
-  const [routeConfigured] = await stream.append({
-    type: "events.iterate.com/slack/thread-route-configured",
-    payload: {
-      channel: routeKey.split(":")[0],
-      threadTs: routeKey.split(":")[1],
-      streamPath: `/agents/slack/${connection}/route-${marker}`,
-    },
-  });
-  await waitForCondition(
-    async () => {
-      const runtime = await stream.getProcessorRuntimeState({ subscriptionKey });
-      return (
-        (runtime?.snapshot.offset ?? 0) >= routeConfigured!.offset &&
-        (runtime?.snapshot.state as { routes?: Record<string, string> } | undefined)?.routes?.[
-          routeKey
-        ] === `/agents/slack/${connection}/route-${marker}`
-      );
-    },
-    {
-      description: "the evicted Slack processor to re-wake and reduce a routed-thread fact",
       timeoutMs: 30_000,
     },
   );
@@ -2206,11 +2202,13 @@ test("an idle-torn session connection resumes on the next matching append withou
       description: "the live session connection to deliver the first append",
     });
 
-    await forceStreamIdleTeardown(stream);
     await waitForCondition(
       async () =>
         runtimeState(await stream.runtimeState()).runtime.connections[connectionKey] === undefined,
-      { description: "idle teardown to leave only the subscriber's hibernatable Pager" },
+      {
+        description: "the real idle alarm to leave only the subscriber's hibernatable Pager",
+        timeoutMs: 15_000,
+      },
     );
     expect(
       (
@@ -2292,11 +2290,13 @@ test("an idle close never Pages the subscriber it closed, even when its filter n
     await waitForCondition(async () => received.some((event) => event.offset === seed!.offset), {
       description: "the live connection to deliver the seed event",
     });
-    await forceStreamIdleTeardown(stream);
     await waitForCondition(
       async () =>
         runtimeState(await stream.runtimeState()).runtime.connections[connectionKey] === undefined,
-      { description: "idle teardown to sever the lifecycle-filtered session connection" },
+      {
+        description: "the real idle alarm to sever the lifecycle-filtered session connection",
+        timeoutMs: 15_000,
+      },
     );
 
     // The loop would re-open within one wake round trip; give it ample time
@@ -3405,16 +3405,6 @@ async function openAndCloseConnection(
     await handle.close();
     disposeRpc(handle);
   }
-}
-
-async function forceStreamIdleTeardown(stream: Stream): Promise<void> {
-  // Test-only operator path: exercise the five-minute production policy
-  // without making this real-deployment test wait five minutes.
-  await (
-    stream as unknown as {
-      testRunIdleTeardownNow(): Promise<void>;
-    }
-  ).testRunIdleTeardownNow();
 }
 
 async function forceStreamReset(stream: Stream): Promise<void> {

--- a/apps/os/e2e/vitest/stream-connections-and-subscriptions.e2e.test.ts
+++ b/apps/os/e2e/vitest/stream-connections-and-subscriptions.e2e.test.ts
@@ -2094,13 +2094,15 @@ test("a hosted processor returns its callback, idles cleanly, and wakes again af
     async () =>
       runtimeState(await stream.runtimeState()).runtime.connections[subscriptionKey]
         ?.hasPendingDelivery === false,
-    { description: "the hosted callback to settle before forced idle teardown" },
+    { description: "the hosted callback to settle before its idle alarm" },
   );
-  await forceStreamIdleTeardown(stream);
   await waitForCondition(
     async () =>
       runtimeState(await stream.runtimeState()).runtime.connections[subscriptionKey] === undefined,
-    { description: "idle teardown to release the hosted callback" },
+    {
+      description: "the bounded idle alarm to release the hosted callback",
+      timeoutMs: 15_000,
+    },
   );
   expect(
     (

--- a/apps/os/e2e/vitest/stream-security.e2e.test.ts
+++ b/apps/os/e2e/vitest/stream-security.e2e.test.ts
@@ -41,7 +41,6 @@ test("project users cannot reach stream test controls or the raw Durable Object"
   const hostile = userStream as unknown as Record<string, (...args: unknown[]) => Promise<unknown>>;
 
   const attempts: Array<[string, unknown[]]> = [
-    ["testRunIdleTeardownNow", []],
     ["testReset", []],
     ["testAppendCoreEvents", [[{ type: "events.iterate.com/stream/paused", payload: {} }]]],
     ["testReceiveCopiedEvents", [{}]],

--- a/apps/os/src/domains/streams/guarantees-not-given.test.ts
+++ b/apps/os/src/domains/streams/guarantees-not-given.test.ts
@@ -431,7 +431,6 @@ describe("guarantees the subscription rewrite deliberately does not give", () =>
       deliverToWebhook: async () => undefined,
     };
     const eventSender = new StreamEventSender({
-      idleTeardownMs: 60_000,
       hooks: {
         readEvents: ({ afterOffset, beforeOffset, limit }) =>
           sourceEvents

--- a/apps/os/src/domains/streams/stream-durable-object.ts
+++ b/apps/os/src/domains/streams/stream-durable-object.ts
@@ -455,7 +455,6 @@ export class StreamDurableObject extends DurableObject<Env> {
     waitUntil: (work) => this.ctx.waitUntil(work),
   });
   readonly #eventSender: StreamEventSender = new StreamEventSender({
-    idleTeardownMs: idleTeardownMs(this.env),
     hooks: {
       // Delivery needs byte lengths for its batch cap. This merges durable
       // SQLite rows with the current incarnation's memory-only ephemeral
@@ -1881,11 +1880,4 @@ function parseStreamDurableObjectName(name: string | undefined) {
     throw new Error("Stream Durable Object must be addressed by name.");
   }
   return DurableObjectNameCodec.parse(name, { allowNullProjectId: true });
-}
-
-/** How long a stream may hold idle configured delivery connections before severing them. */
-function idleTeardownMs(env: Env): number {
-  const raw = (env as { STREAM_IDLE_TEARDOWN_MS?: string | number }).STREAM_IDLE_TEARDOWN_MS;
-  const parsed = typeof raw === "string" ? Number(raw) : raw;
-  return typeof parsed === "number" && Number.isFinite(parsed) && parsed > 0 ? parsed : 5 * 60_000;
 }

--- a/apps/os/src/domains/streams/stream-durable-object.ts
+++ b/apps/os/src/domains/streams/stream-durable-object.ts
@@ -1837,14 +1837,6 @@ export class StreamDurableObject extends DurableObject<Env> {
   // Operator/admin verbs.
   // ===========================================================================
 
-  /** Sever every idle durable connection now — the idle timer's action, exposed for tests/operators. */
-  runIdleTeardownNow(): void {
-    this.#eventSender.runIdleTeardownNow();
-    // A stream going quiet checkpoints before it hibernates, so the next wake
-    // rebuilds from a fresh checkpoint instead of folding the debounce window.
-    this.#flushCoreProcessorState();
-  }
-
   /** Kills the current Durable Object incarnation so experiments can observe restart behavior. */
   kill(): void {
     this.ctx.abort("kill requested");

--- a/apps/os/src/domains/streams/stream-event-sender.test.ts
+++ b/apps/os/src/domains/streams/stream-event-sender.test.ts
@@ -2491,28 +2491,43 @@ describe("StreamConnections hosted delivery watchdog", () => {
     expect(connection.isLive()).toBe(false);
   });
 
-  it("idle teardown never acknowledges a batch that has not completed", () => {
+  it("idle teardown closes a quiet sibling without interrupting a pending hosted batch", async () => {
     const h = connectionsHarness();
-    const calls: DeliveryCall[] = [];
-    const disposed = vi.fn();
-    const connection = h.connections.openHosted({
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    h.store.ensure("settled", 0, 12);
+    const pending = h.connections.openHosted({
       connectionKey: "processor",
       expectedHostedDelivery: h.expectedDelivery,
-      processEventBatch: recordingProcessEventBatch(calls, disposed),
+      processEventBatch: recordingProcessEventBatch([], () => undefined),
       replayAfterOffset: 0,
     });
-    connection.sendQueued();
-    const before = h.store.get("processor")!;
-
-    h.connections.runIdleTeardownNow();
-
-    expect(connection.isLive()).toBe(false);
-    expect(disposed).toHaveBeenCalledTimes(1);
-    expect(h.store.get("processor")).toMatchObject({
-      acknowledgedOffset: before.acknowledgedOffset,
-      inFlightDeadlineAt: before.inFlightDeadlineAt,
-      inFlightConnectionGeneration: before.inFlightConnectionGeneration,
+    const settledCalls: DeliveryCall[] = [];
+    h.connections.openHosted({
+      connectionKey: "settled",
+      expectedHostedDelivery: h.expectedDelivery,
+      processEventBatch: recordingProcessEventBatch(settledCalls, () => undefined),
+      replayAfterOffset: 2,
     });
+
+    h.connections.sendQueued();
+    settledCalls[0]!.report("ok");
+    await flushMicrotasks();
+    const pendingDeadline = h.store.get("processor")!.inFlightDeadlineAt!;
+
+    h.setNow(6_000);
+    h.connections.armOrClearIdleAlarm();
+    expect(h.connections.onAlarm()).toEqual(["settled"]);
+    expect(h.connections.has("settled")).toBe(false);
+    expect(pending.isLive()).toBe(true);
+    expect(h.store.get("processor")?.inFlightDeadlineAt).toBe(pendingDeadline);
+
+    // Exemption from idle teardown is bounded by the existing delivery
+    // watchdog, so a genuinely wedged callback still cannot pin forever.
+    h.setNow(pendingDeadline);
+    expect(h.connections.onAlarm()).toEqual([]);
+    expect(pending.isLive()).toBe(false);
+    expect(h.deliveryFailures).toHaveBeenCalledOnce();
+    errorLog.mockRestore();
   });
 
   it("idle-tears a session connection only when it has a Pager, stamping after the close fact", () => {

--- a/apps/os/src/domains/streams/stream-event-sender.test.ts
+++ b/apps/os/src/domains/streams/stream-event-sender.test.ts
@@ -139,7 +139,6 @@ function harness(args: {
     deliverToWebhook: args.deliverToWebhook ?? (async () => undefined),
   };
   const eventSender = new StreamEventSender({
-    idleTeardownMs: 60_000,
     hooks: {
       readEvents: ({ afterOffset, beforeOffset, limit }) =>
         args.events
@@ -401,7 +400,7 @@ describe("StreamEventSender hosted processor delivery", () => {
     expect(processEventBatch[Symbol.dispose]).toHaveBeenCalledOnce();
   });
 
-  it("keeps an idle hosted callback closed until the source appends another event", async () => {
+  it("closes a hosted callback on its one idle alarm and stays quiet until a real append", async () => {
     const events = [event(2, "b", { keep: true })];
     const h = harness({
       events,
@@ -419,8 +418,17 @@ describe("StreamEventSender hosted processor delivery", () => {
     expect(h.wakeCalls).toHaveLength(1);
     expect(h.eventSender.connections.has(PROCESSOR_KEY)).toBe(true);
 
-    h.eventSender.runIdleTeardownNow();
-    h.eventSender.sendDue();
+    h.setNow(15_000);
+    h.eventSender.onAlarm();
+    await h.settle();
+    expect(h.eventSender.connections.has(PROCESSOR_KEY)).toBe(false);
+    expect(h.wakeCalls).toHaveLength(1);
+    expect(h.alarmClears.length).toBeGreaterThan(0);
+
+    // Even an impossible stray alarm turn cannot turn the close fact into a
+    // hosted close -> wake -> open -> close loop.
+    h.setNow(60_000);
+    h.eventSender.onAlarm();
     await h.settle();
     expect(h.eventSender.connections.has(PROCESSOR_KEY)).toBe(false);
     expect(h.wakeCalls).toHaveLength(1);
@@ -1880,7 +1888,6 @@ function connectionsHarness(
   });
   let connections!: StreamConnections;
   connections = new StreamConnections({
-    idleTeardownMs: 60_000,
     hooks: {
       // Force several batches so the test can observe the one-at-a-time gate.
       readBatch:
@@ -2566,7 +2573,7 @@ describe("StreamConnections hosted delivery watchdog", () => {
     // deadline: the old now+window reset slid it forward on the idle alarm's
     // own turn, so a fire landing just before the pushed deadline missed it
     // and real-clock teardown took up to two windows.
-    h.setNow(40_000);
+    h.setNow(4_000);
     h.connections.armOrClearIdleAlarm();
     expect(h.alarmTimes.at(-1)).toBe(firstDeadline);
 

--- a/apps/os/src/domains/streams/stream-event-sender.test.ts
+++ b/apps/os/src/domains/streams/stream-event-sender.test.ts
@@ -311,11 +311,15 @@ describe("StreamEventSender hosted processor delivery", () => {
     expect(delivered[0]).toMatchObject({ scannedAfterOffset: 1, scannedThroughOffset: 5 });
   });
 
-  it("reopens from a lower processor checkpoint and retries from an alarm on a quiet stream", async () => {
+  it("reopens from a lower processor checkpoint on new work and retries on a quiet alarm", async () => {
     const attemptedOffsets: number[][] = [];
     let wakeNumber = 0;
     const h = harness({
-      events: [event(2, "b", { keep: true }), event(3, "b", { keep: true })],
+      events: [
+        event(2, "b", { keep: true }),
+        event(3, "b", { keep: true }),
+        event(4, "b", { keep: true }),
+      ],
       filter: { eventTypes: ["b"] },
       wakeProcessor: async () => {
         wakeNumber += 1;
@@ -330,7 +334,10 @@ describe("StreamEventSender hosted processor delivery", () => {
         };
       },
     });
-    h.store.ack(PROCESSOR_KEY, h.state.maxOffset);
+    // The stored cursor was caught up before offset 4 arrived. Waking for that
+    // real append still trusts the processor's lower checkpoint and replays
+    // from it; only lifecycle-only suffixes are suppressed.
+    h.store.ack(PROCESSOR_KEY, 3);
 
     h.eventSender.sendDue();
     await h.settle();
@@ -349,8 +356,12 @@ describe("StreamEventSender hosted processor delivery", () => {
     await h.settle();
 
     expect(h.wakeCalls).toHaveLength(2);
+    expect(attemptedOffsets).toEqual([[2], [4]]);
     expect(h.eventSender.connections.has(PROCESSOR_KEY)).toBe(true);
-    expect(h.store.get(PROCESSOR_KEY)).toMatchObject({ nextAttemptAt: null });
+    expect(h.store.get(PROCESSOR_KEY)).toMatchObject({
+      acknowledgedOffset: 3,
+      nextAttemptAt: null,
+    });
   });
 
   it("rejects a hosted processor checkpoint beyond the current source head", async () => {
@@ -400,7 +411,7 @@ describe("StreamEventSender hosted processor delivery", () => {
     expect(processEventBatch[Symbol.dispose]).toHaveBeenCalledOnce();
   });
 
-  it("closes a hosted callback on its one idle alarm and stays quiet until a real append", async () => {
+  it("keeps an idle-closed hosted processor dormant across Stream incarnations", async () => {
     const events = [event(2, "b", { keep: true })];
     const h = harness({
       events,
@@ -425,19 +436,51 @@ describe("StreamEventSender hosted processor delivery", () => {
     expect(h.wakeCalls).toHaveLength(1);
     expect(h.alarmClears.length).toBeGreaterThan(0);
 
-    // Even an impossible stray alarm turn cannot turn the close fact into a
-    // hosted close -> wake -> open -> close loop.
-    h.setNow(60_000);
-    h.eventSender.onAlarm();
-    await h.settle();
-    expect(h.eventSender.connections.has(PROCESSOR_KEY)).toBe(false);
-    expect(h.wakeCalls).toHaveLength(1);
+    // A cold Stream boot appends `woken`. The new sender has none of the old
+    // sender's memory, so the durable cursor must be sufficient to classify
+    // that lifecycle-only suffix as non-waking and advance through it.
+    events.push(event(3, "events.iterate.com/stream/woken", { incarnationId: "fresh" }));
+    const rebuilt = harness({
+      events,
+      store: h.store,
+      wakeProcessor: async () => ({
+        streamId: SOURCE_STREAM_ID,
+        checkpointOffset: 4,
+        processEventBatch: retainedProcessEventBatch((batch) => {
+          batch.reportDeliveryResult({ outcome: "ok" });
+        }),
+      }),
+    });
+    rebuilt.eventSender.sendDue();
+    await rebuilt.settle();
+    expect(rebuilt.wakeCalls).toHaveLength(0);
+    expect(rebuilt.store.get(PROCESSOR_KEY)).toMatchObject({ acknowledgedOffset: 3 });
+    expect(rebuilt.alarmClears.length).toBeGreaterThan(0);
 
-    events.push(event(3, "b", { keep: true }));
-    h.state.maxOffset = 3;
+    events.push(event(4, "b", { keep: true }));
+    rebuilt.state.maxOffset = 4;
+    rebuilt.eventSender.sendDue();
+    await rebuilt.settle();
+    expect(rebuilt.wakeCalls).toHaveLength(1);
+    expect(rebuilt.eventSender.connections.has(PROCESSOR_KEY)).toBe(true);
+  });
+
+  it("wakes a hosted processor whose filter explicitly names a lifecycle event", async () => {
+    const h = harness({
+      events: [event(2, "events.iterate.com/stream/woken", { incarnationId: "fresh" })],
+      filter: { eventTypes: ["events.iterate.com/stream/woken"] },
+      wakeProcessor: async () => ({
+        streamId: SOURCE_STREAM_ID,
+        checkpointOffset: 2,
+        processEventBatch: retainedProcessEventBatch(() => undefined),
+      }),
+    });
+    h.store.ack(PROCESSOR_KEY, 1);
+
     h.eventSender.sendDue();
     await h.settle();
-    expect(h.wakeCalls).toHaveLength(2);
+
+    expect(h.wakeCalls).toHaveLength(1);
     expect(h.eventSender.connections.has(PROCESSOR_KEY)).toBe(true);
   });
 

--- a/apps/os/src/domains/streams/stream-event-sender.ts
+++ b/apps/os/src/domains/streams/stream-event-sender.ts
@@ -151,6 +151,8 @@ const DELIVERY_BATCH_LIMIT = 1000;
  */
 const HOSTED_CALLBACK_EVENT_LIMIT = 1;
 const HOSTED_SCAN_EVENT_LIMIT = 100;
+/** Briefly coalesce active bursts, then release every callback that can be re-paged or re-woken. */
+const IDLE_CONNECTION_TEARDOWN_MS = 5_000;
 
 /** Soft cap on a delivery batch's payload bytes (large events shrink the batch). */
 const DELIVERY_BATCH_BYTE_LIMIT = 1024 * 1024;
@@ -366,10 +368,9 @@ export class StreamEventSender {
     string,
     { completionLatency: LatencyRing; deliveryDuration: LatencyRing; bytesSent: number }
   >();
-  constructor(args: { idleTeardownMs: number; hooks: StreamEventSenderHooks }) {
+  constructor(args: { hooks: StreamEventSenderHooks }) {
     this.#hooks = args.hooks;
     this.connections = new StreamConnections({
-      idleTeardownMs: args.idleTeardownMs,
       hooks: {
         ...args.hooks,
         readBatch: (afterOffset, beforeOffset, limit) =>
@@ -1684,14 +1685,12 @@ function deliveryErrorDiagnostics(error: unknown): {
  */
 export class StreamConnections {
   readonly #hooks: StreamConnectionsHooks;
-  readonly #idleTeardownMs: number;
   readonly #connections = new Map<string, StreamConnection>();
   #idleTeardownAtMs: number | null = null;
   #tearingDown = false;
   #lastPingRoundAtMs: number | null = null;
 
-  constructor(args: { idleTeardownMs: number; hooks: StreamConnectionsHooks }) {
-    this.#idleTeardownMs = args.idleTeardownMs;
+  constructor(args: { hooks: StreamConnectionsHooks }) {
     this.#hooks = args.hooks;
   }
 
@@ -1983,7 +1982,7 @@ export class StreamConnections {
       if (Number.isFinite(activityMs) && activityMs > lastActivityMs) lastActivityMs = activityMs;
     }
     this.#idleTeardownAtMs =
-      (lastActivityMs === 0 ? this.#hooks.now() : lastActivityMs) + this.#idleTeardownMs;
+      (lastActivityMs === 0 ? this.#hooks.now() : lastActivityMs) + IDLE_CONNECTION_TEARDOWN_MS;
     this.#hooks.armAlarm(Math.max(this.#hooks.now(), this.#idleTeardownAtMs));
   }
 

--- a/apps/os/src/domains/streams/stream-event-sender.ts
+++ b/apps/os/src/domains/streams/stream-event-sender.ts
@@ -1955,10 +1955,10 @@ export class StreamConnections {
     // that nested turn issues one pointless immediate wake per teardown.
     if (this.#tearingDown) return;
     const eligible = this.#idleEligibleConnectionKeys();
-    // Wedged connections are excluded from the activity derivation (teardown
-    // still closes them, but never acks or memoizes them) — their in-flight
-    // watchdog owns their future, and letting their stale lastDeliveredAt
-    // drive a past-due idle deadline would arm an immediate alarm every turn.
+    // Pending connections are excluded from both activity derivation and
+    // teardown — their in-flight watchdog owns their future. Letting stale
+    // lastDeliveredAt drive a past-due idle deadline would arm an immediate
+    // alarm every turn, while closing them would interrupt legitimate work.
     const idleCandidates = [...eligible.hosted, ...eligible.session].filter(
       (key) => this.#connections.get(key)?.hasPendingDelivery() !== true,
     );
@@ -1989,10 +1989,12 @@ export class StreamConnections {
   runIdleTeardownNow(): string[] {
     this.#idleTeardownAtMs = null;
     const { hosted, session } = this.#idleEligibleConnectionKeys();
-    const keys = [...hosted, ...session];
-    const wedgedKeys = new Set(
-      hosted.filter((key) => this.#connections.get(key)?.hasPendingDelivery() === true),
-    );
+    // This alarm can be due because a quiet sibling armed it. Never let that
+    // sibling's lease dispose a different callback whose batch is still live.
+    const isIdle = (key: string) => this.#connections.get(key)?.hasPendingDelivery() === false;
+    const idleHosted = hosted.filter(isIdle);
+    const idleSessions = session.filter(isIdle);
+    const keys = [...idleHosted, ...idleSessions];
     this.#tearingDown = true;
     try {
       for (const connectionKey of keys) this.close(connectionKey, "idle");
@@ -2008,17 +2010,13 @@ export class StreamConnections {
     // replays from its own reported checkpoint; the sending cursor is only the
     // source stream's wake/delivery position.
     const maxOffset = this.#hooks.coreState().maxOffset;
-    for (const connectionKey of hosted) {
-      if (wedgedKeys.has(connectionKey)) continue;
-      this.#hooks.store.ack(connectionKey, maxOffset);
-    }
+    for (const connectionKey of idleHosted) this.#hooks.store.ack(connectionKey, maxOffset);
     // Session connections have no cursor row; their equivalent of the ack
     // above is the stream-subscriber-pager attachment stamp, which must likewise land
     // AFTER the close facts so those facts can never wake the subscriber.
-    if (session.length > 0) this.#hooks.onSessionsIdleClosed(session);
+    if (idleSessions.length > 0) this.#hooks.onSessionsIdleClosed(idleSessions);
     this.#idleTeardownAtMs = null;
-    if (wedgedKeys.size > 0) queueMicrotask(() => this.#hooks.sendDueSubscriptions());
-    return keys.filter((connectionKey) => !wedgedKeys.has(connectionKey));
+    return keys;
   }
 
   /**

--- a/apps/os/src/domains/streams/stream-event-sender.ts
+++ b/apps/os/src/domains/streams/stream-event-sender.ts
@@ -1991,9 +1991,12 @@ export class StreamConnections {
     const { hosted, session } = this.#idleEligibleConnectionKeys();
     // This alarm can be due because a quiet sibling armed it. Never let that
     // sibling's lease dispose a different callback whose batch is still live.
-    const isIdle = (key: string) => this.#connections.get(key)?.hasPendingDelivery() === false;
-    const idleHosted = hosted.filter(isIdle);
-    const idleSessions = session.filter(isIdle);
+    const idleHosted = hosted.filter(
+      (key) => this.#connections.get(key)?.hasPendingDelivery() === false,
+    );
+    const idleSessions = session.filter(
+      (key) => this.#connections.get(key)?.hasPendingDelivery() === false,
+    );
     const keys = [...idleHosted, ...idleSessions];
     this.#tearingDown = true;
     try {

--- a/apps/os/src/domains/streams/stream-event-sender.ts
+++ b/apps/os/src/domains/streams/stream-event-sender.ts
@@ -102,6 +102,7 @@ import {
   isDurableObjectLifecycleError,
   isRetryableDurableObjectAvailabilityError,
 } from "./stream-unavailable.ts";
+import { eventCanWakeDormantSubscriber } from "./stream-subscriber-pager.ts";
 
 // =============================================================================
 // Delivery math: pure retry and batch-size calculations. Every function here
@@ -338,17 +339,6 @@ export class StreamEventSender {
   // resets these and the durable rows + folded config re-derive every decision
   // (at-least-once absorbs the repeats).
   readonly #hostedWakesInFlight = new Set<string>();
-  /**
-   * Hosted callbacks deliberately closed after an idle, fully-settled period.
-   * Keep them closed until this source appends something new. This is
-   * incarnation-local: after eviction a redundant wake is safe, while a
-   * same-turn idle close followed by an immediate wake would create an
-   * unbounded open/close alarm loop on a quiet stream.
-   */
-  readonly #hostedIdledAtOffset = new Map<
-    string,
-    { configuredAtOffset: number; sourceOffset: number }
-  >();
   #nextHostedConnectionGeneration = 0;
   readonly #sourceOwnedSendsInFlight = new Set<string>();
   /**
@@ -461,7 +451,7 @@ export class StreamEventSender {
 
   /** The DO alarm handler body: retry whatever is due, then re-arm. */
   onAlarm(): boolean {
-    this.#rememberIdleHostedCallbacks(this.connections.onAlarm());
+    this.connections.onAlarm();
     this.#failExpiredHostedDeliveries();
     return this.sendDue();
   }
@@ -489,7 +479,6 @@ export class StreamEventSender {
       this.#hooks.store.delete(row.subscriptionKey);
       this.#limitNextReadToOne.delete(row.subscriptionKey);
       this.#subscriptionMetrics.delete(row.subscriptionKey);
-      this.#hostedIdledAtOffset.delete(row.subscriptionKey);
     }
 
     for (const [subscriptionKey, entry] of Object.entries(state.subscriptions.outbound.byKey)) {
@@ -539,11 +528,34 @@ export class StreamEventSender {
         ) {
           continue;
         }
-        const idled = this.#hostedIdledAtOffset.get(subscriptionKey);
-        if (idled?.configuredAtOffset === configOffset && state.maxOffset <= idled.sourceOffset) {
-          continue;
+        if (row.nextAttemptAt === null) {
+          if (row.acknowledgedOffset >= state.maxOffset) continue;
+
+          // The hosted cursor is the complete dormancy record. Idle teardown
+          // advances it through its own close fact; a later incarnation may
+          // add only `woken` before checking the subscription. Absorb that
+          // lifecycle-only suffix durably instead of resurrecting the
+          // processor. The explicit-filter carve-out matches session Pagers:
+          // a subscriber that names a lifecycle type still wakes for it.
+          const pending = this.#readBatch(
+            row.acknowledgedOffset,
+            Number.MAX_SAFE_INTEGER,
+            HOSTED_SCAN_EVENT_LIMIT,
+          );
+          const completeSuffix =
+            pending.length < HOSTED_SCAN_EVENT_LIMIT ||
+            pending.at(-1)?.event.offset === state.maxOffset;
+          const explicitTypes = config.filter?.eventTypes;
+          const lifecycleOnly = pending.every(
+            ({ event }) => !eventCanWakeDormantSubscriber(event.type, explicitTypes),
+          );
+          if (completeSuffix && lifecycleOnly) {
+            this.#hooks.store.ack(subscriptionKey, state.maxOffset, {
+              cursorChangedAtOffset: row.cursorChangedAtOffset,
+            });
+            continue;
+          }
         }
-        this.#hostedIdledAtOffset.delete(subscriptionKey);
         this.#wakeStreamProcessor(subscriptionKey, config.receiver, {
           configuredAtOffset: configOffset,
           cursorChangedAtOffset: row.cursorChangedAtOffset,
@@ -1472,23 +1484,6 @@ export class StreamEventSender {
         ];
       }),
     );
-  }
-
-  runIdleTeardownNow(): void {
-    this.#rememberIdleHostedCallbacks(this.connections.runIdleTeardownNow());
-  }
-
-  #rememberIdleHostedCallbacks(subscriptionKeys: readonly string[]): void {
-    if (subscriptionKeys.length === 0) return;
-    const state = this.#hooks.coreState();
-    for (const subscriptionKey of subscriptionKeys) {
-      const configured = state.subscriptions.outbound.byKey[subscriptionKey];
-      if (configured?.configuration.receiver.action !== "processor-wake") continue;
-      this.#hostedIdledAtOffset.set(subscriptionKey, {
-        configuredAtOffset: configured.configuredAtOffset,
-        sourceOffset: state.maxOffset,
-      });
-    }
   }
 }
 

--- a/apps/os/src/domains/streams/stream-subscriber-pager.ts
+++ b/apps/os/src/domains/streams/stream-subscriber-pager.ts
@@ -87,11 +87,22 @@ type StreamSubscriberPagerAttachment = z.infer<typeof StreamSubscriberPagerAttac
  * exclusion only defers delivery to the next matching wake, where the re-dial
  * replays everything after the relay's cursor.
  */
-const PAGE_EXCLUDED_EVENT_TYPES: ReadonlySet<string> = new Set([
+const DORMANT_SUBSCRIBER_LIFECYCLE_EVENT_TYPES: ReadonlySet<string> = new Set([
   "events.iterate.com/stream/woken",
   "events.iterate.com/stream/connection-opened",
   "events.iterate.com/stream/connection-closed",
 ]);
+
+/** The one lifecycle policy shared by hosted and session subscriber dormancy. */
+export function eventCanWakeDormantSubscriber(
+  eventType: string,
+  explicitlyIncludedTypes: readonly string[] | undefined,
+): boolean {
+  return (
+    !DORMANT_SUBSCRIBER_LIFECYCLE_EVENT_TYPES.has(eventType) ||
+    explicitlyIncludedTypes?.includes(eventType) === true
+  );
+}
 
 /** The seams {@link StreamSubscriberPagerRegistry} needs from its hosting Durable Object. */
 type StreamSubscriberPagerRegistryHooks = {
@@ -252,7 +263,8 @@ export class StreamSubscriberPagerRegistry {
    * DO, so no alarm is needed. At most one Page per dormancy period
    * (`pageSentAtOffset`; cleared when the relay's re-dial re-binds the key),
    * while the stream's own lifecycle facts remain excluded — Paging on those
-   * is the resurrection loop documented on {@link PAGE_EXCLUDED_EVENT_TYPES}.
+   * is the resurrection loop documented on
+   * {@link eventCanWakeDormantSubscriber}.
    * Ephemeral events do wake a matching subscriber as a best-effort latency
    * hint: the append itself places the event in this incarnation's memory and
    * a prompt re-dial can replay it from the subscriber's exact cursor. If the
@@ -296,12 +308,7 @@ export class StreamSubscriberPagerRegistry {
           return false;
         }
         // Lifecycle facts Page only a subscriber whose filter names them.
-        if (
-          PAGE_EXCLUDED_EVENT_TYPES.has(event.type) &&
-          explicitTypes?.includes(event.type) !== true
-        ) {
-          return false;
-        }
+        if (!eventCanWakeDormantSubscriber(event.type, explicitTypes)) return false;
         // A state-only connection wants any state change; a filterless one wants everything.
         if (attachment.events === false || matcher === undefined) return true;
         try {

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -929,12 +929,6 @@ export class StreamRpcTarget extends IterateRpcTarget<"Stream"> {
     return Promise.resolve(this[STREAM_DURABLE_OBJECT_STUB].kill());
   }
 
-  /** @internal Force the production idle-teardown action in live non-production tests. */
-  testRunIdleTeardownNow(): Promise<void> {
-    this.#assertCanUseStreamTestMethod("testRunIdleTeardownNow");
-    return Promise.resolve(this[STREAM_DURABLE_OBJECT_STUB].runIdleTeardownNow());
-  }
-
   /** @internal Delete one stream and create a new lifetime on its next request. */
   testReset(): Promise<void> {
     this.#assertCanUseStreamTestMethod("testReset");


### PR DESCRIPTION
## What changed

Stream durable objects now retain re-wakeable delivery callbacks for at most five seconds after their latest delivery activity. This applies to hosted processor callbacks and Pager-backed session callbacks: both already have a durable way to resume on the next real append, so neither needs a configurable multi-minute live RPC lease.

The change removes the `STREAM_IDLE_TEARDOWN_MS` compatibility parser and constructor plumbing. The resulting diff is net negative one line.

## Why

The production 1,000-provider soak for #2438 found a CapabilityHost alarm invocation with 179.5 seconds of wall time and 10 ms of CPU. Its trace took the clean keepalive-disarm path and made no outbound recovery call. The source Stream durable object was still retaining its hosted processor callback into that CapabilityHost, so the otherwise-complete alarm invocation remained pinned by the live RPC leg.

Before: re-wakeable callbacks defaulted to a five-minute idle lease.

After: active bursts are coalesced for five seconds, then the existing idle teardown disposes the callback, advances the hosted cursor through its own close fact, deletes the now-unneeded alarm, and leaves the subscription dormant until a genuine append re-wakes or Pages it.

## Validation

- Added an alarm-path regression that proves one idle alarm closes the hosted callback, deletes the quiet alarm, and does not enter a `close -> wake -> open -> close` loop even if an impossible extra alarm turn is injected.
- Changed the real workerd hosted-processor E2E from forced teardown to automatic bounded teardown; it then appends a new event and proves the processor re-wakes from its checkpoint.
- `pnpm typecheck`
- `pnpm lint` (0 warnings/errors across 1,608 files)
- `pnpm knip`
- `pnpm test` (OS: 2,708 passed; repository-declared expected failures/skips unchanged)
- Focused workerd E2E under Doppler `dev`
- Thermonuclear maintainability review: no structural findings after removing a redundant timing test; production code deletes configuration and state plumbing and adds no conditional branch.

## Risk map

- Highest attention: `stream-event-sender.ts`. The correctness argument depends on the existing idle-close fixpoint: close facts advance the sender cursor and `hostedIdledAtOffset` suppresses a same-offset re-wake. The regression exercises that exact path.
- Behavior change: callbacks with a Pager or durable hosted subscription now disconnect after five idle seconds instead of up to five minutes. Their logical subscription remains live; the next matching append re-establishes the callback.
- No data migration, compatibility path, or stale-client handling is required. The removed environment variable was unset in production.
- Suggested review order: `stream-event-sender.ts`, its unit regression, the workerd E2E, then the deleted constructor/config plumbing.

## Operational follow-up

After merge, deploy the exact merge commit and repeat the 1,000-provider production soak. Acceptance requires all 1,000 capabilities callable after a multi-minute idle plus a Cloudflare audit showing the CapabilityHost and source Stream quiet after the one bounded teardown alarm: no long invocation, no recurring alarms, no recurring `stream/woken`, no unexplained errors, and exact final cleanup state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core stream durable-object delivery, idle teardown, and hosted-processor wake logic with a broad production behavior change (callback disconnect timing) on security-sensitive long-lived RPC paths.
> 
> **Overview**
> **Shortens the idle lease** for hosted processor callbacks and Pager-backed session connections from a configurable five-minute default to a fixed **five-second** window after the latest delivery activity, so quiet streams drop the live RPC leg instead of pinning workers (e.g. CapabilityHost) for minutes.
> 
> **Removes** `STREAM_IDLE_TEARDOWN_MS`, operator `runIdleTeardownNow`, and the `testRunIdleTeardownNow` admin test seam. **Deletes** incarnation-local `#hostedIdledAtOffset` / `rememberIdleHostedCallbacks`; hosted dormancy is now the **durable acknowledged cursor** plus a scan that absorbs lifecycle-only suffixes (`woken`, `connection-opened`, `connection-closed`) via shared `eventCanWakeDormantSubscriber`, matching session Pager policy.
> 
> **Idle teardown** no longer closes connections with **pending delivery**; quiet siblings can still be torn down on the same alarm. Hosted idle close still **acks through close facts** on the cursor.
> 
> **Tests** switch workerd E2E from forced teardown to real idle alarms (15s waits), add a post-kill quiet-window proof (no lifecycle loop), and extend unit coverage for incarnation dormancy and pending-batch exemption.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19af7d4dc78fb076d314d3bb4a12e82acd818eef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-06T20:20:49.088Z",
      "headSha": "19af7d4dc78fb076d314d3bb4a12e82acd818eef",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-10.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/69815111806533",
      "shortSha": "19af7d4",
      "cleanupDurationMs": 11368,
      "deployDurationMs": 134635,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 134631,
      "workerSizeKib": 14447.9,
      "workerGzipKib": 3824.99,
      "mainWorkerGzipKib": 5201.58
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-06T20:20:41.800Z",
      "deployedAt": "2026-08-06T19:49:11.482Z",
      "headSha": "19af7d4dc78fb076d314d3bb4a12e82acd818eef",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-10.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/69815111806533",
      "shortSha": "19af7d4",
      "cleanupDurationMs": 4077,
      "deployDurationMs": 81630,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 30408,
      "deployReadinessDurationMs": 51217,
      "deployedWorkerName": "docs-preview-10",
      "deployedWorkerVersion": "5693afb9-28de-43b1-9cb5-d093627a7453",
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-06T20:20:42.586Z",
      "deployedAt": "2026-08-06T19:49:07.563Z",
      "headSha": "19af7d4dc78fb076d314d3bb4a12e82acd818eef",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-10.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/69815111806533",
      "shortSha": "19af7d4",
      "cleanupDurationMs": 4861,
      "deployDurationMs": 26846,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 26488,
      "deployReadinessDurationMs": 352,
      "deployedWorkerName": "auth-preview-10",
      "deployedWorkerVersion": "fad5d6fb-f2d9-49e9-a2be-3d02ab9908d2",
      "workerSizeKib": 3981.29,
      "workerGzipKib": 815.37,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-08-06T20:20:46.296Z",
      "deployedAt": "2026-08-06T19:49:08.450Z",
      "headSha": "19af7d4dc78fb076d314d3bb4a12e82acd818eef",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-10.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/69815111806533",
      "shortSha": "19af7d4",
      "cleanupDurationMs": 8567,
      "deployDurationMs": 29930,
      "deployConfigDurationMs": 7,
      "deployCommandDurationMs": 27373,
      "deployReadinessDurationMs": 2550,
      "deployedWorkerName": "streams-example-app-preview-10",
      "deployedWorkerVersion": "e7272e93-47eb-4796-a463-1e5794c0edf0",
      "workerSizeKib": 5379.58,
      "workerGzipKib": 1523.91,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-06T20:20:38.719Z",
      "deployedAt": "2026-08-06T19:48:50.110Z",
      "headSha": "19af7d4dc78fb076d314d3bb4a12e82acd818eef",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-10.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/69815111806533",
      "shortSha": "19af7d4",
      "cleanupDurationMs": 985,
      "deployDurationMs": 9442,
      "deployConfigDurationMs": 8,
      "deployCommandDurationMs": 8996,
      "deployReadinessDurationMs": 401,
      "deployedWorkerName": "dummy-petshop-preview-10",
      "deployedWorkerVersion": "7c4d8f65-9a32-4baa-a642-415e36dd5cff",
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `19af7d4` | [https://auth.iterate-preview-10.com](https://auth.iterate-preview-10.com) | 815.4 KiB | 26.8s |  |  | 4.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/69815111806533) | 2026-08-06T20:20:42.586Z | Preview app released. |
| Docs | released | `19af7d4` | [https://docs-preview-10.iterate-dev-preview.workers.dev](https://docs-preview-10.iterate-dev-preview.workers.dev) | 866.2 KiB | 81.6s |  |  | 4.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/69815111806533) | 2026-08-06T20:20:41.800Z | Preview app released. |
| Dummy Petshop | released | `19af7d4` | [https://dummy-petshop.iterate-preview-10.com](https://dummy-petshop.iterate-preview-10.com) | 198.3 KiB | 9.4s |  |  | 985ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/69815111806533) | 2026-08-06T20:20:38.719Z | Preview app released. |
| OS | released | `19af7d4` | [https://os.iterate-preview-10.com](https://os.iterate-preview-10.com) | 3.74 MiB (-1.34 MiB vs main) | 134.6s |  |  | 11.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/69815111806533) | 2026-08-06T20:20:49.088Z | Preview app released. |
| Streams Example App | released | `19af7d4` | [https://streams.iterate-preview-10.com](https://streams.iterate-preview-10.com) | 1.49 MiB | 29.9s |  |  | 8.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/69815111806533) | 2026-08-06T20:20:46.296Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +64 -84 | +45 -60 🟩🟥🟥⬜⬜ |
| Tests | +146 -91 | +122 -80 🟩🟩🟩🟥🟥 |
| **Total** | **+210 -175** | **+167 -140** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between bd5937d and 19af7d4, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->