### PR TITLE
e2e: recycle the local dev server between files under RSS pressure

### DIFF
--- a/apps/os/e2e/test-support/global-setup.ts
+++ b/apps/os/e2e/test-support/global-setup.ts
@@ -99,6 +99,41 @@ async function ensureOsUnderTest(): Promise<void> {
 }
 
 /**
+ * Recycle the local dev server between e2e files when its workerd RSS has grown
+ * past the limit. Local workerd never evicts worker-loader isolates, so a long
+ * suite that creates many projects climbs toward the ~4GB V8 pointer cage and
+ * SIGABRTs mid-run (tasks/miniflare-oom-investigation.md); this turns that
+ * monotonic climb into a sawtooth. STRICT no-op unless this run is actually
+ * driving a LOCAL dev server (`readLive()` is null in CI and against a deployed
+ * target) AND it is over the RSS limit — so normal small local runs and every
+ * CI lane are untouched. The e2e `setupFiles` register this as an `afterAll`.
+ */
+export async function recycleLocalDevServerIfPressured(): Promise<void> {
+  if (process.env.CI) return;
+  const live = localOsDevServer.readLive();
+  if (!live) return;
+  const target = await resolveLocalOsDevTargetOnce();
+  const normalize = (url: string) => url.replace(/\/+$/, "");
+  // Only recycle the exact server this run resolved — never a stray local
+  // server a developer happens to have up while testing a deployed URL.
+  if (normalize(live.baseUrl) !== normalize(target.baseUrl)) return;
+  if (!(await localOsDevServer.killIfMemoryPressured(live))) return;
+  // It was over the limit and got killed; start a fresh, low-RSS server on the
+  // same port so the next file runs against the URL setup.ts already resolved.
+  const started = await startDevServer({ detach: true, port: live.port });
+  if (started.baseUrl && started.pid && started.startedAt) {
+    await waitForHealth({
+      baseUrl: started.baseUrl,
+      pid: started.pid,
+      startedAt: started.startedAt,
+    });
+    console.log(
+      `[e2e] recycled bloated dev server; fresh pid ${started.pid} at ${started.baseUrl}.`,
+    );
+  }
+}
+
+/**
  * Poll `${baseUrl}/api/health` until it answers 200, on the same budget as
  * the Playwright webServer timeout in playwright.config.ts: at least 10s,
  * and up to 180s measured from the server's own startedAt — a freshly

--- a/apps/os/e2e/vitest/setup.ts
+++ b/apps/os/e2e/vitest/setup.ts
@@ -8,11 +8,13 @@
  * surface at /api.
  */
 import { fileURLToPath } from "node:url";
+import { afterAll } from "vitest";
 import {
   cloudflareWorkerVersionOverrideHeaders,
   createCloudflareWorkerVersionOverrideFetch,
 } from "@iterate-com/shared/test-support/cloudflare-worker-version-overrides";
 import { resolveBaseUrl } from "../test-support/dev-server.ts";
+import { recycleLocalDevServerIfPressured } from "../test-support/global-setup.ts";
 
 const appRoot = fileURLToPath(new URL("../..", import.meta.url));
 
@@ -29,3 +31,10 @@ if (Object.keys(cloudflareWorkerVersionOverrideHeaders(process.env)).length > 0)
   const nativeFetch = (stash[nativeFetchKey] ??= globalThis.fetch.bind(globalThis));
   globalThis.fetch = createCloudflareWorkerVersionOverrideFetch(nativeFetch, process.env);
 }
+
+// Between files, recycle the local dev server if its workerd RSS has grown past
+// the limit — the long local suite creates many project isolates that local
+// workerd never evicts, so this turns the monotonic climb toward the ~4GB cage
+// into a sawtooth and the suite survives instead of SIGABRT-ing mid-run. No-op
+// in CI / against a deployed target and on non-pressured runs.
+afterAll(recycleLocalDevServerIfPressured);

