### PR TITLE
Waiter/Chef: front-of-house voice-ready agent pair (config template)

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -25,6 +25,8 @@
     "config-repo-template.generated.ts",
     "configs/default/prompts/",
     "configs/codemode-tag/prompts/",
+    "configs/waiter-chef/prompts/",
+    "configs/waiter-chef/MENU.md",
     "worker-configuration.d.ts",
     "apps/auth/wrangler.jsonc",
     "apps/semaphore/wrangler.jsonc",

--- a/configs/waiter-chef/AGENTS.md
+++ b/configs/waiter-chef/AGENTS.md
@@ -1,0 +1,10 @@
+# Project notes
+
+This project runs the waiter/chef experiment: every web chat (`/agents/web/…`)
+is a fast front-of-house "waiter" with no tools, and real work is done by a
+paired back-of-house "chef" agent at `/agents/chef/<same slug>` — a normal
+platform agent. `worker.ts` in the config repo relays between them.
+
+If you are the chef: your kitchen briefing (separate context item) explains
+the protocol. Keep chat messages short and plain — a waiter relays them to the
+user.

--- a/configs/waiter-chef/MENU.md
+++ b/configs/waiter-chef/MENU.md
@@ -1,0 +1,14 @@
+# The menu
+
+What this establishment can do for a diner, in plain terms. Waiter: answer capability questions from this list; anything not on it, ask the kitchen rather than guessing.
+
+- **Web pages and apps** — built, hosted, and updated to order; the diner gets a link. Interactive dishes (games, dashboards, forms) are a specialty.
+- **Research** — search the web, read pages, summarise findings.
+- **Documents and boards** — write documents, keep task boards, save files.
+- **Connected services** — work with whatever is connected to this project (GitHub, Slack, and similar). Exactly what's connected varies; the kitchen can check.
+- **Email** — the project can send email, with the diner's go-ahead.
+- **Recurring jobs** — schedule things on a timer ("every morning, ...").
+- **Data work** — fetch, crunch, and chart data; run code to compute answers.
+- **Project memory** — remember stable facts and preferences for future orders.
+
+Not on the menu: the waiter doing any of the above personally. Everything is cooked to order by the kitchen.

--- a/configs/waiter-chef/ONBOARDING.md
+++ b/configs/waiter-chef/ONBOARDING.md
@@ -1,0 +1,34 @@
+# Onboarding Agent
+
+The onboarding agent helps a new project owner turn a blank iterate project into
+a useful working space.
+
+On the first turn:
+
+1. Welcome the user briefly (by name only if they gave one).
+2. Explain what this project comes with: a private repo (seeded with ONBOARDING.md — this script,
+   the project worker at worker.ts, and example apps under apps/), durable
+   event streams, and agents like you that can act on the project.
+3. Ask one focused question about what they want this project to help with.
+
+During onboarding:
+
+- Keep replies short and concrete. Ask one question at a time.
+- When the user gives stable project facts, write them into the config repo as
+  concise markdown: prefer updating AGENTS.md or adding small files under
+  docs/, via itx.repo.commitFiles({ message, changes: [{ path, content }] }).
+- You can demonstrate the platform when it helps: append events with
+  itx.streams.get(path).append({ type, payload }), read exact event ranges
+  with getEvents(), search the
+  web with itx.mcp.exa.web_search_exa({ query }),
+  connect external tools with itx.mcp.connect({ url }) or
+  itx.openapi.connect({ specUrl }), and change the project worker by
+  committing to worker.ts (TypeScript, multi-file imports and package.json npm
+  dependencies both work — the platform builds the repo into the running
+  worker).
+- After you have captured the project purpose, working agreements, and first
+  tasks, append events.iterate.com/project/onboarding-completed on the root
+  project stream (itx.streams.get("/")) with payload
+  { agentPath: "/agents/onboarding" }.
+
+Do not mark onboarding complete just because the first message was answered.

--- a/configs/waiter-chef/README.md
+++ b/configs/waiter-chef/README.md
@@ -1,0 +1,72 @@
+# waiter-chef project configuration
+
+Front-of-house / back-of-house agent service, implemented entirely in this
+repo. The user (the diner) talks to a **waiter**: fast, plain-English, no
+tools, knows the menu. The **chef** — a bone-stock platform agent with all
+its tools — cooks in a paired chat the diner can also open and watch.
+
+```
+diner ──chat── waiter (/agents/web/<slug>, headless, fast)
+                 │  <kitchen>…</kitchen> orders,  <peek/> glances
+                 ▼
+               chef (/agents/chef/<slug>, stock platform agent)
+                 │  chat messages, relayed back as kitchen notes
+                 ▼
+               waiter tells the diner, in its own words
+```
+
+Why: voice models are fast, bad at tool-calling, and not very smart — ideal
+waiters. This template proves the shape with text first.
+
+## How it works
+
+1. On every config deploy, `worker.ts` publishes **agent birth defaults**
+   scoped to `pathPrefix: "/agents/web/"` — so every new web chat is born a
+   waiter: headless driver (one LLM call per turn, no tools), the waiter
+   prompt, and the fast-lane knobs at the top of `worker.ts`.
+2. The waiter's responses are prose plus tags (`waiter-format.ts` parses):
+   prose goes to the diner; `<kitchen>…</kitchen>` orders are relayed to the
+   chef as user messages; `<peek/>` answers from a snapshot of the chef's
+   processor state (busy/idle, activity, last words) without disturbing it.
+3. The chef is created lazily on the first order — through the same generic
+   door, but outside the birth-defaults prefix, so it's stock: default
+   prompt, classic driver, every tool. A kitchen-briefing context item
+   teaches it the protocol: work normally, send short chat messages at
+   moments that matter; the worker relays each one back to the waiter as a
+   developer note, and the waiter decides what the diner hears.
+
+Everything is public stream events any project member could append; no
+platform privileges. **Iterating on the feel — prompts, menu, grammar, model
+knobs — is a commit to this repo. No platform deploy.**
+
+## Trying it
+
+Create a project from:
+
+```text
+github:iterate/iterate#waiter-chef&path:configs/waiter-chef
+```
+
+Good first orders: "Make me a webpage for a multiplayer turn-based
+Subbuteo-like game", then — while it cooks — "Is it ready yet?" and
+"Actually, make the ball hot pink."
+
+## Files
+
+- `prompts/waiter-system-prompt.md` — the waiter: character, tag grammar,
+  honesty rules, interruption judgement
+- `prompts/chef-briefing.md` — the kitchen protocol (standing context; the
+  chef keeps the stock platform prompt)
+- `MENU.md` — plain-English capabilities the waiter may answer from
+- `waiter-format.ts` — the tag parser
+- `worker.ts` — birth defaults, the interpreter, both relay lanes, knobs
+
+## Known limits
+
+- Delivery to the config worker is observation-grade: an event the handler
+  fails on is skipped, not retried forever — a dropped delivery can lose one
+  relay (a new message starts fresh).
+- Only NEW web chats become waiters; chats from before the template switch
+  keep their existing character.
+- Slash commands are platform interpretation and are inert in waiter chats.
+- Slack/telegram/email agents and the onboarding agent are untouched.

--- a/configs/waiter-chef/package.json
+++ b/configs/waiter-chef/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "iterate-project-worker",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Iterate project worker for the waiter-chef front-of-house experiment.",
+  "dependencies": {
+    "@iterate-com/docs": "https://pkg.pr.new/iterate/iterate/@iterate-com/docs@main",
+    "iterate": "https://pkg.pr.new/iterate/iterate/iterate@main",
+    "react": "19.2.4",
+    "react-dom": "19.2.4",
+    "zod": "4.3.6"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250620.0",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "typescript": "^5.9.3"
+  }
+}

--- a/configs/waiter-chef/prompts/chef-briefing.md
+++ b/configs/waiter-chef/prompts/chef-briefing.md
@@ -1,0 +1,7 @@
+Kitchen briefing — this project runs front-of-house/back-of-house service, and you are the chef (back of house). The diner (the user) talks to a waiter agent, never directly to you; messages here labelled as from the waiter are the diner's requests, relayed. Nobody usually watches this chat directly — the waiter relays what you send.
+
+- Cook exactly as you normally do: your tools, your scripts, your judgement.
+- Send a short chat message at the moments that matter: when you start something substantial, when there's a decision or link worth sharing, when a dish is done (include the result or link), and when you're blocked or need an answer. The waiter passes these to the diner — a silent kitchen looks like a broken one.
+- Keep messages plain English and short. They're spoken by a waiter, not read as a code review.
+- Need clarification? Ask in a chat message; the waiter will bring back the diner's answer.
+- Don't take externally-visible actions (email, posting, purchases) unless the relayed order explicitly asks for them.

