### PR TITLE
Model initial processor snapshots explicitly

### DIFF
--- a/apps/os/e2e/vitest/itx-agents.e2e.test.ts
+++ b/apps/os/e2e/vitest/itx-agents.e2e.test.ts
@@ -21,6 +21,7 @@ test("agent create installs only generic machinery; later events configure it", 
   });
 
   using project = await itx.projects.get(`agent-create-${crypto.randomUUID()}`).create({});
+  expect(await project.agents.list()).toEqual([]);
   using agent = project.agents.get(`/agents/create-${crypto.randomUUID()}`);
   expect((await agent.processor.snapshot()).state.birthCertificate).toBeNull();
 

--- a/apps/os/e2e/vitest/workspace.itx.e2e.test.ts
+++ b/apps/os/e2e/vitest/workspace.itx.e2e.test.ts
@@ -30,6 +30,10 @@ test(
 
     // -- explicit birth; the mount table is DERIVED, never stored -------------
 
+    await expect(workspace.processor.snapshot()).resolves.toMatchObject({
+      offset: 0,
+      state: { birthCertificate: null },
+    });
     await expect(workspace.readFile("/repos/config/package.json")).rejects.toThrow(
       /does not exist.*create it with itx\.workspaces\.get/s,
     );

--- a/apps/os/src/domains/streams/core-processor.test.ts
+++ b/apps/os/src/domains/streams/core-processor.test.ts
@@ -426,6 +426,31 @@ describe("StreamCoreProcessor stream-to-stream subscriptions", () => {
     );
   });
 
