### PR TITLE
Previews for every open PR: remove the draft skip and the preview label

### DIFF
--- a/.depot/workflows/cloudflare-previews.yml
+++ b/.depot/workflows/cloudflare-previews.yml
@@ -35,22 +35,12 @@ permissions:
   pull-requests: write
   statuses: read
 
-# Draft PRs don't claim a preview slot unless they ask — the `preview` label,
-# marking ready for review, or a manual dispatch (dispatch passes
-# --allow-draft below). The policy lives in scripts/preview/preview.ts
-# (decideDraftPreviewPolicy) where it's unit-tested; the trigger types beyond
-# open/reopen/synchronize just make sure the script runs whenever a PR's
-# draft or label state changes, so it can claim a slot or give one back.
 on:
   pull_request:
     types:
       - opened
       - reopened
       - synchronize
-      - ready_for_review
-      - converted_to_draft
-      - labeled
-      - unlabeled
     paths:
       - .depot/workflows/cloudflare-previews.yml
       - packages/shared/**
@@ -87,11 +77,6 @@ concurrency:
 
 jobs:
   preview:
-    # Label events for anything but the preview opt-in label change nothing
-    # about the preview lifecycle — skip the checkout+install entirely.
-    if: |-
-      (github.event.action != 'labeled' || github.event.label.name == 'preview') &&
-        (github.event.action != 'unlabeled' || github.event.label.name == 'preview')
     name: Preview / deploy + e2e
     # The overlapping test pools peaked below ten cores. Keep the 16-core
     # shape, but start from the same baked workspace used by mainline checks
@@ -139,13 +124,12 @@ jobs:
           TEST_TELEMETRY_ARTIFACT_DIR: test-results/ci-telemetry/raw
         run: |-
           set -euo pipefail
-          # A manual dispatch is an explicit ask for a fresh preview, so it
-          # overrides the draft policy and redeploys even when this exact head
-          # was previously cleaned up and recorded as released.
+          # A manual dispatch is an explicit ask for a fresh preview of the
+          # whole fleet, regardless of what the diff touches.
           doppler run --project _shared --config prd --preserve-env=GITHUB_TOKEN -- pnpm preview run \
             --github-token "$GITHUB_TOKEN" \
             --pull-request-number "${{ github.event.pull_request.number || inputs.pull-request-number }}" \
-            ${{ github.event_name == 'workflow_dispatch' && '--allow-draft --all-apps' || '' }}
+            ${{ github.event_name == 'workflow_dispatch' && '--all-apps' || '' }}
       - name: Normalize and send preview test telemetry
         if: always()
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,15 +75,10 @@ pnpm install && pnpm typecheck && pnpm lint && pnpm knip && pnpm format && pnpm 
 ```
 
 How to open a PR (branch hygiene, body shape, **screenshots that actually
-render**, drafts/previews) — and **after open**: wait for Iterate Review /
+render**, previews) — and **after open**: wait for Iterate Review /
 review bots, address **every** CI/review comment (fix or reply + resolve),
 **never leave threads standing**, **never merge on red CI** unless the human
 explicitly said so: **[Pull requests](docs/pull-requests.md)**.
-
-**Draft PRs don't get a preview deployment** (or preview e2e). If you open a
-PR as a draft and want a preview environment, add the `preview` label; marking
-the PR ready for review also starts previews. Lease model details:
-[Dev environments](docs/dev-environments.md).
 
 ## Repository map
 

--- a/README.md
+++ b/README.md
@@ -101,17 +101,12 @@ pnpm install && pnpm typecheck && pnpm lint && pnpm format && pnpm test
 ```
 
 How to open a PR (branch hygiene, body shape, **screenshots that actually
-render**, drafts/previews) — and **after open**: wait for Iterate Review /
+render**, previews) — and **after open**: wait for Iterate Review /
 review bots, address **every** CI/review comment (fix or reply + resolve),
 **never leave threads standing**, **never merge on red CI** unless the human
 explicitly said so: **[Pull requests](docs/pull-requests.md)**.
 
 **Browser testing:** use **Playwriter** with an isolated headless session by default (or an authorized real-Chrome session when explicitly requested). Give every concurrent agent a unique Playwriter session id. See [Browser testing](docs/browser-testing.md). Keep the Playwriter CLI and skill current.
-
-**Draft PRs don't get a preview deployment** (or preview e2e). If you open a
-PR as a draft and want a preview environment, add the `preview` label; marking
-the PR ready for review also starts previews. Lease model details:
-[Dev environments](docs/dev-environments.md).
 
 ## Repository map
 
@@ -161,7 +156,7 @@ from your machine, and when you need a public callback URL. Doppler/Cloudflare/d
 
 ### Development
 
-- [Pull requests](docs/pull-requests.md) — opening PRs, absolute screenshot URLs, drafts/previews, body hygiene; after open: wait for Iterate Review, address every thread, no merge on red CI
+- [Pull requests](docs/pull-requests.md) — opening PRs, absolute screenshot URLs, previews, body hygiene; after open: wait for Iterate Review, address every thread, no merge on red CI
 - [Browser testing](docs/browser-testing.md) — isolated Playwriter sessions, and reusable test logins
 - [Dev environments](docs/dev-environments.md) — local dev, minting identities, opening project-scoped or platform-wide operator sessions, browsers for agents, preview-from-local
 - [Tunnels](docs/tunnels.md) — public HTTPS URLs for local dev, webhooks, OAuth callbacks, and CI/e2e fixtures

--- a/docs/adding-preview-slots.md
+++ b/docs/adding-preview-slots.md
@@ -111,10 +111,10 @@ The order is:
    OAuth redirect URIs. Verify the GitHub App through its API.
 9. Present the ledger and obtain separate approval for the production
    Semaphore lease write.
-10. Add the `preview` label to a draft canary whose body contains exactly
+10. Open a canary PR whose body contains exactly
     `preview_environment=preview-20`, then prove deploy, e2e, one real
-    Google/GitHub/Slack round trip, and cleanup. Remove the label after cleanup
-    so the still-open draft cannot immediately reacquire a slot.
+    Google/GitHub/Slack round trip, and cleanup. Close the canary after
+    cleanup so it cannot immediately reacquire a slot.
 
 Each failed checkpoint stops the rehearsal. Fix the runbook or automation at
 the point of failure before retrying the slot.
@@ -542,15 +542,14 @@ handover erase.
 
 ## 9. Prove the normal lifecycle
 
-Use a small draft canary PR that touches a preview-shared path. The normal CI
-path is a standalone body directive plus the `preview` label:
+Use a small canary PR that touches a preview-shared path. The normal CI
+path is a standalone body directive:
 
 ```text
 preview_environment=preview-20
 ```
 
-Markdown examples and comments do not count. The directive selects a slot but
-does not make a draft eligible; the label does that. For a fleet sweep, pin,
+Markdown examples and comments do not count. For a fleet sweep, pin,
 run, and clean one new slot at a time:
 
 ```bash
@@ -561,7 +560,7 @@ for n in $(seq 10 19); do
     pnpm preview assign --pull-request-number "$PR" --slot "$n"
 
   doppler run --project _shared --config prd -- \
-    pnpm preview run --pull-request-number "$PR" --allow-draft --all-apps
+    pnpm preview run --pull-request-number "$PR" --all-apps
 
   doppler run --project _shared --config prd -- \
     pnpm preview cleanup --pull-request-number "$PR"
@@ -582,9 +581,9 @@ event window and investigate or explicitly track them before declaring the
 expansion complete.
 
 Close the canary only after all ten slots have passed. Run `status` and
-`reconcile` once more. If the canary is a real work PR rather than a disposable
-one, remove its `preview` label after cleanup instead of closing it; otherwise
-the next preview dispatch can claim another slot for the still-eligible draft.
+`reconcile` once more. Any open PR reacquires a slot on its next preview run,
+so keep that in mind if the canary is a real work PR rather than a disposable
+one.
 
 ## Resuming safely
 

--- a/docs/dev-environments.md
+++ b/docs/dev-environments.md
@@ -348,14 +348,6 @@ invariants:
   GC sweep — see **[Preview resource GC](preview-resource-gc.md)** for how
   teardown is decoupled from releasing the slot (and how disposable data
   expires 3h after last use).
-- **Draft PRs don't claim a slot unless they ask.** Drafts are the default
-  for agent-opened PRs, and nineteen slots don't survive a busy night of them. A
-  draft asks by wearing the `preview` label (durable — previews then behave
-  as for a ready PR), being marked ready for review, or a one-shot explicit
-  run (dispatching the `Cloudflare Previews` workflow, or
-  `pnpm preview deploy --allow-draft`; the next push re-applies the policy).
-  A draft that holds a slot without asking — e.g. a ready PR converted back
-  to draft — gives it back on the next lifecycle run.
 - **The semaphore is the single source of lease truth.** The PR body's
   managed section only _displays_ the slot (and per-app results); it is never
   consulted for ownership and never a reason to skip. Before running tests or
@@ -375,7 +367,7 @@ invariants:
   someone else on it.
 - **Everything is attributable and visible.** `pnpm preview status` shows
   each slot's holder, PR open/closed state, idle/orphaned verdict, open
-  preview-eligible PRs without a slot, and reclaim commands when the fleet
+  PRs without a slot, and reclaim commands when the fleet
   is full for a reason other than "nineteen open PRs". The semaphore UI at
   semaphore.iterate.com shows the same live leases; every lease transition
   (acquired/renewed/evicted/expired/force-released) is logged as an event in
@@ -393,15 +385,13 @@ invariants:
   doppler run --project _shared --config prd -- pnpm preview gc --dry-run
   ```
 
-An eligible PR can request one configured slot by putting an exact standalone
+A PR can request one configured slot by putting an exact standalone
 line in its body:
 
 ```text
 preview_environment=preview-17
 ```
 
-This selects a slot; it does not opt a draft into previews. The PR must still
-carry the `preview` label, be ready for review, or use an explicit one-off run.
 If the requested slot is unknown or held by another owner, acquisition fails
 without forcing the holder or silently falling back to another slot.
 

--- a/docs/pull-requests.md
+++ b/docs/pull-requests.md
@@ -73,9 +73,9 @@ gh api repos/iterate/iterate/pulls/<n> -H "Accept: application/vnd.github.html+j
 gh api -X PATCH repos/iterate/iterate/pulls/<n> --input payload.json
 ```
 
-## Drafts / previews
+## Previews
 
-Drafts don't get a preview unless labeled `preview` or marked ready. Lease details: [Dev environments](./dev-environments.md).
+Every open PR (draft or ready) gets a preview deployment. Lease details: [Dev environments](./dev-environments.md).
 
 ## After open — agents landing a PR
 

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -706,57 +706,15 @@ describe("preview workflow scope", () => {
   });
 });
 
-describe("draft preview policy", () => {
-  const { decideDraftPreviewPolicy } = previewInternals;
-
-  test.for([
-    {
-      name: "deploys ready PRs regardless of labels or leases",
-      input: { allowDraft: false, holdsSlot: false, isDraft: false, labels: [] },
-      expected: "deploy",
-    },
-    {
-      name: "skips drafts that hold no slot",
-      input: { allowDraft: false, holdsSlot: false, isDraft: true, labels: ["bug"] },
-      expected: "skip",
-    },
-    {
-      name: "gives a draft's slot back when the semaphore says it holds one without asking",
-      input: { allowDraft: false, holdsSlot: true, isDraft: true, labels: [] },
-      expected: "teardown",
-    },
-    {
-      name: "deploys drafts wearing the preview label",
-      input: { allowDraft: false, holdsSlot: false, isDraft: true, labels: ["preview"] },
-      expected: "deploy",
-    },
-    {
-      name: "deploys drafts when the caller explicitly allows it",
-      input: { allowDraft: true, holdsSlot: false, isDraft: true, labels: [] },
-      expected: "deploy",
-    },
-  ])("$name", ({ input, expected }) => {
-    expect(decideDraftPreviewPolicy(input)).toBe(expected);
-  });
-
-  test("wires the lifecycle events and the dispatch override into the workflow", () => {
+describe("preview workflow dispatch", () => {
+  test("a manual dispatch redeploys the full fleet", () => {
     const workflow = readFileSync(
       resolve(repoRoot, ".depot/workflows/cloudflare-previews.yml"),
       "utf8",
     );
 
-    // Draft/label transitions must re-run the policy so a PR can claim a
-    // slot (ready_for_review, labeled) or give one back (converted_to_draft,
-    // unlabeled).
-    expect(workflow).toContain("- ready_for_review");
-    expect(workflow).toContain("- converted_to_draft");
-    expect(workflow).toContain("- labeled");
-    expect(workflow).toContain("- unlabeled");
-    // A manual dispatch is an explicit ask for a fresh preview: it bypasses
-    // the draft policy and cannot false-green after cleanup recorded this
-    // exact head as released.
     expect(workflow).toContain(
-      "${{ github.event_name == 'workflow_dispatch' && '--allow-draft --all-apps' || '' }}",
+      "${{ github.event_name == 'workflow_dispatch' && '--all-apps' || '' }}",
     );
   });
 });
@@ -903,8 +861,6 @@ describe("preview test commands", () => {
           pullRequestBody: "",
           pullRequestHeadSha: "head-sha",
           pullRequestHeadRef: "telemetry-branch",
-          pullRequestIsDraft: false,
-          pullRequestLabels: [],
           pullRequestNumber: 2237,
           repositoryFullName: "iterate/iterate",
           workflowRunUrl: "https://github.com/iterate/iterate/actions/runs/123",
@@ -2531,42 +2487,7 @@ describe("lease reclaim verdicts", () => {
 });
 
 describe("preview fleet capacity diagnosis", () => {
-  const { diagnosePreviewFleetCapacity, pullRequestWouldClaimPreviewSlot } = previewInternals;
-
-  test("treats ready PRs and preview-labeled drafts as slot-eligible", () => {
-    expect(pullRequestWouldClaimPreviewSlot({ isDraft: false, labels: [] })).toBe(true);
-    expect(pullRequestWouldClaimPreviewSlot({ isDraft: true, labels: ["preview"] })).toBe(true);
-    expect(pullRequestWouldClaimPreviewSlot({ isDraft: true, labels: [] })).toBe(false);
-  });
-
-  test("does not call a label-less draft slot-less when it actually holds one (--allow-draft)", () => {
-    const diagnosis = diagnosePreviewFleetCapacity({
-      openPullRequests: [
-        {
-          number: 4242,
-          title: "draft dispatched with --allow-draft",
-          url: "https://github.com/iterate/iterate/pull/4242",
-          isDraft: true,
-          labels: [],
-        },
-      ],
-      slots: [
-        {
-          slug: "preview-1",
-          verdict: "active",
-          holder: "pr-4242",
-          pullRequestUrl: "https://github.com/iterate/iterate/pull/4242",
-          pullRequestState: "open",
-          leasedUntil: "2026-07-16T09:20:18.639Z",
-          lastUsedAgo: "2m ago",
-        },
-      ],
-    });
-
-    // It holds a slot, so it must not be reported as "correctly claims no slot".
-    expect(diagnosis.holdersWithOpenPrs).toContain(4242);
-    expect(diagnosis.reasons.some((reason) => reason.includes("claim no slot"))).toBe(false);
-  });
+  const { diagnosePreviewFleetCapacity } = previewInternals;
 
   test("explains a full fleet held mostly by closed PRs despite few open ones", () => {
     const diagnosis = diagnosePreviewFleetCapacity({
@@ -2575,15 +2496,11 @@ describe("preview fleet capacity diagnosis", () => {
           number: 2008,
           title: "ready pr without a slot",
           url: "https://github.com/iterate/iterate/pull/2008",
-          isDraft: false,
-          labels: [],
         },
         {
           number: 1983,
-          title: "draft without opt-in",
+          title: "draft pr without a slot",
           url: "https://github.com/iterate/iterate/pull/1983",
-          isDraft: true,
-          labels: [],
         },
       ],
       slots: [
@@ -2611,7 +2528,7 @@ describe("preview fleet capacity diagnosis", () => {
     expect(diagnosis.availableCount).toBe(0);
     expect(diagnosis.leasedCount).toBe(2);
     expect(diagnosis.orphanedCount).toBe(1);
-    expect(diagnosis.previewEligibleWithoutSlotCount).toBe(1);
+    expect(diagnosis.openWithoutSlotCount).toBe(2);
     expect(diagnosis.reclaimCommands).toEqual(["pnpm preview reclaim --slot preview-1 --force"]);
     expect(diagnosis.reasons.some((reason) => reason.includes("closed/merged"))).toBe(true);
     expect(diagnosis.reasons.some((reason) => reason.includes("#2008"))).toBe(true);

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -56,14 +56,6 @@ type PullRequestCommandOptions = {
   pullRequestNumber?: number;
 };
 
-/** Label a draft PR can wear to get previews despite the draft policy below. */
-const previewOptInLabel = "preview";
-
-const draftPreviewNotice = [
-  "This PR is a draft, so it doesn't claim a preview slot.",
-  `To get previews: add the \`${previewOptInLabel}\` label, mark the PR ready for review, or dispatch the Cloudflare Previews workflow for a one-off run.`,
-].join(" ");
-
 // Cloudflare documents that a Worker/DO code update is globally eventually
 // consistent after the new edge Worker version is serving. A newly addressed
 // Durable Object can therefore still be assigned the prior code for seconds
