### PR TITLE
fix: gate PostHog with capture/sendStreamEvents + pause CI upload

### DIFF
--- a/apps/os/src/config.ts
+++ b/apps/os/src/config.ts
@@ -257,6 +257,8 @@ export const AppConfig = z.object({
   posthog: z
     .object({
       apiKey: publicValue(z.string().trim().min(1)),
+      capture: publicValue(z.boolean().default(false)),
+      sendStreamEvents: publicValue(z.boolean().default(false)),
     })
     .optional(),
 });

--- a/apps/os/src/domains/integrations/posthog.test.ts
+++ b/apps/os/src/domains/integrations/posthog.test.ts
@@ -149,16 +149,6 @@ describe("first-party PostHog stream integration", () => {
     });
   });
 
-  it("does not export stream events from dev or preview deployments", async () => {
-    for (const workerName of ["os", "os-preview-6"]) {
-      const captureFetch = acceptingFetch();
-      await capturePosthogStreamEventBatch(captureArgs([streamEvent()], workerName), {
-        fetch: captureFetch,
-      });
-      expect(captureFetch).not.toHaveBeenCalled();
-    }
-  });
-
   it("drops ephemeral events from capture, including all-ephemeral batches", async () => {
     const durable = streamEvent();
     const ephemeral = streamEvent({

--- a/apps/os/src/domains/integrations/posthog.ts
+++ b/apps/os/src/domains/integrations/posthog.ts
@@ -8,7 +8,6 @@ import { internalStreamId } from "../streams/stream-delivery-utils.ts";
 import { truncateJsonToBytes } from "../../lib/truncate-json.ts";
 
 export const POSTHOG_STREAM_EVENT_MAX_JSON_BYTES = 100 * 1_024;
-const POSTHOG_STREAM_FEED_WORKER_NAME = "os-prd";
 
 const StreamEventTimestamp = z.iso.datetime({ offset: true });
 const ProjectGroupBirthPayload = z.object({
@@ -221,11 +220,6 @@ export async function capturePosthogStreamEventBatch(
   },
   deps: { fetch?: typeof fetch } = {},
 ): Promise<void> {
-  // The complete durable feed is a production observability surface. Preview
-  // and local deployments generate synthetic projects and streams at CI scale;
-  // exporting those facts adds no production signal and can dominate PostHog
-  // usage. WORKER_SELF is the reviewed deployment identity from envs.ts.
-  if (args.workerName !== POSTHOG_STREAM_FEED_WORKER_NAME) return;
   if (args.batch.events.length === 0) {
     throw new Error("PostHog stream delivery batch must contain an event");
   }

--- a/apps/os/src/observability/posthog.test.ts
+++ b/apps/os/src/observability/posthog.test.ts
@@ -39,7 +39,7 @@ import type { AppConfig } from "~/config.ts";
 
 const config = {
   cloudflare: { workerName: "os-prd" },
-  posthog: { apiKey: "phc_test" },
+  posthog: { apiKey: "phc_test", capture: true },
 } as Pick<AppConfig, "cloudflare" | "posthog">;
 
 function captureContext(operation: object = {}) {

--- a/apps/os/src/observability/posthog.ts
+++ b/apps/os/src/observability/posthog.ts
@@ -37,6 +37,7 @@ export async function withPosthogExceptionCapture<T>(
 /** Report an unhandled backend exception without changing the failed operation. */
 export function schedulePosthogException(input: PosthogExceptionContext & { error: unknown }) {
   try {
+    if (input.config.posthog?.capture !== true) return;
     const apiKey = input.config.posthog?.apiKey;
     if (!apiKey || scheduledOperations.has(input.operation)) return;
     scheduledOperations.add(input.operation);

--- a/apps/os/src/routes/__root.tsx
+++ b/apps/os/src/routes/__root.tsx
@@ -120,6 +120,7 @@ function RootComponent() {
       posthog={{
         appStage: config?.cloudflare?.workerName,
         capturePageviews: false,
+        enabled: config?.posthog?.capture === true,
         proxyUrl: "/e",
       }}
       devtools={

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -3276,12 +3276,10 @@ class PostHogIntegrationRpcTarget extends RpcTarget {
     if (batch.projectId !== this.props.projectId) {
       throw new Error("PostHog stream delivery project does not match its itx authority");
     }
-    const config = parseConfig(env).posthog;
-    if (config === undefined) {
-      throw new StreamReceiverUnavailableError("PostHog is not configured for this deployment");
-    }
+    const posthog = parseConfig(env).posthog;
+    if (posthog?.sendStreamEvents !== true) return;
     await capturePosthogStreamEventBatch({
-      apiKey: config.apiKey,
+      apiKey: posthog.apiKey,
       batch,
       projectId: this.props.projectId,
       workerName: env.WORKER_SELF,

--- a/scripts/ci/sync-ci-telemetry.ts
+++ b/scripts/ci/sync-ci-telemetry.ts
@@ -41,9 +41,7 @@ async function main() {
   console.log(`[ci-telemetry] collected ${events.length} idempotent event(s)`);
   if (dryRun) {
     console.log(JSON.stringify(summarize(events), null, 2));
-  } else {
-    await sendPostHogEvents(events);
-  }
+  } else if (process.env.CI_TELEMETRY_POSTHOG_ENABLED === "1") await sendPostHogEvents(events);
   if (failures.length > 0) {
     throw new AggregateError(
       failures.map((failure) => failure.error),

--- a/scripts/ci/upload-test-telemetry.test.ts
+++ b/scripts/ci/upload-test-telemetry.test.ts
@@ -5,7 +5,7 @@ import {
   writeTestTelemetryArtifact,
   type TestTelemetryArtifact,
 } from "@iterate-com/shared/test-support/ci-telemetry";
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { finalizeTestTelemetry, testTelemetryEvents } from "./upload-test-telemetry.ts";
 
 const { sendPostHogEventsMock } = vi.hoisted(() => ({ sendPostHogEventsMock: vi.fn() }));
@@ -14,8 +14,12 @@ vi.mock("./posthog-events.ts", async (importOriginal) => ({
   sendPostHogEvents: sendPostHogEventsMock,
 }));
 
+beforeEach(() => {
+  process.env.CI_TELEMETRY_POSTHOG_ENABLED = "1";
+});
 afterEach(() => {
   sendPostHogEventsMock.mockReset();
+  delete process.env.CI_TELEMETRY_POSTHOG_ENABLED;
 });
 
 const artifact: TestTelemetryArtifact = {

--- a/scripts/ci/upload-test-telemetry.ts
+++ b/scripts/ci/upload-test-telemetry.ts
@@ -101,7 +101,13 @@ export async function finalizeTestTelemetry(options: {
   console.log(
     `[test-telemetry] normalized ${loaded.length} artifact(s) into ${events.length} event(s)`,
   );
-  if (!options.dryRun && !options.cancelled && events.length > 0) await sendPostHogEvents(events);
+  if (
+    !options.dryRun &&
+    !options.cancelled &&
+    events.length > 0 &&
+    process.env.CI_TELEMETRY_POSTHOG_ENABLED === "1"
+  )
+    await sendPostHogEvents(events);
   if (!options.cancelled) {
     const failures = [
       ...(missingWorkspaces.length > 0


### PR DESCRIPTION
## Summary

**+21 / −27** (net −6).

- `APP_CONFIG_POSTHOG.capture` / `sendStreamEvents` (default `false`)
- CI upload only if `CI_TELEMETRY_POSTHOG_ENABLED=1`
- Dropped worker-name stream gate (config flag only)

Doppler `_shared` already set: prd both true; dev/preview both false.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when telemetry leaves the deployment (exceptions, UI capture, stream feed, CI uploads), but behavior is explicit opt-in flags with prd expected to keep capture and sendStreamEvents enabled via Doppler.
> 
> **Overview**
> PostHog no longer sends when only an **apiKey** is present. **`posthog.capture`** (default **false**) must be **true** for browser analytics and backend exception reporting; **`posthog.sendStreamEvents`** must be **true** for durable stream **`stream:append`** export.
> 
> The stream integration drops the **`os-prd`** worker-name guard in **`capturePosthogStreamEventBatch`** and instead no-ops in **`processEventBatch`** when **`sendStreamEvents`** is off (no error if PostHog is “unconfigured” for streams). CI/test telemetry upload to PostHog now requires **`CI_TELEMETRY_POSTHOG_ENABLED=1`**; artifacts are still written either way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3395d6b7bbf263b0c16ad494eecf6d6c1182c90b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-06T20:49:38.235Z",
      "headSha": "3395d6b7bbf263b0c16ad494eecf6d6c1182c90b",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/21944128139101",
      "shortSha": "3395d6b",
      "cleanupDurationMs": 6603,
      "deployDurationMs": 125313,
      "deployConfigDurationMs": 1,
      "deployCommandDurationMs": 125311,
      "workerSizeKib": 14447.9,
      "workerGzipKib": 3824.99,
      "mainWorkerGzipKib": 5201.55
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-06T20:49:34.741Z",
      "deployedAt": "2026-08-06T20:32:50.970Z",
      "headSha": "3395d6b7bbf263b0c16ad494eecf6d6c1182c90b",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-7.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/21944128139101",
      "shortSha": "3395d6b",
      "cleanupDurationMs": 3106,
      "deployDurationMs": 84609,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 16201,
      "deployReadinessDurationMs": 68404,
      "deployedWorkerName": "docs-preview-7",
      "deployedWorkerVersion": "f3eefd99-c744-40e5-a3fa-b4b3029728e9",
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-06T20:49:35.430Z",
      "deployedAt": "2026-08-06T20:33:00.101Z",
      "headSha": "3395d6b7bbf263b0c16ad494eecf6d6c1182c90b",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/21944128139101",
      "shortSha": "3395d6b",
      "cleanupDurationMs": 3791,
      "deployDurationMs": 25378,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 25331,
      "deployReadinessDurationMs": 42,
      "deployedWorkerName": "auth-preview-7",
      "deployedWorkerVersion": "8ee0d938-5935-4209-b5c0-b411dec4948a",
      "workerSizeKib": 3981.5,
      "workerGzipKib": 815.46,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-06T20:49:32.583Z",
      "deployedAt": "2026-08-06T20:32:42.345Z",
      "headSha": "3395d6b7bbf263b0c16ad494eecf6d6c1182c90b",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/21944128139101",
      "shortSha": "3395d6b",
      "cleanupDurationMs": 942,
      "deployDurationMs": 7774,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 7546,
      "deployReadinessDurationMs": 193,
      "deployedWorkerName": "dummy-petshop-preview-7",
      "deployedWorkerVersion": "cf8b2043-de98-4b6c-a5b1-93febf92a6b4",
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `3395d6b` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 815.5 KiB | 25.4s |  |  | 3.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/21944128139101) | 2026-08-06T20:49:35.430Z | Preview app released. |
| Docs | released | `3395d6b` | [https://docs-preview-7.iterate-dev-preview.workers.dev](https://docs-preview-7.iterate-dev-preview.workers.dev) | 866.2 KiB | 84.6s |  |  | 3.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/21944128139101) | 2026-08-06T20:49:34.741Z | Preview app released. |
| Dummy Petshop | released | `3395d6b` | [https://dummy-petshop.iterate-preview-7.com](https://dummy-petshop.iterate-preview-7.com) | 198.3 KiB | 7.8s |  |  | 942ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/21944128139101) | 2026-08-06T20:49:32.583Z | Preview app released. |
| OS | released | `3395d6b` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 3.74 MiB (-1.34 MiB vs main) | 125.3s |  |  | 6.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/21944128139101) | 2026-08-06T20:49:38.235Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +7 -11 | +7 -7 🟩🟩🟥🟥⬜ |
| Tests | +6 -12 | +6 -11 🟩🟩🟥🟥🟥 |
| CI & scripts | +8 -4 | +7 -4 🟩🟩🟥⬜⬜ |
| **Total** | **+21 -27** | **+20 -22** 🟩🟩🟥🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between a048e23 and 3395d6b, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->