### PR TITLE
streams: rename cursor column confirmed_offset → processed_through_offset

### DIFF
--- a/apps/os/src/domains/streams/README.md
+++ b/apps/os/src/domains/streams/README.md
@@ -241,7 +241,7 @@ receiver: {
 ```
 
 The source POSTs one event at a time through the project's attributed egress.
-The 2xx response alone is the acknowledgement (`confirmed_offset`); the
+The 2xx response alone is the acknowledgement (`processed_through_offset`); the
 response body is discarded. Webhook delivery is at-least-once, so a remote
 processor must deduplicate by `(streamId, offset)`. A `jsonataTransform`
 reshapes the POSTed event body while the envelope keeps the real source
@@ -292,11 +292,11 @@ Rebuilding core state counts durable events instead of assuming
 
 `stream-event-sender.ts` reads after each durable cursor, applies the filter,
 sends a bounded batch, and records progress in ONE column whose meaning never
-varies by receiver kind: `confirmed_offset` (the far side durably claims
+varies by receiver kind: `processed_through_offset` (the far side durably claims
 through here). Push kinds write it with the awaited acknowledgement; a hosted
 processor's reported checkpoints write it, while its live batch acks only
 settle the in-flight watchdog. The one scheduling rule, for every kind:
-delivery RESUMES after `confirmed_offset` — anything sent but never confirmed
+delivery RESUMES after `processed_through_offset` — anything sent but never confirmed
 redelivers (at-least-once; receivers dedupe by `(streamId, offset)`).
 
 Guarantees:
@@ -316,7 +316,7 @@ Guarantees:
 - `waitUntilProcessed(name, { offset, timeoutMs? })` on the Stream DO is the
   uniform barrier for every kind. Processor-wake rows delegate to the hosted
   runner's own barrier (precise even mid-connection); every other kind
-  resolves off `confirmed_offset` — the awaited push acknowledgement.
+  resolves off `processed_through_offset` — the awaited push acknowledgement.
 
 Operator commands are literal:
 

--- a/apps/os/src/domains/streams/stream-durable-object.ts
+++ b/apps/os/src/domains/streams/stream-durable-object.ts
@@ -2799,7 +2799,7 @@ export class StreamDurableObject extends DurableObject<Env> {
    * next wake cycle's checkpoint report. Facet placement dials the facet
    * facade; expression placement dials the same public `waitUntilProcessed`
    * verb on the receiver expression's `processor` node. Every OTHER kind
-   * resolves off the durable cursor row (`confirmed_offset >= offset`): the
+   * resolves off the durable cursor row (`processed_through_offset >= offset`): the
    * awaited push acknowledgement (copy/itx/webhook).
    *
    * One-shot like `waitForEvent`: it dies with the RPC caller or this

--- a/apps/os/src/domains/streams/stream-event-sender.ts
+++ b/apps/os/src/domains/streams/stream-event-sender.ts
@@ -705,7 +705,7 @@ export class StreamEventSender {
           ping: response.ping,
         });
         // The wake response's checkpoint IS a reported checkpoint: the far
-        // side durably claims through it, so it lands in `confirmed_offset`.
+        // side durably claims through it, so it lands in `processed_through_offset`.
         // While the connection streams, the stored confirmation deliberately
         // goes stale (batch acks settle the watchdog without confirming); its
         // job is deciding whether to wake the processor when no callback
@@ -2290,7 +2290,7 @@ export class StreamConnections {
                   this.#hooks.hostedDeliveryStillMatches(connectionKey, expectedDelivery)
                 ) {
                   // The batch ack settles the watchdog and failure streak.
-                  // The receiver's durable claim (confirmed_offset) only
+                  // The receiver's durable claim (processed_through_offset) only
                   // moves on reported checkpoints — the wake response's
                   // checkpoint — so an eviction redelivers anything
                   // unconfirmed (at-least-once).

--- a/apps/os/src/domains/streams/stream-storage.ts
+++ b/apps/os/src/domains/streams/stream-storage.ts
@@ -424,16 +424,16 @@ export type SubscriptionCursorStore = {
 export class SqliteSubscriptionCursorStore implements SubscriptionCursorStore {
   static db = defineConfig({
     // The desired schema now (`sqlfu draft` diffs new migrations against it).
-    // v2 (subscription-model redesign, CORE_STATE_VERSION 30): `name` primary
-    // key, ONE `confirmed_offset` cursor, and the mirrored delivery status.
-    // FRESH schema — the redesign ships as a clean break with no data
-    // migration (deploy-time storage reset).
+    // Subscription-model redesign (CORE_STATE_VERSION 30): `name` primary key,
+    // ONE cursor, and the mirrored delivery status. The cursor column is
+    // `processed_through_offset` (v2/v3 named it `confirmed_offset`; the v4
+    // migration renames it — the domain field stays `confirmedOffset`).
     definitions: sql`
       create table subscription_cursors (
         name text primary key,
         configured_at_offset integer not null,
         cursor_changed_at_offset integer not null,
-        confirmed_offset integer not null,
+        processed_through_offset integer not null,
         status text not null default 'active',
         attempt integer not null default 0,
         next_attempt_at integer,
@@ -501,13 +501,25 @@ export class SqliteSubscriptionCursorStore implements SubscriptionCursorStore {
           );
         `,
       },
+      {
+        // The internal cursor column is named for what it stores: the offset
+        // the receiver has processed through. The domain field stays
+        // `confirmedOffset` (the delivery contract's word). RENAME COLUMN is
+        // valid from the v3 state and preserves the live rows, so it is safe
+        // to add after the flag-day deploy already applied v2 + v3.
+        name: "20260807000001_rename_confirmed_offset_to_processed_through_offset",
+        content: sql`
+          alter table subscription_cursors
+          rename column confirmed_offset to processed_through_offset;
+        `,
+      },
     ],
     queries: {
       get: sql.nullableOne<{
         parameters: { name: string };
         result: SubscriptionCursorRowRecord;
       }>`
-        select name, confirmed_offset, status, configured_at_offset,
+        select name, processed_through_offset, status, configured_at_offset,
                attempt, next_attempt_at, in_flight_deadline_at,
                in_flight_connection_generation, last_error,
                failing_event_offset, failing_event_attempt,
@@ -516,7 +528,7 @@ export class SqliteSubscriptionCursorStore implements SubscriptionCursorStore {
         where name = :name
       `,
       list: sql.many<{ result: SubscriptionCursorRowRecord }>`
-        select name, confirmed_offset, status, configured_at_offset,
+        select name, processed_through_offset, status, configured_at_offset,
                attempt, next_attempt_at, in_flight_deadline_at,
                in_flight_connection_generation, last_error,
                failing_event_offset, failing_event_attempt,
@@ -533,14 +545,14 @@ export class SqliteSubscriptionCursorStore implements SubscriptionCursorStore {
         };
       }>`
         insert into subscription_cursors (
-          name, confirmed_offset, configured_at_offset,
+          name, processed_through_offset, configured_at_offset,
           cursor_changed_at_offset, updated_at
         ) values (
           :name, :initialOffset, :configuredAtOffset,
           :cursorChangedAtOffset, :updatedAt
         )
         on conflict (name) do update set
-          confirmed_offset = excluded.confirmed_offset,
+          processed_through_offset = excluded.processed_through_offset,
           status = 'active',
           configured_at_offset = excluded.configured_at_offset,
           attempt = 0,
@@ -564,7 +576,7 @@ export class SqliteSubscriptionCursorStore implements SubscriptionCursorStore {
         };
       }>`
         update subscription_cursors
-        set confirmed_offset = max(confirmed_offset, :offset),
+        set processed_through_offset = max(processed_through_offset, :offset),
             attempt = 0, next_attempt_at = null, in_flight_deadline_at = null,
             in_flight_connection_generation = null,
             last_error = null,
@@ -584,7 +596,7 @@ export class SqliteSubscriptionCursorStore implements SubscriptionCursorStore {
         };
       }>`
         update subscription_cursors
-        set confirmed_offset = max(confirmed_offset, :offset),
+        set processed_through_offset = max(processed_through_offset, :offset),
             attempt = 0, next_attempt_at = null, in_flight_deadline_at = null,
             in_flight_connection_generation = null,
             last_error = null,
@@ -604,7 +616,7 @@ export class SqliteSubscriptionCursorStore implements SubscriptionCursorStore {
         };
       }>`
         update subscription_cursors
-        set confirmed_offset = max(confirmed_offset, :offset),
+        set processed_through_offset = max(processed_through_offset, :offset),
             attempt = 0, next_attempt_at = null, in_flight_deadline_at = null,
             in_flight_connection_generation = null,
             last_error = null,
@@ -621,16 +633,16 @@ export class SqliteSubscriptionCursorStore implements SubscriptionCursorStore {
         parameters: { name: string; offset: number; updatedAt: string };
       }>`
         update subscription_cursors
-        set attempt = case when :offset > confirmed_offset then 0 else attempt end,
-            last_error = case when :offset > confirmed_offset then null else last_error end,
-            failing_event_offset = case when :offset > confirmed_offset then null else failing_event_offset end,
-            failing_event_attempt = case when :offset > confirmed_offset then 0 else failing_event_attempt end,
+        set attempt = case when :offset > processed_through_offset then 0 else attempt end,
+            last_error = case when :offset > processed_through_offset then null else last_error end,
+            failing_event_offset = case when :offset > processed_through_offset then null else failing_event_offset end,
+            failing_event_attempt = case when :offset > processed_through_offset then 0 else failing_event_attempt end,
             failing_event_skips_since_last_success = case
-              when :offset > confirmed_offset then 0 else failing_event_skips_since_last_success end,
+              when :offset > processed_through_offset then 0 else failing_event_skips_since_last_success end,
             next_attempt_at = null,
             in_flight_deadline_at = null,
             in_flight_connection_generation = null,
-            confirmed_offset = max(confirmed_offset, :offset),
+            processed_through_offset = max(processed_through_offset, :offset),
             updated_at = :updatedAt
         where name = :name
       `,
@@ -643,16 +655,16 @@ export class SqliteSubscriptionCursorStore implements SubscriptionCursorStore {
         };
       }>`
         update subscription_cursors
-        set attempt = case when :offset > confirmed_offset then 0 else attempt end,
-            last_error = case when :offset > confirmed_offset then null else last_error end,
-            failing_event_offset = case when :offset > confirmed_offset then null else failing_event_offset end,
-            failing_event_attempt = case when :offset > confirmed_offset then 0 else failing_event_attempt end,
+        set attempt = case when :offset > processed_through_offset then 0 else attempt end,
+            last_error = case when :offset > processed_through_offset then null else last_error end,
+            failing_event_offset = case when :offset > processed_through_offset then null else failing_event_offset end,
+            failing_event_attempt = case when :offset > processed_through_offset then 0 else failing_event_attempt end,
             failing_event_skips_since_last_success = case
-              when :offset > confirmed_offset then 0 else failing_event_skips_since_last_success end,
+              when :offset > processed_through_offset then 0 else failing_event_skips_since_last_success end,
             next_attempt_at = null,
             in_flight_deadline_at = null,
             in_flight_connection_generation = null,
-            confirmed_offset = max(confirmed_offset, :offset),
+            processed_through_offset = max(processed_through_offset, :offset),
             updated_at = :updatedAt
         where name = :name
           and cursor_changed_at_offset = :cursorChangedAtOffset
@@ -719,7 +731,7 @@ export class SqliteSubscriptionCursorStore implements SubscriptionCursorStore {
         };
       }>`
         update subscription_cursors
