### PR TITLE
registry: name-keyed registration for two instances of one contract

### DIFF
--- a/apps/os/src/domains/streams/stream-processor-registry.test.ts
+++ b/apps/os/src/domains/streams/stream-processor-registry.test.ts
@@ -281,6 +281,40 @@ describe("register", () => {
       ),
     ).toThrow(/already registered/);
   });
+
+  it("hosts two instances of one contract under distinct names, independently", async () => {
+    const h = makeHarness();
+    const instance = () =>
+      new RecorderProcessor({
+        stream: h.stream,
+        path: HOME,
+        projectId: null,
+        contract: AlphaContract,
+        hooks: {},
+      });
+
+    // A second instance of one contract collides on the shared slug...
+    expect(() => h.registry.register(instance())).toThrow(/already registered/);
+    // ...but an explicit name hosts it independently of the slug-named instance.
+    h.registry.register(instance(), { name: "alpha-proc-2" });
+    expect(h.registry.names).toContain("alpha-proc-2");
+
+    // Deliver one event to the named instance only.
+    await h.stream.append({ type: REQUESTED, payload: { id: "a" } });
+    await h.deliverPending("alpha-proc-2");
+
+    // Independent progress + fold: the named instance advanced through the
+    // event; the slug-named instance never woke, so its own cursor and folded
+    // state (keyed by its own name) are untouched.
+    expect(await h.registry.reads("alpha-proc-2").snapshot()).toEqual({
+      offset: 1,
+      state: { ids: ["a"] },
+    });
+    expect(await h.registry.reads("alpha-proc").snapshot()).toEqual({
+      offset: 0,
+      state: { ids: [] },
+    });
+  });
 });
 
 describe("catchUp", () => {

--- a/packages/iterate/src/processors/stream-processor-registry.ts
+++ b/packages/iterate/src/processors/stream-processor-registry.ts
@@ -174,16 +174,22 @@ type RegistryEntry = {
 
 /**
  * Options for {@link StreamProcessorRegistry.register}. A processor registers
- * under its contract slug — which IS the subscription name under the identity
- * doctrine (docs/stream-subscription-model-redesign.md): the same string as
- * the stream's catalog key, the facet name under facet placement, and the
- * progress-key component. (Registering two instances of one contract under
- * distinct names is deliberately future work.)
+ * under its contract slug by default — which IS the subscription name under the
+ * identity doctrine (docs/stream-subscription-model-redesign.md): the same
+ * string as the stream's catalog key, the facet name under facet placement,
+ * and the progress-key component. Pass an explicit `name` to register a second
+ * instance of one contract under a distinct name; reads, wake routing, and
+ * progress storage all already key by that name (see `reads`, `resolveProcessorName`,
+ * and `durableObjectProgressStore`), so the instances stay independent.
  */
 export type RegisterProcessorOptions = {
   /** Post-eviction keepalive recovery — REQUIRED for consequential
    * `runInBackground` work (see the module doc). */
   recovery?: boolean;
+  /** Registered/progress name for this instance. Defaults to the contract slug
+   * (name === slug, the identity-doctrine default). Supply a distinct name to
+   * host two instances of one contract on one registry without colliding. */
+  name?: string;
 };
 
 const WakeDeliveryThrowableFields = z.object({
@@ -526,9 +532,10 @@ export function createStreamProcessorRegistry<Live extends object = Record<strin
     },
 
     register(processor, opts) {
-      // The registered name IS the contract slug (one identity — see
-      // RegisterProcessorOptions).
-      const name = processor.contract.slug;
+      // The registered name defaults to the contract slug (one identity — see
+      // RegisterProcessorOptions); an explicit name hosts a second instance of
+      // one contract without colliding.
+      const name = opts?.name ?? processor.contract.slug;
       if (entries.has(name)) {
         throw new Error(`Stream processor name "${name}" is already registered on this registry`);
       }


### PR DESCRIPTION
## What

Follow-up from #2395 (the "multi-instance facade reads" note). The read path (`reads`), wake routing (`resolveProcessorName`), and progress storage (`durableObjectProgressStore`) **already key by the registered name** — only `StreamProcessorRegistry.register()` hard-coded the contract slug, so a second instance of one contract collided on the shared slug. That collision is the actual gap behind "`processor.snapshot()` resolves by registered processor name".

- Add optional `name` to `RegisterProcessorOptions`, defaulting to `processor.contract.slug` (the identity-doctrine default). **Every existing single-instance registration is unchanged.**
- A distinct name now hosts an independent runner with its own cursor + folded state.

## Scope (deliberately bounded)

This is the **registry-layer enabler**. Exposing two-instances-of-one-contract *end to end through a stream* — the facet composition registering the driven runner under the facet name, plus relaxing the configure-time `name == slug` guard — is intentionally **not** in this PR: the composition is path-selected and that is a larger, separately-reviewable change on core routing. This PR closes the read/registration-layer gap safely and additively.

## Verification

- New registry unit test: two instances of `AlphaContract` under `alpha-proc` and `alpha-proc-2`; a wake+delivery to the named instance advances only its cursor/fold, the slug-named instance is untouched. 15/15 in the suite pass.
- `packages/iterate` + `apps/os` typecheck, oxlint (0/0), oxfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive registry API with slug-default preserved; no changes to stream facet wiring or configure-time guards in this PR.
> 
> **Overview**
> **`StreamProcessorRegistry.register`** no longer always keys instances by contract slug only. An optional **`name`** on **`RegisterProcessorOptions`** defaults to **`processor.contract.slug`**, so existing single-instance registrations behave the same; a distinct name lets a second instance of the same contract register without colliding on the shared slug.
> 
> That closes the gap where **`reads`**, wake routing, and **`durableObjectProgressStore`** already keyed by registered name but registration forced slug-only naming. Each named instance gets its own runner, cursor, and folded state.
> 
> A registry unit test registers two **`AlphaContract`** processors as **`alpha-proc`** and **`alpha-proc-2`**, delivers one event only to the named instance, and asserts independent snapshots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c29133220eef26857f22e351091e34974c757365. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-06T21:55:33.609Z",
      "headSha": "c29133220eef26857f22e351091e34974c757365",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/156305825213333",
      "shortSha": "c291332",
      "cleanupDurationMs": 6702,
      "deployDurationMs": 124915,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 124913,
      "workerSizeKib": 14447.9,
      "workerGzipKib": 3824.99,
      "mainWorkerGzipKib": 5218.21
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-06T21:55:30.368Z",
      "deployedAt": "2026-08-06T21:48:23.193Z",
      "headSha": "c29133220eef26857f22e351091e34974c757365",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-1.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/156305825213333",
      "shortSha": "c291332",
      "cleanupDurationMs": 3458,
      "deployDurationMs": 29869,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 29647,
      "deployReadinessDurationMs": 218,
      "deployedWorkerName": "docs-preview-1",
      "deployedWorkerVersion": "1d5992c0-4eec-47ee-913b-e6ff1e29c39f",
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-06T21:55:31.125Z",
      "deployedAt": "2026-08-06T21:48:27.701Z",
      "headSha": "c29133220eef26857f22e351091e34974c757365",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/156305825213333",
      "shortSha": "c291332",
      "cleanupDurationMs": 4214,
      "deployDurationMs": 34445,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 34154,
      "deployReadinessDurationMs": 286,
      "deployedWorkerName": "auth-preview-1",
      "deployedWorkerVersion": "69d11f52-a22c-40b4-ac6c-a12c26abcb41",
      "workerSizeKib": 3981.5,
      "workerGzipKib": 815.47,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-08-06T21:55:34.861Z",
      "deployedAt": "2026-08-06T21:48:22.791Z",
      "headSha": "c29133220eef26857f22e351091e34974c757365",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/156305825213333",
      "shortSha": "c291332",
      "cleanupDurationMs": 7948,
      "deployDurationMs": 29898,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 29243,
      "deployReadinessDurationMs": 650,
      "deployedWorkerName": "streams-example-app-preview-1",
      "deployedWorkerVersion": "4c743916-72a3-4461-be64-a150ee6ae618",
      "workerSizeKib": 5443.57,
      "workerGzipKib": 1540.42,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-06T21:55:27.920Z",
      "deployedAt": "2026-08-06T21:48:01.185Z",
      "headSha": "c29133220eef26857f22e351091e34974c757365",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/156305825213333",
      "shortSha": "c291332",
      "cleanupDurationMs": 1004,
      "deployDurationMs": 7843,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 7601,
      "deployReadinessDurationMs": 200,
      "deployedWorkerName": "dummy-petshop-preview-1",
      "deployedWorkerVersion": "a7bde0fb-7421-4e40-8b15-a208757c1905",
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `c291332` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 815.5 KiB | 34.4s |  |  | 4.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/156305825213333) | 2026-08-06T21:55:31.125Z | Preview app released. |
| Docs | released | `c291332` | [https://docs-preview-1.iterate-dev-preview.workers.dev](https://docs-preview-1.iterate-dev-preview.workers.dev) | 866.2 KiB | 29.9s |  |  | 3.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/156305825213333) | 2026-08-06T21:55:30.368Z | Preview app released. |
| Dummy Petshop | released | `c291332` | [https://dummy-petshop.iterate-preview-1.com](https://dummy-petshop.iterate-preview-1.com) | 198.3 KiB | 7.8s |  |  | 1.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/156305825213333) | 2026-08-06T21:55:27.920Z | Preview app released. |
| OS | released | `c291332` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 3.74 MiB (-1.36 MiB vs main) | 124.9s |  |  | 6.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/156305825213333) | 2026-08-06T21:55:33.609Z | Preview app released. |
| Streams Example App | released | `c291332` | [https://streams.iterate-preview-1.com](https://streams.iterate-preview-1.com) | 1.50 MiB | 29.9s |  |  | 7.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/156305825213333) | 2026-08-06T21:55:34.861Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +15 -8 | +1 -1 🟩⬜⬜⬜⬜ |
| Tests | +34 -0 | +24 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+49 -8** | **+25 -1** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 1d8d5d2 and c291332, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->