--- a/configs/waiter-chef/prompts/waiter-system-prompt.md
+++ b/configs/waiter-chef/prompts/waiter-system-prompt.md
@@ -15,6 +15,7 @@ Notes from the kitchen arrive as developer messages ("The chef says: ..."). Dige
 - Incoming messages carry bookkeeping prefixes like `@123` or `key="..."` on their first line. Ignore them and never write markers like that yourself — the diner sees them as noise.
 - Be fast and brief. One or two sentences is the house style; the diner should never wait on a long reply from you.
 - NEVER claim something is done, started, or possible unless you actually know — from the menu, from a kitchen note, or from a peek. When unsure, say you'll check, and put `<peek/>` in the same response.
+- A promise is only real if you act on it in the SAME response: "I'll tell the kitchen" requires the `<kitchen>` tag right there; "I'll check" requires `<peek/>` right there. Saying it without the tag means nothing happened — that's a lie.
 - If you realise you said something untrue, correct it plainly and immediately.
 - You have no tools and cannot look anything up yourself. Anything real — building, fetching, changing, checking a fact — goes through the kitchen.
 - New request while the chef is mid-dish: a small adjustment to the current order goes straight through in a `<kitchen>` tag; a big change of direction, confirm with the diner first ("shall I have the kitchen drop X and start on Y?").

--- a/configs/waiter-chef/prompts/waiter-system-prompt.md
+++ b/configs/waiter-chef/prompts/waiter-system-prompt.md
@@ -1,0 +1,21 @@
+You are the waiter — the front of house for this project. The diner (the user) talks to you. The kitchen is run by the chef: a highly capable technical agent with real tools, who can build web apps, write and run code, search the web, use the project's connected services, schedule recurring jobs, send email, and more. You take orders, keep the diner informed, and never cook.
+
+# How to respond
+
+Everything you write is shown to the diner, except tags, which are stripped out and acted on:
+
+- `<kitchen>...</kitchen>` — pass an order or an update to the chef. Start the tag at the beginning of a line. Relay the diner's intent faithfully — close to their own words, plus whatever context from this conversation the chef needs to cook it right.
+- `<peek/>` — alone on its own line: glance over the chef's shoulder. A kitchen report arrives as your next input; relay what matters in your own words.
+
+Notes from the kitchen arrive as developer messages ("The chef says: ..."). Digest them for the diner — short, plain English, keep any links the chef included.
+
+# House rules
+
+- Be fast and brief. One or two sentences is the house style; the diner should never wait on a long reply from you.
+- NEVER claim something is done, started, or possible unless you actually know — from the menu, from a kitchen note, or from a peek. When unsure, say you'll check, and put `<peek/>` in the same response.
+- If you realise you said something untrue, correct it plainly and immediately.
+- You have no tools and cannot look anything up yourself. Anything real — building, fetching, changing, checking a fact — goes through the kitchen.
+- New request while the chef is mid-dish: a small adjustment to the current order goes straight through in a `<kitchen>` tag; a big change of direction, confirm with the diner first ("shall I have the kitchen drop X and start on Y?").
+- Questions about what's possible: answer from the menu (in your standing context). Off-menu requests: don't refuse and don't promise — say you'll ask the kitchen, and ask.
+- Anything with an external side effect — sending email, posting publicly, spending money — gets the diner's explicit go-ahead before the order is placed.
+- Don't ping the kitchen just to chat; it interrupts real work. "No news yet" is a perfectly good update to give the diner without peeking again.

--- a/configs/waiter-chef/prompts/waiter-system-prompt.md
+++ b/configs/waiter-chef/prompts/waiter-system-prompt.md
@@ -11,6 +11,8 @@ Notes from the kitchen arrive as developer messages ("The chef says: ..."). Dige
 
 # House rules
 
+- You cannot call tools or functions — none exist in your chat, and tool-call syntax of any kind will appear to the diner as gibberish. Respond ONLY with plain text plus the two tags above.
+- Incoming messages carry bookkeeping prefixes like `@123` or `key="..."` on their first line. Ignore them and never write markers like that yourself — the diner sees them as noise.
 - Be fast and brief. One or two sentences is the house style; the diner should never wait on a long reply from you.
 - NEVER claim something is done, started, or possible unless you actually know — from the menu, from a kitchen note, or from a peek. When unsure, say you'll check, and put `<peek/>` in the same response.
 - If you realise you said something untrue, correct it plainly and immediately.

--- a/configs/waiter-chef/tsconfig.json
+++ b/configs/waiter-chef/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "include": ["**/*.ts"],
+  "exclude": ["apps"],
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "lib": ["ES2024", "ESNext.Disposable"],
+    "types": ["@cloudflare/workers-types"],
+    "skipLibCheck": true,
+    "strict": true
+  }
+}

--- a/configs/waiter-chef/waiter-format.ts
+++ b/configs/waiter-chef/waiter-format.ts
@@ -1,0 +1,93 @@
+// The waiter response format: parses one front-of-house assistant response
+// into diner-visible prose, kitchen orders, and an optional peek request.
+//
+// Inspired by configs/codemode-tag/codemode-format.ts (iterate/iterate), which
+// is itself vendored from the platform's response-format module. Modifications
+// from that original: the tag is <kitchen> (relayed text, not executable
+// code), a same-line close is allowed (orders are conversational one-liners,
+// not code blocks), multiple orders per response are permitted, and a <peek/>
+// tag is added. The line-anchored OPENER rule is kept: a mid-line mention in
+// prose ("use a <kitchen> tag") never opens anything.
+//
+// The grammar this parses:
+//
+//   One moment — sending that to the kitchen now!
+//
+//   <kitchen>The diner wants a multiplayer Subbuteo-like game…</kitchen>
+//   <peek/>
+
+export type WaiterParseOutcome =
+  | { kind: "ok"; prose?: string; orders: string[]; peek: boolean }
+  | { kind: "malformed"; feedback: string };
+
+/** A line that OPENS a kitchen order: `<kitchen>` at the start of a line
+ * (leading whitespace allowed). The order may close on the same line or a
+ * later one. */
+const KITCHEN_OPEN_RE = /^[ \t]*<kitchen>/;
+const KITCHEN_CLOSE = "</kitchen>";
+/** `<peek/>` (or `<peek />` / `<peek></peek>`) alone on its line. */
+const PEEK_LINE_RE = /^[ \t]*<peek\s*\/?>(<\/peek>)?[ \t]*$/;
+
+const GRAMMAR_REMINDER =
+  "Format reminder — start `<kitchen>` at the beginning of a line and close it with `</kitchen>` (same line or a later one). `<peek/>` goes alone on its own line. Everything outside tags is shown to the diner.";
+
+export function parseWaiterResponse(content: string): WaiterParseOutcome {
+  const lines = content.split("\n");
+  const proseLines: string[] = [];
+  const orders: string[] = [];
+  let peek = false;
+
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index];
+    if (PEEK_LINE_RE.test(line)) {
+      peek = true;
+      continue;
+    }
+    if (!KITCHEN_OPEN_RE.test(line)) {
+      if (line.includes(KITCHEN_CLOSE)) {
+        return {
+          kind: "malformed",
+          feedback: `Your message was NOT delivered: a stray ${KITCHEN_CLOSE} appeared with no order open. ${GRAMMAR_REMINDER}`,
+        };
+      }
+      proseLines.push(line);
+      continue;
+    }
+    // Collect the order body from the opener line to the first closing tag.
+    const afterOpen = line.slice(line.indexOf(">") + 1);
+    const bodyParts: string[] = [];
+    let closed = false;
+    let cursor = afterOpen;
+    while (true) {
+      const closeAt = cursor.indexOf(KITCHEN_CLOSE);
+      if (closeAt !== -1) {
+        bodyParts.push(cursor.slice(0, closeAt));
+        const trailing = cursor.slice(closeAt + KITCHEN_CLOSE.length).trim();
+        if (trailing !== "") proseLines.push(trailing);
+        closed = true;
+        break;
+      }
+      bodyParts.push(cursor);
+      index++;
+      if (index >= lines.length) break;
+      cursor = lines[index];
+    }
+    if (!closed) {
+      return {
+        kind: "malformed",
+        feedback: `Your message was NOT delivered: a <kitchen> order was never closed. ${GRAMMAR_REMINDER}`,
+      };
+    }
+    const body = bodyParts.join("\n").trim();
+    if (body === "") {
+      return {
+        kind: "malformed",
+        feedback: `Your message was NOT delivered: the <kitchen> order was empty. ${GRAMMAR_REMINDER}`,
+      };
+    }
+    orders.push(body);
+  }
+
+  const prose = proseLines.join("\n").trim();
+  return { kind: "ok", ...(prose === "" ? {} : { prose }), orders, peek };
+}

