### PR TITLE
Self-heal stale project-directory slug entries on create

### DIFF
--- a/apps/os/src/project-directory.test.ts
+++ b/apps/os/src/project-directory.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   primeProjectDirectory,
   readProjectBySlug,
+  readProjectBySlugAuthoritative,
   type ProjectDirectoryRecord,
 } from "./project-directory.ts";
 
@@ -267,6 +268,69 @@ describe("readProjectBySlug", () => {
     } finally {
       warn.mockRestore();
       vi.useRealTimers();
+    }
+  });
+});
+
+describe("readProjectBySlugAuthoritative", () => {
+  beforeEach(() => auth.getProjectBySlug.mockReset());
+
+  it("re-primes a stale positive cache entry from the auth answer", async () => {
+    const stale = { id: "prj_dead", slug: "reborn", organizationId: null, name: "reborn" };
+    const fresh = { id: "prj_live", slug: "reborn", organizationId: "org_new", name: "reborn" };
+    const directory = {
+      delete: vi.fn().mockResolvedValue(undefined),
+      get: vi.fn().mockResolvedValue(stale),
+      put: vi.fn().mockResolvedValue(undefined),
+    } as unknown as KVNamespace;
+
+    // The cached read path serves the stale record — the bug this heals.
+    await expect(readProjectBySlug(directory, "reborn")).resolves.toEqual(stale);
+
+    auth.getProjectBySlug.mockResolvedValue(fresh);
+    await expect(readProjectBySlugAuthoritative(directory, "reborn")).resolves.toEqual(fresh);
+    expect(auth.getProjectBySlug).toHaveBeenCalledExactlyOnceWith({ projectSlug: "reborn" });
+    expect((directory.put as ReturnType<typeof vi.fn>).mock.calls.map(([key]) => key)).toEqual([
+      "slug:reborn",
+      "project:prj_live",
+    ]);
+
+    // The heal refreshes the in-isolate memo too: cached reads now serve the
+    // live record without waiting for KV visibility.
+    await expect(readProjectBySlug(directory, "reborn")).resolves.toEqual(fresh);
+  });
+
+  it("returns null and writes nothing when auth has no row (admin-lane projects stay cached)", async () => {
+    auth.getProjectBySlug.mockResolvedValue(null);
+    const directory = {
+      delete: vi.fn(),
+      get: vi.fn(),
+      put: vi.fn(),
+    } as unknown as KVNamespace;
+
+    await expect(readProjectBySlugAuthoritative(directory, "kv-only")).resolves.toBeNull();
+    expect(directory.put).not.toHaveBeenCalled();
+    expect(directory.delete).not.toHaveBeenCalled();
+  });
+
+  it("still returns the auth record when the re-prime fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const fresh = { id: "prj_live2", slug: "reborn-2", organizationId: null, name: "reborn-2" };
+      auth.getProjectBySlug.mockResolvedValue(fresh);
+      const directory = {
+        delete: vi.fn().mockResolvedValue(undefined),
+        get: vi.fn().mockResolvedValue(null),
+        put: vi.fn().mockRejectedValue(new Error("KV unavailable")),
+      } as unknown as KVNamespace;
+
+      await expect(readProjectBySlugAuthoritative(directory, "reborn-2")).resolves.toEqual(fresh);
+      expect(warn).toHaveBeenCalledWith(
+        "[project-directory] authoritative re-prime failed; using auth result",
+        expect.objectContaining({ reason: expect.stringContaining("KV unavailable") }),
+      );
+    } finally {
+      warn.mockRestore();
     }
   });
 });

--- a/apps/os/src/project-directory.ts
+++ b/apps/os/src/project-directory.ts
@@ -148,6 +148,38 @@ export async function readProjectBySlug(
   return record;
 }
 
