### PR TITLE
Fix mobile approval specs: restore the Notifications drawer item

### DIFF
--- a/apps/mobile/src/components/project-drawer.tsx
+++ b/apps/mobile/src/components/project-drawer.tsx
@@ -71,7 +71,8 @@ function DrawerButton({ project }: { project: { projectId: string; projectSlug: 
         | "/project/[projectId]"
         | "/project/[projectId]/repos"
         | "/project/[projectId]/integrations"
-        | "/project/[projectId]/media",
+        | "/project/[projectId]/media"
+        | "/project/[projectId]/notifications",
     ) =>
     () => {
       // Only rendered inside the project !== null branch below; the guard is
@@ -159,6 +160,10 @@ function DrawerButton({ project }: { project: { projectId: string; projectSlug: 
                     <DrawerItem
                       label="/media"
                       onPress={() => close(projectRoute("/project/[projectId]/media"))}
+                    />
+                    <DrawerItem
+                      label="/notifications"
+                      onPress={() => close(projectRoute("/project/[projectId]/notifications"))}
                     />
                     <View style={styles.separator} />
                     <DrawerItem

--- a/specs/mobile/approvals.spec.ts
+++ b/specs/mobile/approvals.spec.ts
@@ -287,7 +287,7 @@ test("approve and reject script bursts from inside the chat thread", async ({ pa
     // thread.
     await page.goBack(); // chat → chat list: browser history IS the app's back stack on web
     await page.getByLabel("Open project menu").filter({ visible: true }).click();
-    await page.getByRole("button", { name: "Notifications" }).click();
+    await page.getByRole("button", { name: "/notifications" }).click();
     // Main also journals each scripted outcome message as an "Agent replied"
     // notification. Select only the approval-batch rows: newest first, the
     // reject burst sits above the approve burst.

--- a/specs/mobile/notifications.spec.ts
+++ b/specs/mobile/notifications.spec.ts
@@ -214,7 +214,7 @@ test("the approval push is suppressed in the watched thread and sent when you're
     // reads as a clipped drawer to a reviewer). The product is fine: given a
     // beat, the panel settles at translateX(0) at this exact viewport. Wait
     // for the item to stop moving before pressing.
-    const notificationsItem = page.getByRole("button", { name: "Notifications" });
+    const notificationsItem = page.getByRole("button", { name: "/notifications" });
     await notificationsItem.waitFor();
     await expect
       .poll(async () => {


### PR DESCRIPTION
## What broke

Every open PR's **Cloudflare Previews / Preview / deploy + e2e** check is red on the same two mobile specs, deterministically (retry included):

- `specs/mobile/approvals.spec.ts:40` — `TimeoutError … waiting for getByRole('button', { name: 'Notifications' })`
- `specs/mobile/notifications.spec.ts:42` — same locator, `.waitFor` variant

Two PRs merged into main within an hour of each other and integrated badly:

- **#2453** (`69f7a4dba`, integrations view) reworked the project drawer to path-style labels (`/agents`, `/integrations`, `/repos`) and **dropped the Notifications item entirely**.
- **#2460** (`f83499aa3`) restored the two approval-delivery specs, which reach the Notifications view through that drawer item.

Each was green against its own base; together the specs wait forever for a button that no longer exists.

## Why fix the product, not just the specs

The drawer item was the Notifications view's only in-app entry point. #2460 made Notifications the project's **entire approvals surface** (the standalone Approvals screen is retired — open egress batches are decided in the row expansions). After #2453 the only route in was a push deep-link — and the web build has no push channel at all, so on web the screen was unreachable, full stop. Dropping it looks accidental: #2453's own description frames the change as replacing the retired Examples screen and renaming the group, not retiring approvals.

So:

- **Product**: restore the drawer item, wearing the drawer's new path-style convention — `/notifications`, routed to `/project/[projectId]/notifications`.
- **Specs**: point the two locators at that exact label, the same way `integrations.spec.ts` already asserts `/agents` and `/repos`. (Playwright's substring name matching means the old `"Notifications"` locators would also have passed, but exact-label consistency is clearer.)

## Verification

- `pnpm typecheck`, `lint`, `knip`, `format` — clean
- `apps/mobile` unit tests — 115 passed
- Both failing specs run locally against the dev server + Expo Web (result noted in a comment below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session id: `e89f2eb5-b303-47df-9e5d-5033942f37d8` (subagent)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small navigation and test-only changes with no auth, data, or backend impact; restores an in-app entry point that specs already depend on.
> 
> **Overview**
> Restores the **Notifications** route in the project drawer after it was dropped during the path-style drawer rework, so users (especially on web without push deep links) can open the project notifications view again.
> 
> The drawer adds a **`/notifications`** item that navigates to **`/project/[projectId]/notifications`**, matching labels like **`/agents`** and **`/integrations`**. Mobile e2e specs **`approvals.spec.ts`** and **`notifications.spec.ts`** now click **`getByRole('button', { name: '/notifications' })`** instead of waiting for a **`Notifications`** label that no longer exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3e1e16527c847ad1e09e099dbec9a3267f5c209. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Mobile | +6 -1 | +4 -1 🟩🟩🟩🟩🟥 |
| Tests | +2 -2 | +2 -2 🟩🟩🟥🟥⬜ |
| **Total** | **+8 -3** | **+6 -3** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between f83499a and d3e1e16, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-10T17:44:05.317Z",
      "deployedAt": "2026-08-10T17:32:33.876Z",
      "headSha": "d3e1e16527c847ad1e09e099dbec9a3267f5c209",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/334355882738343",
      "shortSha": "d3e1e16",
      "cleanupDurationMs": 11694,
      "deployDurationMs": 121401,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 107759,
      "deployReadinessDurationMs": 13639,
      "deployedWorkerName": "os-preview-7",
      "deployedWorkerVersion": "0172ce40-a771-479d-af8a-fcf3b3891b2e",
      "testDurationMs": 247249,
      "testRetries": "2 retried: a second project's onboarding turn is served from the AI Gateway cache (vitest x1) — expected { cacheStatus: 'HIT', …(1) } to match object { Object (greeting) } (1 matching property omitted from actual) · workspaces are one namespace: repos auto-mount at /repos/**, scratch lives at the workspace's own path, commits route per mount (vitest x1) — Network connection lost.",
      "workerSizeKib": 20757.3,
      "workerGzipKib": 5223.1,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5234.4
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-10T17:43:56.518Z",
      "deployedAt": "2026-08-10T17:31:01.152Z",
      "headSha": "d3e1e16527c847ad1e09e099dbec9a3267f5c209",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-7.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/334355882738343",
      "shortSha": "d3e1e16",
      "cleanupDurationMs": 2892,
      "deployDurationMs": 38895,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 15033,
      "deployReadinessDurationMs": 23858,
      "deployedWorkerName": "docs-preview-7",
      "deployedWorkerVersion": "9278a937-37ab-4e5f-ac6a-79c0d369ecf8",
      "testDurationMs": 2225,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-10T17:43:57.736Z",
      "deployedAt": "2026-08-10T17:31:06.985Z",
      "headSha": "d3e1e16527c847ad1e09e099dbec9a3267f5c209",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/334355882738343",
      "shortSha": "d3e1e16",
      "cleanupDurationMs": 4109,
      "deployDurationMs": 20953,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 20865,
      "deployReadinessDurationMs": 84,
      "deployedWorkerName": "auth-preview-7",
      "deployedWorkerVersion": "bc0386cf-b03c-4cd4-b246-849b650fa40b",
      "testDurationMs": 10974,
      "testRetries": null,
      "workerSizeKib": 3981.5,
      "workerGzipKib": 815.63,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-10T17:43:54.442Z",
      "deployedAt": "2026-08-10T17:30:52.424Z",
      "headSha": "d3e1e16527c847ad1e09e099dbec9a3267f5c209",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/334355882738343",
      "shortSha": "d3e1e16",
      "cleanupDurationMs": 812,
      "deployDurationMs": 6365,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 6268,
      "deployReadinessDurationMs": 56,
      "deployedWorkerName": "dummy-petshop-preview-7",
      "deployedWorkerVersion": "532b64ee-1700-4c6a-9aa8-f44422fd4be5",
      "testDurationMs": 6109,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `d3e1e16` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 815.6 KiB | 21.0s | 11.0s |  | 4.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/334355882738343) | 2026-08-10T17:43:57.736Z | Preview app released. |
| Docs | released | `d3e1e16` | [https://docs-preview-7.iterate-dev-preview.workers.dev](https://docs-preview-7.iterate-dev-preview.workers.dev) | 866.2 KiB | 38.9s | 2.2s |  | 2.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/334355882738343) | 2026-08-10T17:43:56.518Z | Preview app released. |
| Dummy Petshop | released | `d3e1e16` | [https://dummy-petshop.iterate-preview-7.com](https://dummy-petshop.iterate-preview-7.com) | 198.3 KiB | 6.4s | 6.1s |  | 812ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/334355882738343) | 2026-08-10T17:43:54.442Z | Preview app released. |
| OS | released | `d3e1e16` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 5.10 MiB (-11.3 KiB vs main) | 121.4s | 247.2s | 2 retried: a second project's onboarding turn is served from the AI Gateway cache (vitest x1) — expected { cacheStatus: 'HIT', …(1) } to match object { Object (greeting) } (1 matching property omitted from actual) · workspaces are one namespace: repos auto-mount at /repos/**, scratch lives at the workspace's own path, commits route per mount (vitest x1) — Network connection lost. | 11.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/334355882738343) | 2026-08-10T17:44:05.317Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- mobile-pr-preview -->
## 📱 Mobile preview

Channel `fix-mobile-notifications-button-specs` · runtime `1bf9f0fe0` · **native changes** — needs a fresh install

<details><summary>OTA — switch the installed app to this PR's channel (`d3e1e16`)</summary>

**[Switch this phone to the PR channel](https://os.iterate-preview-7.com/m/preview-channel/fix-mobile-notifications-button-specs?env=preview_7&email=pr2472%2Btest%40nustom.com)**

<a href="https://os.iterate-preview-7.com/m/preview-channel/fix-mobile-notifications-button-specs?env=preview_7&email=pr2472%2Btest%40nustom.com"><img src="https://github.com/iterate/iterate/releases/download/gh-attach-assets/mobile-pr-2472-d3e1e1652-preview_7-ota-scheme.png" width="90" alt="QR code" /></a>

</details>
<details open><summary>Full install — if the app is uninstalled or the runtime differs (`09cb766`)</summary>

**[Open the EAS build install page](https://expo.dev/accounts/mishanustom/projects/iterate/builds/9623bb11-70cc-4263-9f7e-e0c6b95eb209)**

<a href="https://expo.dev/accounts/mishanustom/projects/iterate/builds/9623bb11-70cc-4263-9f7e-e0c6b95eb209"><img src="https://github.com/iterate/iterate/releases/download/gh-attach-assets/mobile-pr-2472-d3e1e1652-install-9623bb11.png" width="90" alt="QR code" /></a>

</details>

<sub>Back to main inside the app: Build info → Reset to default channel. Republishes on every push to this PR.</sub>
<!-- /mobile-pr-preview -->