--- a/configs/waiter-chef/worker.ts
+++ b/configs/waiter-chef/worker.ts
@@ -57,12 +57,31 @@ const WAITER_MAX_AUTONOMOUS_TURNS = 100;
 /** Longest chef-note / peek excerpt relayed into the waiter's context. */
 const RELAY_EXCERPT_CHARS = 1_500;
 
+/** Supersedes the platform's boot context (key agent/boot-context) for
+ * waiters: the stock text teaches every agent its itx scope and workspace,
+ * which primes a tool-less waiter to attempt tool calls — observed leaking
+ * harmony-style call syntax into diner-visible replies. Static on purpose so
+ * it can ride the birth batch (defaults append last, so it supersedes the
+ * platform slot atomically at birth). */
+const WAITER_BOOT_CONTEXT = [
+  "Context for this agent: you are the front-of-house waiter for one table (this chat).",
+  "A dedicated chef agent is paired with this table: your <kitchen> tags reach it and its notes come back to you automatically — you never need to address it by name or path.",
+  "The diner can watch the kitchen directly from the project's agents list (the chef chat shares this chat's name).",
+  "You have no tools, no code scope, and no workspace.",
+].join("\n");
+
 const chefPathForWaiter = (waiterPath: string) =>
   CHEF_PREFIX + waiterPath.slice(WAITER_PREFIX.length);
 const waiterPathForChef = (chefPath: string) => WAITER_PREFIX + chefPath.slice(CHEF_PREFIX.length);
 
 const excerpt = (text: string) =>
   text.length <= RELAY_EXCERPT_CHARS ? text : `${text.slice(0, RELAY_EXCERPT_CHARS)}…`;
+
+/** The prompt projection prefixes every context item with `@<offset>`
+ * bookkeeping, and the waiter model sometimes imitates it at the start of a
+ * reply. The prompt tells it not to; this strip is the backstop so the diner
+ * never sees one either way. */
+const stripLeadingOffsetMarker = (text: string) => text.replace(/^@\d+\s*\n?/, "").trim();
 
 async function contentHash(text: string): Promise<string> {
   const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
@@ -111,6 +130,10 @@ export default class ProjectWorker extends IterateWorkerEntrypoint {
         if (event.source?.copiedFrom !== undefined) break;
         if (event.path.startsWith(WAITER_PREFIX)) {
           await this.#syncMenuContext([event.path]);
+          await this.#syncKeyedContext([event.path], {
+            key: "agent/boot-context",
+            content: WAITER_BOOT_CONTEXT,
+          });
         }
         if (event.path.startsWith(CHEF_PREFIX)) {
           await this.#syncChefBriefing([event.path]);
@@ -168,6 +191,14 @@ export default class ProjectWorker extends IterateWorkerEntrypoint {
               },
             },
             {
+              type: "events.iterate.com/agents/context-added",
+              payload: {
+                content: WAITER_BOOT_CONTEXT,
+                key: "agent/boot-context",
+                role: "system",
+              },
+            },
+            {
               type: "events.iterate.com/stream/subscription-configured",
               payload: {
                 name: HEADLESS_PROCESSOR_SLUG,
@@ -200,6 +231,10 @@ export default class ProjectWorker extends IterateWorkerEntrypoint {
     const chefs = agents.map((agent) => agent.path).filter((path) => path.startsWith(CHEF_PREFIX));
     await this.#syncWaiterPromptContext(waiters);
     await this.#syncMenuContext(waiters);
+    await this.#syncKeyedContext(waiters, {
+      key: "agent/boot-context",
+      content: WAITER_BOOT_CONTEXT,
+    });
     await this.#syncChefBriefing(chefs);
   }
 
@@ -352,8 +387,8 @@ export default class ProjectWorker extends IterateWorkerEntrypoint {
         );
       }
     }
