### PR TITLE
Add minimal Iterate Chrome side panel

### DIFF
--- a/apps/auth/e2e/oauth-code-exchange.e2e.test.ts
+++ b/apps/auth/e2e/oauth-code-exchange.e2e.test.ts
@@ -52,6 +52,7 @@ import {
   ITERATE_ROLE_CLAIM,
 } from "@iterate-com/shared/auth-claims";
 import { createCloudflareWorkerVersionOverrideFetch } from "@iterate-com/shared/test-support/cloudflare-worker-version-overrides";
+import { ITERATE_BROWSER_EXTENSION_ORIGIN } from "../src/server/browser-origin.ts";
 
 function requireAuthBaseUrl(): string {
   const value = process.env.AUTH_BASE_URL?.trim();
@@ -232,10 +233,20 @@ async function mintAuthorizationCode(client: OAuthClient, cookie: string): Promi
   return code!;
 }
 
-async function exchangeToken(body: Record<string, string>): Promise<Response> {
+async function exchangeToken(body: Record<string, string>, origin?: string): Promise<Response> {
   return authFetch(`${issuer}/oauth2/token`, {
     method: "POST",
-    headers: { "content-type": "application/x-www-form-urlencoded" },
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      ...(origin
+        ? {
+            origin,
+            "sec-fetch-dest": "empty",
+            "sec-fetch-mode": "cors",
+            "sec-fetch-site": "cross-site",
+          }
+        : {}),
+    },
     body: new URLSearchParams(body),
   });
 }