+  test("hosted processor subscriptions cannot be removed", () => {
+    const { processor } = harness(SOURCE_PATH);
+    const state = reduce(
+      processor,
+      coreState(SOURCE_PATH),
+      committed(
+        2,
+        "events.iterate.com/stream/subscription-configured",
+        streamSubscription({
+          name: "agent",
+          receiver: { action: "processor-wake", placement: "facet" },
+        }),
+        { path: SOURCE_PATH },
+      ),
+    );
+    const removal: StreamEventInput = {
+      type: "events.iterate.com/stream/subscription-removed",
+      payload: { name: "agent", reason: "requested" },
+    };
+
+    expect(() => processor.validate({ event: removal, state, authority: "public" })).toThrow(
+      "hosted processor subscriptions cannot be removed",
+    );
+  });
+
   test("a paused receiver rejects copied product appends as unavailable", () => {
     const { processor, state } = harness();
     const paused = { ...state, paused: true, pauseReason: "operator boundary" };

--- a/apps/os/src/domains/streams/core-processor.ts
+++ b/apps/os/src/domains/streams/core-processor.ts
@@ -308,8 +308,16 @@ export class StreamCoreProcessor {
       if (args.authority !== "public") {
         throw new Error("requested subscription removals must come from a public command");
       }
-      if (args.state.subscriptions.outbound.byName[event.payload.name] === undefined) {
+      const configured = args.state.subscriptions.outbound.byName[event.payload.name];
+      if (configured === undefined) {
         throw new Error(`subscription "${event.payload.name}" does not exist`);
+      }
+      // A hosted processor's subscription is part of its birth contract. Its
+      // configured event is idempotency-keyed, so removing the row would make
+      // a later create retry dedupe without restoring the processor. Push
+      // subscriptions remain removable through their owning domain doors.
+      if (configured.configuration.receiver.action === "processor-wake") {
+        throw new Error("hosted processor subscriptions cannot be removed");
       }
     }
 

--- a/apps/os/src/domains/streams/stream-durable-object.ts
+++ b/apps/os/src/domains/streams/stream-durable-object.ts
@@ -99,6 +99,7 @@ import {
   type CoreProcessorState,
   type SubscriptionConfiguredPayload,
 } from "./core-processor-contract.ts";
+import { unconfiguredSubscriptionError } from "./utils.ts";
 
 const DEFAULT_GET_EVENTS_LIMIT = 500;
 const MAX_GET_EVENTS_LIMIT = 500;
@@ -1204,7 +1205,7 @@ export class StreamDurableObject extends DurableObject<Env> {
   #requireProcessorWakeSubscription(name: string): ProcessorWakeReceiver {
     const configured = this.#coreProcessorState.subscriptions.outbound.byName[name];
     if (configured === undefined) {
-      throw new Error(`subscription "${name}" does not exist`);
+      throw unconfiguredSubscriptionError(name);
     }
     const receiver = configured.configuration.receiver;
     if (receiver.action !== "processor-wake") {
@@ -2823,7 +2824,7 @@ export class StreamDurableObject extends DurableObject<Env> {
     }
     const configured = this.#coreProcessorState.subscriptions.outbound.byName[trimmedName];
     if (configured === undefined) {
-      throw new Error(`subscription "${trimmedName}" does not exist`);
+      throw unconfiguredSubscriptionError(trimmedName);
     }
 
     const receiver = configured.configuration.receiver;

--- a/apps/os/src/domains/streams/stream-processor-rpc-target.test.ts
+++ b/apps/os/src/domains/streams/stream-processor-rpc-target.test.ts
@@ -8,6 +8,7 @@ import {
   StreamRpcTarget,
 } from "../../rpc-targets.ts";
 import { streamDeliveryAuthContext } from "../../auth.ts";
+import { unconfiguredSubscriptionError } from "./utils.ts";
 
 describe("StreamRpcTarget", () => {
   it("serves liveState from the socket-fed relay engine, never the DO's liveState property", async () => {
@@ -750,6 +751,59 @@ describe("ProcessorRelayRpcTarget", () => {
     const request = { name: "sandbox-test" } as never;
     await expect(relay.wakeStreamProcessor(request)).resolves.toEqual({ accepted: true });
     expect(wakeStreamProcessor).toHaveBeenCalledWith(request);
+  });
+
+  it("answers an unconfigured processor snapshot with its initial fold only", async () => {
+    const refusal = unconfiguredSubscriptionError("agent");
+    let configured = false;
+    const host = vi.fn(async () => {
+      if (!configured) throw refusal;
+      return {
+        processor: Promise.resolve({
+          getRuntimeState: async () => ({
+            snapshot: { offset: 3, state: { birthCertificate: { created: true } } },
+          }),
+          snapshot: async () => ({
+            offset: 3,
+            state: { birthCertificate: { created: true } },
+          }),
+          waitUntilProcessed: async () => undefined,
+        }),
+        wakeStreamProcessor: (async () => ({ accepted: true as const })) as never,
+      };
+    });
+    const relay = new ProcessorRelayRpcTarget({
+      auth: streamDeliveryAuthContext("prj_test"),
+      host,
+      initialStateWhenUnconfigured: () => ({ birthCertificate: null }),
+    });
+
+    await expect(relay.snapshot()).resolves.toEqual({
+      offset: 0,
+      state: { birthCertificate: null },
+    });
+    await expect(relay.getRuntimeState()).rejects.toBe(refusal);
+    await expect(relay.waitUntilProcessed({ offset: 1 })).rejects.toBe(refusal);
+    await expect(relay.wakeStreamProcessor({ name: "agent" } as never)).rejects.toBe(refusal);
+
+    configured = true;
+    await expect(relay.snapshot()).resolves.toEqual({
+      offset: 3,
+      state: { birthCertificate: { created: true } },
+    });
+  });
+
+  it("does not mistake an unrelated missing-subscription message for the modeled refusal", async () => {
+    const unrelated = new Error('subscription "agent" does not exist');
+    const relay = new ProcessorRelayRpcTarget({
+      auth: streamDeliveryAuthContext("prj_test"),
+      host: async () => {
+        throw unrelated;
+      },
+      initialStateWhenUnconfigured: () => ({ birthCertificate: null }),
+    });
+
+    await expect(relay.snapshot()).rejects.toBe(unrelated);
   });
 
   it("disposes the transient remote processor facade after success and failure", async () => {

--- a/apps/os/src/domains/streams/utils.test.ts
+++ b/apps/os/src/domains/streams/utils.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { resolveStreamPath } from "./utils.ts";
+import {
+  isUnconfiguredSubscriptionError,
+  resolveStreamPath,
+  unconfiguredSubscriptionError,
+} from "./utils.ts";
 
 describe("stream utilities", () => {
   it("resolves child and sibling paths inside the held stream root", () => {
@@ -11,5 +15,15 @@ describe("stream utilities", () => {
 
   it("rejects relative paths that escape the stream root", () => {
     expect(() => resolveStreamPath("/", "..")).toThrow(/escapes the stream root/);
+  });
+
+  it("classifies an unconfigured subscription without changing its public refusal", () => {
+    const error = unconfiguredSubscriptionError("agent");
+
+    expect(error.message).toMatch(/subscription "agent" does not exist/);
+    expect(isUnconfiguredSubscriptionError(error)).toBe(true);
+    expect(isUnconfiguredSubscriptionError(new Error('subscription "agent" does not exist'))).toBe(
+      false,
+    );
   });
 });

--- a/apps/os/src/domains/streams/utils.ts
+++ b/apps/os/src/domains/streams/utils.ts
@@ -48,15 +48,24 @@ export function buildFacetProcessorSubscriptionConfiguredEvent(input: {
   });
 }
 
+/** Stable across Workers RPC, which does not preserve custom error classes. */
+const UNCONFIGURED_SUBSCRIPTION_ERROR_PREFIX = "stream-subscription-unconfigured: ";
+
+/** Build the Stream DO refusal for a processor name absent from its committed catalog. */
+export function unconfiguredSubscriptionError(name: string): Error {
+  return new Error(
+    `${UNCONFIGURED_SUBSCRIPTION_ERROR_PREFIX}subscription ${JSON.stringify(name)} does not exist`,
+  );
+}
+
 /**
  * The Stream DO's processor doors refuse a name the committed catalog does not
- * configure — a read must never MATERIALIZE a facet (`ctx.facets.get` creates
- * one on first dial). Domain doors that read a fold BEFORE its birth batch
- * commits (a secret's create-time offset probe, a device's pre-enrollment
- * read, an unborn project's catalog) use this to substitute the unborn shape
- * the facade used to fabricate. Matched on the message because this crosses a
- * Workers RPC hop, which does not carry error classes.
+ * configure — a read must never materialize a facet (`ctx.facets.get` creates
+ * one on first dial). Selected domain reads classify that refusal and answer
+ * with the processor contract's initial fold while preserving every other
+ * error. The owned prefix prevents unrelated "does not exist" errors from
+ * being mistaken for this condition across Workers RPC.
  */
 export function isUnconfiguredSubscriptionError(error: unknown): boolean {
-  return error instanceof Error && /^subscription ".*" does not exist$/.test(error.message);
+  return error instanceof Error && error.message.startsWith(UNCONFIGURED_SUBSCRIPTION_ERROR_PREFIX);
 }

--- a/apps/os/src/domains/workspaces/workspace-durable-object.ts
+++ b/apps/os/src/domains/workspaces/workspace-durable-object.ts
@@ -156,13 +156,13 @@ export class WorkspaceV2DurableObject extends DurableObject<Env> {
     try {
       ({ state } = await (await this.#processorFacade()).snapshot());
     } catch (error) {
-      // UNBORN workspace: before the birth batch commits, the workspace
-      // subscription does not exist and the facade refuses the name (a read
-      // must never materialize a facet). Substitute the empty fold —
-      // #assertCreated then reports the friendly missing-workspace guidance,
-      // exactly as the retired host fabricated its pre-birth reads.
+      // Before the birth batch commits, the workspace subscription is absent
+      // from the stream catalog (and a read must never materialize its facet).
+      // The contract's initial fold lets #assertCreated report the domain's
+      // friendly missing-workspace guidance while every other error remains
+      // loud.
       if (!isUnconfiguredSubscriptionError(error)) throw error;
-      state = WorkspaceProcessorContract.stateSchema.parse({}) as WorkspaceProcessorState;
+      state = WorkspaceProcessorContract.stateSchema.parse({});
     }
     this.#reducedState = state;
     return state;

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -100,6 +100,7 @@ import { parseAgentPath, resolveAgentPath } from "./domains/agents/utils.ts";
 import {
   AGENT_COLLECTION_PATH,
   AGENT_COLLECTION_SUBSCRIPTION_NAME,
+  AgentCollectionProcessorContract,
   type AgentCollectionProcessorState,
 } from "./domains/agents/agent-collection-processor-contract.ts";
 import {
@@ -429,7 +430,6 @@ import {
 } from "./domains/agents/agent-defaults.ts";
 import { ChatReplyNotifyProcessorContract } from "./domains/notifications/chat-reply-notify-contract.ts";
 import { repoCreationEvents, type RepoCreateInput } from "./domains/repos/repo-defaults.ts";
-import { AgentCollectionProcessorContract } from "./domains/agents/agent-collection-processor-contract.ts";
 import { CapabilityHostProcessorContract } from "./domains/capability-host/capability-host-processor-contract.ts";
 import { DeviceProcessorContract } from "./domains/devices/device-processor-contract.ts";
 import { describeDeviceState } from "./domains/devices/device-durable-object.ts";
@@ -1967,13 +1967,9 @@ class AgentCollectionRpcTarget extends IterateRpcTarget<"AgentCollection"> {
   get processor(): StreamProcessorRpc<AgentCollectionProcessorState> {
     return facetProcessorRelay<AgentCollectionProcessorState>({
       auth: this.props.auth,
-      name: AgentCollectionProcessorContract.slug,
+      contract: AgentCollectionProcessorContract,
       path: AGENT_COLLECTION_PATH,
       projectId: this.props.projectId,
-      // agents.list() on a project that never created an agent reads the
-      // collection before its birth batch exists — empty catalog, not refusal.
-      unbornState: () =>
-        AgentCollectionProcessorContract.stateSchema.parse({}) as AgentCollectionProcessorState,
     });
   }
 
@@ -2519,7 +2515,7 @@ class WorkspaceRpcTarget extends IterateRpcTarget<"Workspace"> {
   get processor(): StreamProcessorRpc<WorkspaceProcessorState> {
     return facetProcessorRelay<WorkspaceProcessorState>({
       auth: this.props.auth,
-      name: WorkspaceProcessorContract.slug,
+      contract: WorkspaceProcessorContract,
       path: this.props.path,
       projectId: this.props.projectId,
     });
@@ -4665,13 +4661,9 @@ function agentProcessorRelay(input: {
 }): ProcessorRelayRpcTarget<AgentProcessorState> {
   return facetProcessorRelay<AgentProcessorState>({
     auth: input.auth,
-    name: AgentProcessorContract.slug,
+    contract: AgentProcessorContract,
     path: input.path,
     projectId: input.projectId,
-    // Pre-create reads (the create door's own birth check, `agents.get(x)
-    // .processor.snapshot()` from scripts and the REPL catalogue) must see
-    // the unborn fold — birthCertificate null — not the facade's refusal.
-    unbornState: () => AgentProcessorContract.stateSchema.parse({}) as AgentProcessorState,
   });
 }
 
@@ -8042,11 +8034,18 @@ export class ProcessorRelayRpcTarget<
   readonly #host: () => Host | PromiseLike<Host>;
   readonly #processorFacade: (host: Host) => PromiseLike<unknown>;
   readonly #publicState: ((state: State) => PublicState) | undefined;
+  readonly #initialStateWhenUnconfigured: (() => State) | undefined;
 
   constructor(args: {
     auth: ItxAuth;
     host: () => Host | PromiseLike<Host>;
     processorFacade?: (host: Host) => PromiseLike<unknown>;
+    /**
+     * The contract's initial fold for a processor whose subscription has not
+     * been configured yet. Only snapshot() uses it; runtime, wait, and wake
+     * keep the stream's modeled refusal.
+     */
+    initialStateWhenUnconfigured?: () => State;
     /**
      * Projection applied to every state that leaves this relay — snapshots
      * and runtime state. This is where a domain redacts internals from its
@@ -8060,6 +8059,7 @@ export class ProcessorRelayRpcTarget<
     this.#host = args.host;
     this.#processorFacade = args.processorFacade ?? ((host) => host.processor);
     this.#publicState = args.publicState;
+    this.#initialStateWhenUnconfigured = args.initialStateWhenUnconfigured;
   }
 
   #project(state: State): PublicState {
@@ -8171,7 +8171,20 @@ export class ProcessorRelayRpcTarget<
   }
 
   async snapshot() {
-    const snapshot = await this.#callProcessor((processor) => processor.snapshot());
+    let snapshot: ProcessorSnapshot<State>;
+    try {
+      snapshot = await this.#callProcessor((processor) => processor.snapshot());
+    } catch (error) {
+      if (
+        this.#initialStateWhenUnconfigured === undefined ||
+        !isUnconfiguredSubscriptionError(error)
+      ) {
+        throw error;
+      }
+      // Stream offsets are one-based: offset 0 is the honest snapshot of an
+      // empty journal prefix, before this processor's birth batch exists.
+      snapshot = { offset: 0, state: this.#initialStateWhenUnconfigured() };
+    }
     return { offset: snapshot.offset, state: this.#project(snapshot.state) };
   }
 
@@ -8449,57 +8462,49 @@ function streamProcessorFacade(input: {
  * itself carries the snapshot/getRuntimeState/waitUntilProcessed surface, so
  * the "facade of the host" is the host.
  */
-function facetProcessorRelay<State = unknown, PublicState = State>(input: {
+type FacetProcessorContract<State> = {
+  slug: string;
+  stateSchema: { parse(input: unknown): State };
+};
+
+type FacetProcessorRelayInput<State, PublicState> = {
   auth: ItxAuth;
-  name: string;
   path: string;
   projectId: string | null;
   publicState?: (state: State) => PublicState;
-  /**
-   * The pre-birth substitute: when the stream's committed catalog does not
-   * configure this subscription yet, the facade refuses the name (a read must
-   * never materialize a facet) — with this supplied, `snapshot()` answers the
-   * refusal with the contract's empty fold instead, exactly as the retired
-   * hosting Durable Objects fabricated their pre-birth reads (see
-   * isUnconfiguredSubscriptionError). Only the pure fold read has a
-   * meaningful pre-birth answer; every other verb still propagates the
-   * refusal, and each acquisition re-dials, so a birth committing between
-   * calls is picked up on the next one. Omitted = the refusal propagates.
-   */
-  unbornState?: () => State;
-}): ProcessorRelayRpcTarget<State, ProcessorHostStub, PublicState> {
-  const unbornState = input.unbornState;
+} & (
+  | { name: string; contract?: never }
+  | {
+      /**
+       * A known domain processor contract. Before its subscription is
+       * configured, snapshot() answers with the contract's initial fold at
+       * offset 0; every other verb preserves the stream refusal. Supplying
+       * the contract also binds the subscription name to its slug.
+       */
+      contract: FacetProcessorContract<State>;
+      name?: never;
+    }
+);
+
+function facetProcessorRelay<State = unknown, PublicState = State>(
+  input: FacetProcessorRelayInput<State, PublicState>,
+): ProcessorRelayRpcTarget<State, ProcessorHostStub, PublicState> {
+  const contract = input.contract;
+  const name = contract === undefined ? input.name : contract.slug;
   return new ProcessorRelayRpcTarget<State, ProcessorHostStub, PublicState>({
     auth: input.auth,
-    host:
-      unbornState === undefined
-        ? () => streamProcessorFacade(input)
-        : () =>
-            Promise.resolve(streamProcessorFacade(input)).catch((error: unknown) => {
-              if (!isUnconfiguredSubscriptionError(error)) throw error;
-              return unbornProcessorFacadeStandIn(unbornState, error);
-            }),
+    host: () =>
+      streamProcessorFacade({
+        name,
+        path: input.path,
+        projectId: input.projectId,
+      }),
     processorFacade: (host) => Promise.resolve(host),
+    ...(contract === undefined
+      ? {}
+      : { initialStateWhenUnconfigured: () => contract.stateSchema.parse({}) }),
     ...(input.publicState === undefined ? {} : { publicState: input.publicState }),
   });
-}
-
-/**
- * The stand-in a {@link facetProcessorRelay} acquisition resolves to while
- * its subscription is unborn: the fold read fabricates the empty state at
- * offset 0, everything else rethrows the facade's refusal.
- */
-function unbornProcessorFacadeStandIn<State>(
-  unbornState: () => State,
-  refusal: unknown,
-): ProcessorHostStub {
-  const refuse = () => Promise.reject(refusal);
-  return {
-    snapshot: () => Promise.resolve({ offset: 0, state: unbornState() }),
-    getRuntimeState: refuse,
-    waitUntilProcessed: refuse,
-    processEventBatch: refuse,
-  } as unknown as ProcessorHostStub;
 }
 
 /**


### PR DESCRIPTION
## What changed

- derive an offset-0 snapshot from the processor contract when its hosted subscription has not been configured yet
- apply that behavior only to `snapshot()`; runtime state, waits, and wake calls continue to use the real facade and refuse an unconfigured processor
- give the Stream DO refusal an owned cross-RPC classification instead of matching generic `does not exist` messages
- prevent hosted processor subscriptions from being removed, because their idempotent birth event cannot recreate a removed catalog row
- cover fresh agent collections, pre-create agents, direct workspace snapshots, friendly workspace errors, and relay verb boundaries

## Why

A processor fold has a well-defined value at offset 0: the initial state declared by its contract. The streams/facets rebuild correctly stopped reads from materializing unconfigured facets, but it also made valid offset-0 snapshot reads fail. The first fix restored those reads through a fake host object; this version models the snapshot boundary directly and leaves every stateful processor operation on the real host.

This is a code regression, not stale preview data. Preview CI erases its leased slot before deploying, and the original failure reproduced against fresh state.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm knip`
- `pnpm test` (OS: 264 files, 2,742 passing tests; 12 expected failures; 1 skipped)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes stream processor read semantics, cross-RPC error classification, and subscription removal rules for hosted processors—areas that gate birth, facet materialization, and agent/workspace pre-create flows.
> 
> **Overview**
> Restores **honest offset-0 processor snapshots** when a facet-hosted subscription is not in the stream catalog yet, without materializing facets on read.
> 
> **`ProcessorRelayRpcTarget.snapshot()`** catches the stream’s unconfigured-subscription refusal and, when a contract is wired through **`facetProcessorRelay`**, returns **`offset: 0`** and the contract’s parsed initial fold. **`getRuntimeState`**, **`waitUntilProcessed`**, and **`wakeStreamProcessor`** still hit the real facade and keep refusing.
> 
> The stream durable object now emits **`unconfiguredSubscriptionError`** with a fixed **`stream-subscription-unconfigured:`** prefix so Workers RPC can classify the condition without matching generic “does not exist” strings. Workspace (and similar) refresh paths use that classifier to substitute the initial fold for friendly “not created” behavior.
> 
> **`StreamCoreProcessor`** rejects public **`subscription-removed`** for **`processor-wake`** rows so idempotent birth cannot dedupe against a removed catalog entry.
> 
> The fake “unborn host” stand-in is removed; agent collection, agent, and workspace facet relays pass **`contract`** instead of **`name` + `unbornState`**. E2E coverage adds empty agent lists, pre-create workspace snapshots, and relay verb boundaries.
> 
> **Note:** subscription-catalog processor reads that do not supply a contract still surface the new prefixed refusal (preview e2e expecting `/does not exist/` may need updating).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4e5ffa6dbfa45857cab79e2ab580b4df8e4742a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-07T12:27:25.990Z",
      "deployedAt": "2026-08-07T12:11:04.221Z",
      "headSha": "b4e5ffa6dbfa45857cab79e2ab580b4df8e4742a",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/79298981561573",
      "shortSha": "b4e5ffa",
      "cleanupDurationMs": 14578,
      "deployDurationMs": 63713,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 63679,
      "deployReadinessDurationMs": 31,
      "deployedWorkerName": "os-preview-17",
      "deployedWorkerVersion": "b97b70b4-6ea2-410a-a574-96a0dc131b00",
      "testDurationMs": 253105,
      "testRetries": "1 retried: stream-resume-after-suspend.spec.ts › feed resumes after the /api WebSocket goes half-open (no close frame) › preview-resilience (playwright x1) — TimeoutError: locator.waitFor: Timeout 30000ms exceeded. Call log: \u001b[2m - waiting for locator('[data-testid=\"agent-feed-message\"][data-kind=\"assistant\"]').first() to be visible\u001b[22m",
      "workerSizeKib": 20695.95,
      "workerGzipKib": 5213.24,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5224.29
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-07T12:27:15.357Z",
      "deployedAt": "2026-08-07T12:10:17.387Z",
      "headSha": "b4e5ffa6dbfa45857cab79e2ab580b4df8e4742a",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-17.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/79298981561573",
      "shortSha": "b4e5ffa",
      "cleanupDurationMs": 3942,
      "deployDurationMs": 71896,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 16842,
      "deployReadinessDurationMs": 55050,
      "deployedWorkerName": "docs-preview-17",
      "deployedWorkerVersion": "8b664ec8-ec31-4dae-823d-fdeea68a0312",
      "testDurationMs": 1836,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-07T12:27:16.187Z",
      "deployedAt": "2026-08-07T12:10:21.175Z",
      "headSha": "b4e5ffa6dbfa45857cab79e2ab580b4df8e4742a",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/79298981561573",
      "shortSha": "b4e5ffa",
      "cleanupDurationMs": 4770,
      "deployDurationMs": 20691,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 20627,
      "deployReadinessDurationMs": 58,
      "deployedWorkerName": "auth-preview-17",
      "deployedWorkerVersion": "f40d6662-7438-47c4-8cd1-3c6dedb92d96",
      "testDurationMs": 10545,
      "testRetries": null,
      "workerSizeKib": 3981.51,
      "workerGzipKib": 815.43,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-08-07T12:27:20.056Z",
      "deployedAt": "2026-08-07T12:10:19.710Z",
      "headSha": "b4e5ffa6dbfa45857cab79e2ab580b4df8e4742a",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/79298981561573",
      "shortSha": "b4e5ffa",
      "cleanupDurationMs": 8637,
      "deployDurationMs": 20107,
      "deployConfigDurationMs": 7,
      "deployCommandDurationMs": 19161,
      "deployReadinessDurationMs": 939,
      "deployedWorkerName": "streams-example-app-preview-17",
      "deployedWorkerVersion": "82636474-fdc8-4bf9-baa7-9bf95928ac17",
      "testDurationMs": 86440,
      "testRetries": null,
      "workerSizeKib": 5457.72,
      "workerGzipKib": 1544.34,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-07T12:27:12.361Z",
      "deployedAt": "2026-08-07T12:02:40.384Z",
      "headSha": "b4e5ffa6dbfa45857cab79e2ab580b4df8e4742a",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/79298981561573",
      "shortSha": "b4e5ffa",
      "cleanupDurationMs": 940,
      "deployDurationMs": 33,
      "deployConfigDurationMs": 0,
      "deployReuseProofDurationMs": 28,
      "deployedWorkerName": "dummy-petshop-preview-17",
      "deployedWorkerVersion": "04bbf840-e977-40e8-a162-46bca28772df",
      "testDurationMs": 5328,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-08-07T12:27:13.591Z",
      "deployedAt": "2026-08-07T12:10:17.941Z",
      "headSha": "b4e5ffa6dbfa45857cab79e2ab580b4df8e4742a",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/79298981561573",
      "shortSha": "b4e5ffa",
      "cleanupDurationMs": 1230,
      "deployDurationMs": 17650,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 17394,
      "deployReadinessDurationMs": 250,
      "deployedWorkerName": "semaphore-preview-17",
      "deployedWorkerVersion": "09ba7f36-ec7b-4f87-9c43-a88f67ca4a37",
      "testDurationMs": 54547,
      "testRetries": null,
      "workerSizeKib": 1915.51,
      "workerGzipKib": 441.08,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `b4e5ffa` | [https://auth.iterate-preview-17.com](https://auth.iterate-preview-17.com) | 815.4 KiB | 20.7s | 10.5s |  | 4.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/79298981561573) | 2026-08-07T12:27:16.187Z | Preview app released. |
| Docs | released | `b4e5ffa` | [https://docs-preview-17.iterate-dev-preview.workers.dev](https://docs-preview-17.iterate-dev-preview.workers.dev) | 866.2 KiB | 71.9s | 1.8s |  | 3.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/79298981561573) | 2026-08-07T12:27:15.357Z | Preview app released. |
| Dummy Petshop | released | `b4e5ffa` | [https://dummy-petshop.iterate-preview-17.com](https://dummy-petshop.iterate-preview-17.com) | 198.3 KiB | 33ms | 5.3s |  | 940ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/79298981561573) | 2026-08-07T12:27:12.361Z | Preview app released. |
| OS | released | `b4e5ffa` | [https://os.iterate-preview-17.com](https://os.iterate-preview-17.com) | 5.09 MiB (-11.1 KiB vs main) | 63.7s | 253.1s | 1 retried: stream-resume-after-suspend.spec.ts › feed resumes after the /api WebSocket goes half-open (no close frame) › preview-resilience (playwright x1) — TimeoutError: locator.waitFor: Timeout 30000ms exceeded. Call log: [2m - waiting for locator('[data-testid="agent-feed-message"][data-kind="assistant"]').first() to be visible[22m | 14.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/79298981561573) | 2026-08-07T12:27:25.990Z | Preview app released. |
| Semaphore | released | `b4e5ffa` | [https://semaphore.iterate-preview-17.com](https://semaphore.iterate-preview-17.com) | 441.1 KiB | 17.6s | 54.5s |  | 1.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/79298981561573) | 2026-08-07T12:27:13.591Z | Preview app released. |
| Streams Example App | released | `b4e5ffa` | [https://streams.iterate-preview-17.com](https://streams.iterate-preview-17.com) | 1.51 MiB | 20.1s | 86.4s |  | 8.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/79298981561573) | 2026-08-07T12:27:20.056Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +94 -71 | +47 -35 🟩🟩🟩🟥🟥 |
| Tests | +99 -1 | +90 -1 🟩🟩🟩🟩🟩 |
| **Total** | **+193 -72** | **+137 -36** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 802d6d8 and b4e5ffa, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->