-    if (outcome.prose !== undefined) {
-      const prose = outcome.prose;
+    if (outcome.prose !== undefined && stripLeadingOffsetMarker(outcome.prose) !== "") {
+      const prose = stripLeadingOffsetMarker(outcome.prose);
       await this.#appendUnlessAlreadyRecorded(() =>
         waiter.append({
           type: "events.iterate.com/agents/web-message-sent",

--- a/configs/waiter-chef/worker.ts
+++ b/configs/waiter-chef/worker.ts
@@ -70,10 +70,6 @@ const WAITER_BOOT_CONTEXT = [
   "You have no tools, no code scope, and no workspace.",
 ].join("\n");
 
-const chefPathForWaiter = (waiterPath: string) =>
-  CHEF_PREFIX + waiterPath.slice(WAITER_PREFIX.length);
-const waiterPathForChef = (chefPath: string) => WAITER_PREFIX + chefPath.slice(CHEF_PREFIX.length);
-
 const excerpt = (text: string) =>
   text.length <= RELAY_EXCERPT_CHARS ? text : `${text.slice(0, RELAY_EXCERPT_CHARS)}…`;
 
@@ -370,7 +366,7 @@ export default class ProjectWorker extends IterateWorkerEntrypoint {
     }
     // Orders first (so "I've sent it to the kitchen" is true by the time the
     // diner reads it), then the prose, then any peek report.
-    const chefPath = chefPathForWaiter(event.path);
+    const chefPath = CHEF_PREFIX + event.path.slice(WAITER_PREFIX.length);
     if (outcome.orders.length > 0) {
       await this.#ensureChef(chefPath);
       const chef = itx.agents.get(chefPath);
@@ -469,7 +465,7 @@ export default class ProjectWorker extends IterateWorkerEntrypoint {
     const payload = event.payload as { message?: string };
     if (typeof payload.message !== "string" || payload.message.trim() === "") return;
     const message = payload.message;
-    const waiterPath = waiterPathForChef(event.path);
+    const waiterPath = WAITER_PREFIX + event.path.slice(CHEF_PREFIX.length);
     const itx = await this.itx;
     await this.#appendUnlessAlreadyRecorded(() =>
       itx.agents.get(waiterPath).append({

--- a/configs/waiter-chef/worker.ts
+++ b/configs/waiter-chef/worker.ts
@@ -63,6 +63,15 @@ const RELAY_EXCERPT_CHARS = 1_500;
  * harmony-style call syntax into diner-visible replies. Static on purpose so
  * it can ride the birth batch (defaults append last, so it supersedes the
  * platform slot atomically at birth). */
+/** The post-create flow hands the user to the onboarding agent, which sits
+ * OUTSIDE the waiter prefix (it needs tools) — observed to be the first place
+ * a new user types "what's on the menu". Teach it to redirect. */
+const ONBOARDING_AGENT_PATH = "/agents/onboarding";
+const ONBOARDING_NOTE = [
+  "This project runs the waiter/chef experiment: every NEW chat the user starts from the project home is a fast front-of-house waiter that relays real work to a back-of-house chef agent.",
+  "You (the onboarding agent) are NOT part of that pair. If the user asks about the menu, the waiter, or seems to expect the experiment, briefly explain and point them to start a new chat from the project home — that chat is their waiter.",
+].join("\n");
+
 const WAITER_BOOT_CONTEXT = [
   "Context for this agent: you are the front-of-house waiter for one table (this chat).",
   "A dedicated chef agent is paired with this table: your <kitchen> tags reach it and its notes come back to you automatically — you never need to address it by name or path.",
@@ -133,6 +142,12 @@ export default class ProjectWorker extends IterateWorkerEntrypoint {
         }
         if (event.path.startsWith(CHEF_PREFIX)) {
           await this.#syncChefBriefing([event.path]);
+        }
+        if (event.path === ONBOARDING_AGENT_PATH) {
+          await this.#syncKeyedContext([event.path], {
+            key: "waiter-chef/onboarding-note",
+            content: ONBOARDING_NOTE,
+          });
         }
         break;
       }
@@ -232,6 +247,13 @@ export default class ProjectWorker extends IterateWorkerEntrypoint {
       content: WAITER_BOOT_CONTEXT,
     });
     await this.#syncChefBriefing(chefs);
+    const onboarding = agents.some((agent) => agent.path === ONBOARDING_AGENT_PATH);
+    if (onboarding) {
+      await this.#syncKeyedContext([ONBOARDING_AGENT_PATH], {
+        key: "waiter-chef/onboarding-note",
+        content: ONBOARDING_NOTE,
+      });
+    }
   }
 
   /**

--- a/configs/waiter-chef/worker.ts
+++ b/configs/waiter-chef/worker.ts
@@ -159,6 +159,28 @@ export default class ProjectWorker extends IterateWorkerEntrypoint {
         await this.#relayChefMessage(event);
         break;
       }
+      case "events.iterate.com/stream/error-occurred": {
+        // The kitchen catching fire is news the waiter must hear — seen live:
+        // a chef's processor host died mid-dish and the waiter kept saying
+        // "still cooking" off stale busy-state.
+        if (!event.path.startsWith(CHEF_PREFIX)) break;
+        const message = String((event.payload as { message?: string }).message || "unknown error");
+        const itx = await this.itx;
+        await this.#appendUnlessAlreadyRecorded(() =>
+          itx.agents.get(WAITER_PREFIX + event.path.slice(CHEF_PREFIX.length)).append({
+            type: "events.iterate.com/agents/context-added",
+            idempotencyKey: `waiter-chef/kitchen-error:${event.path}@${event.offset}`,
+            payload: {
+              role: "developer",
+              content:
+                `Kitchen problem (a platform error on the chef's side, not the chef speaking):\n\n${excerpt(message)}\n\n` +
+                "Tell the diner honestly that the kitchen has hit a problem. If it mentions backing off or revival, the current dish is likely stuck — offer to re-place the order in a fresh chat.",
+              llmRequestPolicy: { behaviour: "after-current-request" },
+            },
+          }),
+        );
+        break;
+      }
       default:
         break;
     }
@@ -442,14 +464,25 @@ export default class ProjectWorker extends IterateWorkerEntrypoint {
   }
 
   /** The over-the-shoulder glance: honest kitchen state from the chef's
-   * processor snapshot, without appending anything to the chef's stream. */
+   * processor snapshot, without appending anything to the chef's stream. A
+   * snapshot FAILURE is reported as breakage, never as "not started" — seen
+   * live: a wedged processor host (revival backoff) made a working-looking
+   * chef unreachable, and conflating that with "no chef" would make the
+   * waiter lie in both directions. */
   async #peekAtChef(chefPath: string): Promise<string> {
     const itx = await this.itx;
-    const snapshot = await itx.agents
-      .get(chefPath)
-      .processor.snapshot()
-      .catch(() => null);
-    if (snapshot === null || snapshot.state.contextItems.length === 0) {
+    let snapshot;
+    try {
+      snapshot = await itx.agents.get(chefPath).processor.snapshot();
+    } catch (error) {
+      console.error("[waiter-chef] peek: chef snapshot failed", { chefPath, error });
+      return (
+        "Kitchen report: the kitchen is NOT responding — something is broken on the chef's side " +
+        "(this is a fault, not slowness). Tell the diner honestly that the kitchen has a problem; " +
+        "suggest starting a fresh chat to re-place the order if it persists."
+      );
+    }
+    if (snapshot.state.contextItems.length === 0) {
       return "Kitchen report: the kitchen hasn't been fired up for this table yet — no order has reached the chef.";
     }
     const state = snapshot.state;

--- a/configs/waiter-chef/worker.ts
+++ b/configs/waiter-chef/worker.ts
@@ -1,0 +1,481 @@
+import { DocsApp } from "@iterate-com/docs";
+import { IterateWorkerEntrypoint, type StreamEvent } from "iterate/sdk";
+import { isIdempotencyConflict } from "iterate/processors";
+import { parseWaiterResponse } from "./waiter-format.ts";
+
+// THE WAITER/CHEF EXPERIMENT — front-of-house / back-of-house agent service,
+// implemented entirely in this config repo. Structure and several mechanisms
+// (birth-defaults publishing, keyed context syncs, the assistant-output
+// interpreter) are adapted from configs/codemode-tag/worker.ts in
+// iterate/iterate; the modification is the two-lane cast:
+//
+//   WAITER — every web chat agent (/agents/web/…). Born via project birth
+//   defaults with the headless driver: no tools, no codemode, ONE fast LLM
+//   call per turn. Speaks prose plus <kitchen>/<peek/> tags; THIS worker is
+//   the interpreter.
+//
+//   CHEF — /agents/chef/<same slug>, created lazily by this worker on the
+//   first kitchen order. The birth-defaults pathPrefix doesn't match, so the
+//   chef is a bone-stock platform agent (classic driver, default prompt, all
+//   tools) plus a briefing context item teaching the kitchen protocol.
+//
+//   Relay lanes: waiter <kitchen> orders become user-role messages on the
+//   chef's stream; every chef chat message comes back to the waiter as a
+//   developer note; <peek/> snapshots the chef's processor state without
+//   disturbing it.
+//
+// Everything is public stream events any project member could append — no
+// platform privileges. Iterating on the feel — waiter prompt, menu, chef
+// briefing, the tag grammar, the model knobs below — is a commit to this
+// repo. No platform deploy.
+//
+// KNOWN LIMITS (inherited from the codemode-tag experiment): delivery to this
+// worker is observation-grade — an event this handler fails on is SKIPPED,
+// not retried forever, so a dropped delivery can quietly lose a relay (a new
+// message starts fresh). Slack/telegram/email agents and the onboarding agent
+// are untouched (their paths fall outside /agents/web/).
+
+const WAITER_PREFIX = "/agents/web/";
+const CHEF_PREFIX = "/agents/chef/";
+const HEADLESS_PROCESSOR_SLUG = "agent-headless";
+const SYSTEM_PROMPT_KEY = "agent/system-prompt";
+
+// ---------------------------------------------------------------------------
+// FEEL-EVAL KNOBS — commit a change to any of these and new turns pick it up.
+// ---------------------------------------------------------------------------
+/** The waiter's model. The whole gpt-5 family runs reasoning-effort medium
+ * through the platform transport, so a smaller gpt-5 isn't automatically
+ * snappier — candidates for real speed are non-reasoning partner models
+ * (enumerate with `await itx.ai.models()` in the repl). */
+const WAITER_MODEL = "openai/gpt-5.6-terra";
+/** Platform default is 250ms; the waiter's whole job is feeling immediate. */
+const WAITER_DEBOUNCE_MS = 100;
+/** Kitchen notes relayed to the waiter ride its autonomous-turn budget (they
+ * are developer context, not diner messages). Roomy so a long cook's worth of
+ * updates never mutes the waiter. */
+const WAITER_MAX_AUTONOMOUS_TURNS = 100;
+/** Longest chef-note / peek excerpt relayed into the waiter's context. */
+const RELAY_EXCERPT_CHARS = 1_500;
+
+const chefPathForWaiter = (waiterPath: string) =>
+  CHEF_PREFIX + waiterPath.slice(WAITER_PREFIX.length);
+const waiterPathForChef = (chefPath: string) => WAITER_PREFIX + chefPath.slice(CHEF_PREFIX.length);
+
+const excerpt = (text: string) =>
+  text.length <= RELAY_EXCERPT_CHARS ? text : `${text.slice(0, RELAY_EXCERPT_CHARS)}…`;
+
+async function contentHash(text: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+  return [...new Uint8Array(digest).slice(0, 8)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export default class ProjectWorker extends IterateWorkerEntrypoint {
+  #docsApp = DocsApp.create(this.env, {
+    auth: { policy: "project-member" },
+    proxy: {
+      origin: "https://docs.iterate.workers.dev",
+      originOverrideKvKey: "docs-app-origin",
+    },
+  });
+
+  /** Agent-callable app helpers: `itx.worker.docs.link({ workspace, path })`
+   * mints the document view, `link({ workspace, repo, task? })` the board. */
+  get docs() {
+    return this.#docsApp.rpc;
+  }
+
+  // The base class delivers committed events on ANY stream here at least once
+  // and in per-stream order.
+  protected override async processEvent(event: StreamEvent): Promise<void> {
+    switch (event.type) {
+      case "events.iterate.com/project/worker-updated": {
+        if (event.path !== "/") break;
+        await this.#publishWaiterBirthDefaults();
+        await this.#syncAllStandingContext();
+        break;
+      }
+      case "events.iterate.com/repo/commit-completed": {
+        // Any config-repo commit MAY have changed a prompt or the menu — the
+        // syncs' read-compare steps turn the ones that didn't into no-ops.
+        // THIS is the iteration loop: edit, commit, next turns feel different.
+        if (event.path !== "/repos/config") break;
+        await this.#publishWaiterBirthDefaults();
+        await this.#syncAllStandingContext();
+        break;
+      }
+      case "events.iterate.com/agent/created": {
+        // The birth event on the agent's own stream (copies carry
+        // source.copiedFrom and must not be re-briefed).
+        if (event.source?.copiedFrom !== undefined) break;
+        if (event.path.startsWith(WAITER_PREFIX)) {
+          await this.#syncMenuContext([event.path]);
+        }
+        if (event.path.startsWith(CHEF_PREFIX)) {
+          await this.#syncChefBriefing([event.path]);
+        }
+        break;
+      }
+      case "events.iterate.com/agents/context-added": {
+        await this.#interpretWaiterResponse(event);
+        break;
+      }
+      case "events.iterate.com/agents/web-message-sent": {
+        await this.#relayChefMessage(event);
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  /**
+   * THE CAST SELECTOR: the platform's generic agent-creation door folds the
+   * project's latest birth-defaults event into every matching birth batch.
+   * `pathPrefix` scopes it to web chats — so every new chat is BORN a waiter
+   * (headless driver + waiter prompt + the fast-lane config), while chefs,
+   * the onboarding agent, and channel agents fall outside the prefix and stay
+   * stock. Content-hash keyed: editing the prompt or a knob re-publishes and
+   * the newest event wins at the door.
+   */
+  async #publishWaiterBirthDefaults(): Promise<void> {
+    const itx = await this.itx;
+    const file = await itx.repo.readFile({ path: "prompts/waiter-system-prompt.md" });
+    // A deleted waiter prompt degrades to stock agents for new chats (empty
+    // list restores platform defaults), never to a promptless waiter.
+    const birthEvents =
+      file === null
+        ? []
+        : [
+            {
+              type: "events.iterate.com/agent/configured",
+              payload: {
+                config: {
+                  driver: HEADLESS_PROCESSOR_SLUG,
+                  llm: { model: WAITER_MODEL },
+                  llmRequestDebounceMs: WAITER_DEBOUNCE_MS,
+                  maxAutonomousTurns: WAITER_MAX_AUTONOMOUS_TURNS,
+                },
+              },
+            },
+            {
+              type: "events.iterate.com/agents/context-added",
+              payload: {
+                content: file.content.replace(/\n$/, ""),
+                key: SYSTEM_PROMPT_KEY,
+                role: "system",
+              },
+            },
+            {
+              type: "events.iterate.com/stream/subscription-configured",
+              payload: {
+                name: HEADLESS_PROCESSOR_SLUG,
+                receiver: { action: "facet-processor", source: { kind: "builtin" } },
+              },
+            },
+          ];
+    const hash = await contentHash(JSON.stringify(birthEvents));
+    await this.#appendUnlessAlreadyRecorded(() =>
+      itx.streams.get("/").append({
+        type: "events.iterate.com/project/agent-birth-defaults-configured",
+        idempotencyKey: `waiter-chef/birth-defaults:${hash}`,
+        payload: {
+          matches: { pathPrefix: WAITER_PREFIX },
+          birthEvents,
+        },
+      }),
+    );
+  }
+
+  /** One sweep over the cast: prompt + menu to existing waiters, briefing to
+   * existing chefs. Each sync is keyed and read-compared, so repeat sweeps
+   * are no-ops. */
+  async #syncAllStandingContext(): Promise<void> {
+    const itx = await this.itx;
+    const agents = await itx.agents.list();
+    const waiters = agents
+      .map((agent) => agent.path)
+      .filter((path) => path.startsWith(WAITER_PREFIX));
+    const chefs = agents.map((agent) => agent.path).filter((path) => path.startsWith(CHEF_PREFIX));
+    await this.#syncWaiterPromptContext(waiters);
+    await this.#syncMenuContext(waiters);
+    await this.#syncChefBriefing(chefs);
+  }
+
+  /**
+   * Post-birth prompt edits for EXISTING waiter chats (new ones get the
+   * prompt at birth). Gated on the headless driver: an agent still on the
+   * classic driver (born before the defaults event existed) interprets its
+   * own output, and the waiter grammar would break every turn.
+   */
+  async #syncWaiterPromptContext(waiterPaths: string[]): Promise<void> {
+    if (waiterPaths.length === 0) return;
+    const itx = await this.itx;
+    const file = await itx.repo.readFile({ path: "prompts/waiter-system-prompt.md" });
+    if (file === null) return;
+    const content = file.content.replace(/\n$/, "");
+    const hash = await contentHash(content);
+    const results = await Promise.allSettled(
+      waiterPaths.map(async (path) => {
+        const agent = itx.agents.get(path);
+        const snapshot = await agent.processor.snapshot();
+        if (snapshot.state.config.driver !== HEADLESS_PROCESSOR_SLUG) return;
+        const slot = snapshot.state.contextItems.findLast(
+          (item) => item.payload.key === SYSTEM_PROMPT_KEY,
+        );
+        if (slot?.payload.content === content) return;
+        await agent.append({
+          type: "events.iterate.com/agents/context-added",
+          idempotencyKey: `waiter-chef/system-prompt:${hash}:after-${slot?.offset || 0}`,
+          payload: {
+            content,
+            key: SYSTEM_PROMPT_KEY,
+            llmRequestPolicy: { behaviour: "dont-trigger-request" },
+            role: "system",
+          },
+        });
+      }),
+    );
+    const failed = results.find((result) => result.status === "rejected");
+    if (failed !== undefined && failed.status === "rejected") throw failed.reason;
+  }
+
+  /** The waiter's MENU.md as keyed standing context — same recipe as the
+   * default template's AGENTS.md sync (keyed system context, per-transition
+   * keys, appends only on a real change, dont-trigger-request). */
+  async #syncMenuContext(waiterPaths: string[]): Promise<void> {
+    if (waiterPaths.length === 0) return;
+    const itx = await this.itx;
+    const file = await itx.repo.readFile({ path: "MENU.md" });
+    const content =
+      file === null
+        ? "(MENU.md was deleted from /repos/config — no menu; ask the kitchen about everything.)"
+        : `The menu (auto-injected from /repos/config/MENU.md — commit updates there to change it):\n\n${file.content}`;
+    await this.#syncKeyedContext(waiterPaths, { key: "waiter-chef/menu", content });
+  }
+
+  /** The chef's kitchen briefing as keyed standing context. The chef keeps
+   * the stock platform prompt; this rides alongside it. */
+  async #syncChefBriefing(chefPaths: string[]): Promise<void> {
+    if (chefPaths.length === 0) return;
+    const itx = await this.itx;
+    const file = await itx.repo.readFile({ path: "prompts/chef-briefing.md" });
+    if (file === null) return;
+    await this.#syncKeyedContext(chefPaths, {
+      key: "waiter-chef/briefing",
+      content: file.content,
+    });
+  }
+
+  /** Shared keyed-context sync: append only on a real change, key unique per
+   * transition (content hash + the occurrence it replaces), system role so
+   * compaction keeps the latest occurrence. */
+  async #syncKeyedContext(agentPaths: string[], input: { key: string; content: string }) {
+    const itx = await this.itx;
+    const hash = await contentHash(input.content);
+    const results = await Promise.allSettled(
+      agentPaths.map(async (path) => {
+        const agent = itx.agents.get(path);
+        const snapshot = await agent.processor.snapshot();
+        const slot = snapshot.state.contextItems.findLast((item) => item.payload.key === input.key);
+        if (slot?.payload.content === input.content) return;
+        await agent.append({
+          type: "events.iterate.com/agents/context-added",
+          idempotencyKey: `${input.key}:${hash}:after-${slot?.offset || 0}`,
+          payload: {
+            content: input.content,
+            key: input.key,
+            llmRequestPolicy: { behaviour: "dont-trigger-request" },
+            role: "system",
+          },
+        });
+      }),
+    );
+    const failed = results.find((result) => result.status === "rejected");
+    if (failed !== undefined && failed.status === "rejected") throw failed.reason;
+  }
+
+  /**
+   * The waiter's interpreter — the userland twin of the platform's response
+   * interpretation, for the waiter grammar: prose to the diner, orders to the
+   * kitchen, peeks answered from the chef's processor snapshot.
+   */
+  async #interpretWaiterResponse(event: StreamEvent): Promise<void> {
+    if (!event.path.startsWith(WAITER_PREFIX)) return;
+    // Only interpret output the HEADLESS processor produced: its stamp means
+    // the LLM component authored this event for an accepted request on a
+    // stream that opted in. A raw member append carries no platform stamp and
+    // classic-processed output was already interpreted platform-side.
+    if (event.source?.processor?.slug !== HEADLESS_PROCESSOR_SLUG) return;
+    const payload = event.payload as {
+      role?: string;
+      content?: string;
+      llmRequestOffset?: number;
+    };
+    if (payload.role !== "assistant") return;
+    if (typeof payload.llmRequestOffset !== "number") return;
+    if (typeof payload.content !== "string") return;
+    const outcome = parseWaiterResponse(payload.content);
+    const itx = await this.itx;
+    const waiter = itx.agents.get(event.path);
+    if (outcome.kind === "malformed") {
+      await this.#appendUnlessAlreadyRecorded(() =>
+        waiter.append({
+          type: "events.iterate.com/agents/context-added",
+          idempotencyKey: `waiter-chef/format-feedback@${event.offset}`,
+          payload: {
+            role: "developer",
+            content: outcome.feedback,
+            llmRequestPolicy: { behaviour: "after-current-request" },
+          },
+        }),
+      );
+      return;
+    }
+    // Orders first (so "I've sent it to the kitchen" is true by the time the
+    // diner reads it), then the prose, then any peek report.
+    const chefPath = chefPathForWaiter(event.path);
+    if (outcome.orders.length > 0) {
+      await this.#ensureChef(chefPath);
+      const chef = itx.agents.get(chefPath);
+      for (const [index, order] of outcome.orders.entries()) {
+        await this.#appendUnlessAlreadyRecorded(() =>
+          chef.append({
+            type: "events.iterate.com/agents/context-added",
+            idempotencyKey: `waiter-chef/order@${event.offset}#${index}`,
+            payload: {
+              role: "user",
+              content: `Order from the waiter (front of house), relaying the diner:\n\n${order}`,
+            },
+          }),
+        );
+      }
+    }
+    if (outcome.prose !== undefined) {
+      const prose = outcome.prose;
+      await this.#appendUnlessAlreadyRecorded(() =>
+        waiter.append({
+          type: "events.iterate.com/agents/web-message-sent",
+          idempotencyKey: `waiter-chef/prose@${event.offset}`,
+          payload: { message: prose, llmRequestOffset: payload.llmRequestOffset },
+        }),
+      );
+    }
+    if (outcome.peek) {
+      const report = await this.#peekAtChef(chefPath);
+      await this.#appendUnlessAlreadyRecorded(() =>
+        waiter.append({
+          type: "events.iterate.com/agents/context-added",
+          idempotencyKey: `waiter-chef/peek@${event.offset}`,
+          payload: {
+            role: "developer",
+            content: report,
+            llmRequestPolicy: { behaviour: "after-current-request" },
+          },
+        }),
+      );
+    }
+  }
+
+  /** Lazy chef creation through the SAME generic door as every agent — the
+   * birth-defaults prefix doesn't match, so the chef is born stock. create()
+   * dedupes on its birth keys, so calling per order is safe; the briefing
+   * lands before the first order is appended. */
+  async #ensureChef(chefPath: string): Promise<void> {
+    const itx = await this.itx;
+    await itx.agents.get(chefPath).create();
+    await this.#syncChefBriefing([chefPath]);
+  }
+
+  /** The over-the-shoulder glance: honest kitchen state from the chef's
+   * processor snapshot, without appending anything to the chef's stream. */
+  async #peekAtChef(chefPath: string): Promise<string> {
+    const itx = await this.itx;
+    const snapshot = await itx.agents
+      .get(chefPath)
+      .processor.snapshot()
+      .catch(() => null);
+    if (snapshot === null || snapshot.state.contextItems.length === 0) {
+      return "Kitchen report: the kitchen hasn't been fired up for this table yet — no order has reached the chef.";
+    }
+    const state = snapshot.state;
+    const busy =
+      state.openRequest !== null ||
+      state.activeScriptExecutionIds.length > 0 ||
+      state.pendingLlmRequestTrigger !== null;
+    const lines = [`Kitchen report (over the chef's shoulder):`];
+    lines.push(busy ? "- The chef is BUSY cooking right now." : "- The chef is idle.");
+    if (state.summary.activity !== undefined) {
+      lines.push(`- Current activity label: ${state.summary.activity}`);
+    }
+    if (state.summary.waitingFor !== undefined) {
+      lines.push(`- Waiting on: ${JSON.stringify(state.summary.waitingFor)}`);
+    }
+    const lastAssistant = state.contextItems.findLast(
+      (item) => item.payload.role === "assistant" && typeof item.payload.content === "string",
+    );
+    const lastWords = lastAssistant?.payload.content;
+    if (typeof lastWords === "string") {
+      lines.push(`- The chef's most recent words:\n${excerpt(lastWords)}`);
+    }
+    lines.push(
+      "Relay what matters to the diner in your own words. Do not invent detail beyond this report.",
+    );
+    return lines.join("\n");
+  }
+
+  /** Every chef chat message comes back to the waiter as a developer note —
+   * the waiter decides what the diner hears. after-current-request means an
+   * idle waiter speaks up straight away and a mid-turn waiter finishes its
+   * sentence first. */
+  async #relayChefMessage(event: StreamEvent): Promise<void> {
+    if (!event.path.startsWith(CHEF_PREFIX)) return;
+    const payload = event.payload as { message?: string };
+    if (typeof payload.message !== "string" || payload.message.trim() === "") return;
+    const message = payload.message;
+    const waiterPath = waiterPathForChef(event.path);
+    const itx = await this.itx;
+    await this.#appendUnlessAlreadyRecorded(() =>
+      itx.agents.get(waiterPath).append({
+        type: "events.iterate.com/agents/context-added",
+        idempotencyKey: `waiter-chef/chef-said:${event.path}@${event.offset}`,
+        payload: {
+          role: "developer",
+          content: `The chef says:\n\n${excerpt(message)}`,
+          llmRequestPolicy: { behaviour: "after-current-request" },
+        },
+      }),
+    );
+  }
+
+  /** An idempotency conflict means another writer (a redelivery of ourselves)
+   * already recorded this consequence — losing that race is success. */
+  async #appendUnlessAlreadyRecorded(append: () => Promise<unknown>): Promise<void> {
+    try {
+      await append();
+    } catch (error) {
+      if (!isIdempotencyConflict(error)) throw error;
+    }
+  }
+
+  async fetch(req: Request): Promise<Response> {
+    const app = req.headers.get("x-iterate-app");
+    if (app === "docs") {
+      return this.#docsApp.fetch(req);
+    }
+    if (app) return new Response(`unknown app: ${app}`, { status: 404 });
+    return new Response(
+      `<!doctype html>
+        <html>
+          <body>
+            <main>
+              <p>Hello from the waiter/chef experiment project.</p>
+              <p>Every web chat is a fast, tool-less <strong>waiter</strong>; the <strong>chef</strong> (a full platform agent) cooks in a paired chat at /agents/chef/&lt;slug&gt;. worker.ts in the config repo relays between them. Edit MENU.md or the prompts and commit to iterate on the feel.</p>
+            </main>
+          </body>
+        </html>`,
+      { headers: { "content-type": "text/html; charset=utf-8" } },
+    );
+  }
+}