-        set confirmed_offset = :offset,
+        set processed_through_offset = :offset,
             attempt = 0, next_attempt_at = null, last_error = null,
             in_flight_deadline_at = null,
             in_flight_connection_generation = null,
@@ -952,7 +964,7 @@ export function pruneOrphanedSubscriptionCursorRows(
 
 type SubscriptionCursorRowRecord = {
   name: string;
-  confirmed_offset: number;
+  processed_through_offset: number;
   status: string;
   configured_at_offset: number;
   attempt: number;
@@ -969,7 +981,7 @@ type SubscriptionCursorRowRecord = {
 function rowFromRecord(record: SubscriptionCursorRowRecord): SubscriptionCursorRow {
   return {
     name: record.name,
-    confirmedOffset: record.confirmed_offset,
+    confirmedOffset: record.processed_through_offset,
     // Safe: the TEXT column is written exclusively by this store from typed
     // SubscriptionCursorRow values, so it only ever holds
     // SubscriptionCursorStatus members; SQLite just can't express the union.


### PR DESCRIPTION
## What

Fast-follow to the #2395 flag-day (CORE_STATE_VERSION 30). Renames the internal subscription-cursor SQL column `confirmed_offset` → `processed_through_offset` — it's named for what it stores (the offset the receiver has processed through). The **domain field stays `confirmedOffset`** (the delivery contract's word); only the storage column, its row record, and doc/comment references change.

- Additive migration **v4** (`alter table subscription_cursors rename column …`) — valid from the v3 state, non-destructive, preserves live rows.
- All `stream-storage.ts` queries + `SubscriptionCursorRowRecord` updated; `rowFromRecord` maps `confirmedOffset: record.processed_through_offset`.
- Comment/doc references in `stream-event-sender.ts`, `stream-durable-object.ts`, and the streams `README.md` updated to the new column name.

## Why not collapse the migrations?

The runbook fast-follow also proposed collapsing `v2+v3` into one. That's **intentionally left out**: prd was deployed from `ffe683145` (which carries `[v2, v3]`) *after* the erase, so live stream DOs have already applied v2+v3. Collapsing the migration list now would create a migration-history mismatch on live prd — not worth another erase for a cosmetic tidy. The rename rides an additive v4 instead.

## Verification

- `stream-storage` / `stream-event-sender` / `core-processor-replay` suites: 69/69 pass (migrations v2→v3→v4 applied against a fresh DB, all queries exercised).
- apps/os typecheck, oxlint (0/0), oxfmt all clean.
- v2/v3 migration content left byte-identical (checksums preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches durable subscription delivery cursor storage and migrations on live stream DOs; behavior is intended to be rename-only with preserved rows, but any migration or query mismatch would affect delivery resume and `waitUntilProcessed` barriers.
> 
> **Overview**
> Fast-follow after CORE_STATE_VERSION 30: the **`subscription_cursors`** SQLite column **`confirmed_offset`** is renamed to **`processed_through_offset`** so storage matches what the column holds (the offset the receiver has processed through). The domain type and APIs still use **`confirmedOffset`**; **`rowFromRecord`** maps **`confirmedOffset`** from **`processed_through_offset`**.
> 
> Adds migration **v4** with **`ALTER TABLE … RENAME COLUMN`** (non-destructive on v3). **`stream-storage.ts`** schema, queries, and **`SubscriptionCursorRowRecord`** are updated; comments in **`stream-event-sender.ts`**, **`stream-durable-object.ts`**, and the streams **`README`** refer to the new column name where they described the durable cursor row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3f124be3fe270d1a448ca9d648445a3414da464. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-06T21:35:09.440Z",
      "headSha": "b3f124be3fe270d1a448ca9d648445a3414da464",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-15.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/580988768134831",
      "shortSha": "b3f124b",
      "cleanupDurationMs": 12984,
      "deployDurationMs": 125187,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 125184,
      "workerSizeKib": 14447.9,
      "workerGzipKib": 3824.99,
      "mainWorkerGzipKib": 5218.22
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-06T21:35:00.519Z",
      "deployedAt": "2026-08-06T21:19:01.213Z",
      "headSha": "b3f124be3fe270d1a448ca9d648445a3414da464",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-15.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/580988768134831",
      "shortSha": "b3f124b",
      "cleanupDurationMs": 4060,
      "deployDurationMs": 31002,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 21553,
      "deployReadinessDurationMs": 9446,
      "deployedWorkerName": "docs-preview-15",
      "deployedWorkerVersion": "4445e430-2200-46e1-a995-8a06b25e0e27",
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-06T21:35:01.676Z",
      "deployedAt": "2026-08-06T21:19:08.289Z",
      "headSha": "b3f124be3fe270d1a448ca9d648445a3414da464",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-15.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/580988768134831",
      "shortSha": "b3f124b",
      "cleanupDurationMs": 5215,
      "deployDurationMs": 29024,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 28628,
      "deployReadinessDurationMs": 391,
      "deployedWorkerName": "auth-preview-15",
      "deployedWorkerVersion": "3f2f8ae7-7c35-4f12-9e13-58d204518413",
      "workerSizeKib": 3981.51,
      "workerGzipKib": 815.5,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-08-06T21:35:08.457Z",
      "deployedAt": "2026-08-06T21:19:07.995Z",
      "headSha": "b3f124be3fe270d1a448ca9d648445a3414da464",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-15.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/580988768134831",
      "shortSha": "b3f124b",
      "cleanupDurationMs": 11993,
      "deployDurationMs": 29089,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 28332,
      "deployReadinessDurationMs": 751,
      "deployedWorkerName": "streams-example-app-preview-15",
      "deployedWorkerVersion": "f7a02d87-76c9-47d2-ad7c-bcad41462f28",
      "workerSizeKib": 5443.28,
      "workerGzipKib": 1540.39,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-06T21:34:57.514Z",
      "deployedAt": "2026-08-06T21:18:45.250Z",
      "headSha": "b3f124be3fe270d1a448ca9d648445a3414da464",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-15.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/580988768134831",
      "shortSha": "b3f124b",
      "cleanupDurationMs": 1049,
      "deployDurationMs": 5797,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 5533,
      "deployReadinessDurationMs": 204,
      "deployedWorkerName": "dummy-petshop-preview-15",
      "deployedWorkerVersion": "ddcc272e-8c4a-47c7-8653-6fc68bb1409c",
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `b3f124b` | [https://auth.iterate-preview-15.com](https://auth.iterate-preview-15.com) | 815.5 KiB | 29.0s |  |  | 5.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/580988768134831) | 2026-08-06T21:35:01.676Z | Preview app released. |
| Docs | released | `b3f124b` | [https://docs-preview-15.iterate-dev-preview.workers.dev](https://docs-preview-15.iterate-dev-preview.workers.dev) | 866.2 KiB | 31.0s |  |  | 4.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/580988768134831) | 2026-08-06T21:35:00.519Z | Preview app released. |
| Dummy Petshop | released | `b3f124b` | [https://dummy-petshop.iterate-preview-15.com](https://dummy-petshop.iterate-preview-15.com) | 198.3 KiB | 5.8s |  |  | 1.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/580988768134831) | 2026-08-06T21:34:57.514Z | Preview app released. |
| OS | released | `b3f124b` | [https://os.iterate-preview-15.com](https://os.iterate-preview-15.com) | 3.74 MiB (-1.36 MiB vs main) | 125.2s |  |  | 13.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/580988768134831) | 2026-08-06T21:35:09.440Z | Preview app released. |
| Streams Example App | released | `b3f124b` | [https://streams.iterate-preview-15.com](https://streams.iterate-preview-15.com) | 1.50 MiB | 29.1s |  |  | 12.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/580988768134831) | 2026-08-06T21:35:08.457Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +42 -30 | +6 -1 🟩🟩🟩🟥⬜ |
| Docs | +4 -4 | +4 -4 🟩🟩🟩🟥🟥 |
| **Total** | **+46 -34** | **+10 -5** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 3a518b6 and b3f124b, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->