--- a/apps/os/scripts/dev.ts
+++ b/apps/os/scripts/dev.ts
@@ -172,6 +172,10 @@ export async function attach() {
 export const localOsDevServer = {
   readLive: () => readDevServerInfo(APP_ROOT, { requireLive: true }),
   resolveTarget: resolveLocalOsDevServerTarget,
+  /** Kill the live server iff its workerd RSS is over the limit; returns
+   * whether it was killed. The e2e lane calls this between files to recycle a
+   * bloating local server before it SIGABRTs mid-suite (see evictIfMemoryPressured). */
+  killIfMemoryPressured: evictIfMemoryPressured,
 };
 
 export const doppler = {


### PR DESCRIPTION
## What

Follow-up from #2395 (the "local e2e OOMs after ~11 projects" note). Local `workerd` never evicts worker-loader isolates and the facet model creates more per-project isolates, so the long local e2e suite climbs toward the fixed ~4GB V8 pointer cage and **SIGABRTs mid-run** (all tests pass on a fresh server; **deployed isolates are unaffected** — Cloudflare evicts cold loader isolates platform-side). Root cause is the known `tasks/miniflare-oom-investigation.md` leak.

The dev server already evicts a bloated server at run **start** (`resolveTarget → evictIfMemoryPressured`). This adds a **between-file recycle** so the monotonic mid-run climb becomes a sawtooth: the e2e `setupFiles` register `recycleLocalDevServerIfPressured` as an `afterAll`, reusing the existing eviction check + `startDevServer` + health-wait.

## Blast radius: local dev only

The recycle is a **strict no-op** unless this run is actually driving a LOCAL dev server (`localOsDevServer.readLive()` is null in CI and against a deployed target) **and** workerd RSS is over `ITERATE_DEV_WORKERD_RSS_LIMIT_MB`. So:
- **Every CI lane is untouched** (CI always sets `APP_CONFIG_BASE_URL` / has no local server; also short-circuits on `process.env.CI`).
- **Normal small local runs are untouched** (never over the limit → never recycles).
- Its only effect is on the long local full-suite run that **otherwise SIGABRTs** — strictly better than the status quo.

It only recycles the exact server this run resolved (never a stray local server a dev has up while testing a deployed URL). The e2e config already provisions a fresh project per test, so a between-file server restart is safe.

## Verification

- `apps/os` typecheck, oxlint (0/0), oxfmt clean.
- Runtime smoke: the helper's no-op path (no live server) loads and returns cleanly.
- Full functional proof (forcing a mid-suite recycle) needs the long local suite + a live dev server; the mechanism reuses functions already proven in `globalSetup` (`evictIfMemoryPressured`, `startDevServer`, `waitForHealth`).

> Note: this is the pragmatic local-dev band-aid. Removing the ceiling entirely (a local worker-loader LRU / project-worker teardown) remains larger infra work — see `tasks/miniflare-oom-investigation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness and local dev lifecycle only; gated on CI, deployed targets, and RSS threshold, with no production or auth changes.
> 
> **Overview**
> Adds a **between-file recycle** for the local OS dev server during long e2e runs. After each Vitest file, `recycleLocalDevServerIfPressured` (registered via `afterAll` in the itx e2e setup) checks whether this run is driving the resolved local server and whether workerd RSS exceeds `ITERATE_DEV_WORKERD_RSS_LIMIT_MB`; only then it kills the bloated process and starts a fresh detached server on the same port with the existing health wait.
> 
> This extends the run-start eviction already in `resolveTarget` / `evictIfMemoryPressured` so mid-suite memory growth from non-evicting local worker-loader isolates becomes a sawtooth instead of a climb to ~4GB and **SIGABRT**. **`localOsDevServer.killIfMemoryPressured`** is exposed from `dev.ts` for the e2e lane.
> 
> The path is a **strict no-op** in CI, against deployed `APP_CONFIG_BASE_URL`, when RSS is under the limit, or when the live server URL does not match the run’s resolved target—so normal short local runs and CI lanes are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15222e804b948757b839fced7e0a2b3051edc598. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +44 -0 | +23 -0 🟩🟩🟩🟩🟩 |
| CI & scripts | +4 -0 | +1 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+48 -0** | **+24 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 1d8d5d2 and 15222e8, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->