### PR TITLE
Agent feed: show script-sent replies as soon as the script settles

### DIFF
--- a/apps/os/src/components/agent-ui-reducer.test.ts
+++ b/apps/os/src/components/agent-ui-reducer.test.ts
@@ -507,6 +507,72 @@ describe("agent-ui reducer", () => {
     });
   });
 
+  // Regression: prod stream agents/web/2026-08-07t15-50-03-269z. The script
+  // sent the visible reply (deferred while its code step ran), settled, and
+  // the stream went quiet — the journal fold alone must emit the reply, not
+  // hold it hostage until a runtime transition or some future event arrives.
+  test("flushes a script-sent reply when its script settles and nothing else is running", () => {
+    const state = reduceAll([
+      {
+        type: "events.iterate.com/agents/context-added",
+        payload: {
+          role: "user",
+          actor: { type: "user", origin: "web" },
+          content: "ok what model are you using?",
+        },
+      },
+      {
+        type: "events.iterate.com/agent/llm-request-requested",
+        offset: 10,
+        payload: { model: "xai/grok-4.5" },
+      },
+      {
+        type: "events.iterate.com/agents/context-added",
+        payload: {
+          role: "assistant",
+          llmRequestOffset: 10,
+          content: "```ts\nasync (itx) => {\n  await itx.chat.sendMessage('grok');\n}\n```",
+        },
+      },
+      {
+        type: "events.iterate.com/agent/llm-request-settled",
+        payload: { requestOffset: 10, result: { status: "succeeded", text: "…" } },
+      },
+      {
+        type: "events.iterate.com/capability-host/script-run-requested",
+        payload: {
+          executionId: "agent-output:12",
+          code: "async (itx) => {\n  await itx.chat.sendMessage('grok');\n}",
+          expiresAt: SCRIPT_EXPIRES_AT,
+        },
+      },
+      {
+        type: "events.iterate.com/agents/web-message-sent",
+        payload: { message: "I'm using **xai/grok-4.5**." },
+      },
+      {
+        type: "events.iterate.com/capability-host/script-run-settled",
+        payload: { executionId: "agent-output:12", settlement: { status: "succeeded" } },
+      },
+    ]);
+
+    expect(state.live).toBeNull();
+    expect(state.deferredAssistantMessages).toEqual([]);
+    expect(state.items.map((item) => item.kind)).toEqual(["user", "activity", "assistant"]);
+    expect(state.items.at(-1)).toMatchObject({
+      kind: "assistant",
+      text: "I'm using **xai/grok-4.5**.",
+    });
+    expect(state.items[1]).toMatchObject({
+      kind: "activity",
+      status: "done",
+      steps: [
+        { kind: "llm", status: "done", outcome: "completed" },
+        { kind: "code", executionId: "agent-output:12", status: "done", success: true },
+      ],
+    });
+  });
+
   test("accumulates agent llm-response-chunk deltas", () => {
     const state = reduceAll([
       {

--- a/packages/ui/src/components/events/agent-ui-reducer.ts
+++ b/packages/ui/src/components/events/agent-ui-reducer.ts
@@ -842,7 +842,20 @@ function reduceAgentUiEvent(
         // earlier round when this one's script didn't update it.
         ...(state.summaryActivity == null ? {} : { activitySummary: state.summaryActivity }),
       };
-      return { ...state, live: { ...state.live, steps } };
+      const next = { ...state, live: { ...state.live, steps } };
+      // A visible reply the script sent was deferred while its step ran (see
+      // emitAssistantMessageItem). If this settle is the turn's last journal
+      // fact — nothing running, no follow-up round — no later event exists to
+      // flush it, and the runtime-transition flush is a transient overlay on
+      // a lane that can lag or wedge independently. Journal facts alone must
+      // surface a sent message: settle the activity here and flush.
+      if (
+        (next.deferredAssistantMessages.length > 0 || next.queuedUserMessages.length > 0) &&
+        !steps.some((candidate) => candidate.status === "running")
+      ) {
+        return flushDeferredMessages(settleLive(next, timestampMs, items), items);
+      }
+      return next;
     }
 
     case AGENT_SUMMARY_UPDATED: {

--- a/tasks/agent-feed-deferred-reply-flush.md
+++ b/tasks/agent-feed-deferred-reply-flush.md
@@ -1,0 +1,60 @@
+---
+status: implemented
+size: small
+---
+
+# Agent feed: flush script-sent replies when the script settles
+
+**Status:** implemented with a regression test; awaiting review. Remaining:
+none in this scope (stale runtime-lane phantom spinner and prd delivery errors
+are tracked separately, see links at the bottom).
+
+## Problem
+
+Prod incident (stream `agents/web/2026-08-07t15-50-03-269z`, project misha,
+2026-08-07): the agent answered a message in 15 seconds — request settled,
+script ran, `web-message-sent` durably appended — but the web UI showed
+"Waiting for a response" for 11+ minutes and never rendered the reply.
+
+Mechanism in the shared feed reducer
+(`packages/ui/src/components/events/agent-ui-reducer.ts`):
+
+1. A reply sent from inside a script (`itx.chat.sendMessage(...)`) arrives
+   while the script's code step is still running, so `emitAssistantMessageItem`
+   defers the bubble (correct: ordering).
+2. `script-run-settled` marks the step done but never flushes
+   `deferredAssistantMessages`.
+3. The only flush lived in `reduceAgentUiRuntime` — the transient live-state
+   runtime overlay. When that lane lags or wedges (it did), the reply stays
+   invisible forever. Journal replays (page reload, TUI, mobile) had the same
+   hole: journal facts alone never emitted the bubble.
+
+## Fix
+
+- [x] Failing spec mirroring the prod event sequence — journal facts alone
+      must emit the reply. _`apps/os/src/components/agent-ui-reducer.test.ts`,
+      "flushes a script-sent reply when its script settles and nothing else is
+      running"._
+- [x] At `SCRIPT_EXECUTION_COMPLETED`: when no steps remain running and
+      deferred/queued messages exist, settle the live activity and flush.
+      _One conditional in the reducer; no behavior change for turns without
+      deferred messages._
+- [x] Verify consumers: os reducer suite (46), os components/lib (412),
+      browser client-libraries (94), stream-tui (41), `@iterate-com/ui`
+      typecheck — all green.
+
+## Implementation notes
+
+The flush deliberately settles the activity: if the turn continues after
+sending a message, the next round starts a fresh activity group — honest
+chronology (the message really was sent mid-turn), and a sent message must
+never wait on a liveness signal to become visible.
+
+Related follow-ups (out of scope here):
+
+- [stream-subscriber-deliveries-stall-mid-turn](stream-subscriber-deliveries-stall-mid-turn.md)
+  — the stale `useLiveState` runtime lane that hid this bug and still causes a
+  phantom spinner when wedged (prd sighting appended).
+- [prd-subrequest-depth-limit-breaks-deliveries](prd-subrequest-depth-limit-breaks-deliveries.md)
+  — `Subrequest depth limit exceeded` skipping subscription deliveries and
+  putting processor revival into a 360m backoff plateau.

--- a/tasks/prd-subrequest-depth-limit-breaks-deliveries.md
+++ b/tasks/prd-subrequest-depth-limit-breaks-deliveries.md
@@ -1,0 +1,47 @@
+---
+state: todo
+priority: high
+size: medium
+---
+
+# prd: "Subrequest depth limit exceeded" breaks subscriptions and processor revival
+
+## Evidence (prd, 2026-08-07, stream `agents/web/2026-08-07t15-50-03-269z`, project misha)
+
+Two durable `stream/error-occurred` facts during a normal web-agent conversation:
+
+- offset 220 (15:50:31): `subscription "project-worker" skipped failing event at
+  offset 209 after 3 event-specific attempts: Subrequest depth limit exceeded.
+  This request recursed through Workers too many times.` — a durable
+  subscriber permanently skipped an event.
+- offset 783 (15:53:39): `processor host revival has failed 3 consecutive
+  times on version f836fa59-…; backing off (plateau 360m). A deploy resets the
+  budget.` — the agent processor host on that stream is in a 6-hour revival
+  backoff. Same likely root cause.
+
+Also observed on the same stream from ~15:56 onward: a ~25s
+open → idle-close (+5s) → wake-socket "departed" (+19s) → reopen churn loop for
+the browser's session connection (`vbrowser-feed@7|browser-raw-events@7`),
+appending 3 connection events per cycle indefinitely while the tab stays open.
+
+## Why it matters
+
+Cloudflare's subrequest depth limit is hit when delivery/wake/RPC hops ride an
+already-deep request chain (append → wake → deliver → append → …). Agent turns
+are exactly such chains. Consequences seen live: skipped subscriber events
+(stale project-worker projections), revival backoff plateaus that only a deploy
+resets, and (plausibly) the flapping worker↔DO sockets behind the churn loop.
+
+## Goal
+
+- Reproduce/instrument: log request depth (or a hop counter) at delivery and
+  revival dial sites; find which chain exceeds the limit.
+- Break the chain: deliveries and revival dials should start from a fresh
+  execution context (alarm/queue hop) rather than inheriting the appending
+  request's depth.
+- Reconsider the 5s-after-open idle close observed in prd (config says 5m
+  default `STREAM_IDLE_TEARDOWN_MS`, unset in prd) and the resulting
+  3-events-per-25s churn on quiet-but-watched streams.
+
+Related: [stream-subscriber-deliveries-stall-mid-turn](stream-subscriber-deliveries-stall-mid-turn.md),
+[streaming-ui-resume-wedge](streaming-ui-resume-wedge.md).

--- a/tasks/stream-subscriber-deliveries-stall-mid-turn.md
+++ b/tasks/stream-subscriber-deliveries-stall-mid-turn.md
@@ -56,6 +56,31 @@ Find and fix the server-side reason deliveries stop mid-turn:
   subscription accepted by a pre-creation instance should either carry over
   or be terminated at creation time.
 
+## prd sighting, 2026-08-07 (runtime lane variant)
+
+Stream `agents/web/2026-08-07t15-50-03-269z` (project misha): every LLM request
+succeeded server-side and the reply was durably sent 15s after the user's
+message, yet the open tab showed "Waiting for a response 692.5s" (11.5+ min)
+and never rendered the reply. The Agent DO's `liveState.get()` was correct
+(zero runtime since offset 1288), so this wedge was the **client**
+`useLiveState` runtime-lane subscription staying stale despite its 45s ping
+watchdog — a second lane with the same dead-transport shape as the event-lane
+stall documented here. Two consequences stacked:
+
+1. Stale active runtime (`llmRequests.requested: 1`) kept projecting a phantom
+   live activity with a counting clock.
+2. The reply bubble stayed in `deferredAssistantMessages` because the flush
+   lived only in `reduceAgentUiRuntime` (the runtime overlay). Fixed
+   2026-08-07: the journal fold now settles + flushes at
+   `script-run-settled` when nothing is running
+   (`packages/ui/src/components/events/agent-ui-reducer.ts`), so a wedged
+   runtime lane can no longer hide a sent message.
+
+The stale-runtime phantom spinner remains reproducible whenever the runtime
+lane wedges; see also
+[prd-subrequest-depth-limit-breaks-deliveries](prd-subrequest-depth-limit-breaks-deliveries.md)
+for the prd-side delivery errors observed on the same stream.
+
 ## Repro
 
 - Deterministic-ish on a preview slot: open


### PR DESCRIPTION
## What

A reply the agent sends from inside a script (`itx.chat.sendMessage(...)`) could stay invisible forever, with the feed stuck on a phantom "Waiting for a response" spinner — even though the backend finished the turn in seconds. Live in prd on 2026-08-07 (`agents/web/2026-08-07t15-50-03-269z`): the reply was durably appended 15s after the user's message; the open tab showed "Waiting for a response 692.5s" and never rendered it.

## Why

The shared feed reducer defers a `web-message-sent` bubble while the sending script's code step is still running (correct — the bubble belongs after the activity that produced it). But `script-run-settled` never flushed the deferral; the only flush lived in `reduceAgentUiRuntime`, the **transient live-state runtime overlay**. So chat correctness depended on a second, independently-wedgeable lane:

```
web-message-sent      → deferred (code step running)   ✓ by design
script-run-settled    → step done… and nothing flushes ✗ wedge
[stream goes quiet]   → reply invisible until some future event
```

Journal replays (page reload, TUI, mobile) had the same hole: journal facts alone never emitted the turn's final reply.

## How

One conditional in `agent-ui-reducer.ts` at `SCRIPT_EXECUTION_COMPLETED`: when no steps remain running and deferred/queued messages exist, settle the live activity and flush. Turns without deferred messages are unchanged. If a turn continues after sending a message, the next round starts a fresh activity group — honest chronology.

Regression test mirrors the prod event sequence exactly (request → assistant script → settle → script-run-requested → web-message-sent → script-run-settled) and asserts the journal fold alone emits the reply.

Also records the incident's infra evidence in `tasks/`: a new task for the prd `Subrequest depth limit exceeded` failures (skipped subscription delivery, processor revival in a 360m backoff plateau) and a prd sighting appended to the mid-turn delivery-stall task, covering the stale `useLiveState` runtime lane that made this reducer hole user-visible.

## Verification

- New spec red before / green after; 46 reducer tests, 412 os components/lib, 94 browser client-libraries, 41 stream-tui all green; `@iterate-com/ui` typecheck clean.

Task file: `tasks/complete/2026-08-07-agent-feed-deferred-reply-flush.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session: `7ff650c2-0b63-480a-8942-b60e4937eae4`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-07T16:55:56.304Z",
      "deployedAt": "2026-08-07T16:50:55.998Z",
      "headSha": "e825aea560d73286676b19808f7c39cc85f901d6",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/448527761593556",
      "shortSha": "e825aea",
      "cleanupDurationMs": 12362,
      "deployDurationMs": 124673,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 84824,
      "deployReadinessDurationMs": 39846,
      "deployedWorkerName": "os-preview-2",
      "deployedWorkerVersion": "2d463ebf-f204-4e63-a68a-1f550cd1568c",
      "testDurationMs": 192318,
      "testRetries": null,
      "workerSizeKib": 20204.98,
      "workerGzipKib": 5099.93,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5224.04
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-07T16:55:47.785Z",
      "deployedAt": "2026-08-07T16:49:59.674Z",
      "headSha": "e825aea560d73286676b19808f7c39cc85f901d6",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-2.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/448527761593556",
      "shortSha": "e825aea",
      "cleanupDurationMs": 3840,
      "deployDurationMs": 31890,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 28497,
      "deployReadinessDurationMs": 3387,
      "deployedWorkerName": "docs-preview-2",
      "deployedWorkerVersion": "523a03b0-2514-40d2-9856-2ed58bac9b56",
      "testDurationMs": 2623,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-08-07T16:55:45.223Z",
      "deployedAt": "2026-08-07T16:49:56.034Z",
      "headSha": "e825aea560d73286676b19808f7c39cc85f901d6",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/448527761593556",
      "shortSha": "e825aea",
      "cleanupDurationMs": 1275,
      "deployDurationMs": 24924,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 24855,
      "deployReadinessDurationMs": 62,
      "deployedWorkerName": "semaphore-preview-2",
      "deployedWorkerVersion": "83d89796-b57e-45fc-8c4a-6641f5c248af",
      "testDurationMs": 23798,
      "testRetries": null,
      "workerSizeKib": 1915.51,
      "workerGzipKib": 441.08,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-07T16:55:48.667Z",
      "deployedAt": "2026-08-07T16:50:14.824Z",
      "headSha": "e825aea560d73286676b19808f7c39cc85f901d6",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/448527761593556",
      "shortSha": "e825aea",
      "cleanupDurationMs": 4714,
      "deployDurationMs": 44185,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 43644,
      "deployReadinessDurationMs": 535,
      "deployedWorkerName": "auth-preview-2",
      "deployedWorkerVersion": "fa9ca3d4-823d-4cef-878e-b92600545224",
      "testDurationMs": 11986,
      "testRetries": null,
      "workerSizeKib": 3979.33,
      "workerGzipKib": 814.9,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-08-07T16:55:53.175Z",
      "deployedAt": "2026-08-07T16:50:18.709Z",
      "headSha": "e825aea560d73286676b19808f7c39cc85f901d6",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/448527761593556",
      "shortSha": "e825aea",
      "cleanupDurationMs": 9220,
      "deployDurationMs": 48515,
      "deployConfigDurationMs": 7,
      "deployCommandDurationMs": 47528,
      "deployReadinessDurationMs": 979,
      "deployedWorkerName": "streams-example-app-preview-2",
      "deployedWorkerVersion": "ba4a956a-c185-48d6-ac2e-796af4f1abdb",
      "testDurationMs": 64194,
      "testRetries": null,
      "workerSizeKib": 5339.11,
      "workerGzipKib": 1513.25,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-07T16:55:46.498Z",
      "deployedAt": "2026-08-07T16:50:04.574Z",
      "headSha": "e825aea560d73286676b19808f7c39cc85f901d6",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/448527761593556",
      "shortSha": "e825aea",
      "cleanupDurationMs": 1275,
      "deployDurationMs": 8779,
      "deployConfigDurationMs": 1,
      "deployCommandDurationMs": 8472,
      "deployReadinessDurationMs": 303,
      "deployedWorkerName": "dummy-petshop-preview-2",
      "deployedWorkerVersion": "82631fc0-6704-460a-a85d-a8d652fd35db",
      "testDurationMs": 7247,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `e825aea` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 814.9 KiB | 44.2s | 12.0s |  | 4.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/448527761593556) | 2026-08-07T16:55:48.667Z | Preview app released. |
| Docs | released | `e825aea` | [https://docs-preview-2.iterate-dev-preview.workers.dev](https://docs-preview-2.iterate-dev-preview.workers.dev) | 866.2 KiB | 31.9s | 2.6s |  | 3.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/448527761593556) | 2026-08-07T16:55:47.785Z | Preview app released. |
| Dummy Petshop | released | `e825aea` | [https://dummy-petshop.iterate-preview-2.com](https://dummy-petshop.iterate-preview-2.com) | 198.3 KiB | 8.8s | 7.2s |  | 1.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/448527761593556) | 2026-08-07T16:55:46.498Z | Preview app released. |
| OS | released | `e825aea` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 4.98 MiB (-124.1 KiB vs main) | 124.7s | 192.3s |  | 12.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/448527761593556) | 2026-08-07T16:55:56.304Z | Preview app released. |
| Semaphore | released | `e825aea` | [https://semaphore.iterate-preview-2.com](https://semaphore.iterate-preview-2.com) | 441.1 KiB | 24.9s | 23.8s |  | 1.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/448527761593556) | 2026-08-07T16:55:45.223Z | Preview app released. |
| Streams Example App | released | `e825aea` | [https://streams.iterate-preview-2.com](https://streams.iterate-preview-2.com) | 1.48 MiB | 48.5s | 64.2s |  | 9.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/448527761593556) | 2026-08-07T16:55:53.175Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| UI components | +14 -1 | +8 -1 🟩⬜⬜⬜⬜ |
| Tests | +66 -0 | +60 -0 🟩🟩🟩⬜⬜ |
| Docs | +132 -0 | +106 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+212 -1** | **+174 -1** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 46af107 and e825aea, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared `agent-ui-reducer` feed logic used across web, mobile, and TUI; the new flush is gated on “no running steps” and existing deferred/queued queues, with a targeted regression test, but incorrect settling could still affect activity grouping on edge turns.
> 
> **Overview**
> Fixes agent feed chat where a reply sent from inside a running script (`itx.chat.sendMessage`) could stay invisible indefinitely—even after the backend finished and durably journaled `web-message-sent`—while the UI showed a phantom “Waiting for a response” state.
> 
> **Root cause:** Deferred assistant bubbles were only flushed in `reduceAgentUiRuntime` (the transient live-state overlay). Journal-only folds (reload, TUI, mobile) and wedged client runtime lanes never triggered that flush when `script-run-settled` marked the code step done.
> 
> **Change:** On `SCRIPT_EXECUTION_COMPLETED`, when no activity steps remain running and deferred or queued messages exist, the reducer now **settles the live activity and flushes** deferred messages from journal facts alone—same path as the runtime overlay, without depending on a later event or healthy `useLiveState`.
> 
> A regression test mirrors the prod stream event sequence. Task notes document the incident and related infra follow-ups (stale runtime lane spinner, subrequest depth limit on deliveries).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e825aea560d73286676b19808f7c39cc85f901d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->