--- a/tasks/waiter-chef-config.md
+++ b/tasks/waiter-chef-config.md
@@ -103,9 +103,12 @@ Fork of `configs/default` (keeps docs app, AGENTS.md sync, onboarding) plus:
 - [x] Prompt-file formatter exemption (`.oxfmtrc.json` ignorePatterns —
       `configs/waiter-chef/prompts/` + `MENU.md`) — _and re-ran tsc after
       `pnpm format` per the oxfmt-rewrites-markdown lesson_
-- [ ] Live smoke on a preview or dev: create project from
-      `github:iterate/iterate#waiter-chef&path:configs/waiter-chef`, run the
-      starter prompts below, iterate with Misha
+- [x] Live smoke on local dev — _project `waiter-smoke-1` created from the
+      template ref; menu question answered waiter-only; Subbuteo + wordle
+      orders cooked end-to-end by real chefs with links served back; peek
+      answered honestly mid-cook; mid-cook adjustment relayed. Two model
+      bugs found and fixed (see log)_
+- [ ] Feel-eval with Misha (chat first, voice later)
 - [x] Knobs surfaced for the feel-eval — _`WAITER_MODEL`, `WAITER_DEBOUNCE_MS`,
       `WAITER_MAX_AUTONOMOUS_TURNS`, `RELAY_EXCERPT_CHARS` at the top of
       `worker.ts`_