+/**
+ * Authoritative slug read: skip the positive KV cache and ask the auth worker
+ * directly, re-priming the cache on a hit. The heal path for stale positive
+ * entries — a slug whose auth row was deleted and later re-registered with a
+ * fresh id (preview erase cycles, prod delete-then-recreate) keeps its old KV
+ * record forever otherwise. Null when auth has no row: admin-lane projects
+ * live only in KV, so a null here must never be used to evict them.
+ */
+export async function readProjectBySlugAuthoritative(
+  directory: KVNamespace,
+  slug: string,
+): Promise<ProjectDirectoryRecord | null> {
+  const project = await itxEnv.AUTH.getProjectBySlug({ projectSlug: slug });
+  if (!project) return null;
+  const record = {
+    id: project.id,
+    slug: project.slug,
+    organizationId: project.organizationId,
+    name: project.name,
+  };
+  try {
+    await primeProjectDirectory(directory, record);
+  } catch (error) {
+    // Auth's answer stands on its own; a failed re-prime only means the next
+    // cached read may still see the stale record and heal again.
+    console.warn("[project-directory] authoritative re-prime failed; using auth result", {
+      reason: errorMessage(error),
+    });
+  }
+  return record;
+}
+
 /** Fast existence/metadata check by project id (KV only — no auth fallback:
  * ids are primed at create and re-primed by every slug read). */
 export async function readProjectById(

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -74,6 +74,7 @@ import {
   listProjectDirectory,
   primeProjectDirectory,
   readProjectById,
+  readProjectBySlugAuthoritative,
   resolveProjectIdBySlug,
   type ProjectIdentity,
 } from "./project-directory.ts";
@@ -6348,12 +6349,46 @@ export class ProjectRpcTarget extends IterateRpcTarget<"Project"> {
       existing.auth.assertCanAccessProject(existing.projectId);
       this.#props = existing;
     } else {
+      let identity = await this.identity();
       if (args.projectId !== undefined && args.projectId !== this.#projectId) {
-        throw new Error(
-          `project create() received id "${args.projectId}" for handle "${this.#projectId}"`,
+        // The handle's id came from the KV directory cache; the caller's from
+        // auth claims (e.g. the welcome page's ?ensureBirth retry). On
+        // disagreement the auth worker is the tiebreaker: an erase cycle
+        // (previews) or a delete-then-recreate leaves a stale positive
+        // `slug:` key shadowing the real project. If auth maps this slug to
+        // the caller's id, re-key the handle and continue as that project
+        // instead of failing setup forever.
+        const authoritative = await readProjectBySlugAuthoritative(
+          env.PROJECT_DIRECTORY,
+          identity.slug,
         );
+        if (authoritative === null || authoritative.id !== args.projectId) {
+          throw new Error(
+            `project create() received id "${args.projectId}" for handle "${this.#projectId}"`,
+          );
+        }
+        widenProjectAccess(this.#props.auth, authoritative.id);
+        const healed: ExistingProjectRpcTargetProps = {
+          auth: this.#props.auth,
+          capabilityHost: new CapabilityHostRpcTarget({
+            auth: this.#props.auth,
+            ctx: this.#props.ctx,
+            path: "/",
+            projectId: authoritative.id,
+          }),
+          ctx: this.#props.ctx,
+          streamContext: streamContextForAuth(this.#props.auth),
+          projectId: authoritative.id,
+        };
+        healed.auth.assertCanAccessProject(healed.projectId);
+        this.#props = healed;
+        identity = {
+          projectId: authoritative.id,
+          slug: authoritative.slug,
+          organizationId: authoritative.organizationId,
+          name: authoritative.name,
+        };
       }
-      const identity = await this.identity();
       registered = {
         organizationId: identity.organizationId,
         projectId: identity.projectId,

--- a/tasks/project-directory-slug-self-heal.md
+++ b/tasks/project-directory-slug-self-heal.md
@@ -33,7 +33,7 @@ born. Auth D1 (source of truth) knew only `prj_NEW`.
 When create() receives an explicit `projectId` that disagrees with the
 handle's id, treat the auth worker as tiebreaker instead of failing:
 
-- [ ] `readProjectBySlugAuthoritative(directory, slug)` in
+- [x] `readProjectBySlugAuthoritative(directory, slug)` in
       `project-directory.ts`: skip the positive KV cache, ask
       `AUTH.getProjectBySlug` directly; on a hit re-prime the cache
       (best-effort) and return the record; null when auth has no row

--- a/tasks/project-directory-slug-self-heal.md
+++ b/tasks/project-directory-slug-self-heal.md
@@ -38,11 +38,11 @@ handle's id, treat the auth worker as tiebreaker instead of failing:
       `AUTH.getProjectBySlug` directly; on a hit re-prime the cache
       (best-effort) and return the record; null when auth has no row
       (admin-lane projects live only in KV — never heal those away).
-- [ ] in `ProjectRpcTarget.create()`: on id mismatch, resolve the handle's
+- [x] in `ProjectRpcTarget.create()`: on id mismatch, resolve the handle's
       current slug authoritatively; if auth maps it to the caller's id,
       re-key the handle to that project (widen + assert access, rebuild
       props) and continue; otherwise throw the original mismatch error.
-- [ ] unit tests for the helper (auth hit → record + re-prime + memo
+- [x] unit tests for the helper (auth hit → record + re-prime + memo
       refresh; auth miss → null, no prime).
 
 Out of scope: proactively invalidating KV on auth-side project delete

--- a/tasks/project-directory-slug-self-heal.md
+++ b/tasks/project-directory-slug-self-heal.md
@@ -1,0 +1,50 @@
+---
+status: in-progress
+size: small
+---
+
+# Self-heal stale project-directory slug entries
+
+## Status
+
+Spec + implementation in one sitting; small change. See PR.
+
+## Problem (observed live on preview-14)
+
+The os project-directory KV cache is deliberately no-expiry ("slugs are
+immutable, create overwrites its keys" — `project-directory.ts`). That
+invariant breaks whenever a slug's auth-side row is deleted and the slug is
+later re-registered with a new id:
+
+- preview erase cycles: e2e signups all derive org/project `nustom` from
+  `*+test@nustom.com` emails, so successive lease/erase cycles recreate the
+  same slug with fresh ids while a KV entry survives;
+- prod: delete a project in the auth UI, recreate the slug — os routes the
+  slug to the dead id forever.
+
+Observed failure: `?ensureBirth` runs
+`projects.get("nustom").create({projectId: prj_NEW})`; the handle resolved
+stale `prj_OLD` from KV, and create()'s id-mismatch guard throws →
+"Project setup could not be resumed" toast on every reload, project never
+born. Auth D1 (source of truth) knew only `prj_NEW`.
+
+## Fix
+
+When create() receives an explicit `projectId` that disagrees with the
+handle's id, treat the auth worker as tiebreaker instead of failing:
+
+- [ ] `readProjectBySlugAuthoritative(directory, slug)` in
+      `project-directory.ts`: skip the positive KV cache, ask
+      `AUTH.getProjectBySlug` directly; on a hit re-prime the cache
+      (best-effort) and return the record; null when auth has no row
+      (admin-lane projects live only in KV — never heal those away).
+- [ ] in `ProjectRpcTarget.create()`: on id mismatch, resolve the handle's
+      current slug authoritatively; if auth maps it to the caller's id,
+      re-key the handle to that project (widen + assert access, rebuild
+      props) and continue; otherwise throw the original mismatch error.
+- [ ] unit tests for the helper (auth hit → record + re-prime + memo
+      refresh; auth miss → null, no prime).
+
+Out of scope: proactively invalidating KV on auth-side project delete
+(cross-worker choreography; the lazy heal covers the read path that
+matters).


### PR DESCRIPTION
The os project-directory KV cache is no-expiry by design ("slugs are immutable, create overwrites its keys"). That invariant breaks when a slug's auth-side row is deleted and the slug is later re-registered with a new id — preview erase cycles hit it constantly (every `*+test@nustom.com` signup derives the same `nustom` slug), and prod can hit it via delete-project-then-recreate-slug.

Observed live on preview-14: KV said `nustom → prj_2effabae…` while auth D1 (source of truth) said `nustom → prj_19a03ffb…`. The welcome page's `?ensureBirth` retry does `projects.get("nustom").create({projectId})`, the handle resolves the dead id from KV, and create()'s id-mismatch guard throws — **"Project setup could not be resumed. Reload to try again."** on every reload, project never born.

Now the mismatch guard treats the auth worker as tiebreaker before failing:

```ts
// caller (welcome page) knows the real id from auth claims:
await session.projects.get("nustom").create({ projectId: "prj_NEW" });
// before: KV's stale prj_OLD wins → throw → setup stuck forever
// after:  AUTH.getProjectBySlug("nustom") → prj_NEW → re-prime KV,
//         re-key the handle, continue birth as prj_NEW
```

Auth-miss slugs still throw the original error — admin-lane projects live only in KV and must never be healed away.

- `readProjectBySlugAuthoritative` in `project-directory.ts`: bypass the positive cache, consult auth, re-prime (best-effort) on a hit; unit-tested (stale-entry heal + memo refresh, auth-miss no-op, re-prime failure tolerance).
- `ProjectRpcTarget.create()`: on explicit-id mismatch, heal via the authoritative read; widen + assert access against the healed id.

Out of scope: proactive KV invalidation on auth-side project delete — the lazy heal covers the read path that matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session: `53ae58d9-2d95-47c4-9228-a4050cd02997`

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +70 -3 | +51 -3 🟩🟩🟩🟩🟩 |
| Tests | +64 -0 | +52 -0 🟩🟩🟩🟩🟩 |
| Docs | +50 -0 | +39 -0 🟩🟩🟩🟩⬜ |
| **Total** | **+184 -3** | **+142 -3** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 276a6e6 and e582166, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-11T20:02:45.418Z",
      "deployedAt": "2026-08-11T19:37:42.638Z",
      "headSha": "e5821662c1d21d685ab30862ebbde39189171db5",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/134064493610004",
      "shortSha": "e582166",
      "cleanupDurationMs": 21383,
      "deployDurationMs": 70045,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 68530,
      "deployReadinessDurationMs": 1512,
      "deployedWorkerName": "os-preview-11",
      "deployedWorkerVersion": "8dca82b1-5ff5-41a2-91bb-3cf74b86bb24",
      "testDurationMs": 252080,
      "testRetries": null,
      "workerSizeKib": 20778.69,
      "workerGzipKib": 5229.14,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5240.01
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-11T20:02:26.469Z",
      "deployedAt": "2026-08-11T19:36:58.690Z",
      "headSha": "e5821662c1d21d685ab30862ebbde39189171db5",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-11.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/134064493610004",
      "shortSha": "e582166",
      "cleanupDurationMs": 2430,
      "deployDurationMs": 24979,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 24580,
      "deployReadinessDurationMs": 396,
      "deployedWorkerName": "docs-preview-11",
      "deployedWorkerVersion": "5958ca7b-ee7b-48a7-a352-8b1b7257c59d",
      "testDurationMs": 2775,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-11T20:02:27.883Z",
      "deployedAt": "2026-08-11T19:37:07.733Z",
      "headSha": "e5821662c1d21d685ab30862ebbde39189171db5",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/134064493610004",
      "shortSha": "e582166",
      "cleanupDurationMs": 3843,
      "deployDurationMs": 33959,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 33621,
      "deployReadinessDurationMs": 333,
      "deployedWorkerName": "auth-preview-11",
      "deployedWorkerVersion": "a0a85697-4bf3-4be2-8cab-8f80beab4698",
      "testDurationMs": 12277,
      "testRetries": null,
      "workerSizeKib": 3981.51,
      "workerGzipKib": 815.44,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-11T20:02:25.461Z",
      "deployedAt": "2026-08-11T19:36:43.369Z",
      "headSha": "e5821662c1d21d685ab30862ebbde39189171db5",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/134064493610004",
      "shortSha": "e582166",
      "cleanupDurationMs": 1417,
      "deployDurationMs": 9472,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 9230,
      "deployReadinessDurationMs": 210,
      "deployedWorkerName": "dummy-petshop-preview-11",
      "deployedWorkerVersion": "e0585380-d9aa-4d71-b1e8-d3fd939750ec",
      "testDurationMs": 32849,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `e582166` | [https://auth.iterate-preview-11.com](https://auth.iterate-preview-11.com) | 815.4 KiB | 34.0s | 12.3s |  | 3.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/134064493610004) | 2026-08-11T20:02:27.883Z | Preview app released. |
| Docs | released | `e582166` | [https://docs-preview-11.iterate-dev-preview.workers.dev](https://docs-preview-11.iterate-dev-preview.workers.dev) | 866.2 KiB | 25.0s | 2.8s |  | 2.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/134064493610004) | 2026-08-11T20:02:26.469Z | Preview app released. |
| Dummy Petshop | released | `e582166` | [https://dummy-petshop.iterate-preview-11.com](https://dummy-petshop.iterate-preview-11.com) | 198.3 KiB | 9.5s | 32.8s |  | 1.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/134064493610004) | 2026-08-11T20:02:25.461Z | Preview app released. |
| OS | released | `e582166` | [https://os.iterate-preview-11.com](https://os.iterate-preview-11.com) | 5.11 MiB (-10.9 KiB vs main) | 70.0s | 252.1s |  | 21.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/134064493610004) | 2026-08-11T20:02:45.418Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->