### PR TITLE
repos: fail loudly on get() at a path claimed by another facet family

### DIFF
--- a/apps/os/e2e/vitest/stream-security.e2e.test.ts
+++ b/apps/os/e2e/vitest/stream-security.e2e.test.ts
@@ -210,12 +210,13 @@ test("a processor read for an unconfigured name does not mint a facet", async ()
   }).rejects.toThrow(/does not exist/);
 });
 
-// A repo born at a path CLAIMED by another facet family could never wake (the
+// A repo at a path CLAIMED by another facet family could never wake (the
 // composition registers the claiming family, not the repo processor), so the
-// old behaviour committed the birth batch and then hung the caller forever
-// waiting for a repos/created that could not come. The door now fails loudly
-// BEFORE committing anything.
-test("repo create refuses paths claimed by another processor family", async () => {
+// old behaviour hung the caller forever — create committed a birth batch that
+// waited for a repos/created that could not come, and a plain read returned a
+// handle that silently halted. The collection's get() door now fails loudly
+// for BOTH, before committing or dialing anything.
+test("repo create and read refuse paths claimed by another processor family", async () => {
   const marker = crypto.randomUUID();
   using session = withItxSession();
   using itx = session.authenticate({ type: "admin-secret", secret: adminSecret() });
@@ -227,6 +228,12 @@ test("repo create refuses paths claimed by another processor family", async () =
   await expect(async () => {
     await project.repos.get(`/secrets/${marker}`).create({ type: "empty" });
   }).rejects.toThrow(/reserved by the "secret" processor family/);
+
+  // The same door guards the READ path: a repo op at a claimed path must fail
+  // loudly rather than hang on a facet that can never wake.
+  await expect(async () => {
+    await project.repos.get(`/agents/${marker}`).whoami();
+  }).rejects.toThrow(/no repo at .*reserved by the "agent" processor family/);
 
   // Nothing was committed at the refused path.
   expect(

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -1902,9 +1902,24 @@ class RepoCollectionRpcTarget<
 
   /** The repo at a path. */
   get(path: string): RepoRpcTarget {
+    const normalizedPath = normalizePath(path);
+    // A path CLAIMED by another facet family can never host a repo: the facet
+    // composition registers that family instead, so every repo operation at
+    // this path would silently halt (the repo facet wake fails "unknown
+    // processor name" forever). Fail loudly on the read path too, mirroring
+    // the create() guard.
+    const family = facetProcessorFamilyForPath({
+      path: normalizedPath,
+      projectId: this.props.projectId,
+    });
+    if (family !== "repo") {
+      throw new Error(
+        `no repo at "${normalizedPath}": that path is reserved by the "${family}" processor family`,
+      );
+    }
     return new RepoRpcTarget({
       auth: this.props.auth,
-      path: normalizePath(path),
+      path: normalizedPath,
       projectId: this.props.projectId,
     });
   }


### PR DESCRIPTION
## What

Follow-up from #2395. Repos are the **ELSE arm** of the facet family selection (`processor-facet-families.ts`): `repos.get(path)` accepts any path *not* claimed by another family. `create()` already refuses a claimed path (rpc-targets.ts), but the **read path** — `RepoCollectionRpcTarget.get()` — returned a handle whose operations silently halt: the facet composition registers the claiming family, so the repo facet wake fails "unknown processor name" forever and the caller hangs.

This guards `get()` with the same `facetProcessorFamilyForPath` check, so any repo op at a claimed path (`/agents/**`, `/secrets/**`, `/devices/**`, `/`, …) fails loudly. Since `create()` routes through `get()`, one guard now covers both paths.

## Verification

- Extends `stream-security.e2e.test.ts` ("repo create and read refuse paths claimed by another processor family") to assert the read path (`repos.get('/agents/x').whoami()`) rejects loudly.
- apps/os typecheck, oxlint (0/0), oxfmt clean.
- Deployment-global repos (null projectId) are always family `repo`, so nothing there is falsely rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Boundary validation mirroring an existing create guard; no auth or data-model changes beyond failing fast on invalid paths.
> 
> **Overview**
> **`RepoCollectionRpcTarget.get()`** now applies the same **`facetProcessorFamilyForPath`** check that **`create()`** already used, so paths reserved for agent/secret/device (etc.) families throw immediately instead of returning a handle whose ops hang on a facet that cannot wake.
> 
> The stream-security e2e test is renamed and extended to assert **`repos.get('/agents/…').whoami()`** rejects with the new **no repo at … reserved** message, alongside the existing create-path assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c0fb5f375cbc33ca3ac4c3200d20ffee971e2b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +16 -1 | +11 -1 🟩🟩🟩🟩🟩 |
| Tests | +12 -5 | +4 -1 🟩🟩⬜⬜⬜ |
| **Total** | **+28 -6** | **+15 -2** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 3a518b6 and 6c0fb5f, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-06T21:35:04.157Z",
      "headSha": "6c0fb5f375cbc33ca3ac4c3200d20ffee971e2b1",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/442312086774736",
      "shortSha": "6c0fb5f",
      "cleanupDurationMs": 7438,
      "deployDurationMs": 124688,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 124685,
      "workerSizeKib": 14447.9,
      "workerGzipKib": 3824.99,
      "mainWorkerGzipKib": 5218.22
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-06T21:34:59.533Z",
      "deployedAt": "2026-08-06T21:27:24.466Z",
      "headSha": "6c0fb5f375cbc33ca3ac4c3200d20ffee971e2b1",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-4.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/442312086774736",
      "shortSha": "6c0fb5f",
      "cleanupDurationMs": 2812,
      "deployDurationMs": 32591,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 32355,
      "deployReadinessDurationMs": 233,
      "deployedWorkerName": "docs-preview-4",
      "deployedWorkerVersion": "5615a622-04fc-4aa6-a49e-9a34c349213f",
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-06T21:35:00.041Z",
      "deployedAt": "2026-08-06T21:27:37.921Z",
      "headSha": "6c0fb5f375cbc33ca3ac4c3200d20ffee971e2b1",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/442312086774736",
      "shortSha": "6c0fb5f",
      "cleanupDurationMs": 3318,
      "deployDurationMs": 46107,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 45809,
      "deployReadinessDurationMs": 294,
      "deployedWorkerName": "auth-preview-4",
      "deployedWorkerVersion": "1f4c656e-45e7-4930-bf6f-f8306d74fed2",
      "workerSizeKib": 3981.5,
      "workerGzipKib": 815.47,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-06T21:34:57.475Z",
      "deployedAt": "2026-08-06T21:27:01.592Z",
      "headSha": "6c0fb5f375cbc33ca3ac4c3200d20ffee971e2b1",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/442312086774736",
      "shortSha": "6c0fb5f",
      "cleanupDurationMs": 749,
      "deployDurationMs": 9673,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 9447,
      "deployReadinessDurationMs": 188,
      "deployedWorkerName": "dummy-petshop-preview-4",
      "deployedWorkerVersion": "401a8f00-70b1-46e7-a12d-4a6a9a033558",
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `6c0fb5f` | [https://auth.iterate-preview-4.com](https://auth.iterate-preview-4.com) | 815.5 KiB | 46.1s |  |  | 3.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/442312086774736) | 2026-08-06T21:35:00.041Z | Preview app released. |
| Docs | released | `6c0fb5f` | [https://docs-preview-4.iterate-dev-preview.workers.dev](https://docs-preview-4.iterate-dev-preview.workers.dev) | 866.2 KiB | 32.6s |  |  | 2.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/442312086774736) | 2026-08-06T21:34:59.533Z | Preview app released. |
| Dummy Petshop | released | `6c0fb5f` | [https://dummy-petshop.iterate-preview-4.com](https://dummy-petshop.iterate-preview-4.com) | 198.3 KiB | 9.7s |  |  | 749ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/442312086774736) | 2026-08-06T21:34:57.475Z | Preview app released. |
| OS | released | `6c0fb5f` | [https://os.iterate-preview-4.com](https://os.iterate-preview-4.com) | 3.74 MiB (-1.36 MiB vs main) | 124.7s |  |  | 7.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/442312086774736) | 2026-08-06T21:35:04.157Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->