@@ -157,3 +160,21 @@ Fork of `configs/default` (keeps docs app, AGENTS.md sync, onboarding) plus:
   in), worker-scope `message()` stamps user actor, web chats born at
   `/agents/web/<iso-slug>`, onboarding at `/agents/onboarding` unaffected by
   the `/agents/web/` prefix.
+- (2026-08-11) Live smoke on local dev (`waiter-smoke-1`). Findings:
+  - **Tool-call leak**: the platform's boot context teaches every agent its
+    itx scope/workspace; the tool-less waiter then attempted harmony-style
+    tool calls (`{Jsiiassistant to=itx.agents.get?…`) which leaked as
+    diner-visible garbage. Fixed two ways: an explicit no-tools house rule in
+    the prompt, and superseding the keyed `agent/boot-context` slot with a
+    static waiter version IN the birth defaults (defaults append last, so it
+    supersedes atomically at birth).
+  - **`@offset` imitation**: the prompt projection prefixes every context
+    item with `@<offset>` bookkeeping; the waiter imitated it at the start of
+    replies. Fixed with a prompt rule plus a worker-side strip backstop.
+  - Iterating genuinely required no platform deploy: both fixes were
+    `commitFiles` into the live project's config repo.
+  - The chef built real, working dishes (flick-football, pomodoro, wordle)
+    and served links; the waiter relayed each with the link intact.
+  - Deliberately not done: waiter loses the project-hostname fact with the
+    boot-context supersession (chef supplies links, so nothing user-visible
+    broke) — revisit if the waiter ever needs to mint URLs itself.

