### PR TITLE
Reset Streams example storage on schema version changes

### DIFF
--- a/apps/streams-example-app/scripts/deploy.ts
+++ b/apps/streams-example-app/scripts/deploy.ts
@@ -21,8 +21,16 @@ import { streamsExampleEnvs } from "../../../envs.ts";
 import { bakeStaticAuthJwks } from "../../../scripts/lib/bake-auth-jwks.ts";
 import { ensureProxiedDnsRecord } from "../../../scripts/lib/deploy-helpers.ts";
 import { deployApp } from "../../../scripts/lib/deploy-app.ts";
+import { resetWorkerDurableObjectsOnVersionChange } from "../../../scripts/lib/do-reset.ts";
 import { parseConfig } from "../src/config.ts";
-import { envShapedVars, REQUIRED_SECRETS } from "./generate-wrangler-config.ts";
+import {
+  COMPATIBILITY_DATE,
+  envShapedVars,
+  REQUIRED_SECRETS,
+  STREAMS_EXAMPLE_STORAGE_VERSION,
+} from "./generate-wrangler-config.ts";
+
+const APP_ROOT = fileURLToPath(new URL("..", import.meta.url));
 
 /** Deploy apps/streams-example-app to a deployed environment (see scripts/lib/deploy-app.ts for the pipeline). */
 export default async function deploy(
@@ -32,7 +40,7 @@ export default async function deploy(
   } = {},
 ) {
   await deployApp({
-    appRoot: fileURLToPath(new URL("..", import.meta.url)),
+    appRoot: APP_ROOT,
     appLabel: "apps/streams-example-app",
     envs: streamsExampleEnvs,
     dopplerProject: "streams-example-app",
@@ -66,6 +74,17 @@ export default async function deploy(
       // Parse the exact env the worker will see (secrets + generated vars)
       // with the worker's own schema — the strongest possible pre-flight.
       parseConfig({ ...secretValues, ...envShapedVars(ctx.env) });
+    },
+    beforeDeploy: async (ctx, _secretValues, credentials) => {
+      await resetWorkerDurableObjectsOnVersionChange({
+        ctx,
+        workerName: ctx.env.workerName,
+        cwd: APP_ROOT,
+        credentials,
+        compatibilityDate: COMPATIBILITY_DATE,
+        containerClassNames: [],
+        dataVersion: STREAMS_EXAMPLE_STORAGE_VERSION,
+      });
     },
     smokes: (env) => [
       {

--- a/apps/streams-example-app/scripts/generate-wrangler-config.ts
+++ b/apps/streams-example-app/scripts/generate-wrangler-config.ts
@@ -36,6 +36,16 @@ export const REQUIRED_SECRETS = [
 export const COMPATIBILITY_DATE = "2026-06-17";
 
 /**
+ * Bump `current` whenever the embedded StreamDurableObject cannot safely open
+ * storage written by the previous version. Deploys erase that Worker's DOs
+ * once before uploading the new version; unchanged deploys preserve them.
+ */
+export const STREAMS_EXAMPLE_STORAGE_VERSION = {
+  bindingName: "STREAMS_EXAMPLE_STORAGE_VERSION",
+  current: "1",
+} as const;
+
+/**
  * Env-shaping config that is NOT secret and already lives in envs.ts —
  * emitted as per-env `vars` so the worker's runtime base URL and auth issuer
  * can never drift from the envs.ts entry that names the worker.
@@ -44,6 +54,7 @@ export function envShapedVars(env: StreamsExampleEnv) {
   return {
     APP_CONFIG_BASE_URL: env.baseUrl,
     APP_CONFIG_ITERATE_AUTH__ISSUER: `${env.authBaseUrl}/api/auth`,
+    [STREAMS_EXAMPLE_STORAGE_VERSION.bindingName]: STREAMS_EXAMPLE_STORAGE_VERSION.current,
   };
 }
 

--- a/scripts/lib/deploy-app.ts
+++ b/scripts/lib/deploy-app.ts
@@ -27,8 +27,8 @@ export interface SmokeProbe {
  *
  *   resolve --env → assert resources provisioned → collect secrets →
  *   app-specific prepare (migrations, seeds, config preflight) → build plus
- *   explicitly independent prerequisites → deploy code+secrets in one version →
- *   smoke-probe → ✅
+ *   explicitly independent prerequisites → final pre-deploy mutations → deploy
+ *   code+secrets in one version → smoke-probe → ✅
  *
  * Durable Object classes are declared in each app's wrangler config
  * `exports` map and reconciled by the server on every deploy — no migration
@@ -89,6 +89,15 @@ export async function deployApp<E extends DeployableEnv>(input: {
    * still running.
    */
   concurrentBuildWork?: (
+    ctx: EnvContext<E>,
+    secretValues: Record<string, string>,
+    credentials: Record<string, string>,
+  ) => Promise<void> | void;
+  /**
+   * Runs only after a successful build, immediately before code upload. Use
+   * for destructive rollout steps that must not run when the build is broken.
+   */
+  beforeDeploy?: (
     ctx: EnvContext<E>,
     secretValues: Record<string, string>,
     credentials: Record<string, string>,
@@ -157,6 +166,7 @@ export async function deployApp<E extends DeployableEnv>(input: {
     }
     builtConfig = findBuiltWranglerConfig(input.appRoot);
   }
+  await input.beforeDeploy?.(ctx, secretValues, credentials);
   extraDeployArgs.push(...(input.extraDeployArgs?.(ctx, secretValues) ?? []));
 
   await deployWithSecrets({

--- a/scripts/lib/do-reset.test.ts
+++ b/scripts/lib/do-reset.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test, vi } from "vitest";
-import { detachExternalDurableObjectBindings, resetWorkerDurableObjects } from "./do-reset.ts";
+import {
+  detachExternalDurableObjectBindings,
+  resetWorkerDurableObjects,
+  resetWorkerDurableObjectsOnVersionChange,
+} from "./do-reset.ts";
 import { CloudflareApiError } from "./env-context.ts";
 
 type Settings = {
@@ -421,5 +425,106 @@ describe("resetWorkerDurableObjects", () => {
 
     expect(uploadAttempts).toBe(1);
     expect(cf.mock.calls.some(([path]) => path.includes("/settings"))).toBe(false);
+  });
+});
+
+describe("resetWorkerDurableObjectsOnVersionChange", () => {
+  const workerName = "streams-example-app-preview-13";
+  const dataVersion = {
+    bindingName: "STREAMS_EXAMPLE_STORAGE_VERSION",
+    current: "1",
+  };
+
+  test("resets an existing Worker that predates the current data version", async () => {
+    let parkedMetadata: unknown;
+    const cf = vi.fn(async (path: string, init?: RequestInit) => {
+      if (path === `/workers/scripts/${workerName}/settings`) return { bindings: [] };
+      if (path === "/workers/scripts") return [{ id: workerName }];
+      if (path.startsWith("/workers/durable_objects/namespaces?")) {
+        return [
+          {
+            id: "stream-namespace",
+            script: workerName,
+            class: "StreamDurableObject",
+          },
+        ];
+      }
+      if (path === "/containers/applications") return [];
+      if (path === `/workers/scripts/${workerName}` && init?.method === "PUT") {
+        const body = init.body;
+        expect(body).toBeInstanceOf(FormData);
+        if (!(body instanceof FormData)) throw new Error("expected a FormData Worker upload");
+        const metadata = body.get("metadata");
+        expect(typeof metadata).toBe("string");
+        if (typeof metadata !== "string") throw new Error("expected string Worker metadata");
+        parkedMetadata = JSON.parse(metadata);
+        return undefined;
+      }
+      throw new Error(`unexpected Cloudflare request: ${path}`);
+    });
+
+    await expect(
+      resetWorkerDurableObjectsOnVersionChange({
+        ctx: { cf } as never,
+        workerName,
+        cwd: "/tmp/streams-example-app",
+        credentials: {},
+        compatibilityDate: "2026-06-17",
+        containerClassNames: [],
+        dataVersion,
+      }),
+    ).resolves.toMatchObject({ action: "reset" });
+    expect(parkedMetadata).toMatchObject({
+      migrations: { steps: [{ deleted_classes: ["StreamDurableObject"] }] },
+    });
+  });
+
+  test("keeps storage when the deployed data version matches", async () => {
+    const cf = vi.fn(async (path: string) => {
+      if (path === `/workers/scripts/${workerName}/settings`) {
+        return {
+          bindings: [
+            {
+              name: dataVersion.bindingName,
+              text: dataVersion.current,
+              type: "plain_text",
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected Cloudflare request: ${path}`);
+    });
+
+    await expect(
+      resetWorkerDurableObjectsOnVersionChange({
+        ctx: { cf } as never,
+        workerName,
+        cwd: "/tmp/streams-example-app",
+        credentials: {},
+        compatibilityDate: "2026-06-17",
+        containerClassNames: [],
+        dataVersion,
+      }),
+    ).resolves.toEqual({ action: "skipped", reason: "data version unchanged" });
+    expect(cf).toHaveBeenCalledTimes(1);
+  });
+
+  test("does nothing when the Worker has never been deployed", async () => {
+    const cf = vi.fn(async (path: string) => {
+      throw new CloudflareApiError("GET", path, 404, [{ message: "Worker not found" }]);
+    });
+
+    await expect(
+      resetWorkerDurableObjectsOnVersionChange({
+        ctx: { cf } as never,
+        workerName,
+        cwd: "/tmp/streams-example-app",
+        credentials: {},
+        compatibilityDate: "2026-06-17",
+        containerClassNames: [],
+        dataVersion,
+      }),
+    ).resolves.toEqual({ action: "skipped", reason: "script does not exist" });
+    expect(cf).toHaveBeenCalledTimes(1);
   });
 });

--- a/scripts/lib/do-reset.ts
+++ b/scripts/lib/do-reset.ts
@@ -25,6 +25,7 @@ import { createHash } from "node:crypto";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { z } from "zod";
 import { CloudflareApiError, type DeployableEnv, type EnvContext } from "./env-context.ts";
 
 /** The slice of EnvContext the reset needs: the account-scoped CF API fetch. */
@@ -41,6 +42,18 @@ type WorkerSettings = {
   annotations?: Record<string, unknown>;
   bindings?: WorkerBinding[];
 };
+
+const WorkerDataVersionSettings = z.looseObject({
+  bindings: z
+    .array(
+      z.looseObject({
+        name: z.unknown().optional(),
+        text: z.unknown().optional(),
+        type: z.unknown().optional(),
+      }),
+    )
+    .optional(),
+});
 
 const SETTINGS_SCAN_CONCURRENCY = 10;
 
@@ -570,6 +583,63 @@ export async function resetWorkerDurableObjects(input: {
       `; parked at 503 until the next deploy`,
   );
   return { action: "reset", deletedClasses, keptContainerClasses: kept };
+}
+
+/**
+ * Reset a Worker's Durable Objects exactly once when an app advances its
+ * explicitly deployed data version. The version lives in a plain-text Worker
+ * binding, so it changes atomically with the real code upload after this
+ * function parks the old Worker.
+ */
+export async function resetWorkerDurableObjectsOnVersionChange(
+  input: Parameters<typeof resetWorkerDurableObjects>[0] & {
+    dataVersion: Readonly<{ bindingName: string; current: string }>;
+  },
+): ReturnType<typeof resetWorkerDurableObjects> {
+  const settingsPath = `/workers/scripts/${encodeURIComponent(input.workerName)}/settings`;
+  let rawSettings: unknown;
+  try {
+    rawSettings = await input.ctx.cf(settingsPath);
+  } catch (error) {
+    if (error instanceof CloudflareApiError && error.status === 404) {
+      console.log(
+        `DO reset: worker ${input.workerName} does not exist — no data version to upgrade`,
+      );
+      return { action: "skipped", reason: "script does not exist" };
+    }
+    throw error;
+  }
+
+  const settings = WorkerDataVersionSettings.parse(rawSettings);
+  const versionBindings = (settings.bindings ?? []).filter(
+    (binding) => binding.name === input.dataVersion.bindingName,
+  );
+  if (versionBindings.length > 1) {
+    throw new Error(
+      `DO reset: worker ${input.workerName} has multiple ${input.dataVersion.bindingName} bindings`,
+    );
+  }
+  const versionBinding = versionBindings[0];
+  if (
+    versionBinding &&
+    (versionBinding.type !== "plain_text" || typeof versionBinding.text !== "string")
+  ) {
+    throw new Error(
+      `DO reset: worker ${input.workerName} has an invalid ${input.dataVersion.bindingName} binding`,
+    );
+  }
+  const deployedVersion = versionBinding?.text;
+  if (deployedVersion === input.dataVersion.current) {
+    console.log(
+      `DO reset: worker ${input.workerName} data version ${deployedVersion} unchanged — keeping Durable Objects`,
+    );
+    return { action: "skipped", reason: "data version unchanged" };
+  }
+
+  console.log(
+    `DO reset: worker ${input.workerName} data version ${deployedVersion ?? "unversioned"} → ${input.dataVersion.current} — resetting Durable Objects before deploy`,
+  );
+  return resetWorkerDurableObjects(input);
 }
 
 /**


### PR DESCRIPTION
## What

- Give the Streams Example App an explicit storage epoch, deployed as a plain Worker variable.
- After a successful build and immediately before upload, compare that epoch with the live Worker. A missing or changed value destroys that Worker's Durable Objects once; an unchanged value is a read-only no-op.
- Add the small shared `beforeDeploy` hook needed to keep destructive rollout work after build success.
- Cover the mismatch/reset, match/preserve, and first-deploy/no-worker paths.

Before:

```text
build → deploy over the existing StreamDurableObject storage
```

After:

```text
build → compare deployed storage epoch → reset once if changed → deploy code + new epoch
```

## Why

The original report was directionally right but slightly overbroad. Normal preview handover already selects `streams-example-app` as a slot data owner and invokes its destroy command. The uncovered cases are:

- a redeploy into the same still-leased preview slot, which deliberately preserves that PR's existing deployment; and
- production deploys, which do not run the app's manual `erase-data` command.

The example app owns its own `StreamDurableObject` namespace, separate from OS. That means the OS-only erase in the [#2395 rollout runbook](https://github.com/iterate/iterate/pull/2395) could not reset this app's stream storage.

A read-only Cloudflare check on 2026-08-07 confirmed that both `streams-example-app-prd` and `streams-example-app-preview-13` currently have a `StreamDurableObject` namespace and no storage-version marker.

## Impact

The first Streams Example App deploy after merge advances unversioned storage to epoch `1`, so it will erase that app's example stream data in production and in each preview slot when that slot next deploys. Later epoch-`1` deploys preserve data.

For a future deliberately incompatible Stream storage change, bump `STREAMS_EXAMPLE_STORAGE_VERSION.current`; the next deploy then performs the same one-time reset.

## Risk map

- **Highest attention:** `scripts/lib/do-reset.ts` reads an external settings shape, validates it, and fails closed on malformed or duplicate version bindings before deciding whether to destroy data.
- **Operational ordering:** `scripts/lib/deploy-app.ts` runs `beforeDeploy` only after the build and concurrent prerequisites succeed, minimizing the parked-Worker window before upload.
- **Expected merge effect:** the initial unversioned → `1` rollout intentionally invalidates disposable Streams Example App data. No OS project data is touched.
- **Suggested review order:** version-gate helper and tests → Streams deploy/config wiring → shared pipeline hook.

## Checks

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm format`
- `pnpm test`
- focused preview handover invariant: 1 passed
- focused DO reset regression suite: 11 passed
- generated Wrangler config inspected for the epoch variable in production and all preview environments

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-07T10:25:35.293Z",
      "deployedAt": "2026-08-07T10:09:24.920Z",
      "headSha": "9ea86d9401f41f1d0199817946f3cdefa18d4968",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-14.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/178473707296262",
      "shortSha": "9ea86d9",
      "cleanupDurationMs": 10080,
      "deployDurationMs": 86983,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 37161,
      "deployReadinessDurationMs": 49819,
      "deployedWorkerName": "os-preview-14",
      "deployedWorkerVersion": "21e4d69b-baa3-4c1b-8335-9bf409e59c77",
      "testDurationMs": 166958,
      "testRetries": "7 retried: catalogue example \"agent-send-message\" runs identically across runtimes (vitest x1, still failed) — example \"agent-send-message\" failed in the node runtime: subscription \"agent\" does not exist · agent answers after explicit creation applies its model configuration event (vitest x1) — stream-unavailable: Internal error in Durable Object storage caused object to be reset; reference = 72dd8noo6igfgk997po45a9h · a script run's parked hold survives a stream Durable Object restart (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 30000ms (the public deadline expired while recovery re-armed one-shot waits). · agent create installs only generic machinery; later events configure it (vitest x1, still failed) — subscription \"agent\" does not exist · runScript caps an in-script sandbox timeout to its absolute deadline and kills the process group (vitest x1) — {\"status\":\"failed\",\"error\":\"Script execution orphaned: the incarnation running it went away before completing (eviction mid-run). It may have partially executed; it was NOT re-run.\",\"failureKind\":\"orphaned\",\"phase\":\"recovery\",\"executionMayHaveOccurred\":true,\"cancellation\":\"external-work-may-conti... · workspaces are one namespace: repos auto-mount at /repos/**, scratch lives at the workspace's own path, commits route per mount (vitest x1, still failed) — expected [Function] to throw error matching /does not exist.*create it with itx\\.…/s but got 'subscription \"workspace\" does not exi…' · repl-examples.spec.ts › itx REPL catalogue examples › runs \"agent-send-message\" through the project REPL › web (playwright x1, still failed) — Error: REPL entry errored: Error: subscription \"agent\" does not exist at e.evaluateImpl (https://os.iterate-preview-14.com/assets/dist-DAV5x_C2.js:1:31755) at e.evaluateWithDepth (https://os.iterate-preview-14.com/assets/dist-DAV5x_C2.js:1:29480) at e.evaluate (https://os.iterate-preview-14.com/a...",
      "workerSizeKib": 20673.46,
      "workerGzipKib": 5206.89,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5218.26
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-07T10:25:30.019Z",
      "deployedAt": "2026-08-07T10:08:58.614Z",
      "headSha": "9ea86d9401f41f1d0199817946f3cdefa18d4968",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-14.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/178473707296262",
      "shortSha": "9ea86d9",
      "cleanupDurationMs": 4804,
      "deployDurationMs": 13118,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 10852,
      "deployReadinessDurationMs": 2261,
      "deployedWorkerName": "docs-preview-14",
      "deployedWorkerVersion": "1c9a3b79-0036-4091-9a74-ccff56ef2c26",
      "testDurationMs": 1875,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-08-07T10:25:26.290Z",
      "deployedAt": "2026-08-07T09:53:20.059Z",
      "headSha": "9ea86d9401f41f1d0199817946f3cdefa18d4968",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-14.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/178473707296262",
      "shortSha": "9ea86d9",
      "cleanupDurationMs": 1071,
      "deployDurationMs": 37134,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 36960,
      "deployReadinessDurationMs": 167,
      "deployedWorkerName": "semaphore-preview-14",
      "deployedWorkerVersion": "7e0ad8f0-6066-4fb1-b7ae-5ab7f9da1beb",
      "testDurationMs": 22955,
      "testRetries": null,
      "workerSizeKib": 1915.51,
      "workerGzipKib": 441.08,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-07T10:25:29.884Z",
      "deployedAt": "2026-08-07T10:09:04.491Z",
      "headSha": "9ea86d9401f41f1d0199817946f3cdefa18d4968",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-14.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/178473707296262",
      "shortSha": "9ea86d9",
      "cleanupDurationMs": 4663,
      "deployDurationMs": 17041,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 16728,
      "deployReadinessDurationMs": 308,
      "deployedWorkerName": "auth-preview-14",
      "deployedWorkerVersion": "a299776a-6bbc-4c89-875b-36cc2f6f8a68",
      "testDurationMs": 10999,
      "testRetries": null,
      "workerSizeKib": 3981.51,
      "workerGzipKib": 815.44,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-08-07T10:25:33.663Z",
      "deployedAt": "2026-08-07T09:53:12.257Z",
      "headSha": "9ea86d9401f41f1d0199817946f3cdefa18d4968",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-14.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/178473707296262",
      "shortSha": "9ea86d9",
      "cleanupDurationMs": 8439,
      "deployDurationMs": 30129,
      "deployConfigDurationMs": 7,
      "deployCommandDurationMs": 29155,
      "deployReadinessDurationMs": 965,
      "deployedWorkerName": "streams-example-app-preview-14",
      "deployedWorkerVersion": "749cb76a-b014-4c7f-8389-f05f0874121c",
      "testDurationMs": 51215,
      "testRetries": null,
      "workerSizeKib": 5443.57,
      "workerGzipKib": 1540.42,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-07T10:25:27.451Z",
      "deployedAt": "2026-08-07T09:53:18.157Z",
      "headSha": "9ea86d9401f41f1d0199817946f3cdefa18d4968",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-14.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/178473707296262",
      "shortSha": "9ea86d9",
      "cleanupDurationMs": 1160,
      "deployDurationMs": 251,
      "deployConfigDurationMs": 7,
      "deployReuseProofDurationMs": 206,
      "deployedWorkerName": "dummy-petshop-preview-14",
      "deployedWorkerVersion": "2c609558-7d56-4757-98bf-a31461468429",
      "testDurationMs": 6277,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `9ea86d9` | [https://auth.iterate-preview-14.com](https://auth.iterate-preview-14.com) | 815.4 KiB | 17.0s | 11.0s |  | 4.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/178473707296262) | 2026-08-07T10:25:29.884Z | Preview app released. |
| Docs | released | `9ea86d9` | [https://docs-preview-14.iterate-dev-preview.workers.dev](https://docs-preview-14.iterate-dev-preview.workers.dev) | 866.2 KiB | 13.1s | 1.9s |  | 4.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/178473707296262) | 2026-08-07T10:25:30.019Z | Preview app released. |
| Dummy Petshop | released | `9ea86d9` | [https://dummy-petshop.iterate-preview-14.com](https://dummy-petshop.iterate-preview-14.com) | 198.3 KiB | 251ms | 6.3s |  | 1.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/178473707296262) | 2026-08-07T10:25:27.451Z | Preview app released. |
| OS | released | `9ea86d9` | [https://os.iterate-preview-14.com](https://os.iterate-preview-14.com) | 5.08 MiB (-11.4 KiB vs main) | 87.0s | 167.0s | 7 retried: catalogue example "agent-send-message" runs identically across runtimes (vitest x1, still failed) — example "agent-send-message" failed in the node runtime: subscription "agent" does not exist · agent answers after explicit creation applies its model configuration event (vitest x1) — stream-unavailable: Internal error in Durable Object storage caused object to be reset; reference = 72dd8noo6igfgk997po45a9h · a script run's parked hold survives a stream Durable Object restart (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 30000ms (the public deadline expired while recovery re-armed one-shot waits). · agent create installs only generic machinery; later events configure it (vitest x1, still failed) — subscription "agent" does not exist · runScript caps an in-script sandbox timeout to its absolute deadline and kills the process group (vitest x1) — {"status":"failed","error":"Script execution orphaned: the incarnation running it went away before completing (eviction mid-run). It may have partially executed; it was NOT re-run.","failureKind":"orphaned","phase":"recovery","executionMayHaveOccurred":true,"cancellation":"external-work-may-conti... · workspaces are one namespace: repos auto-mount at /repos/**, scratch lives at the workspace's own path, commits route per mount (vitest x1, still failed) — expected [Function] to throw error matching /does not exist.*create it with itx\.…/s but got 'subscription "workspace" does not exi…' · repl-examples.spec.ts › itx REPL catalogue examples › runs "agent-send-message" through the project REPL › web (playwright x1, still failed) — Error: REPL entry errored: Error: subscription "agent" does not exist at e.evaluateImpl (https://os.iterate-preview-14.com/assets/dist-DAV5x_C2.js:1:31755) at e.evaluateWithDepth (https://os.iterate-preview-14.com/assets/dist-DAV5x_C2.js:1:29480) at e.evaluate (https://os.iterate-preview-14.com/a... | 10.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/178473707296262) | 2026-08-07T10:25:35.293Z | Preview app released. |
| Semaphore | released | `9ea86d9` | [https://semaphore.iterate-preview-14.com](https://semaphore.iterate-preview-14.com) | 441.1 KiB | 37.1s | 23.0s |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/178473707296262) | 2026-08-07T10:25:26.290Z | Preview app released. |
| Streams Example App | released | `9ea86d9` | [https://streams.iterate-preview-14.com](https://streams.iterate-preview-14.com) | 1.50 MiB | 30.1s | 51.2s |  | 8.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/178473707296262) | 2026-08-07T10:25:33.663Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +106 -1 | +99 -1 🟩🟩🟩🟩🟩 |
| CI & scripts | +114 -4 | +84 -2 🟩🟩🟩🟩⬜ |
| **Total** | **+220 -5** | **+183 -3** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 24fc4c4 and 9ea86d9, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Destructive pre-deploy DO reset is gated on a Cloudflare settings read; the first rollout intentionally erases Streams Example App durable object data when advancing to epoch 1, including production and preview slots on next deploy.
> 
> **Overview**
> Adds a **storage epoch** for the Streams Example App (`STREAMS_EXAMPLE_STORAGE_VERSION`, deployed as a plain Worker var) and wires deploy so incompatible storage is cleared **once** before upload when the live epoch is missing or stale.
> 
> **Deploy pipeline:** `deploy-app` gains a `beforeDeploy` hook that runs only after a successful build, immediately before `wrangler` upload—so destructive rollout steps (DO reset) do not run on broken builds.
> 
> **Version gate:** `resetWorkerDurableObjectsOnVersionChange` reads the deployed Worker’s version binding via Cloudflare settings, fails closed on duplicate or malformed bindings, skips when the worker does not exist or the epoch matches, and otherwise calls the existing DO reset (park + tombstone `StreamDurableObject`) before the real deploy ships the new epoch.
> 
> **Operational note:** The first deploy after merge treats unversioned workers as behind epoch `1`, so **example stream DO data** in production and preview slots is intentionally wiped on that rollout; later deploys at `1` preserve storage. Future incompatible storage changes bump `current` in `generate-wrangler-config.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ea86d9401f41f1d0199817946f3cdefa18d4968. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->