### PR TITLE
Give the half-open resume spec's first paint a cold-preview budget

### DIFF
--- a/specs/stream-resume-after-suspend.spec.ts
+++ b/specs/stream-resume-after-suspend.spec.ts
@@ -220,9 +220,10 @@ test("feed resumes after the /api WebSocket goes half-open (no close frame)", as
   page,
   baseURL,
 }) => {
-  // The greeting-settle wait (up to 120s) stacks on the probe window and the
-  // two send assertions, so this lane gets the heavy ceiling.
-  test.setTimeout(300_000);
+  // The greeting-settle wait (up to 120s) stacks on the probe window, the
+  // paint wait (90s — see that step), and the two send assertions, so this
+  // lane gets the heavy ceiling.
+  test.setTimeout(360_000);
   await using fixture = await helpers.createFixture("suspend-halfopen");
   if (!baseURL) throw new Error("Playwright baseURL fixture is required.");
   await installSocketKillSwitch(page);
@@ -254,10 +255,20 @@ test("feed resumes after the /api WebSocket goes half-open (no close frame)", as
   // the explicit bounded waits.
   await test.step("half-open: paint greeting and settle composer", async () => {
     await spinnerWaiter.settings.run({ disabled: true }, async () => {
+      // 90s, not 30s: on a cold preview deployment this first paint rides a
+      // freshly deployed worker plus a cold Stream DO chain, and 30s failed
+      // BOTH in-run tries on 3 of 5 preview runs during 2026-08-07 (every
+      // job-level retry passed — pure cold-start latency, and this step runs
+      // BEFORE any half-open is induced, so no resilience signal is at
+      // stake). The 120s waits around this step already assume this lane is
+      // slow. If this step keeps flaking at 90s, stop bumping and QUARANTINE
+      // the spec per docs/testing.md — at that point the lane is telling us
+      // preview first-paint has a real problem, and absorbing it here would
+      // hide it.
       await page
         .locator('[data-testid="agent-feed-message"][data-kind="assistant"]')
         .first()
-        .waitFor({ timeout: 30_000 });
+        .waitFor({ timeout: 90_000 });
       await page.getByRole("button", { name: "Send message" }).waitFor({ timeout: 120_000 });
     });
   });


### PR DESCRIPTION
## Give the half-open resume spec's first paint a cold-preview budget

`stream-resume-after-suspend.spec.ts › feed resumes after the /api WebSocket goes half-open (no close frame)` has been failing **before any half-open is induced**: its greeting-paint *setup* wait had a 30s budget, and on cold preview deployments that first paint rides a freshly deployed worker plus a cold Stream DO chain.

The record on 2026-08-07: failed **both in-run tries on 3 of 5 preview runs** (across two unrelated branches, one byte-identical to main in all stream code), and passed on **every job-level retry** — pure cold-start latency, taxing every PR with manual preview retries. The resilience assertions the spec exists for were never the failing step.

- Paint wait 30s → **90s** (the surrounding waits in the same test already get 120s; the spec's own header calls this the heavy lane).
- Test ceiling 300s → 360s to keep the stacked budgets honest.
- The comment now says the quiet part: **if it keeps flaking at 90s, quarantine the spec per docs/testing.md** instead of bumping again — at that point the lane is reporting a real preview first-paint problem, and absorbing it would hide it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timeout and comment changes in one spec; no production or runtime behavior.
> 
> **Overview**
> Raises **setup** timeouts in the half-open WebSocket resume Playwright test so cold preview deployments can finish greeting paint before any half-open stimulus runs.
> 
> The first assistant message paint wait goes from **30s → 90s**, with a comment documenting 2026-08-07 preview flakes (failed in-run tries, passed on job retries) and pointing to **quarantine per `docs/testing.md`** if 90s still flakes—so further bumps don’t mask a real first-paint problem. The test’s overall ceiling moves **300s → 360s** so stacked greeting, paint, and send waits stay within the budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 906660bef3f6fe8199a4c04e397bfdf65e1120f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-07T12:56:41.801Z",
      "deployedAt": "2026-08-07T12:48:59.063Z",
      "headSha": "906660bef3f6fe8199a4c04e397bfdf65e1120f3",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/568279689936976",
      "shortSha": "906660b",
      "cleanupDurationMs": 16490,
      "deployDurationMs": 93146,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 69627,
      "deployReadinessDurationMs": 23517,
      "deployedWorkerName": "os-preview-12",
      "deployedWorkerVersion": "34e9bef8-a300-49f1-9233-8ee845c256b5",
      "testDurationMs": 249229,
      "testRetries": "1 retried: stream-resume-after-suspend.spec.ts › feed resumes after the /api WebSocket goes half-open (no close frame) › preview-resilience (playwright x1) — TimeoutError: locator.waitFor: Timeout 90000ms exceeded. Call log: \u001b[2m - waiting for locator('[data-testid=\"agent-feed-message\"][data-kind=\"assistant\"]').first() to be visible\u001b[22m",
      "workerSizeKib": 20695.95,
      "workerGzipKib": 5213.24,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5223.95
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-07T12:56:27.757Z",
      "deployedAt": "2026-08-07T12:48:17.928Z",
      "headSha": "906660bef3f6fe8199a4c04e397bfdf65e1120f3",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-12.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/568279689936976",
      "shortSha": "906660b",
      "cleanupDurationMs": 2443,
      "deployDurationMs": 28702,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 28490,
      "deployReadinessDurationMs": 209,
      "deployedWorkerName": "docs-preview-12",
      "deployedWorkerVersion": "9f33d194-fb08-4e98-a119-810e5e59b98a",
      "testDurationMs": 2293,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-07T12:56:29.035Z",
      "deployedAt": "2026-08-07T12:48:22.116Z",
      "headSha": "906660bef3f6fe8199a4c04e397bfdf65e1120f3",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/568279689936976",
      "shortSha": "906660b",
      "cleanupDurationMs": 3721,
      "deployDurationMs": 33012,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 32677,
      "deployReadinessDurationMs": 330,
      "deployedWorkerName": "auth-preview-12",
      "deployedWorkerVersion": "43f887cf-23a0-47d3-af92-59ecbc8d8689",
      "testDurationMs": 11637,
      "testRetries": null,
      "workerSizeKib": 3981.51,
      "workerGzipKib": 815.54,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-07T12:56:26.173Z",
      "deployedAt": "2026-08-07T12:47:59.457Z",
      "headSha": "906660bef3f6fe8199a4c04e397bfdf65e1120f3",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/568279689936976",
      "shortSha": "906660b",
      "cleanupDurationMs": 857,
      "deployDurationMs": 10261,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 9984,
      "deployReadinessDurationMs": 239,
      "deployedWorkerName": "dummy-petshop-preview-12",
      "deployedWorkerVersion": "6c650a41-c75d-4eab-addd-c34cfb9018fc",
      "testDurationMs": 10588,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `906660b` | [https://auth.iterate-preview-12.com](https://auth.iterate-preview-12.com) | 815.5 KiB | 33.0s | 11.6s |  | 3.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/568279689936976) | 2026-08-07T12:56:29.035Z | Preview app released. |
| Docs | released | `906660b` | [https://docs-preview-12.iterate-dev-preview.workers.dev](https://docs-preview-12.iterate-dev-preview.workers.dev) | 866.2 KiB | 28.7s | 2.3s |  | 2.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/568279689936976) | 2026-08-07T12:56:27.757Z | Preview app released. |
| Dummy Petshop | released | `906660b` | [https://dummy-petshop.iterate-preview-12.com](https://dummy-petshop.iterate-preview-12.com) | 198.3 KiB | 10.3s | 10.6s |  | 857ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/568279689936976) | 2026-08-07T12:56:26.173Z | Preview app released. |
| OS | released | `906660b` | [https://os.iterate-preview-12.com](https://os.iterate-preview-12.com) | 5.09 MiB (-10.7 KiB vs main) | 93.1s | 249.2s | 1 retried: stream-resume-after-suspend.spec.ts › feed resumes after the /api WebSocket goes half-open (no close frame) › preview-resilience (playwright x1) — TimeoutError: locator.waitFor: Timeout 90000ms exceeded. Call log: [2m - waiting for locator('[data-testid="agent-feed-message"][data-kind="assistant"]').first() to be visible[22m | 16.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/568279689936976) | 2026-08-07T12:56:41.801Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +15 -4 | +2 -2 🟩🟩🟩🟥🟥 |
| **Total** | **+15 -4** | **+2 -2** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between fba1e2e and 906660b, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->