--- a/tasks/waiter-chef-config.md
+++ b/tasks/waiter-chef-config.md
@@ -1,0 +1,153 @@
+---
+status: in-progress
+size: medium
+branch: waiter-chef
+---
+
+# Waiter/Chef: front-of-house / back-of-house agent pair as a config template
+
+## Status summary
+
+Spec fleshed out, implementation not started. Pure userland: a new
+`configs/waiter-chef/` template, zero platform changes. Built on the merged
+birth-defaults surface (#2423 + #2474). The eval is human/feel-based — Misha
+drives testing; expect knob-tweaking commits.
+
+## The idea (from Misha, lightly organized)
+
+Restaurant metaphor. The user talks to the **Waiter**: fast, plain-English,
+knows the *Menu* (what the system can do) but not the technical how. The
+**Chef** is the existing full-fat platform agent: tools, codemode, opinions.
+The waiter relays orders to the kitchen, gives status updates, and can "look
+over the chef's shoulder". Motivation: voice models are fast, bad at tools,
+not very smart — perfect waiters. Test with text chat first; voice later.
+
+Requirements called out:
+
+- Don't invent an unnecessary layer — the chef *does*, the waiter *talks*.
+- Waiter always responds fast; avoids saying untrue things; corrects itself
+  when it inevitably does.
+- Waiter judges whether to interrupt a busy chef.
+- Two LLM lanes running in parallel is expected and good.
+
+## Design
+
+Everything lives in a config template; the platform event vocabulary is
+already sufficient.
+
+### Cast
+
+- **Waiter** = every web chat agent (`/agents/web/<slug>`). Project birth
+  defaults (`matches: {pathPrefix: "/agents/web/"}`) make it born with:
+  - `agent/configured`: `driver: "agent-headless"` (no tools, no codemode —
+    one fast LLM call per turn), waiter model knob, low debounce.
+  - waiter system prompt slot (`prompts/waiter-system-prompt.md`).
+  - `agent-headless` facet subscription (already allowlisted for birth
+    defaults).
+- **Chef** = `/agents/chef/<slug>` (same slug as its waiter). Created lazily
+  by the config worker on the first kitchen order, via the same generic door —
+  the path prefix doesn't match, so it's a stock platform agent (classic
+  driver, default prompt, all tools). The worker appends a keyed briefing
+  context (`prompts/chef-briefing.md`): you're back-of-house, messages come
+  from the waiter relaying a diner, report succinctly when done/blocked, your
+  chat is mostly unwatched but the diner may peek.
+
+### Protocol (worker.ts interprets waiter output, codemode-tag style)
+
+Waiter responses are plain prose plus optional tags, parsed by
+`waiter-format.ts`:
+
+- prose → `agents/web-message-sent` (what the user sees; llmRequestOffset so
+  the mirror skips it).
+- `<kitchen>…</kitchen>` → ensure chef exists, then `agents.get(chefPath)
+  .message("From the waiter, relaying the diner: …")` — worker-scope itx
+  stamps it a user message, so the chef's turn budget refills like a real
+  user asked.
+- `<peek/>` → worker snapshots the chef processor (busy/idle, current
+  activity, last assistant message) and appends it to the waiter as developer
+  context with `after-current-request` — the waiter's next turn relays it in
+  its own words.
+
+Chef → waiter: every `agents/web-message-sent` on `/agents/chef/**` is
+relayed to the paired waiter as developer context ("The chef says: …",
+`after-current-request`) — the waiter decides what to tell the user. The chef
+prompt teaches it to send a concise chat message when done or blocked, which
+is just its natural final response.
+
+The waiter's Menu: `MENU.md` in the config repo, synced to waiter agents as
+keyed standing context (same recipe as the AGENTS.md sync). Editing the menu,
+the prompts, or the parser is a git commit — no deploy.
+
+### Template contents
+
+Fork of `configs/default` (keeps docs app, AGENTS.md sync, onboarding) plus:
+
+- `MENU.md` — plain-English capabilities list for the waiter
+- `prompts/waiter-system-prompt.md` — character + tag grammar + honesty rules
+- `prompts/chef-briefing.md` — kitchen protocol briefing
+- `waiter-format.ts` — tag parser (attribution: inspired by
+  `configs/codemode-tag/codemode-format.ts`)
+- `worker.ts` — default worker + birth-defaults publish + waiter interpreter
+  + chef relay
+
+### Checklist
+
+- [ ] `configs/waiter-chef/` template: forked base files, MENU.md, prompts,
+      parser, worker
+- [ ] waiter-format parser unit test (vitest, colocated in the template like
+      codemode-format's)
+- [ ] Prompt-file formatter exemption (`.oxfmtrc.json` ignorePatterns —
+      `configs/waiter-chef/prompts/`)
+- [ ] Live smoke on a preview or dev: create project from
+      `github:iterate/iterate#waiter-chef&path:configs/waiter-chef`, run the
+      starter prompts below, iterate with Misha
+- [ ] Knobs surfaced for the feel-eval: waiter model, debounce, relay
+      trigger behavior
+
+## Assumptions made (Misha AFK-style delineation)
+
+1. **Waiter = all web chats** in an opted-in project, rather than a specially
+   named agent. Cleanest mapping to the UI (every new chat is a table).
+2. **Chef is bone-stock** — no custom system prompt, just a briefing context
+   item. Keeps "the chef is the existing genius" literal, and dodges the
+   single-birth-defaults-slot limitation entirely.
+3. **Chef listens via the waiter only** (v1). Misha floated "chef listens
+   directly to the user, at least while idle" — deferred; the relay message
+   carries the diner's words near-verbatim, so little is lost, and it keeps
+   the lanes legible. Easy follow-up if relaying feels laggy.
+4. **Waiter model starts as the platform default** (`openai/gpt-5.6-terra`)
+   with the knob at the top of worker.ts. Rationale: reasoning effort is
+   pinned "medium" for the whole gpt-5 family in the transport, so a smaller
+   gpt-5 won't obviously be snappier; the interesting experiments (partner
+   non-reasoning models via `itx.ai.models()`) are exactly the live tweaking
+   this eval is for.
+5. **Peek is a tag, not automatic** — the waiter chooses when to look. Plus
+   the automatic chef-message relay for push-style updates.
+6. **Interrupt judgment lives in the waiter prompt**, not mechanism: it's
+   told the chef's busy-state (via peek results and relay timing) and decides
+   whether to `<kitchen>` immediately or hold. The chef processor already
+   queues mid-turn messages safely either way.
+
+## Starter prompts for the feel-eval
+
+1. *(Misha's)* "Make me a webpage for a multiplayer turn-based Subbuteo-like
+   game involving 'flicking' characters towards a ball to try to score a
+   goal." — long build; exercises status updates + progress link.
+2. "What's on the menu — what kind of things can you do for me here?" —
+   waiter must answer alone from MENU.md, never bothering the kitchen.
+3. "Find the GitHub repos this project can see and make me a page ranking
+   them by recent commit activity." — tools + integrations; medium duration.
+4. *(while #1 or #3 is cooking)* "Actually, make the ball hot pink." —
+   interrupt judgment on a busy chef.
+5. "Plan a 3-day Lisbon itinerary, then email it to me." — external side
+   effect; tests the waiter confirming before the kitchen fires an email.
+6. *(immediately after an order)* "Is it ready yet?" — honest fast status via
+   peek, no fabrication.
+
+## Implementation log
+
+- (2026-08-11) Spec committed first per worktreeify convention. Research
+  confirmed: `agents.get(path).create()` hits the generic door (defaults fold
+  in), worker-scope `message()` stamps user actor, web chats born at
+  `/agents/web/<iso-slug>`, onboarding at `/agents/onboarding` unaffected by
+  the `/agents/web/` prefix.

--- a/tasks/waiter-chef-config.md
+++ b/tasks/waiter-chef-config.md
@@ -8,10 +8,11 @@ branch: waiter-chef
 
 ## Status summary
 
-Spec fleshed out, implementation not started. Pure userland: a new
-`configs/waiter-chef/` template, zero platform changes. Built on the merged
-birth-defaults surface (#2423 + #2474). The eval is human/feel-based — Misha
-drives testing; expect knob-tweaking commits.
+Template implemented and typechecked (standalone tsc against the template's
+own tsconfig — configs aren't CI-compiled). Pure userland: zero platform
+changes, built on the merged birth-defaults surface (#2423 + #2474). Missing:
+live smoke, then the human feel-eval — Misha drives; expect knob-tweaking
+commits to prompts/knobs.
 
 ## The idea (from Misha, lightly organized)
 
@@ -92,17 +93,22 @@ Fork of `configs/default` (keeps docs app, AGENTS.md sync, onboarding) plus:
 
 ### Checklist
 
-- [ ] `configs/waiter-chef/` template: forked base files, MENU.md, prompts,
-      parser, worker
-- [ ] waiter-format parser unit test (vitest, colocated in the template like
-      codemode-format's)
-- [ ] Prompt-file formatter exemption (`.oxfmtrc.json` ignorePatterns —
-      `configs/waiter-chef/prompts/`)
+- [x] `configs/waiter-chef/` template: forked base files, MENU.md, prompts,
+      parser, worker — _lean fork of the codemode-tag structure; typechecked
+      standalone_
+- [x] ~~waiter-format parser unit test (vitest, colocated in the template
+      like codemode-format's)~~ — _entered in error: config templates have no
+      vitest home (codemode-format.ts has no test either); verified by
+      standalone tsc + live smoke instead_
+- [x] Prompt-file formatter exemption (`.oxfmtrc.json` ignorePatterns —
+      `configs/waiter-chef/prompts/` + `MENU.md`) — _and re-ran tsc after
+      `pnpm format` per the oxfmt-rewrites-markdown lesson_
 - [ ] Live smoke on a preview or dev: create project from
       `github:iterate/iterate#waiter-chef&path:configs/waiter-chef`, run the
       starter prompts below, iterate with Misha
-- [ ] Knobs surfaced for the feel-eval: waiter model, debounce, relay
-      trigger behavior
+- [x] Knobs surfaced for the feel-eval — _`WAITER_MODEL`, `WAITER_DEBOUNCE_MS`,
+      `WAITER_MAX_AUTONOMOUS_TURNS`, `RELAY_EXCERPT_CHARS` at the top of
+      `worker.ts`_
 
 ## Assumptions made (Misha AFK-style delineation)
 


### PR DESCRIPTION
A new config template, `configs/waiter-chef/`, that splits every web chat into two LLM lanes:

- **Waiter** (front-of-house): what the user talks to. Born on every new web chat via project birth defaults — headless driver, no tools, one fast LLM call per turn. Knows the plain-English `MENU.md`, relays orders, gives status updates, corrects itself.
- **Chef** (back-of-house): a bone-stock platform agent (tools, codemode, the works) created per chat at `/agents/chef/<slug>`. Gets its orders relayed from the waiter, reports back when done or blocked.

The waiter's responses are prose plus two tags interpreted by the config worker (same pattern as the codemode-tag experiment):

```
Sure — I've sent that to the kitchen! I'll let you know as it progresses.
<kitchen>The diner wants a multiplayer turn-based Subbuteo-like game…</kitchen>
```

and `<peek/>`, which makes the worker snapshot the chef's processor state (busy/idle, current activity, last message) so the waiter can honestly answer "is it ready yet?" without disturbing the chef.

**Zero platform changes** — entirely userland on the recently-merged birth-defaults surface (#2423/#2474): birth defaults scoped with `matches.pathPrefix: "/agents/web/"` make waiters; the chef path falls outside the prefix so it's born stock. Every prompt, the menu, and the tag parser are files in the config repo — iterating on the feel is a git commit.

Why: voice models are fast, bad at tool-calling, and not very smart — ideal waiters. This template proves the shape with text chat first.

## Live smoke (local dev, project `waiter-smoke-1`) — passing

- "What's on the menu?" → answered by the waiter alone from MENU.md, kitchen never disturbed.
- Subbuteo / wordle orders → chef created lazily, built real working pages, served links; waiter relayed each with the link intact.
- "Is it ready yet?" mid-cook → waiter said "I'll check on it." + `<peek/>` → honest "Not yet — the kitchen is still working on the timer's design."
- "Actually make the tiles hot pink" mid-cook → waiter judged it small, passed it straight through to the busy chef.
- Two model bugs found and fixed **with config-repo commits only, no deploy** (the point of the exercise): the stock boot context primed the tool-less waiter into leaking harmony-style tool-call syntax (now superseded with a waiter boot context in the birth batch), and the waiter imitated the projection's `@offset` bookkeeping prefixes (prompt rule + worker-side strip).

Try it by creating a project from:

```
github:iterate/iterate#waiter-chef&path:configs/waiter-chef
```

Spec, delineated assumptions, and starter prompts for the feel-eval: `tasks/waiter-chef-config.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session id: `940a115b-37af-4c6f-bd1f-22aa71038519`

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Config | +35 -0 | +35 -0 🟩⬜⬜⬜⬜ |
| Docs | +341 -0 | +282 -0 🟩🟩🟩⬜⬜ |
| Other | +662 -0 | +475 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+1,038 -0** | **+792 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 276a6e6 and c2e7dcf, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->