### PR TITLE
fix: pause PostHog for non-prd and CI uploads

### DIFF
--- a/apps/os/src/observability/posthog.test.ts
+++ b/apps/os/src/observability/posthog.test.ts
@@ -39,8 +39,9 @@ import type { AppConfig } from "~/config.ts";
 
 const config = {
   cloudflare: { workerName: "os-prd" },
+  environmentName: "prd",
   posthog: { apiKey: "phc_test" },
-} as Pick<AppConfig, "cloudflare" | "posthog">;
+} as Pick<AppConfig, "cloudflare" | "environmentName" | "posthog">;
 
 function captureContext(operation: object = {}) {
   const pending: Promise<unknown>[] = [];

--- a/apps/os/src/observability/posthog.ts
+++ b/apps/os/src/observability/posthog.ts
@@ -5,7 +5,7 @@ const POSTHOG_HOST = "https://eu.i.posthog.com";
 const scheduledOperations = new WeakSet<object>();
 
 type PosthogExceptionContext = {
-  config: Pick<AppConfig, "cloudflare" | "posthog">;
+  config: Pick<AppConfig, "cloudflare" | "environmentName" | "posthog">;
   distinctId?: string;
   /** One unique object per Cloudflare invocation; deduplicates nested boundaries. */
   operation: object;
@@ -37,6 +37,8 @@ export async function withPosthogExceptionCapture<T>(
 /** Report an unhandled backend exception without changing the failed operation. */
 export function schedulePosthogException(input: PosthogExceptionContext & { error: unknown }) {
   try {
+    // Preview/dev: no exception capture even if APP_CONFIG_POSTHOG is set.
+    if (input.config.environmentName !== "prd") return;
     const apiKey = input.config.posthog?.apiKey;
     if (!apiKey || scheduledOperations.has(input.operation)) return;
     scheduledOperations.add(input.operation);

--- a/apps/os/src/routes/__root.tsx
+++ b/apps/os/src/routes/__root.tsx
@@ -120,6 +120,8 @@ function RootComponent() {
       posthog={{
         appStage: config?.cloudflare?.workerName,
         capturePageviews: false,
+        // Product capture only in production (preview/dev keys still may be present).
+        enabled: config?.environmentName === "prd",
         proxyUrl: "/e",
       }}
       devtools={

--- a/scripts/ci/sync-ci-telemetry.ts
+++ b/scripts/ci/sync-ci-telemetry.ts
@@ -41,8 +41,10 @@ async function main() {
   console.log(`[ci-telemetry] collected ${events.length} idempotent event(s)`);
   if (dryRun) {
     console.log(JSON.stringify(summarize(events), null, 2));
-  } else {
+  } else if (process.env.CI_TELEMETRY_POSTHOG_ENABLED === "1") {
     await sendPostHogEvents(events);
+  } else {
+    console.log("[ci-telemetry] PostHog delivery paused (CI_TELEMETRY_POSTHOG_ENABLED!=1)");
   }
   if (failures.length > 0) {
     throw new AggregateError(

--- a/scripts/ci/upload-test-telemetry.test.ts
+++ b/scripts/ci/upload-test-telemetry.test.ts
@@ -5,7 +5,7 @@ import {
   writeTestTelemetryArtifact,
   type TestTelemetryArtifact,
 } from "@iterate-com/shared/test-support/ci-telemetry";
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { finalizeTestTelemetry, testTelemetryEvents } from "./upload-test-telemetry.ts";
 
 const { sendPostHogEventsMock } = vi.hoisted(() => ({ sendPostHogEventsMock: vi.fn() }));
@@ -14,8 +14,13 @@ vi.mock("./posthog-events.ts", async (importOriginal) => ({
   sendPostHogEvents: sendPostHogEventsMock,
 }));
 
+beforeEach(() => {
+  process.env.CI_TELEMETRY_POSTHOG_ENABLED = "1";
+});
+
 afterEach(() => {
   sendPostHogEventsMock.mockReset();
+  delete process.env.CI_TELEMETRY_POSTHOG_ENABLED;
 });
 
 const artifact: TestTelemetryArtifact = {

--- a/scripts/ci/upload-test-telemetry.ts
+++ b/scripts/ci/upload-test-telemetry.ts
@@ -101,7 +101,16 @@ export async function finalizeTestTelemetry(options: {
   console.log(
     `[test-telemetry] normalized ${loaded.length} artifact(s) into ${events.length} event(s)`,
   );
-  if (!options.dryRun && !options.cancelled && events.length > 0) await sendPostHogEvents(events);
+  // PostHog upload paused (billing). Artifacts still normalized/retained.
+  // Re-enable: CI_TELEMETRY_POSTHOG_ENABLED=1
+  if (
+    !options.dryRun &&
+    !options.cancelled &&
+    events.length > 0 &&
+    process.env.CI_TELEMETRY_POSTHOG_ENABLED === "1"
+  ) {
+    await sendPostHogEvents(events);
+  }
   if (!options.cancelled) {
     const failures = [
       ...(missingWorkspaces.length > 0


### PR DESCRIPTION
## Summary

Small kill switch for PostHog cost:

1. **Product capture** (browser + backend exceptions): only when `environmentName === "prd"`. Stream feed was already `os-prd`-only.
2. **CI telemetry upload**: still normalizes/retains artifacts; skips PostHog unless `CI_TELEMETRY_POSTHOG_ENABLED=1`.

**+26 / −5** across 6 files. No new helpers, schema fields, or docs novels.

### Volume context

| Project | Aug MTD | Notes |
| --- | ---: | --- |
| prd | ~6.7M | mostly CI + stream:append |
| stg/preview | ~128 | negligible |
| dev | ~161 | negligible |

CI pause is the real savings. Production `stream:append` is unchanged.

## Test plan

- [x] scripts + os posthog unit tests
- [ ] After merge: CI logs no PostHog upload; no new `ci test *` events unless env re-enabled

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +5 -1 | +2 -0 🟩⬜⬜⬜⬜ |
| Tests | +8 -2 | +7 -2 🟩🟩🟥⬜⬜ |
| CI & scripts | +13 -2 | +11 -2 🟩🟩🟩🟩🟥 |
| **Total** | **+26 -5** | **+20 -4** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between e8a8611 and 1b54ee8, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-06T20:28:42.932Z",
      "headSha": "1b54ee80cbd60b4e0a10f7a959461d7d802740a7",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/194985613433638",
      "shortSha": "1b54ee8",
      "cleanupDurationMs": 10155,
      "deployDurationMs": 132984,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 132981,
      "workerSizeKib": 14447.9,
      "workerGzipKib": 3824.99,
      "mainWorkerGzipKib": 5201.58
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-06T20:28:35.614Z",
      "deployedAt": "2026-08-06T20:14:46.040Z",
      "headSha": "1b54ee80cbd60b4e0a10f7a959461d7d802740a7",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-12.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/194985613433638",
      "shortSha": "1b54ee8",
      "cleanupDurationMs": 2833,
      "deployDurationMs": 20379,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 11735,
      "deployReadinessDurationMs": 8640,
      "deployedWorkerName": "docs-preview-12",
      "deployedWorkerVersion": "55bdb656-1bd7-4ca7-a695-0c0ee3b60a90",
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-06T20:28:36.491Z",
      "deployedAt": "2026-08-06T20:14:54.303Z",
      "headSha": "1b54ee80cbd60b4e0a10f7a959461d7d802740a7",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/194985613433638",
      "shortSha": "1b54ee8",
      "cleanupDurationMs": 3708,
      "deployDurationMs": 20331,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 19997,
      "deployReadinessDurationMs": 331,
      "deployedWorkerName": "auth-preview-12",
      "deployedWorkerVersion": "04c66046-7845-4069-b72e-7dfea6541017",
      "workerSizeKib": 3981.29,
      "workerGzipKib": 815.54,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-06T20:28:33.443Z",
      "deployedAt": "2026-08-06T20:14:47.157Z",
      "headSha": "1b54ee80cbd60b4e0a10f7a959461d7d802740a7",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/194985613433638",
      "shortSha": "1b54ee8",
      "cleanupDurationMs": 657,
      "deployDurationMs": 13284,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 12804,
      "deployReadinessDurationMs": 429,
      "deployedWorkerName": "dummy-petshop-preview-12",
      "deployedWorkerVersion": "bcbdd0f4-3e14-4aa2-af5f-94877c5bceec",
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `1b54ee8` | [https://auth.iterate-preview-12.com](https://auth.iterate-preview-12.com) | 815.5 KiB | 20.3s |  |  | 3.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/194985613433638) | 2026-08-06T20:28:36.491Z | Preview app released. |
| Docs | released | `1b54ee8` | [https://docs-preview-12.iterate-dev-preview.workers.dev](https://docs-preview-12.iterate-dev-preview.workers.dev) | 866.2 KiB | 20.4s |  |  | 2.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/194985613433638) | 2026-08-06T20:28:35.614Z | Preview app released. |
| Dummy Petshop | released | `1b54ee8` | [https://dummy-petshop.iterate-preview-12.com](https://dummy-petshop.iterate-preview-12.com) | 198.3 KiB | 13.3s |  |  | 657ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/194985613433638) | 2026-08-06T20:28:33.443Z | Preview app released. |
| OS | released | `1b54ee8` | [https://os.iterate-preview-12.com](https://os.iterate-preview-12.com) | 3.74 MiB (-1.34 MiB vs main) | 133.0s |  |  | 10.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/194985613433638) | 2026-08-06T20:28:42.932Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->