@@ -75,28 +67,6 @@ const draftPreviewNotice = [
 const previewMinimumDeploymentAgeMs = 90_000;
 const previewRolloutRemainingSecondsEnvironment = "PREVIEW_APP_ROLLOUT_REMAINING_SECONDS";
 
-/**
- * Draft PRs don't hold preview slots unless they ask: there are only nine
- * slots and drafts are the default for agent-opened PRs, so a busy night of
- * drafts was exhausting the fleet before any human asked for a preview.
- * "Asking" = the `preview` label, marking ready for review, or an explicit
- * `--allow-draft` run (the workflow_dispatch path). A draft that still holds
- * a slot per the semaphore (it was ready once, or opted out again) gives it
- * back.
- */
-function decideDraftPreviewPolicy(input: {
-  allowDraft: boolean;
-  holdsSlot: boolean;
-  isDraft: boolean;
-  labels: string[];
-}): "deploy" | "skip" | "teardown" {
-  if (!input.isDraft || input.allowDraft || input.labels.includes(previewOptInLabel)) {
-    return "deploy";
-  }
-
-  return input.holdsSlot ? "teardown" : "skip";
-}
-
 type DeployCommandOptions = PullRequestCommandOptions & {
   /**
    * Deploy every preview app regardless of the diff. Diff selection only
@@ -106,13 +76,6 @@ type DeployCommandOptions = PullRequestCommandOptions & {
    * happening to touch a fleet-shared path.
    */
   allApps?: boolean;
-  /**
-   * Deploy even when the PR is a draft without the `preview` label. Draft
-   * PRs otherwise skip previews (or give their slot back); an explicit
-   * invocation — workflow_dispatch, the flake-hunt marathon, a human at a
-   * terminal — is an ask, so those callers pass this.
-   */
-  allowDraft?: boolean;
 };
 
 /** One PR context + runtime shared by every phase of a preview command. */
@@ -303,7 +266,7 @@ export async function testTarget(options: TestTargetOptions) {
  * structurally gone. The lease is shared through the semaphore itself (same
  * holder; test's adopt re-issues the slot deploy just claimed), never
  * through a handed-around copy. A deploy failure throws before any test
- * runs; a draft skip skips both phases.
+ * runs.
  */
 export async function run(options: DeployCommandOptions = {}) {
   const { context, runtime } = await resolvePreviewCommandSetup(options);
@@ -311,10 +274,6 @@ export async function run(options: DeployCommandOptions = {}) {
     const deployResult = await measurePreviewDeployRun(telemetry, () =>
       deployPreviewApps({ context, options, runtime, telemetry }),
     );
-    if ("skippedReason" in deployResult && deployResult.skippedReason === "draft") {
-      return deployResult;
-    }
-
     // A "nothing to deploy" skip still tests. Unchanged apps may reuse their
     // exact recorded Worker versions, but every PR head earns its own e2e
     // result; a previous head's green is never promoted to this check.
@@ -433,61 +392,8 @@ async function deployPreviewApps({
       : "PR body shows no slot — this PR has not recorded a deploy yet",
   );
 
-  // The semaphore is the single source of lease truth: the draft policy's
-  // "does this PR hold a slot?" question goes there, not to the PR body,
-  // whose copy can be stale (a cancelled run can claim without recording).
   const semaphore = runtime.createPreviewSemaphoreResourceClient();
   const holder = pullRequestHolder(context.pullRequestNumber);
-  const heldSlots = await listSlotsLeasedToHolder(semaphore, holder);
-  const draftPolicy = decideDraftPreviewPolicy({
-    allowDraft: options.allowDraft === true,
-    holdsSlot: heldSlots.length > 0,
-    isDraft: context.pullRequestIsDraft,
-    labels: context.pullRequestLabels,
-  });
-  if (draftPolicy === "skip") {
-    logPreview(
-      `draft PR without the ${previewOptInLabel} label — not claiming a preview slot (mark ready, add the label, or pass --allow-draft)`,
-    );
-    const update = await updatePreviewState(context, (state) => ({
-      ...state,
-      notice: draftPreviewNotice,
-    }));
-    return {
-      ok: true,
-      skipped: true,
-      skippedReason: "draft",
-      state: update.state,
-    };
-  }
-  if (draftPolicy === "teardown") {
-    logPreview(
-      `draft PR without the ${previewOptInLabel} label holds ${heldSlots.map((slot) => slot.slug).join(", ")} — tearing down and releasing the slot (mark ready, add the label, or pass --allow-draft to keep previews)`,
-    );
-    const cleanupResult = await cleanupPreviewForPullRequest({ ...runtime, context });
-    if (!cleanupResult.ok) {
-      // ok=false means the lease RELEASE failed (a failed teardown alone
-      // still releases and reports ok — see cleanupPreviewForPullRequest).
-      throw new Error("Failed to release the draft PR's preview slot lease.");
-    }
-    // Pin the post-teardown state in this write: the GitHub read inside
-    // updatePreviewState can be stale (read-after-write lag) and would
-    // otherwise resurrect the released lease and app rows — and this run's
-    // test step would then re-acquire the slot the draft just gave up.
-    const update = await updatePreviewState(context, (state) => ({
-      ...state,
-      ...cleanupResult.state,
-      notice: draftPreviewNotice,
-    }));
-    return {
-      ok: true,
-      skipped: true,
-      skippedReason: "draft",
-      releasedLease: cleanupResult.released,
-      state: update.state,
-    };
-  }
-
   const selectedApps = options.allApps
     ? (logPreview("--all-apps: deploying the full preview fleet regardless of diff"),
       Object.values(cloudflarePreviewApps))
@@ -1277,7 +1183,7 @@ export async function assign(options: AssignOptions = {}) {
 /**
  * Show environment config lease inventory, cross-check holders against GitHub
  * PR state, and explain why the fleet can look full even when only a handful
- * of PRs are open (orphaned closed-PR leases, idle holds, draft opt-ins, …).
+ * of PRs are open (orphaned closed-PR leases, idle holds, manual holds, …).
  *
  *   doppler run --project _shared --config prd -- pnpm preview status
  */
@@ -1326,9 +1232,6 @@ export async function status(options: StatusOptions = {}) {
       number: pullRequest.number,
       title: pullRequest.title,
       url: pullRequest.url,
-      isDraft: pullRequest.isDraft,
-      labels: pullRequest.labels,
-      previewEligible: pullRequestWouldClaimPreviewSlot(pullRequest),
       holdsSlot: diagnosis.holdersWithOpenPrs.includes(pullRequest.number),
     })),
     diagnosis,
@@ -2839,8 +2742,6 @@ type PullRequestPreviewContext = {
   pullRequestBody: string;
   pullRequestHeadSha: string;
   pullRequestHeadRef?: string;
-  pullRequestIsDraft: boolean;
-  pullRequestLabels: string[];
   pullRequestNumber: number;
   repositoryFullName: string;
   workflowRunUrl: string | null;
@@ -4713,21 +4614,7 @@ type PreviewDiagnosisOpenPullRequest = {
   number: number;
   title: string;
   url: string;
-  isDraft: boolean;
-  labels: string[];
 };
-
-/**
- * Draft PRs only claim a slot when they opt in (same policy as deploy). Used
- * by `preview status` so "9 open PRs" is not compared apples-to-oranges with
- * the 9-slot fleet.
- */
-function pullRequestWouldClaimPreviewSlot(pullRequest: {
-  isDraft: boolean;
-  labels: readonly string[];
-}): boolean {
-  return !pullRequest.isDraft || pullRequest.labels.includes(previewOptInLabel);
-}
 
 type PreviewDiagnosisSlot = {
   slug: string;
@@ -4755,17 +4642,8 @@ function diagnosePreviewFleetCapacity(input: {
   const holdersWithOpenPrs = input.openPullRequests
     .map((pullRequest) => pullRequest.number)
     .filter((number) => leased.some((slot) => parsePullRequestHolder(slot.holder) === number));
-  const previewEligibleOpen = input.openPullRequests.filter(pullRequestWouldClaimPreviewSlot);
-  const previewEligibleWithoutSlot = previewEligibleOpen.filter(
+  const openWithoutSlot = input.openPullRequests.filter(
     (pullRequest) => !holdersWithOpenPrs.includes(pullRequest.number),
-  );
-  // Drafts that opted in via a one-shot `--allow-draft` dispatch hold a slot
-  // without the label, so exclude any that actually hold one — otherwise we'd
-  // tell the operator it "correctly claims no slot" next to holdsSlot: true.
-  const openButIneligible = input.openPullRequests.filter(
-    (pullRequest) =>
-      !pullRequestWouldClaimPreviewSlot(pullRequest) &&
-      !holdersWithOpenPrs.includes(pullRequest.number),
   );
   const closedHolders = leased.filter((slot) => slot.pullRequestState === "closed");
   const nonPrHolders = leased.filter((slot) => parsePullRequestHolder(slot.holder) === null);
@@ -4800,16 +4678,9 @@ function diagnosePreviewFleetCapacity(input: {
         .join(", ")}.`,
     );
   }
-  if (previewEligibleWithoutSlot.length > 0) {
+  if (openWithoutSlot.length > 0) {
     reasons.push(
-      `${previewEligibleWithoutSlot.length} open preview-eligible PR(s) have no slot: ${previewEligibleWithoutSlot
-        .map((pullRequest) => `#${pullRequest.number}`)
-        .join(", ")}.`,
-    );
-  }
-  if (openButIneligible.length > 0) {
-    reasons.push(
-      `${openButIneligible.length} open draft PR(s) without the \`${previewOptInLabel}\` label correctly claim no slot: ${openButIneligible
+      `${openWithoutSlot.length} open PR(s) have no slot: ${openWithoutSlot
         .map((pullRequest) => `#${pullRequest.number}`)
         .join(", ")}.`,
     );
@@ -4818,10 +4689,10 @@ function diagnosePreviewFleetCapacity(input: {
     input.openPullRequests.length > 0 &&
     closedHolders.length === 0 &&
     available.length === 0 &&
-    previewEligibleOpen.length <= input.slots.length
+    input.openPullRequests.length <= input.slots.length
   ) {
     reasons.push(
-      `Open-PR count alone (${input.openPullRequests.length} open, ${previewEligibleOpen.length} preview-eligible) does not explain a full fleet — check idle/manual holders above.`,
+      `Open-PR count alone (${input.openPullRequests.length} open) does not explain a full fleet — check idle/manual holders above.`,
     );
   }
 
@@ -4834,9 +4705,7 @@ function diagnosePreviewFleetCapacity(input: {
     closedHolders.length > 0 ? `${closedHolders.length} orphaned (closed PR)` : null,
     idle.length > 0 ? `${idle.length} idle` : null,
     active.length > 0 ? `${active.length} active` : null,
-    previewEligibleWithoutSlot.length > 0
-      ? `${previewEligibleWithoutSlot.length} open PR(s) waiting for a slot`
-      : null,
+    openWithoutSlot.length > 0 ? `${openWithoutSlot.length} open PR(s) waiting for a slot` : null,
   ].filter(Boolean);
 
   return {
@@ -4846,8 +4715,7 @@ function diagnosePreviewFleetCapacity(input: {
     idleCount: idle.length,
     activeCount: active.length,
     openPullRequestCount: input.openPullRequests.length,
-    previewEligibleOpenCount: previewEligibleOpen.length,
-    previewEligibleWithoutSlotCount: previewEligibleWithoutSlot.length,
+    openWithoutSlotCount: openWithoutSlot.length,
     holdersWithOpenPrs,
     nextLeaseExpiryAt:
       leased
@@ -4876,10 +4744,6 @@ async function listOpenPullRequestsForPreviewDiagnosis(
     number: pullRequest.number,
     title: pullRequest.title,
     url: pullRequest.html_url,
-    isDraft: Boolean(pullRequest.draft),
-    labels: (pullRequest.labels ?? [])
-      .map((label) => (typeof label === "string" ? label : label.name))
-      .filter((name): name is string => typeof name === "string" && name.length > 0),
   }));
 }
 
@@ -6183,8 +6047,6 @@ async function resolvePullRequestPreviewContext(params: {
     pullRequestBody: pullRequest.data.body || "",
     pullRequestHeadSha: pullRequest.data.head.sha,
     pullRequestHeadRef: pullRequest.data.head.ref,
-    pullRequestIsDraft: pullRequest.data.draft === true,
-    pullRequestLabels: pullRequest.data.labels.map((label) => label.name),
     pullRequestNumber: params.pullRequestNumber,
     repositoryFullName,
     workflowRunUrl:
@@ -6211,7 +6073,6 @@ export const previewInternals = {
   claimEnvironmentConfigLease,
   classifyEnvironmentConfigLeases,
   classifyLeaseForReclaim,
-  decideDraftPreviewPolicy,
   describeEnvironmentConfigLeases,
   describeForcePushCompareHazard,
   describeLostSlotOwnership,
@@ -6220,7 +6081,6 @@ export const previewInternals = {
   evaluateCloudflareZoneCheck,
   holderPullRequestUrl,
   pullRequestHolder,
-  pullRequestWouldClaimPreviewSlot,
   requireExplicitReclaimForce,
   retakeRecordedSlotIfFree,
   resolveSlotWaitTotalMs,

--- a/tasks/complete/2026-08-10-remove-draft-preview-policy.md
+++ b/tasks/complete/2026-08-10-remove-draft-preview-policy.md
@@ -1,0 +1,36 @@
+---
+status: done
+size: small
+---
+
+# Remove the draft-PR preview skip and the `preview` label
+
+Draft PRs currently skip preview deploy + e2e unless they wear the `preview`
+label, are marked ready, or a human dispatches with `--allow-draft`. Misha:
+"get rid of the draft-doesnt-get-preview thing it's too annoying" — and remove
+the `preview` label logic and everything downstream of it.
+
+Rationale: the policy dated from a nine-slot fleet that a busy bedtime of
+agent-opened drafts could exhaust. The fleet is nineteen slots now, and the
+policy costs more in confusion (PRs silently without previews) than it saves
+in capacity. If contention returns, `tasks/stealable-preview-leases.md` is the
+finer-grained fix.
+
+## Checklist
+
+- [x] remove `decideDraftPreviewPolicy`, the skip/teardown branches, `previewOptInLabel`, the draft PR-body notice, and `--allow-draft` from `scripts/preview/preview.ts` _— deploy now always claims a slot; dispatch keeps `--all-apps` only_
+- [x] drop draft/label lifecycle triggers (`ready_for_review`, `converted_to_draft`, `labeled`, `unlabeled`) and the label-filter job `if:` from `.depot/workflows/cloudflare-previews.yml` _— `opened`/`reopened`/`synchronize` suffice_
+- [x] simplify `preview status` diagnosis: no more "preview-eligible" split _— `previewEligibleWithoutSlotCount` → `openWithoutSlotCount`; open-PR listing no longer fetches draft/label state_
+- [x] update tests _— deleted the policy suite; kept a dispatch `--all-apps` assertion; diagnosis fixtures simplified_
+- [x] docs: CLAUDE.md, README.md, docs/pull-requests.md, docs/dev-environments.md, docs/adding-preview-slots.md _— canary runbook no longer labels drafts_
+- [x] mark `tasks/stealable-preview-leases.md` as premise-removed _— status: maybe, only relevant if slot contention returns_
+
+## Implementation notes
+
+- The workflow's `on:` triggers are registered from the default branch, so
+  drafts start getting previews once this merges. The preview *script* runs
+  from the PR head though, so this PR itself deploys a preview despite being
+  a draft — self-demonstrating.
+- Existing `preview`-labeled PRs are unaffected; the label just becomes inert.
+- `pr-dashboard.yml` keeps its `converted_to_draft` trigger — that's for the
+  dashboard, unrelated to the preview policy.

--- a/tasks/stealable-preview-leases.md
+++ b/tasks/stealable-preview-leases.md
@@ -1,9 +1,16 @@
 ---
-status: ready
+status: maybe
 size: medium
 ---
 
 # Stealable preview leases for draft PRs
+
+> **Update 2026-08-10:** the v1 draft-skip policy (and the `preview` opt-in
+> label, `--allow-draft`, `decideDraftPreviewPolicy`) was removed outright —
+> every open PR now gets previews, draft or not. That deletes this task's
+> premise and its "revert v1" checklist items. The stealing idea only becomes
+> relevant again if slot contention returns; the draft/ready split would then
+> need a different priority signal since drafts are no longer second-class.
 
 Follow-up to `tasks/complete/2026-07-07-draft-prs-no-preview-lease.md` (PR
 #1720), which is the blunt v1: draft PRs skip previews entirely unless they


### PR DESCRIPTION
Every open PR now gets a preview deployment + e2e, draft or not. The draft-skip policy, the `preview` opt-in label, and `--allow-draft` are gone.

Before:

> This PR is a draft, so it doesn't claim a preview slot. To get previews: add the `preview` label, mark the PR ready for review, or dispatch the Cloudflare Previews workflow…

After: drafts just deploy, like any PR.

## What's removed

- `decideDraftPreviewPolicy` and its skip/teardown branches in `scripts/preview/preview.ts`, plus the `preview` label constant, the draft PR-body notice, and the `--allow-draft` flag (dispatch keeps `--all-apps`).
- The `ready_for_review` / `converted_to_draft` / `labeled` / `unlabeled` triggers and the label-filter job `if:` in `cloudflare-previews.yml` — `opened`/`reopened`/`synchronize` cover everything now.
- The "preview-eligible" split in `preview status`: `previewEligibleWithoutSlotCount` → `openWithoutSlotCount`; the open-PR listing no longer fetches draft/label state.
- Docs mentions across CLAUDE.md, README, pull-requests, dev-environments, and the adding-preview-slots canary runbook.

## Notes

- The policy dated from a nine-slot fleet; at nineteen slots it cost more in confusion than it saved in capacity. If contention returns, `tasks/stealable-preview-leases.md` (now marked premise-removed) is the finer-grained fix.
- Trigger types register from the default branch, so the trimmed `on:` block takes effect on merge. The preview *script* runs from the PR head, so this draft PR should claim a slot and deploy — self-demonstrating.
- Existing `preview`-labeled PRs are unaffected; the label becomes inert.

Session: `7982ae17-6922-440f-a039-9e23d5c2713a`

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +6 -89 | +6 -77 🟥🟥🟥⬜⬜ |
| CI & scripts | +12 -168 | +10 -115 🟥🟥🟥🟥🟥 |
| Docs | +61 -39 | +53 -37 🟩🟩🟥🟥⬜ |
| **Total** | **+79 -296** | **+69 -229** 🟩🟥🟥🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 93932be and 2ee1cbf, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-10T13:12:55.724Z",
      "deployedAt": "2026-08-10T12:21:35.738Z",
      "headSha": "2ee1cbfe39de78363a0ca0e6dc6b5861e7e88764",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/183305037681749",
      "shortSha": "2ee1cbf",
      "cleanupDurationMs": 12050,
      "deployDurationMs": 76266,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 74315,
      "deployReadinessDurationMs": 1949,
      "deployedWorkerName": "os-preview-11",
      "deployedWorkerVersion": "a4c21bcb-6e9c-43e6-90c7-9d30f1a271bb",
      "testDurationMs": 235694,
      "testRetries": null,
      "workerSizeKib": 20749.27,
      "workerGzipKib": 5220.17,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5231.55
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-10T13:12:47.463Z",
      "deployedAt": "2026-08-10T12:20:52.506Z",
      "headSha": "2ee1cbfe39de78363a0ca0e6dc6b5861e7e88764",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-11.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/183305037681749",
      "shortSha": "2ee1cbf",
      "cleanupDurationMs": 3786,
      "deployDurationMs": 32499,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 31081,
      "deployReadinessDurationMs": 1415,
      "deployedWorkerName": "docs-preview-11",
      "deployedWorkerVersion": "90930dfa-00a1-495e-ad89-9019d1ee5ac1",
      "testDurationMs": 2348,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-08-10T13:12:44.507Z",
      "deployedAt": "2026-08-10T12:20:51.177Z",
      "headSha": "2ee1cbfe39de78363a0ca0e6dc6b5861e7e88764",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/183305037681749",
      "shortSha": "2ee1cbf",
      "cleanupDurationMs": 829,
      "deployDurationMs": 29990,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 29750,
      "deployReadinessDurationMs": 235,
      "deployedWorkerName": "semaphore-preview-11",
      "deployedWorkerVersion": "2a7476b6-240b-48ec-85f3-93ae3404ea99",
      "testDurationMs": 64642,
      "testRetries": null,
      "workerSizeKib": 1915.51,
      "workerGzipKib": 441.08,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-10T13:12:48.518Z",
      "deployedAt": "2026-08-10T12:21:00.576Z",
      "headSha": "2ee1cbfe39de78363a0ca0e6dc6b5861e7e88764",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/183305037681749",
      "shortSha": "2ee1cbf",
      "cleanupDurationMs": 4837,
      "deployDurationMs": 39439,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 39148,
      "deployReadinessDurationMs": 286,
      "deployedWorkerName": "auth-preview-11",
      "deployedWorkerVersion": "c0eea793-e10a-4bbf-9bc2-57d2dd9796a0",
      "testDurationMs": 12857,
      "testRetries": null,
      "workerSizeKib": 3981.51,
      "workerGzipKib": 815.61,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-08-10T13:12:52.812Z",
      "deployedAt": "2026-08-10T12:20:47.734Z",
      "headSha": "2ee1cbfe39de78363a0ca0e6dc6b5861e7e88764",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/183305037681749",
      "shortSha": "2ee1cbf",
      "cleanupDurationMs": 9129,
      "deployDurationMs": 27010,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 26304,
      "deployReadinessDurationMs": 698,
      "deployedWorkerName": "streams-example-app-preview-11",
      "deployedWorkerVersion": "88ea71cc-8c54-4d9b-9840-55d4983b7e59",
      "testDurationMs": 93392,
      "testRetries": "1 retried: stream-browser.spec.ts › scroll to bottom affordance counts new events while away from tail › chromium (playwright x1) — Error: \u001b[2mexpect(\u001b[22m\u001b[31mlocator\u001b[39m\u001b[2m).\u001b[22mtoBeVisible\u001b[2m(\u001b[22m\u001b[2m)\u001b[22m failed Locator: locator('[data-testid=\\'event-meta\\']').filter({ hasText: 'events.iterate.com/stream/created' }).first() Expected: visible Timeout: 15000ms Error: element(s) not found Call log: \u001b[2m - Expect \"toBeV...",
      "workerSizeKib": 5490.8,
      "workerGzipKib": 1550.3,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-10T13:12:45.911Z",
      "deployedAt": "2026-08-10T12:20:54.576Z",
      "headSha": "2ee1cbfe39de78363a0ca0e6dc6b5861e7e88764",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/183305037681749",
      "shortSha": "2ee1cbf",
      "cleanupDurationMs": 1404,
      "deployDurationMs": 6369,
      "deployConfigDurationMs": 1,
      "deployCommandDurationMs": 6139,
      "deployReadinessDurationMs": 226,
      "deployedWorkerName": "dummy-petshop-preview-11",
      "deployedWorkerVersion": "76c43c69-7243-48dc-825e-d9d3a843b6a6",
      "testDurationMs": 50660,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `2ee1cbf` | [https://auth.iterate-preview-11.com](https://auth.iterate-preview-11.com) | 815.6 KiB | 39.4s | 12.9s |  | 4.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/183305037681749) | 2026-08-10T13:12:48.518Z | Preview app released. |
| Docs | released | `2ee1cbf` | [https://docs-preview-11.iterate-dev-preview.workers.dev](https://docs-preview-11.iterate-dev-preview.workers.dev) | 866.2 KiB | 32.5s | 2.3s |  | 3.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/183305037681749) | 2026-08-10T13:12:47.463Z | Preview app released. |
| Dummy Petshop | released | `2ee1cbf` | [https://dummy-petshop.iterate-preview-11.com](https://dummy-petshop.iterate-preview-11.com) | 198.3 KiB | 6.4s | 50.7s |  | 1.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/183305037681749) | 2026-08-10T13:12:45.911Z | Preview app released. |
| OS | released | `2ee1cbf` | [https://os.iterate-preview-11.com](https://os.iterate-preview-11.com) | 5.10 MiB (-11.4 KiB vs main) | 76.3s | 235.7s |  | 12.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/183305037681749) | 2026-08-10T13:12:55.724Z | Preview app released. |
| Semaphore | released | `2ee1cbf` | [https://semaphore.iterate-preview-11.com](https://semaphore.iterate-preview-11.com) | 441.1 KiB | 30.0s | 64.6s |  | 829ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/183305037681749) | 2026-08-10T13:12:44.507Z | Preview app released. |
| Streams Example App | released | `2ee1cbf` | [https://streams.iterate-preview-11.com](https://streams.iterate-preview-11.com) | 1.51 MiB | 27.0s | 93.4s | 1 retried: stream-browser.spec.ts › scroll to bottom affordance counts new events while away from tail › chromium (playwright x1) — Error: [2mexpect([22m[31mlocator[39m[2m).[22mtoBeVisible[2m([22m[2m)[22m failed Locator: locator('[data-testid=\'event-meta\']').filter({ hasText: 'events.iterate.com/stream/created' }).first() Expected: visible Timeout: 15000ms Error: element(s) not found Call log: [2m - Expect "toBeV... | 9.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/183305037681749) | 2026-08-10T13:12:52.812Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Operational change: draft PRs will consume preview slots and CI time, which can increase fleet contention despite nineteen slots; the deploy path is simpler but behavior for many concurrent drafts shifts materially.
> 
> **Overview**
> **Every open PR** (draft or ready) now goes through the normal preview deploy + e2e path. The old opt-in model—`preview` label, ready-for-review, or `--allow-draft`—is removed end to end.
> 
> In **`scripts/preview/preview.ts`**, `decideDraftPreviewPolicy`, draft skip/teardown in deploy/`run`, the PR-body draft notice, and **`--allow-draft`** are deleted. PR context no longer loads draft or label fields. **`preview status`** diagnosis drops the “preview-eligible” split and reports **`openWithoutSlotCount`** instead.
> 
> **`.depot/workflows/cloudflare-previews.yml`** only triggers on `opened` / `reopened` / `synchronize` (no label or draft lifecycle events), removes the label-filter job `if`, and keeps manual dispatch as **`--all-apps`** only.
> 
> Docs and the adding-preview-slots canary runbook are updated; **`tasks/stealable-preview-leases.md`** is marked premise-removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ee1cbfe39de78363a0ca0e6dc6b5861e7e88764. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->