@@ -344,10 +355,16 @@ describe("deployed auth OAuth2/OIDC provider", () => {
     expect(code).toBeTruthy();
 
     // 3. token exchange with the RFC 8707 resource OS itself uses.
-    const tokenResponse = await exchangeToken({
-      ...codeExchangeBody(client, code!),
-      resource: OS_RESOURCE,
-    });
+    // Chrome attaches the extension origin and Fetch Metadata headers to its
+    // service-worker fetch. The metadata forces better-auth's origin check;
+    // omitting it makes a non-browser test silently skip the failing branch.
+    const tokenResponse = await exchangeToken(
+      {
+        ...codeExchangeBody(client, code!),
+        resource: OS_RESOURCE,
+      },
+      ITERATE_BROWSER_EXTENSION_ORIGIN,
+    );
     expect(tokenResponse.status).toBe(200);
     const tokens = (await tokenResponse.json()) as {
       access_token: string;

--- a/apps/auth/src/server/auth.ts
+++ b/apps/auth/src/server/auth.ts
@@ -48,7 +48,7 @@ export const auth = betterAuth({
     if (!allowedOrigin) return [];
     // The allowed requester plus this deployment's own origins — loopback
     // and extension clients must be listed explicitly.
-    const trusted: string[] = [allowedOrigin, config.authAppOrigin];
+    const trusted = [allowedOrigin, config.authAppOrigin];
     if (config.publicUrl) trusted.push(config.publicUrl);
     return trusted;
   },

--- a/apps/auth/src/server/auth.ts
+++ b/apps/auth/src/server/auth.ts
@@ -6,24 +6,7 @@ import { generateDefaultAvatar } from "@iterate-com/shared/default-avatar";
 import { config, env } from "./env.ts";
 import { getAuthPlugins } from "./auth-plugins.ts";
 import { authJwt } from "./auth-jwt.ts";
-
-/**
- * THE browser-origin trust decision, in one place. Loopback origins: on
- * test-automation stages (fixedTestOtpEnabled — local/dev/preview, never
- * production) ANY loopback port is trusted, because the Expo Web mobile app's
- * browser-side OAuth (discovery, dynamic registration, token exchange —
- * native apps never hit CORS) runs on a random port per invocation;
- * production trusts only the MCP inspector's fixed port 6274. Everything
- * else must BE this deployment: the auth app origin, or its public alias.
- */
-export function isAllowedBrowserOrigin(origin: string | null | undefined) {
-  if (!origin || !URL.canParse(origin)) return false;
-  const url = new URL(origin);
-  const isLoopback =
-    url.protocol === "http:" && ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname);
-  if (isLoopback) return config.fixedTestOtpEnabled || url.port === "6274";
-  return url.origin === config.authAppOrigin || url.origin === config.publicUrl;
-}
+import { resolveAllowedBrowserOrigin } from "./browser-origin.ts";
 
 export type ProjectIngressTokenPayload = {
   type: "project-ingress";
@@ -61,11 +44,11 @@ export const auth = betterAuth({
   }),
   trustedOrigins: (request) => {
     const origin = request?.headers.get("origin");
-    if (!origin || !isAllowedBrowserOrigin(origin)) return [];
+    const allowedOrigin = resolveAllowedBrowserOrigin(origin, config);
+    if (!allowedOrigin) return [];
     // The allowed requester plus this deployment's own origins — loopback
-    // clients pass the predicate on shape, so the requester must be listed
-    // explicitly.
-    const trusted: string[] = [new URL(origin).origin, config.authAppOrigin];
+    // and extension clients must be listed explicitly.
+    const trusted: string[] = [allowedOrigin, config.authAppOrigin];
     if (config.publicUrl) trusted.push(config.publicUrl);
     return trusted;
   },

--- a/apps/auth/src/server/browser-origin.test.ts
+++ b/apps/auth/src/server/browser-origin.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { ITERATE_BROWSER_EXTENSION_ORIGIN, resolveAllowedBrowserOrigin } from "./browser-origin.ts";
+
+const productionPolicy = {
+  authAppOrigin: "https://auth.iterate.com",
+  publicUrl: undefined,
+  fixedTestOtpEnabled: false,
+};
+
+describe("resolveAllowedBrowserOrigin", () => {
+  it("allows the production Iterate browser extension origin without turning it into null", () => {
+    assert.equal(
+      resolveAllowedBrowserOrigin(ITERATE_BROWSER_EXTENSION_ORIGIN, productionPolicy),
+      ITERATE_BROWSER_EXTENSION_ORIGIN,
+    );
+  });
+
+  it("rejects a different Chrome extension", () => {
+    assert.equal(
+      resolveAllowedBrowserOrigin(
+        "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        productionPolicy,
+      ),
+      null,
+    );
+  });
+
+  it("keeps the existing deployment and loopback policy", () => {
+    assert.equal(
+      resolveAllowedBrowserOrigin("https://auth.iterate.com", productionPolicy),
+      "https://auth.iterate.com",
+    );
+    assert.equal(
+      resolveAllowedBrowserOrigin("http://localhost:6274", productionPolicy),
+      "http://localhost:6274",
+    );
+    assert.equal(resolveAllowedBrowserOrigin("http://localhost:8123", productionPolicy), null);
+    assert.equal(
+      resolveAllowedBrowserOrigin("http://localhost:8123", {
+        ...productionPolicy,
+        fixedTestOtpEnabled: true,
+      }),
+      "http://localhost:8123",
+    );
+  });
+});

--- a/apps/auth/src/server/browser-origin.ts
+++ b/apps/auth/src/server/browser-origin.ts
@@ -1,0 +1,43 @@
+export const ITERATE_BROWSER_EXTENSION_ORIGIN =
+  "chrome-extension://miplldbnkopaghnkiebdkefnmokobeco";
+
+/**
+ * THE browser-origin trust decision, in one place. Loopback origins: on
+ * test-automation stages (fixedTestOtpEnabled — local/dev/preview, never
+ * production) ANY loopback port is trusted, because the Expo Web mobile app's
+ * browser-side OAuth runs on a random port per invocation. Production trusts
+ * only the MCP inspector's fixed port 6274. The stable Iterate browser
+ * extension origin is also trusted. Everything else must be this deployment:
+ * the auth app origin or its public alias.
+ *
+ * Returns the exact origin CORS and better-auth should trust, or rejects it.
+ */
+export function resolveAllowedBrowserOrigin(
+  origin: string | null | undefined,
+  policy: {
+    authAppOrigin: string;
+    publicUrl?: string;
+    fixedTestOtpEnabled: boolean;
+  },
+) {
+  if (!origin || !URL.canParse(origin)) return null;
+
+  // WHATWG URL reports a `null` origin for extension schemes. Preserve the
+  // exact stable extension origin so better-auth can compare the Origin
+  // header instead of accidentally trusting or returning the string "null".
+  if (origin.startsWith("chrome-extension:")) {
+    return origin === ITERATE_BROWSER_EXTENSION_ORIGIN ? origin : null;
+  }
+
+  const url = new URL(origin);
+  const normalizedOrigin = url.origin;
+  const isLoopback =
+    url.protocol === "http:" && ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname);
+  if (isLoopback) {
+    return policy.fixedTestOtpEnabled || url.port === "6274" ? normalizedOrigin : null;
+  }
+  if (normalizedOrigin === policy.authAppOrigin || normalizedOrigin === policy.publicUrl) {
+    return normalizedOrigin;
+  }
+  return null;
+}

--- a/apps/auth/src/server/worker.ts
+++ b/apps/auth/src/server/worker.ts
@@ -22,7 +22,8 @@ import { cors } from "hono/cors";
 import { RequestHeadersPlugin } from "@orpc/server/plugins";
 import { onError, ORPCError } from "@orpc/server";
 import { RPCHandler } from "@orpc/server/fetch";
-import { auth, isAllowedBrowserOrigin } from "./auth.ts";
+import { auth } from "./auth.ts";
+import { resolveAllowedBrowserOrigin } from "./browser-origin.ts";
 import { db } from "./db/index.ts";
 import { config } from "./env.ts";
 import { hono, variablesProvider, type Variables } from "./utils/hono.ts";
@@ -51,9 +52,7 @@ const AUTH_ISSUER_PATH = "/api/auth";
 app.use(
   cors({
     origin: (origin) => {
-      if (!origin || !URL.canParse(origin)) return null;
-      const normalizedOrigin = new URL(origin).origin;
-      return isAllowedBrowserOrigin(normalizedOrigin) ? normalizedOrigin : null;
+      return resolveAllowedBrowserOrigin(origin, config);
     },
     credentials: true,
     allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],

--- a/apps/browser-extension/README.md
+++ b/apps/browser-extension/README.md
@@ -1,0 +1,61 @@
+# Iterate browser extension
+
+A deliberately small internal Chrome extension. It opens as a side panel,
+connects to one Iterate project, shows that project's live processor state, and
+provides the project with a capability for opening an HTTP(S) page in Chrome.
+
+This extension is not published in the Chrome Web Store. Install its unpacked
+build from this repository.
+
+## Install
+
+Chrome 114 or newer and Node.js 22.15 or newer are required.
+
+1. From the repository root, install dependencies and build the extension:
+
+   ```bash
+   pnpm install
+   pnpm --dir apps/browser-extension build
+   ```
+
+2. Open `chrome://extensions` in Chrome.
+3. Enable **Developer mode**.
+4. Click **Load unpacked** and select `apps/browser-extension/dist` from this
+   checkout. Select `dist`, not `apps/browser-extension`.
+5. Open **Iterate** from Chrome's Extensions menu. Its toolbar action opens the
+   side panel beside the current page.
+6. Sign in, approve project access, and enter the project slug (for example,
+   `voice-test`).
+
+After rebuilding, click **Reload** on the extension's `chrome://extensions`
+card. During development, `pnpm --dir apps/browser-extension dev` rebuilds on
+file changes; Chrome still needs that reload to pick up each build.
+
+## What it does
+
+- Authenticates with `auth.iterate.com` using authorization code + PKCE and the
+  WebExtension Identity API. The service worker owns the interactive flow so it
+  can finish independently of the panel UI.
+- Uses `configureIterateSession`, `useItx`, and `useLiveState` from the published
+  `iterate` SDK to connect to `os.iterate.com` with the resulting bearer token.
+- Mounts `itx.chrome.openPage({ url })` at the selected project's root and shows
+  a ready-to-post agent prompt that exercises it.
+- Renders `itx.liveState.reduced` in a read-only text area.
+
+The manifest asks only for `identity`, `sidePanel`, and `storage`. Opening a new
+tab through `chrome.tabs.create()` does not require the broad `tabs` permission.
+All executable code is bundled into the extension; no code is loaded remotely.
+
+## Stable production identity
+
+The production OAuth client is public: there is intentionally no client secret
+inside a browser extension. It is registered with `auth.iterate.com` for the
+callback returned by `chrome.identity.getRedirectURL()`:
+
+- extension ID: `miplldbnkopaghnkiebdkefnmokobeco`
+- OAuth client ID: `kOlPgrOieTduTzepGDCODpHDeLIZJDyo`
+- callback: `https://miplldbnkopaghnkiebdkefnmokobeco.chromiumapp.org/`
+
+The manifest's public `key` preserves the legacy extension ID. Changing that
+key changes both the extension origin and OAuth callback, so the auth origin
+allowlist and OAuth client registration must be updated in the same release.

--- a/apps/browser-extension/index.html
+++ b/apps/browser-extension/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Iterate</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/browser-extension/package.json
+++ b/apps/browser-extension/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@iterate-com/browser-extension",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch",
+    "typecheck": "tsgo --noEmit"
+  },
+  "dependencies": {
+    "iterate": "workspace:*",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "zod": "4.3.6"
+  },
+  "devDependencies": {
+    "@types/chrome": "^0.1.6",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "6.0.1",
+    "vite": "8.0.9"
+  }
+}

--- a/apps/browser-extension/public/manifest.json
+++ b/apps/browser-extension/public/manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": 3,
+  "name": "Iterate",
+  "description": "Share Chrome with an Iterate project and view its live processor state.",
+  "version": "0.1.0",
+  "minimum_chrome_version": "114",
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAspgSUwSfiXguZe3WByjp613X57nr6/xazInTLwa7flo9sR1XREgiLCG1ZcrWR8LoottD2Hbs9ESpRLbIapj6rDAZwc/o3Q9HNVqNaS1AyInNG3WFHs8EFM/zS5UWZ5FxV5hHwQv5/soV24FDkcfvjJ81GwwizSsBxG0YTap+2WRQZkyipnQLQLgpf7Ei+MfIhUchxb4TBjgs9dKCD6ObRkHunEg3NUENGoVoKAs3+CctotvenoxgTsjLByC3tJBRwF7NLorAockPz7l6THWwi1F7J25LpvUpB0TdYrU8U2ygNUefU7+dWgkN13av5iAll2/sFNPJEsnwGpfVNagJZwIDAQAB",
+  "action": {
+    "default_title": "Open Iterate"
+  },
+  "side_panel": {
+    "default_path": "index.html"
+  },
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "permissions": ["identity", "sidePanel", "storage"],
+  "host_permissions": ["https://auth.iterate.com/*", "https://os.iterate.com/*"]
+}

--- a/apps/browser-extension/src/App.tsx
+++ b/apps/browser-extension/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { Component, Suspense, useEffect, useState, type ReactNode } from "react";
 import {
   configureIterateSession,
   disconnectIterateSession,
@@ -97,13 +97,38 @@ export function App() {
         />
       </label>
       {projectSlug ? (
-        <>
-          <BrowserCapability key={projectSlug} projectSlug={projectSlug} />
-          <ProjectState projectSlug={projectSlug} />
-        </>
+        <ProjectBoundary key={projectSlug} onReset={logOut}>
+          <Suspense fallback={<p>Connecting to project…</p>}>
+            <BrowserCapability projectSlug={projectSlug} />
+            <ProjectState projectSlug={projectSlug} />
+          </Suspense>
+        </ProjectBoundary>
       ) : null}
     </main>
   );
+}
+
+class ProjectBoundary extends Component<
+  { children: ReactNode; onReset: () => Promise<void> },
+  { error?: Error }
+> {
+  state: { error?: Error } = {};
+
+  static getDerivedStateFromError(cause: unknown) {
+    return { error: cause instanceof Error ? cause : new Error(String(cause)) };
+  }
+
+  render() {
+    if (!this.state.error) return this.props.children;
+    return (
+      <section>
+        <p className="error">{this.state.error.message}</p>
+        <button type="button" onClick={() => void this.props.onReset()}>
+          Sign in again
+        </button>
+      </section>
+    );
+  }
 }
 
 function BrowserCapability({ projectSlug }: { projectSlug: string }) {

--- a/apps/browser-extension/src/App.tsx
+++ b/apps/browser-extension/src/App.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useState } from "react";
+import {
+  configureIterateSession,
+  disconnectIterateSession,
+  reconnectIterateSession,
+  useItx,
+  useLiveState,
+  type CapabilityProvision,
+} from "iterate/sdk/itx/react";
+import { getAccessToken, isSignedIn, requestSignIn, signOut } from "./auth.ts";
+import {
+  browserCapability,
+  browserCapabilityInstructions,
+  browserCapabilityTypes,
+} from "./browser-capability.ts";
+
+const PROJECT_STORAGE_KEY = "iterateProjectSlug";
+
+configureIterateSession({
+  baseUrl: "https://os.iterate.com",
+  credentials: async ({ forceRefresh }) => ({
+    type: "bearer",
+    token: await getAccessToken(forceRefresh),
+  }),
+});
+
+export function App() {
+  const [authenticated, setAuthenticated] = useState<boolean>();
+  const [projectSlug, setProjectSlug] = useState("");
+  const [error, setError] = useState<string>();
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    void Promise.all([isSignedIn(), chrome.storage.local.get(PROJECT_STORAGE_KEY)]).then(
+      ([signedIn, stored]) => {
+        setAuthenticated(signedIn);
+        const savedSlug = stored[PROJECT_STORAGE_KEY];
+        if (typeof savedSlug === "string") setProjectSlug(savedSlug);
+      },
+    );
+  }, []);
+
+  async function authenticate() {
+    setBusy(true);
+    setError(undefined);
+    try {
+      await requestSignIn();
+      setAuthenticated(true);
+      reconnectIterateSession();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function logOut() {
+    await signOut();
+    disconnectIterateSession();
+    setAuthenticated(false);
+  }
+
+  async function updateProjectSlug(value: string) {
+    setProjectSlug(value);
+    await chrome.storage.local.set({ [PROJECT_STORAGE_KEY]: value });
+  }
+
+  if (authenticated === undefined) return <main>Loading…</main>;
+  if (!authenticated) {
+    return (
+      <main>
+        <h1>Iterate</h1>
+        <p>Sign in to view a project's live processor state.</p>
+        <button type="button" disabled={busy} onClick={authenticate}>
+          {busy ? "Signing in…" : "Sign in with Iterate"}
+        </button>
+        {error ? <p className="error">{error}</p> : null}
+      </main>
+    );
+  }
+
+  return (
+    <main>
+      <header>
+        <h1>Project state</h1>
+        <button className="secondary" type="button" onClick={logOut}>
+          Sign out
+        </button>
+      </header>
+      <label>
+        Project slug
+        <input
+          value={projectSlug}
+          onChange={(event) => void updateProjectSlug(event.target.value.trim())}
+          placeholder="my-project"
+          spellCheck={false}
+        />
+      </label>
+      {projectSlug ? (
+        <>
+          <BrowserCapability key={projectSlug} projectSlug={projectSlug} />
+          <ProjectState projectSlug={projectSlug} />
+        </>
+      ) : null}
+    </main>
+  );
+}
+
+function BrowserCapability({ projectSlug }: { projectSlug: string }) {
+  const itx = useItx(projectSlug);
+  const proofPrompt = `Use the ${projectSlug} project capability to call itx.chrome.openPage({ url: "https://example.com/?iterate-capability-proof=${encodeURIComponent(projectSlug)}" }). Then report the returned tabId and url.`;
+  const [state, setState] = useState<
+    { status: "connecting" } | { status: "available" } | { error: string; status: "error" }
+  >({ status: "connecting" });
+
+  useEffect(() => {
+    let provision: CapabilityProvision | undefined;
+    let stopped = false;
+    setState({ status: "connecting" });
+
+    void itx
+      .provideCapability({
+        capability: browserCapability,
+        instructions: browserCapabilityInstructions,
+        path: ["chrome"],
+        type: "live",
+        types: browserCapabilityTypes,
+      })
+      .then(
+        (mounted) => {
+          if (stopped) {
+            mounted[Symbol.dispose]();
+            return;
+          }
+          provision = mounted;
+          setState({ status: "available" });
+        },
+        (cause: unknown) => {
+          if (!stopped) {
+            setState({
+              error: cause instanceof Error ? cause.message : String(cause),
+              status: "error",
+            });
+          }
+        },
+      );
+
+    return () => {
+      stopped = true;
+      provision?.[Symbol.dispose]();
+    };
+  }, [itx]);
+
+  return (
+    <section className="capability">
+      <div className="status">
+        <span>Chrome capability</span>
+        <span>{state.status}</span>
+      </div>
+      <code>itx.chrome.openPage({`{ url }`})</code>
+      <div className="proof">
+        <span>Post this to an agent to prove it works</span>
+        <p>{proofPrompt}</p>
+      </div>
+      {state.status === "error" ? <p className="error">{state.error}</p> : null}
+    </section>
+  );
+}
+
+function ProjectState({ projectSlug }: { projectSlug: string }) {
+  const state = useLiveState(
+    (itx) => itx.liveState,
+    (project) => project.reduced,
+    [],
+    { slug: projectSlug },
+  );
+
+  return (
+    <section>
+      <div className="status">
+        <span>{state.status}</span>
+        <button className="secondary" type="button" onClick={state.refresh}>
+          Refresh
+        </button>
+      </div>
+      <textarea
+        aria-label="Project processor state"
+        readOnly
+        value={
+          state.value === undefined
+            ? "Waiting for live state…"
+            : JSON.stringify(state.value, null, 2)
+        }
+      />
+      {state.error ? <p className="error">{state.error}</p> : null}
+    </section>
+  );
+}

--- a/apps/browser-extension/src/auth.ts
+++ b/apps/browser-extension/src/auth.ts
@@ -21,7 +21,7 @@ const TokenResponse = z.object({
 });
 
 export async function isSignedIn() {
-  return (await readTokens()) !== undefined;
+  return Boolean(await readTokens());
 }
 
 export async function requestSignIn() {

--- a/apps/browser-extension/src/auth.ts
+++ b/apps/browser-extension/src/auth.ts
@@ -1,0 +1,151 @@
+import { z } from "zod";
+
+const AUTH_ISSUER = "https://auth.iterate.com/api/auth";
+const CLIENT_ID = "kOlPgrOieTduTzepGDCODpHDeLIZJDyo";
+const OS_RESOURCE = "https://os.iterate.com";
+const TOKEN_STORAGE_KEY = "iterateOAuthTokens";
+
+const TokenSet = z.object({
+  accessToken: z.string().min(1),
+  accessTokenExpiresAt: z.number(),
+  refreshToken: z.string().min(1).optional(),
+});
+const SignInResponse = z.discriminatedUnion("ok", [
+  z.object({ ok: z.literal(true) }),
+  z.object({ ok: z.literal(false), error: z.string() }),
+]);
+const TokenResponse = z.object({
+  access_token: z.string().min(1),
+  expires_in: z.number().optional(),
+  refresh_token: z.string().min(1).optional(),
+});
+
+export async function isSignedIn() {
+  return (await readTokens()) !== undefined;
+}
+
+export async function requestSignIn() {
+  const response = SignInResponse.parse(
+    await chrome.runtime.sendMessage({ type: "iterate:sign-in" }),
+  );
+  if (!response.ok) throw new Error(response.error);
+}
+
+export async function signIn() {
+  const redirectUri = chrome.identity.getRedirectURL();
+  const state = randomBase64Url(24);
+  const verifier = randomBase64Url(48);
+  const challenge = await sha256Base64Url(verifier);
+  const authorizeUrl = new URL(`${AUTH_ISSUER}/oauth2/authorize`);
+  authorizeUrl.search = new URLSearchParams({
+    response_type: "code",
+    client_id: CLIENT_ID,
+    redirect_uri: redirectUri,
+    scope: "openid profile email offline_access project",
+    resource: OS_RESOURCE,
+    state,
+    code_challenge: challenge,
+    code_challenge_method: "S256",
+    prompt: "consent",
+  }).toString();
+
+  const callback = await chrome.identity.launchWebAuthFlow({
+    interactive: true,
+    url: authorizeUrl.toString(),
+  });
+  if (!callback) throw new Error("OAuth did not return a callback URL.");
+
+  const callbackUrl = new URL(callback);
+  const oauthError = callbackUrl.searchParams.get("error");
+  if (oauthError) {
+    throw new Error(callbackUrl.searchParams.get("error_description") ?? oauthError);
+  }
+  if (callbackUrl.searchParams.get("state") !== state) {
+    throw new Error("OAuth state did not match.");
+  }
+  const code = callbackUrl.searchParams.get("code");
+  if (!code) throw new Error("OAuth callback contained no authorization code.");
+
+  await exchangeTokens(
+    new URLSearchParams({
+      grant_type: "authorization_code",
+      client_id: CLIENT_ID,
+      code,
+      redirect_uri: redirectUri,
+      code_verifier: verifier,
+      resource: OS_RESOURCE,
+    }),
+  );
+}
+
+export async function signOut() {
+  await chrome.storage.local.remove(TOKEN_STORAGE_KEY);
+}
+
+export async function getAccessToken(forceRefresh = false) {
+  const tokens = await readTokens();
+  if (!tokens) throw new Error("Sign in to Iterate first.");
+  if (!forceRefresh && tokens.accessTokenExpiresAt > Date.now() + 30_000) {
+    return tokens.accessToken;
+  }
+  if (!tokens.refreshToken) {
+    await signOut();
+    throw new Error("Your Iterate session expired. Sign in again.");
+  }
+
+  try {
+    return await exchangeTokens(
+      new URLSearchParams({
+        grant_type: "refresh_token",
+        client_id: CLIENT_ID,
+        refresh_token: tokens.refreshToken,
+        resource: OS_RESOURCE,
+      }),
+      tokens.refreshToken,
+    );
+  } catch (error) {
+    await signOut();
+    throw error;
+  }
+}
+
+async function exchangeTokens(body: URLSearchParams, currentRefreshToken?: string) {
+  const response = await fetch(`${AUTH_ISSUER}/oauth2/token`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body,
+  });
+  if (!response.ok) {
+    throw new Error(`OAuth token exchange failed (${response.status}): ${await response.text()}`);
+  }
+  const result = TokenResponse.parse(await response.json());
+  const tokens = {
+    accessToken: result.access_token,
+    accessTokenExpiresAt: Date.now() + (result.expires_in ?? 300) * 1_000,
+    refreshToken: result.refresh_token ?? currentRefreshToken,
+  };
+  await chrome.storage.local.set({ [TOKEN_STORAGE_KEY]: tokens });
+  return tokens.accessToken;
+}
+
+async function readTokens() {
+  const stored = await chrome.storage.local.get(TOKEN_STORAGE_KEY);
+  const tokens = TokenSet.safeParse(stored[TOKEN_STORAGE_KEY]);
+  return tokens.success ? tokens.data : undefined;
+}
+
+function randomBase64Url(byteLength: number) {
+  const bytes = crypto.getRandomValues(new Uint8Array(byteLength));
+  return bytesToBase64Url(bytes);
+}
+
+async function sha256Base64Url(value: string) {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return bytesToBase64Url(new Uint8Array(digest));
+}
+
+function bytesToBase64Url(bytes: Uint8Array) {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/u, "");
+}

--- a/apps/browser-extension/src/background.ts
+++ b/apps/browser-extension/src/background.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+import { signIn } from "./auth.ts";
+
+const SignInMessage = z.object({ type: z.literal("iterate:sign-in") });
+
+void chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
+
+chrome.runtime.onMessage.addListener((message: unknown, _sender, sendResponse) => {
+  if (!SignInMessage.safeParse(message).success) return;
+
+  void signIn().then(
+    () => sendResponse({ ok: true }),
+    (cause: unknown) =>
+      sendResponse({
+        ok: false,
+        error: cause instanceof Error ? cause.message : String(cause),
+      }),
+  );
+  return true;
+});

--- a/apps/browser-extension/src/browser-capability.ts
+++ b/apps/browser-extension/src/browser-capability.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+const OpenPageInput = z.strictObject({
+  url: z.string().min(1),
+});
+
+export const browserCapability = {
+  async openPage(input: unknown) {
+    const { url } = OpenPageInput.parse(input);
+    const target = new URL(url);
+    if (target.protocol !== "http:" && target.protocol !== "https:") {
+      throw new Error("openPage() only accepts http and https URLs.");
+    }
+
+    const tab = await chrome.tabs.create({ active: true, url: target.href });
+    if (tab.id === undefined) {
+      throw new Error("Chrome opened the page without returning a tab ID.");
+    }
+
+    return { tabId: tab.id, url: target.href };
+  },
+};
+
+export const browserCapabilityInstructions =
+  "The user's live Chrome browser. Call itx.chrome.openPage({ url }) to open an http or https page in a new active tab.";
+
+export const browserCapabilityTypes = `
+export interface ChromeBrowser {
+  openPage(input: { url: string }): Promise<{ tabId: number; url: string }>;
+}
+`;

--- a/apps/browser-extension/src/main.tsx
+++ b/apps/browser-extension/src/main.tsx
@@ -1,0 +1,13 @@
+import "./style.css";
+
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.tsx";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Missing #root element.");
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/apps/browser-extension/src/style.css
+++ b/apps/browser-extension/src/style.css
@@ -1,0 +1,125 @@
+:root {
+  color: #18212a;
+  background: #f6f4ef;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 280px;
+}
+
+main {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+}
+
+header,
+.status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+h1,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: 18px;
+}
+
+label,
+section {
+  display: grid;
+  gap: 8px;
+}
+
+.capability {
+  padding: 10px;
+  border: 1px solid #dcd8cf;
+  border-radius: 8px;
+  background: #eeece6;
+}
+
+.proof {
+  display: grid;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.proof p {
+  user-select: text;
+  border: 1px solid #dcd8cf;
+  border-radius: 6px;
+  background: white;
+  padding: 8px;
+  font-weight: 400;
+  line-height: 1.4;
+}
+
+code {
+  overflow-wrap: anywhere;
+  font-size: 11px;
+}
+
+label,
+.status {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+input,
+textarea,
+button {
+  border: 1px solid #c9c5bc;
+  border-radius: 8px;
+  font: inherit;
+}
+
+input,
+textarea {
+  background: white;
+  padding: 10px;
+}
+
+textarea {
+  width: 100%;
+  min-height: 360px;
+  height: calc(100vh - 260px);
+  resize: vertical;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+button {
+  cursor: pointer;
+  color: white;
+  background: #18212a;
+  padding: 8px 12px;
+}
+
+button.secondary {
+  color: #18212a;
+  background: transparent;
+}
+
+button:disabled {
+  cursor: wait;
+  opacity: 0.6;
+}
+
+.error {
+  color: #a42121;
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}

--- a/apps/browser-extension/tsconfig.json
+++ b/apps/browser-extension/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
+    "jsx": "react-jsx",
+    "lib": ["DOM", "ES2024"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2024",
+    "types": ["chrome", "vite/client"]
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/apps/browser-extension/vite.config.ts
+++ b/apps/browser-extension/vite.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
@@ -6,8 +7,8 @@ export default defineConfig({
   build: {
     rollupOptions: {
       input: {
-        panel: new URL("./index.html", import.meta.url).pathname,
-        background: new URL("./src/background.ts", import.meta.url).pathname,
+        panel: fileURLToPath(new URL("./index.html", import.meta.url)),
+        background: fileURLToPath(new URL("./src/background.ts", import.meta.url)),
       },
       output: {
         entryFileNames: (chunk) =>

--- a/apps/browser-extension/vite.config.ts
+++ b/apps/browser-extension/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    rollupOptions: {
+      input: {
+        panel: new URL("./index.html", import.meta.url).pathname,
+        background: new URL("./src/background.ts", import.meta.url).pathname,
+      },
+      output: {
+        entryFileNames: (chunk) =>
+          chunk.name === "background" ? "background.js" : "assets/[name]-[hash].js",
+      },
+    },
+  },
+});

--- a/knip.ts
+++ b/knip.ts
@@ -123,6 +123,14 @@ function makeDocsWorkspace(): WorkspaceConfig {
   };
 }
 
+function makeBrowserExtensionWorkspace(): WorkspaceConfig {
+  return {
+    entry: ["vite.config.ts", "src/background.ts", "src/main.tsx"],
+    project: ["src/**/*.{ts,tsx}", "vite.config.ts"],
+    vite: false,
+  };
+}
+
 function makeCloudflareTanStackAppWorkspace(workerEnvShim: string): WorkspaceConfig {
   return {
     entry: ["vite.config.ts", "scripts/router.ts", "scripts/**/*.ts", "src/worker.ts!"],
@@ -224,6 +232,7 @@ const config: KnipConfig = {
     "!apps/tanstack",
     "!apps/kit",
     "!apps/docs",
+    "!apps/browser-extension",
     "packages/*",
     "!packages/shared",
     "!packages/ui",
@@ -252,6 +261,7 @@ const config: KnipConfig = {
     "apps/tanstack": makeTanstackTodoWorkspace(),
     "apps/kit": makeKitWorkspace(),
     "apps/docs": makeDocsWorkspace(),
+    "apps/browser-extension": makeBrowserExtensionWorkspace(),
     "packages/shared": makeSharedWorkspace(),
     "packages/ui": makeUiWorkspace(),
     "packages/iterate": makeIterateCliWorkspace(),

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint:check": "pnpm lint",
     "lint:fix": "oxlint . --fix",
     "test:oxlint-plugin": "pnpm --dir lint test",
-    "knip": "knip --workspace apps/os --workspace apps/semaphore --workspace apps/streams-example-app --workspace apps/tanstack --workspace apps/kit --workspace apps/docs --workspace packages/shared --workspace packages/ui --workspace packages/iterate --workspace packages/workspace-documents",
+    "knip": "knip --workspace apps/os --workspace apps/semaphore --workspace apps/streams-example-app --workspace apps/tanstack --workspace apps/kit --workspace apps/docs --workspace apps/browser-extension --workspace packages/shared --workspace packages/ui --workspace packages/iterate --workspace packages/workspace-documents",
     "prepare": "is-ci || husky",
     "spec": "playwright test --config playwright.config.ts",
     "e2e": "pnpm --dir apps/os e2e",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -341,6 +341,37 @@ importers:
         specifier: 4.107.0
         version: 4.107.0(@cloudflare/workers-types@4.20260621.1(patch_hash=ae8908e1d45f2ea02ffeabf1230701598cc2878240ef700403ff76df72677af2))
 
+  apps/browser-extension:
+    dependencies:
+      iterate:
+        specifier: workspace:*
+        version: link:../../packages/iterate
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+      zod:
+        specifier: 4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@types/chrome':
+        specifier: ^0.1.6
+        version: 0.1.43
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: 6.0.1
+        version: 6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.0))(@babel/runtime@7.28.6)(rolldown@1.1.0)(vite@8.0.9(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.9(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0))
+      vite:
+        specifier: 8.0.9
+        version: 8.0.9(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+
   apps/docs:
     devDependencies:
       '@cloudflare/vite-plugin':
@@ -6702,6 +6733,9 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/chrome@0.1.43':
+    resolution: {integrity: sha512-ukH/HhmR6ht+UTX3PLUWJxgJ/RQcK2Foj4lBzsF24SIWsXgqhGuXqjd8FFuwioPP7d/JUKLM4g8GZxw3F4HTcA==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -6819,6 +6853,12 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/filesystem@0.0.36':
+    resolution: {integrity: sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==}
+
+  '@types/filewriter@0.0.33':
+    resolution: {integrity: sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==}
+
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
@@ -6830,6 +6870,9 @@ packages:
 
   '@types/hammerjs@2.0.46':
     resolution: {integrity: sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==}
+
+  '@types/har-format@1.2.16':
+    resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -19764,6 +19807,11 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/chrome@0.1.43':
+    dependencies:
+      '@types/filesystem': 0.0.36
+      '@types/har-format': 1.2.16
+
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-axis@3.0.6':
@@ -19906,6 +19954,12 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/filesystem@0.0.36':
+    dependencies:
+      '@types/filewriter': 0.0.33
+
+  '@types/filewriter@0.0.33': {}
+
   '@types/geojson@7946.0.16': {}
 
   '@types/glob@7.1.3':
@@ -19918,6 +19972,8 @@ snapshots:
       '@types/node': 24.12.4
 
   '@types/hammerjs@2.0.46': {}
+
+  '@types/har-format@1.2.16': {}
 
   '@types/hast@3.0.4':
     dependencies:


### PR DESCRIPTION
## What

- Add a deliberately small Manifest V3 Chrome side panel under `apps/browser-extension`.
- Authenticate through the existing public `auth.iterate.com` OAuth client with authorization code + PKCE; no client secret ships in Chrome.
- Use `configureIterateSession`, `useItx`, and `useLiveState` from the `iterate` SDK to render `itx.liveState.reduced` for a selected project.
- Mount a live `itx.chrome.openPage({ url })` capability at the project root and render a ready-to-post agent verification prompt.
- Preserve the exact allowlisted `chrome-extension://` origin through Auth CORS and Better Auth validation.
- Document the complete unpacked installation, update, and stable-identity workflow.

## Why

A Chrome extension Origin is an opaque-origin URL: `new URL(origin).origin` becomes `null`. Auth normalized the incoming extension origin that way before checking Better Auth trusted origins, so authorization completed but token exchange failed with `403 INVALID_ORIGIN`.

After this change Auth preserves the one exact allowlisted Iterate extension origin while rejecting every other extension origin. The extension then uses the resulting project-scoped bearer token through the shared Iterate session keeper and React hooks.

## Capability surface

```ts
await itx.chrome.openPage({ url: "https://example.com" });
// => { tabId: number, url: string }
```

Only HTTP and HTTPS URLs are accepted. `chrome.tabs.create()` does not require the broad `tabs` permission, so the manifest requests only `identity`, `sidePanel`, and `storage`.

## Extension structure

The extension itself is **716 physical lines**, excluding generated `dist/` output and dependencies. The separate Auth origin validation and tests are outside this count.

| Area | Lines | Files | Responsibility |
| --- | ---: | --- | --- |
| React side panel | 236 | `src/App.tsx`, `src/main.tsx` | Sign-in/project UI, SDK session setup, `useLiveState` rendering, and capability lifecycle. |
| OAuth + token storage | 151 | `src/auth.ts` | Authorization Code + PKCE, refresh, Zod response validation, and `chrome.storage.local` persistence. |
| Browser integration | 51 | `src/background.ts`, `src/browser-capability.ts` | Open the panel from the toolbar, run OAuth in the service worker, validate URLs, and expose `itx.chrome.openPage`. |
| Styling | 125 | `src/style.css` | Side-panel layout and component styling. |
| Chrome surface | 32 | `public/manifest.json`, `index.html` | Manifest V3 identity, least-privilege permissions, background worker, and side-panel entry point. |
| Build configuration | 60 | `package.json`, `tsconfig.json`, `vite.config.ts` | React/TypeScript dependencies and two-entry Vite build. |
| Installation docs | 61 | `README.md` | Build, load-unpacked, stable-ID, update, and troubleshooting instructions. |
| **Total** | **716** |  |  |

The runtime TypeScript/TSX is **438 lines**. Its flow is: toolbar click → side panel → background-owned OAuth → project-scoped Iterate session → `useLiveState` subscription plus a live `itx.chrome.openPage` capability.

## Production proof

The unpacked extension was exercised against production with its stable extension ID and public OAuth client:

- OAuth completed and project access was granted.
- The side panel connected to `voice-test` and rendered live reduced processor state.
- The capability mounted as `itx.chrome.openPage` at the project root.
- Agent `/agents/voice/2026-08-06-174838` received the generated proof paragraph and successfully opened `https://example.com/?iterate-capability-proof=voice-test`, returning tab ID `2131332428` and the same URL.

## Checks

- `pnpm install`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm format`
- `pnpm test`
- `pnpm --dir apps/browser-extension build`
- `pnpm --dir apps/auth test` (95 passed)
- React Doctor: 100/100, no findings

## Risk map

- **Highest attention:** `apps/auth/src/server/browser-origin.ts` is an authentication trust boundary. Correctness depends on returning the raw origin only for one exact stable Chrome extension ID while retaining the existing auth/public-origin and bounded loopback policies. Unit coverage and the deployed OAuth e2e request now include Chrome Fetch Metadata headers so Better Auth actually exercises this branch.
- **Merge behavior:** Auth accepts one additional browser origin. No other Chrome extension is trusted. The extension remains an internal unpacked build and is not submitted to the Chrome Web Store by this PR. Existing users must rebuild and reload the unpacked extension to receive source changes.
- **Operational identity:** the public OAuth client `kOlPgrOieTduTzepGDCODpHDeLIZJDyo`, callback, manifest public key, and Auth origin allowlist are one stable identity and must change together.
- **Review order:** review `browser-origin.ts` plus its unit/e2e coverage first, then `src/auth.ts` and the manifest, then `App.tsx`/`browser-capability.ts`, then build configuration and README.

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +645 -26 | +547 -14 🟩🟩🟩🟩🟩 |
| Tests | +70 -6 | +63 -6 🟩⬜⬜⬜⬜ |
| Config | +62 -1 | +62 -1 🟩⬜⬜⬜⬜ |
| Docs | +61 -0 | +46 -0 🟩⬜⬜⬜⬜ |
| Other | +10 -0 | +9 -0 🟩⬜⬜⬜⬜ |
| Generated | +56 -0 | +47 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+904 -33** | **+774 -21** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between bd5937d and 2b965a1, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-06T20:20:23.130Z",
      "headSha": "2b965a1f57fee0fa4cc8edd97a6d1655e20fda95",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/305223276186731",
      "shortSha": "2b965a1",
      "cleanupDurationMs": 7581,
      "deployDurationMs": 134889,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 134885,
      "workerSizeKib": 14447.9,
      "workerGzipKib": 3824.99,
      "mainWorkerGzipKib": 5201.58
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-06T20:20:19.307Z",
      "deployedAt": "2026-08-06T20:03:14.563Z",
      "headSha": "2b965a1f57fee0fa4cc8edd97a6d1655e20fda95",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-17.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/305223276186731",
      "shortSha": "2b965a1",
      "cleanupDurationMs": 3754,
      "deployDurationMs": 34885,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 34597,
      "deployReadinessDurationMs": 283,
      "deployedWorkerName": "docs-preview-17",
      "deployedWorkerVersion": "8b29182b-ee81-42c7-b2b0-0cf528610923",
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-08-06T20:20:16.416Z",
      "deployedAt": "2026-08-06T20:03:13.185Z",
      "headSha": "2b965a1f57fee0fa4cc8edd97a6d1655e20fda95",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/305223276186731",
      "shortSha": "2b965a1",
      "cleanupDurationMs": 860,
      "deployDurationMs": 33407,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 33218,
      "deployReadinessDurationMs": 184,
      "deployedWorkerName": "semaphore-preview-17",
      "deployedWorkerVersion": "3fb6774c-4f28-43c5-9c4b-0c954142e468",
      "workerSizeKib": 1915.51,
      "workerGzipKib": 441.08,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-06T20:20:20.764Z",
      "deployedAt": "2026-08-06T20:03:10.090Z",
      "headSha": "2b965a1f57fee0fa4cc8edd97a6d1655e20fda95",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/305223276186731",
      "shortSha": "2b965a1",
      "cleanupDurationMs": 5207,
      "deployDurationMs": 30458,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 30122,
      "deployReadinessDurationMs": 330,
      "deployedWorkerName": "auth-preview-17",
      "deployedWorkerVersion": "0baa9628-b519-4665-8241-42da67383a33",
      "workerSizeKib": 3981.51,
      "workerGzipKib": 815.36,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-08-06T20:20:24.482Z",
      "deployedAt": "2026-08-06T20:03:01.479Z",
      "headSha": "2b965a1f57fee0fa4cc8edd97a6d1655e20fda95",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/305223276186731",
      "shortSha": "2b965a1",
      "cleanupDurationMs": 8923,
      "deployDurationMs": 22561,
      "deployConfigDurationMs": 8,
      "deployCommandDurationMs": 21509,
      "deployReadinessDurationMs": 1044,
      "deployedWorkerName": "streams-example-app-preview-17",
      "deployedWorkerVersion": "7dfd37ab-3003-451c-82fe-f616e6487c44",
      "workerSizeKib": 5380.84,
      "workerGzipKib": 1524.29,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-06T20:20:17.669Z",
      "deployedAt": "2026-08-06T20:03:14.981Z",
      "headSha": "2b965a1f57fee0fa4cc8edd97a6d1655e20fda95",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/305223276186731",
      "shortSha": "2b965a1",
      "cleanupDurationMs": 1252,
      "deployDurationMs": 12709,
      "deployConfigDurationMs": 0,
      "deployCommandDurationMs": 12453,
      "deployReadinessDurationMs": 252,
      "deployedWorkerName": "dummy-petshop-preview-17",
      "deployedWorkerVersion": "04ab5807-20f2-47d9-9809-5016f084e1b0",
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `2b965a1` | [https://auth.iterate-preview-17.com](https://auth.iterate-preview-17.com) | 815.4 KiB | 30.5s |  |  | 5.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/305223276186731) | 2026-08-06T20:20:20.764Z | Preview app released. |
| Docs | released | `2b965a1` | [https://docs-preview-17.iterate-dev-preview.workers.dev](https://docs-preview-17.iterate-dev-preview.workers.dev) | 866.2 KiB | 34.9s |  |  | 3.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/305223276186731) | 2026-08-06T20:20:19.307Z | Preview app released. |
| Dummy Petshop | released | `2b965a1` | [https://dummy-petshop.iterate-preview-17.com](https://dummy-petshop.iterate-preview-17.com) | 198.3 KiB | 12.7s |  |  | 1.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/305223276186731) | 2026-08-06T20:20:17.669Z | Preview app released. |
| OS | released | `2b965a1` | [https://os.iterate-preview-17.com](https://os.iterate-preview-17.com) | 3.74 MiB (-1.34 MiB vs main) | 134.9s |  |  | 7.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/305223276186731) | 2026-08-06T20:20:23.130Z | Preview app released. |
| Semaphore | released | `2b965a1` | [https://semaphore.iterate-preview-17.com](https://semaphore.iterate-preview-17.com) | 441.1 KiB | 33.4s |  |  | 860ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/305223276186731) | 2026-08-06T20:20:16.416Z | Preview app released. |
| Streams Example App | released | `2b965a1` | [https://streams.iterate-preview-17.com](https://streams.iterate-preview-17.com) | 1.49 MiB | 22.6s |  |  | 8.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/305223276186731) | 2026-08-06T20:20:24.482Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the auth CORS/trusted-origin boundary to admit one fixed Chrome extension origin; incorrect matching could widen or break OAuth token exchange for browser clients.
> 
> **Overview**
> Adds **`apps/browser-extension`**, an internal Manifest V3 side panel that signs in to production auth with PKCE (service worker), connects to OS via the Iterate SDK, shows a project’s live reduced state, and exposes **`itx.chrome.openPage`** as a live capability.
> 
> **Auth** centralizes browser-origin policy in **`resolveAllowedBrowserOrigin`**: it keeps the exact allowlisted **`chrome-extension://`** origin (instead of `new URL(origin).origin` becoming `null`), wires that through CORS and Better Auth **`trustedOrigins`**, and adds unit tests plus OAuth e2e coverage that sends the extension origin and Fetch Metadata headers on token exchange.
> 
> Repo tooling registers the new workspace in **knip** and root **knip** script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b965a1f57fee0fa4cc8edd97a6d1655e20fda95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

