### PR TITLE
Media: durable media/uploaded event, server-side analysis (obligation pattern)

### DIFF
--- a/apps/mobile/e2e/media-agent-retrieval.e2e.test.ts
+++ b/apps/mobile/e2e/media-agent-retrieval.e2e.test.ts
@@ -3,8 +3,9 @@
 // find): capture three fake screenshots — the lesson email plus two decoys —
 // then retrieve through the SAME door an agent uses, the media-search
 // catalogue example run via capabilityHost.runScript. Proves the whole
-// chain: capture pipeline → OCR transcript → example discoverable in the
-// catalogue → keyword search finds the right item with a usable answer.
+// chain: upload → server-side analysis (the seeded MediaApp processor) →
+// OCR transcript → example discoverable in the catalogue → keyword search
+// finds the right item with a usable answer.
 //
 //   doppler run --config dev -- pnpm --dir apps/mobile test:e2e   # local dev (pnpm dev must be running)
 
@@ -15,7 +16,7 @@ import { expect, test } from "vitest";
 import { connectItx } from "iterate/node";
 import { mintForgedAccessToken } from "../../../scripts/auth/forge-token.ts";
 import { phoneRunnableExamples } from "../src/lib/examples.ts";
-import { buildProcessScript, mediaFilePath } from "../src/lib/media.ts";
+import { buildUploadedEvent, MEDIA_PROCESSED_EVENT_TYPE, mediaFilePath } from "../src/lib/media.ts";
 import { portlessOrigin, requireEnv, resolveBaseUrl } from "./e2e-helpers.ts";
 
 const FIXTURES = ["swim-email.png", "decoy-receipt.png", "decoy-code.png"];
@@ -40,15 +41,18 @@ test("an agent-style media-search run finds the swimming lesson among decoys", a
   });
   using project = connectItx({ baseUrl, auth: { type: "bearer", token }, projectId });
 
-  // Capture all three the way the Media screen does.
+  // Capture all three the way the Media screen does: bytes + one uploaded
+  // event each; the seeded MediaApp processor analyzes server-side.
+  const stream = project.streams.get("/media");
+  const uploads: { stableKey: string; offset: number }[] = [];
   for (const filename of FIXTURES) {
     const png = readFileSync(resolve(import.meta.dirname, "fixtures", filename));
     const stableKey = createHash("sha256").update(png.toString("base64")).digest("hex");
     await project.files
       .get(mediaFilePath(stableKey, filename))
       .put({ data: new Uint8Array(png), contentType: "image/png" });
-    await project.capabilityHost.runScript(
-      buildProcessScript({
+    const [uploaded] = await stream.append(
+      buildUploadedEvent({
         wipeGeneration: 0,
         stableKey,
         filename,
@@ -58,9 +62,20 @@ test("an agent-style media-search run finds the swimming lesson among decoys", a
         source: "picker",
         capturedAt: null,
         isScreenshot: null,
-        mode: "capture",
       }),
     );
+    uploads.push({ stableKey, offset: uploaded!.offset });
+  }
+  // Search needs the transcripts: wait for every item's analysis settlement.
+  for (const upload of uploads) {
+    const processed: any = await stream.waitForEvent({
+      afterOffset: Math.min(...uploads.map((entry) => entry.offset)),
+      eventTypes: [MEDIA_PROCESSED_EVENT_TYPE],
+      predicate: (event: any) =>
+        event.payload.stableKey === upload.stableKey && event.payload.error === null,
+      timeoutMs: 120_000,
+    });
+    expect(processed.payload).toMatchObject({ stableKey: upload.stableKey });
   }
 
   // Retrieval through the agent door: the media-search catalogue example,

--- a/apps/mobile/e2e/media.e2e.test.ts
+++ b/apps/mobile/e2e/media.e2e.test.ts
@@ -1,12 +1,13 @@
-// Live proof of the media capture pipeline: the exact bytes-then-script
+// Live proof of the media capture pipeline: the exact bytes-then-append
 // sequence the Media screen performs (see app/project/[projectId]/media.tsx)
-// against a real project — upload to itx.files, then one
-// capabilityHost.runScript doing toMarkdown → vision transcript+tags →
-// append. Also the repo's live proof that IMAGE input to itx.ai.toMarkdown
-// works (the cf-ai-to-markdown example only exercises CSV/HTML and is
-// e2eProven: false). The fixture (e2e/fixtures/ticket.png) renders "Train to
-// Florence / Seat 21A", so the transcript assertion is a real full-text OCR
-// check, not just shape.
+// against a real project — upload to itx.files, then ONE durable
+// media/uploaded append — followed by the SERVER-side analysis reaction (the
+// seeded MediaApp processor drives toMarkdown → vision transcript+tags and
+// settles with a media/processed event). Also the repo's live proof that
+// IMAGE input to itx.ai.toMarkdown works (the cf-ai-to-markdown example only
+// exercises CSV/HTML and is e2eProven: false). The fixture
+// (e2e/fixtures/ticket.png) renders "Train to Florence / Seat 21A", so the
+// transcript assertion is a real full-text OCR check, not just shape.
 //
 //   doppler run --config dev -- pnpm --dir apps/mobile test:e2e   # local dev (pnpm dev must be running)
 
@@ -17,15 +18,15 @@ import { expect, test } from "vitest";
 import { connectItx } from "iterate/node";
 import { mintForgedAccessToken } from "../../../scripts/auth/forge-token.ts";
 import {
-  buildProcessScript,
-  MEDIA_CAPTURED_EVENT_TYPE,
-  MEDIA_EVENT_TYPES,
+  buildReanalyzeEvent,
+  buildUploadedEvent,
   MEDIA_PROCESSED_EVENT_TYPE,
+  MEDIA_UPLOADED_EVENT_TYPE,
   mediaFilePath,
 } from "../src/lib/media.ts";
 import { portlessOrigin, requireEnv, resolveBaseUrl } from "./e2e-helpers.ts";
 
-test("media capture: bytes → description → transcript+tags → captured event, idempotently; re-analyze overlays", async () => {
+test("media upload: bytes → uploaded event → server-side analysis settles a processed event; re-analyze overlays", async () => {
   const baseUrl = resolveBaseUrl();
 
   using adminSession = connectItx({
@@ -45,7 +46,7 @@ test("media capture: bytes → description → transcript+tags → captured even
   });
   using project = connectItx({ baseUrl, auth: { type: "bearer", token }, projectId });
 
-  // The screen's exact sequence: hash → put bytes → runScript.
+  // The screen's exact sequence: hash → put bytes → append uploaded.
   const png = readFileSync(resolve(import.meta.dirname, "fixtures/ticket.png"));
   const base64 = png.toString("base64");
   const stableKey = createHash("sha256").update(base64).digest("hex");
@@ -54,7 +55,8 @@ test("media capture: bytes → description → transcript+tags → captured even
     .get(mediaFilePath(stableKey, filename))
     .put({ data: new Uint8Array(png), contentType: "image/png" });
 
-  const captureScript = buildProcessScript({
+  const stream = project.streams.get("/media");
+  const uploadedInput = buildUploadedEvent({
     stableKey,
     wipeGeneration: 0,
     filename,
@@ -64,52 +66,44 @@ test("media capture: bytes → description → transcript+tags → captured even
     source: "picker",
     capturedAt: null,
     isScreenshot: null,
-    mode: "capture",
   });
-  const execution = await project.capabilityHost.runScript(captureScript);
-  const event: any = execution.result;
-
-  expect(event).toMatchObject({
-    type: MEDIA_CAPTURED_EVENT_TYPE,
+  const [uploaded] = await stream.append(uploadedInput);
+  expect(uploaded).toMatchObject({
+    type: MEDIA_UPLOADED_EVENT_TYPE,
     offset: expect.any(Number),
-    payload: {
-      stableKey,
-      filename,
-      contentType: "image/png",
-      processedBy: expect.stringContaining("@cf/"),
-    },
+  });
+
+  // Re-appending the same upload (retry, re-pick) dedupes to the SAME event.
+  const [rerun] = await stream.append(uploadedInput);
+  expect(rerun).toMatchObject({ offset: uploaded!.offset });
+
+  // The seeded MediaApp processor reacts server-side: no socket held open,
+  // no client involvement — the settlement just arrives on the stream.
+  const processed: any = await stream.waitForEvent({
+    afterOffset: uploaded!.offset,
+    eventTypes: [MEDIA_PROCESSED_EVENT_TYPE],
+    predicate: (event: any) => event.payload.stableKey === stableKey,
+    timeoutMs: 120_000,
+  });
+  expect(processed.payload).toMatchObject({
+    stableKey,
+    error: null,
+    requestOffset: uploaded!.offset,
+    processedBy: expect.stringContaining("@cf/"),
   });
   // The vision models actually read the image: the description says
   // SOMETHING, and the transcript contains the rendered ticket text.
-  expect(event.payload.markdown.length).toBeGreaterThan(0);
-  expect(event.payload.transcript.toLowerCase()).toContain("florence");
-  expect(Array.isArray(event.payload.tags)).toBe(true);
+  expect(processed.payload.markdown.length).toBeGreaterThan(0);
+  expect(processed.payload.transcript.toLowerCase()).toContain("florence");
+  expect(Array.isArray(processed.payload.tags)).toBe(true);
 
-  // Re-running the same capture (retry, re-pick) must return the SAME event.
-  const rerun = await project.capabilityHost.runScript(captureScript);
-  expect(rerun.result).toMatchObject({ offset: event.offset });
-
-  // Re-analyze appends a processed event the list derivation overlays.
-  const reprocess = await project.capabilityHost.runScript(
-    buildProcessScript({
-      stableKey,
-      wipeGeneration: 0,
-      filename,
-      contentType: "image/png",
-      width: 280,
-      height: 110,
-      source: "picker",
-      capturedAt: null,
-      isScreenshot: null,
-      mode: { reprocessNonce: "e2e-1" },
-    }),
-  );
-  expect(reprocess.result).toMatchObject({ type: MEDIA_PROCESSED_EVENT_TYPE });
-
-  // The list read the screen performs sees one capture + one reprocess.
-  const events = await project.streams.get("/media").getEvents({ eventTypes: MEDIA_EVENT_TYPES });
-  expect(events.map((entry: any) => entry.type)).toEqual([
-    MEDIA_CAPTURED_EVENT_TYPE,
-    MEDIA_PROCESSED_EVENT_TYPE,
-  ]);
+  // Re-analyze is a durable request the same server pipeline answers.
+  await stream.append(buildReanalyzeEvent(stableKey, "e2e-1"));
+  const reprocessed: any = await stream.waitForEvent({
+    afterOffset: processed.offset,
+    eventTypes: [MEDIA_PROCESSED_EVENT_TYPE],
+    predicate: (event: any) => event.payload.stableKey === stableKey,
+    timeoutMs: 120_000,
+  });
+  expect(reprocessed.payload).toMatchObject({ stableKey, error: null });
 });

--- a/apps/mobile/src/app/project/[projectId]/media.tsx
+++ b/apps/mobile/src/app/project/[projectId]/media.tsx
@@ -2,12 +2,14 @@
 // they show. "Add" picks from the photo library (PHPicker — no permission,
 // no native module, ships OTA). Per image: sha256 the payload, skip if the
 // /media stream already has that idempotency key, upload bytes to itx.files,
-// then one capabilityHost.runScript call does
-// toMarkdown → vision transcript+tags → append server-side (lib/media.ts
-// builds the script and owns the taxonomy). Picked items appear immediately
-// as pending cards (three at a time in flight) and resolve into real rows as
-// their events land on the live stream. Tap a thumbnail for full screen;
-// "Re-analyze" reruns the pipeline and overlays the newest result.
+// then ONE cheap durable media/uploaded append — analysis happens
+// server-side (the MediaApp processor reacts to the event and overlays a
+// media/processed settlement; lib/media.ts owns the client vocabulary).
+// Picked items appear immediately as pending cards (three at a time in
+// flight), resolve into real rows as their uploaded events land on the live
+// stream, and show "Analyzing…" until the settlement arrives — locking the
+// phone mid-pass loses nothing. Tap a thumbnail for full screen;
+// "Re-analyze" appends a reanalyze request the same server pipeline answers.
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import * as Crypto from "expo-crypto";
@@ -29,7 +31,8 @@ import { Markdown } from "../../../components/markdown.tsx";
 import { MediaViewer } from "../../../components/media-viewer.tsx";
 import { getProjectItx } from "../../../lib/itx.ts";
 import {
-  buildProcessScript,
+  buildReanalyzeEvent,
+  buildUploadedEvent,
   buildWipeScript,
   extendedSinceIso,
   readWipeGeneration,
@@ -58,7 +61,7 @@ import { useLiveEvents } from "../../../lib/use-live-events.ts";
 type PendingItem = {
   previewUri: string;
   filename: string;
-  status: "waiting" | "analyzing" | "skipped" | "error";
+  status: "waiting" | "uploading" | "skipped" | "error";
   error?: string;
 };
 
@@ -111,14 +114,14 @@ export default function MediaScreen() {
           onProgress: setSyncProgress,
           // Discovered screenshots appear immediately as pending cards with
           // local previews, exactly like picked ones, and resolve into real
-          // rows as their captured events land on the live stream.
+          // rows as their uploaded events land on the live stream.
           onCandidate: (candidate) =>
             setPending((current) => [
               ...current,
               {
                 previewUri: candidate.previewUri,
                 filename: candidate.filename,
-                status: "analyzing",
+                status: "uploading",
               },
             ]),
           onCandidateDone: (candidate, error) =>
@@ -191,7 +194,7 @@ export default function MediaScreen() {
       const wipeGeneration = await readWipeGeneration(stream);
       await mapWithConcurrency(picked, 3, async (image) => {
         try {
-          setStatus(image, "analyzing");
+          setStatus(image, "uploading");
           const stableKey = await Crypto.digestStringAsync(
             Crypto.CryptoDigestAlgorithm.SHA256,
             image.base64,
@@ -208,8 +211,10 @@ export default function MediaScreen() {
             data: base64ToUint8Array(image.base64),
             contentType: image.contentType,
           });
-          await project.capabilityHost.runScript(
-            buildProcessScript({
+          // The durable birth fact — analysis follows server-side and lands
+          // as a media/processed event over the live stream.
+          await stream.append(
+            buildUploadedEvent({
               stableKey,
               wipeGeneration,
               filename: image.filename,
@@ -219,11 +224,11 @@ export default function MediaScreen() {
               source: "picker",
               capturedAt: null,
               isScreenshot: null,
-              mode: "capture",
             }),
           );
-          // The captured event arrives over the live connection and renders
-          // as a real row; drop the pending card.
+          // The uploaded event arrives over the live connection and renders
+          // as a real row (with its own "Analyzing…" badge); drop the
+          // pending card.
           setPending((current) => current.filter((row) => row.previewUri !== image.previewUri));
         } catch (error) {
           setStatus(image, "error", error instanceof Error ? error.message : String(error));
@@ -238,8 +243,8 @@ export default function MediaScreen() {
   // Chips: taxonomy order first, then novel model-coined tags actually in use.
   const tagsInUse = new Set(items.flatMap((item) => item.payload.tags));
   const chipTags = [
-    ...MEDIA_TAGS.map(({ tag }) => tag).filter((tag) => tagsInUse.has(tag)),
-    ...[...tagsInUse].filter((tag) => !MEDIA_TAGS.some(({ tag: known }) => known === tag)).sort(),
+    ...MEDIA_TAGS.filter((tag) => tagsInUse.has(tag)),
+    ...[...tagsInUse].filter((tag) => !MEDIA_TAGS.includes(tag)).sort(),
   ];
 
   return (
@@ -577,7 +582,7 @@ function PendingRow({
           <View style={styles.pendingSpinnerRow}>
             <ActivityIndicator color={colors.textMuted} size="small" />
             <Text style={styles.pendingStatus}>
-              {row.status === "waiting" ? "Waiting…" : "Analyzing…"}
+              {row.status === "waiting" ? "Waiting…" : "Uploading…"}
             </Text>
           </View>
         )}
@@ -609,20 +614,11 @@ function MediaRow({
   const reanalyze = useMutation({
     mutationFn: async () => {
       const project = await getProjectItx(baseUrl, projectId);
-      await project.capabilityHost.runScript(
-        buildProcessScript({
-          stableKey: item.payload.stableKey,
-          wipeGeneration: 0, // reprocess keys on its nonce, not the capture identity
-          filename: item.payload.filename,
-          contentType: item.payload.contentType,
-          width: item.payload.width,
-          height: item.payload.height,
-          source: item.payload.source,
-          capturedAt: item.payload.capturedAt,
-          isScreenshot: item.payload.isScreenshot,
-          mode: { reprocessNonce: Date.now().toString(36) },
-        }),
-      );
+      // A durable request the server-side pipeline answers; the row shows
+      // "Analyzing…" (via deriveMediaList) until the settlement arrives.
+      await project.streams
+        .get(MEDIA_STREAM_PATH)
+        .append(buildReanalyzeEvent(item.payload.stableKey, Date.now().toString(36)));
       // The processed event arrives over the live stream and re-renders the
       // row through deriveMediaList — nothing to invalidate here.
     },
@@ -654,9 +650,22 @@ function MediaRow({
           <View style={expanded ? undefined : styles.markdownCollapsed}>
             <Markdown markdown={item.payload.markdown} preview />
           </View>
-        ) : (
+        ) : item.analysis.status === "pending" ? null : (
           <Text style={styles.markdown}>(no description)</Text>
         )}
+        {item.analysis.status === "pending" ? (
+          // Born from an uploaded event (or re-analyzing): the server-side
+          // settlement will overlay this row when it lands.
+          <View style={styles.pendingSpinnerRow}>
+            <ActivityIndicator color={colors.textMuted} size="small" />
+            <Text style={styles.pendingStatus}>Analyzing…</Text>
+          </View>
+        ) : null}
+        {item.analysis.status === "failed" ? (
+          <Text numberOfLines={expanded ? undefined : 2} style={styles.pendingError}>
+            {`Analysis failed: ${item.analysis.error || "unknown error"}`}
+          </Text>
+        ) : null}
         {expanded && item.payload.transcript ? (
           <Text selectable style={styles.transcript}>
             {item.payload.transcript}

--- a/apps/mobile/src/lib/media-sync.ts
+++ b/apps/mobile/src/lib/media-sync.ts
@@ -1,16 +1,19 @@
 // The Expo-welded half of the screenshot sync engine: permission flow,
 // screenshots-album enumeration, byte reads, and driving each new asset
-// through the same capture pipeline the picker uses (media.ts). The pure
-// pass-planning rules live in media-sync-core.ts. Sync is device-initiated
-// push per the original spec: the phone with the toggle on decides to run a
-// pass (Media screen open or "Sync now"); there is no background task.
+// through the same capture pipeline the picker uses (media.ts) — now just
+// hash + upload + one durable media/uploaded append per item; analysis is
+// server-side (the MediaApp processor reacts to the event), so a pass is
+// fast and backgrounding mid-pass loses ~nothing. The pure pass-planning
+// rules live in media-sync-core.ts. Sync is device-initiated push per the
+// original spec: the phone with the toggle on decides to run a pass (Media
+// screen open or "Sync now"); there is no background task.
 
 import * as Crypto from "expo-crypto";
 import * as MediaLibrary from "expo-media-library";
 import type { ProjectStub } from "iterate/sdk/itx/react";
 import { uint8ArrayToBase64 } from "./encoding.ts";
 import {
-  buildProcessScript,
+  buildUploadedEvent,
   mapWithConcurrency,
   MEDIA_STREAM_PATH,
   mediaFilePath,
@@ -37,7 +40,7 @@ export type SyncPassResult =
 
 /**
  * One sync pass: newest screenshots first, hash each, skip what the stream
- * already has, capture the rest through the standard pipeline. Safe to run
+ * already has, upload the rest and append their birth events. Safe to run
  * repeatedly — the stop rule makes caught-up passes cheap.
  */
 export type SyncCandidate = { previewUri: string; filename: string };
@@ -50,7 +53,7 @@ export async function runSyncPass(input: {
   onProgress: (message: string) => void;
   /** A new (not-yet-captured) screenshot was found — show it immediately. */
   onCandidate: (candidate: SyncCandidate) => void;
-  /** Its server-side processing settled; error is null on success. */
+  /** Its upload settled; error is null on success. */
   onCandidateDone: (candidate: SyncCandidate, error: string | null) => void;
 }): Promise<SyncPassResult> {
   const permission = await MediaLibrary.requestPermissionsAsync();
@@ -121,18 +124,19 @@ export async function runSyncPass(input: {
     after = page.endCursor;
   }
 
-  // Processing: the discovered new ones, 3-wide like the picker flow.
+  // Upload the discovered new ones, 3-wide like the picker flow: bytes to
+  // files, then the durable birth event. Analysis follows server-side.
   let synced = 0;
   let failed = 0;
   await mapWithConcurrency(candidates, 3, async (candidate) => {
-    input.onProgress(`Analyzing ${synced + 1} of ${candidates.length} new…`);
+    input.onProgress(`Uploading ${synced + 1} of ${candidates.length} new…`);
     try {
       await input.project.files.get(mediaFilePath(candidate.stableKey, candidate.filename)).put({
         data: candidate.base64,
         contentType: candidate.contentType,
       });
-      await input.project.capabilityHost.runScript(
-        buildProcessScript({
+      await stream.append(
+        buildUploadedEvent({
           stableKey: candidate.stableKey,
           wipeGeneration,
           filename: candidate.filename,
@@ -142,14 +146,13 @@ export async function runSyncPass(input: {
           source: "library-sync",
           capturedAt: candidate.capturedAt,
           isScreenshot: true,
-          mode: "capture",
         }),
       );
       input.onCandidateDone(candidate, null);
       synced += 1;
     } catch (error) {
-      // One oversized/failed screenshot must not sink the whole pass; its
-      // card shows the error and the next pass will retry it.
+      // One failed upload must not sink the whole pass; its card shows the
+      // error and the next pass will retry it.
       input.onCandidateDone(candidate, error instanceof Error ? error.message : String(error));
       failed += 1;
     }

--- a/apps/mobile/src/lib/media.test.ts
+++ b/apps/mobile/src/lib/media.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
 import {
-  buildProcessScript,
+  buildReanalyzeEvent,
+  buildUploadedEvent,
   buildWipeScript,
   extendedSinceIso,
   mediaIdempotencyKey,
@@ -10,35 +11,24 @@ import {
   mapWithConcurrency,
   MEDIA_CAPTURED_EVENT_TYPE,
   MEDIA_PROCESSED_EVENT_TYPE,
+  MEDIA_REANALYZE_REQUESTED_EVENT_TYPE,
+  MEDIA_UPLOADED_EVENT_TYPE,
   MEDIA_WIPED_EVENT_TYPE,
   mediaFilePath,
   normalizedImageFilename,
   type MediaListItem,
 } from "./media.ts";
 
-// The script builder's output is what actually runs server-side, so the
-// tests EVALUATE it against a fake itx rather than asserting on the string.
+// Analysis is server-side now (iterate/starter-apps/media — analysis.test.ts
+// and media-analysis.test.ts over there own the pipeline and obligation
+// behavior); these tests cover the phone's half: the durable event builders,
+// the list derivation with its analysis states, and the wipe script.
 
-test("capture script describes, transcribes, tags, and appends one idempotent event", async () => {
-  const itx = fakeItx({
-    toMarkdown: { format: "markdown", data: "A train ticket from Rome to Florence.\n" },
-    // OpenAI-style answer shape (what llama on Workers AI actually returns),
-    // wrapped in chatter the JSON extractor must see through.
-    visionAnswer: {
-      choices: [
-        {
-          message: {
-            content:
-              'Here is the JSON: {"title": "Trenitalia ticket to Florence", "transcript": "Train to Florence\\nSeat 21A", "tags": ["logistics", "Screenshot!", "screenshot"]}',
-          },
-        },
-      ],
-    },
-  });
-  const result = await runScript(
-    buildProcessScript({
-      wipeGeneration: 0,
+test("buildUploadedEvent: the whole durable capture is one metadata append", () => {
+  expect(
+    buildUploadedEvent({
       stableKey: "abc123",
+      wipeGeneration: 0,
       filename: "IMG_0001.PNG",
       contentType: "image/png",
       width: 1170,
@@ -46,25 +36,17 @@ test("capture script describes, transcribes, tags, and appends one idempotent ev
       source: "picker",
       capturedAt: null,
       isScreenshot: null,
-      mode: "capture",
     }),
-    itx,
-  );
-
-  expect(itx.calls.bytesPath).toBe("/media/abc123-IMG_0001.PNG");
-  expect(itx.calls.visionBody.messages[0].content[1].image_url.url).toMatch(
-    /^data:image\/png;base64,/,
-  );
-  expect(itx.calls.appended).toMatchObject({
-    type: MEDIA_CAPTURED_EVENT_TYPE,
+  ).toEqual({
+    type: MEDIA_UPLOADED_EVENT_TYPE,
+    // Shared spelling with legacy captured events: an item captured before
+    // the uploaded-event split can never re-enter as a duplicate.
     idempotencyKey: "media-captured-abc123",
     payload: {
       stableKey: "abc123",
-      title: "Trenitalia ticket to Florence",
-      markdown: "A train ticket from Rome to Florence.",
-      transcript: "Train to Florence\nSeat 21A",
-      // lowercased, punctuation folded, deduped
-      tags: ["logistics", "screenshot"],
+      path: "/media/abc123-IMG_0001.PNG",
+      filename: "IMG_0001.PNG",
+      contentType: "image/png",
       width: 1170,
       height: 2532,
       source: "picker",
@@ -72,194 +54,28 @@ test("capture script describes, transcribes, tags, and appends one idempotent ev
       isScreenshot: null,
     },
   });
-  expect(result).toMatchObject({ offset: 1 });
-});
-
-test("reprocess mode appends a processed event and skips the dedup check", async () => {
-  const existing = { offset: 7, type: MEDIA_CAPTURED_EVENT_TYPE };
-  const itx = fakeItx({
-    existingEvent: existing, // would short-circuit a capture — must be ignored
-    toMarkdown: { format: "markdown", data: "Better description." },
-    visionAnswer: {
-      choices: [{ message: { content: '{"transcript": "", "tags": ["receipt"]}' } }],
-    },
-  });
-  await runScript(
-    buildProcessScript({
-      wipeGeneration: 0,
+  // Wipe generation flows into the key, so post-wipe re-captures come back.
+  expect(
+    buildUploadedEvent({
       stableKey: "abc123",
-      filename: "IMG_0001.PNG",
-      contentType: "image/png",
-      width: 10,
-      height: 10,
-      source: "picker",
-      capturedAt: null,
-      isScreenshot: null,
-      mode: { reprocessNonce: "n1" },
-    }),
-    itx,
-  );
-  expect(itx.calls.appended).toMatchObject({
-    type: MEDIA_PROCESSED_EVENT_TYPE,
-    idempotencyKey: "media-processed-abc123-n1",
-    payload: { stableKey: "abc123", markdown: "Better description.", tags: ["receipt"] },
-  });
-  // Reprocess payloads carry no file facts — the captured event owns those.
-  expect(itx.calls.appended.payload.path).toBeUndefined();
-});
-
-test("oversized images are downscaled for the vision call only", async () => {
-  const itx = fakeItx({
-    toMarkdown: { format: "markdown", data: "desc" },
-    visionAnswer: {
-      choices: [{ message: { content: '{"title": "t", "transcript": "", "tags": []}' } }],
-    },
-    fileBytes: new Uint8Array(1_500_000),
-  });
-  await runScript(
-    buildProcessScript({
-      wipeGeneration: 0,
-      stableKey: "big",
-      filename: "tall.png",
-      contentType: "image/png",
-      width: 1170,
-      height: 20_000,
-      source: "picker",
-      capturedAt: null,
-      isScreenshot: null,
-      mode: "capture",
-    }),
-    itx,
-  );
-  expect(itx.calls.transformInput).toMatchObject({
-    transforms: [{ width: 1280 }],
-    output: { format: "image/jpeg" },
-  });
-  // The AI call got the small jpeg; the stored original was untouched.
-  expect(itx.calls.visionBody.messages[0].content[1].image_url.url).toMatch(
-    /^data:image\/jpeg;base64,/,
-  );
-});
-
-test("hostile filenames cannot break out of the script", async () => {
-  const filename = 'x"; process.exit(1);   //`${boom}`.png';
-  const itx = fakeItx({
-    toMarkdown: { format: "markdown", data: "desc" },
-    visionAnswer: {
-      choices: [{ message: { content: '{"transcript": "", "tags": ["clipping"]}' } }],
-    },
-  });
-  await runScript(
-    buildProcessScript({
-      wipeGeneration: 0,
-      stableKey: "k1",
-      filename,
-      contentType: "image/png",
-      width: 10,
-      height: 10,
-      source: "picker",
-      capturedAt: null,
-      isScreenshot: null,
-      mode: "capture",
-    }),
-    itx,
-  );
-  expect(itx.calls.appended).toMatchObject({ payload: { filename, tags: ["clipping"] } });
-});
-
-test("already-captured stableKey short-circuits before any AI call", async () => {
-  const existing = { offset: 7, type: MEDIA_CAPTURED_EVENT_TYPE };
-  const itx = fakeItx({
-    existingEvent: existing,
-    toMarkdown: { format: "markdown", data: "unused" },
-    visionAnswer: { choices: [{ message: { content: "{}" } }] },
-  });
-  const result = await runScript(
-    buildProcessScript({
-      wipeGeneration: 0,
-      stableKey: "dup",
+      wipeGeneration: 42,
       filename: "a.png",
       contentType: "image/png",
       width: 1,
       height: 1,
-      source: "picker",
-      capturedAt: null,
-      isScreenshot: null,
-      mode: "capture",
+      source: "library-sync",
+      capturedAt: "2026-08-10T09:00:00.000Z",
+      isScreenshot: true,
     }),
-    itx,
-  );
-  expect(result).toBe(existing);
-  expect(itx.calls.bytesPath).toBeUndefined();
-  expect(itx.calls.appended).toBeUndefined();
+  ).toMatchObject({ idempotencyKey: "media-captured-abc123-g42" });
 });
 
-test("unparseable vision output degrades to untagged + empty transcript; conversion error throws", async () => {
-  const itx = fakeItx({
-    toMarkdown: { format: "markdown", data: "desc" },
-    visionAnswer: { choices: [{ message: { content: "I could not decide, sorry!" } }] },
+test("buildReanalyzeEvent keys each request separately", () => {
+  expect(buildReanalyzeEvent("abc123", "n1")).toEqual({
+    type: MEDIA_REANALYZE_REQUESTED_EVENT_TYPE,
+    idempotencyKey: "media-reanalyze-abc123-n1",
+    payload: { stableKey: "abc123" },
   });
-  await runScript(
-    buildProcessScript({
-      wipeGeneration: 0,
-      stableKey: "k2",
-      filename: "a.png",
-      contentType: "image/png",
-      width: 1,
-      height: 1,
-      source: "picker",
-      capturedAt: null,
-      isScreenshot: null,
-      mode: "capture",
-    }),
-    itx,
-  );
-  expect(itx.calls.appended).toMatchObject({ payload: { tags: ["untagged"], transcript: "" } });
-
-  const failing = fakeItx({
-    toMarkdown: { format: "error", error: "unsupported" },
-    visionAnswer: { choices: [{ message: { content: "{}" } }] },
-  });
-  await expect(
-    runScript(
-      buildProcessScript({
-        wipeGeneration: 0,
-        stableKey: "k3",
-        filename: "b.png",
-        contentType: "image/png",
-        width: 1,
-        height: 1,
-        source: "picker",
-        capturedAt: null,
-        isScreenshot: null,
-        mode: "capture",
-      }),
-      failing,
-    ),
-  ).rejects.toThrow(/toMarkdown failed for b.png: unsupported/);
-});
-
-test("empty tags array is preserved — conservative no-tags is a valid answer", async () => {
-  const itx = fakeItx({
-    toMarkdown: { format: "markdown", data: "desc" },
-    visionAnswer: { choices: [{ message: { content: '{"transcript": "hi", "tags": []}' } }] },
-  });
-  await runScript(
-    buildProcessScript({
-      wipeGeneration: 0,
-      stableKey: "k4",
-      filename: "a.png",
-      contentType: "image/png",
-      width: 1,
-      height: 1,
-      source: "picker",
-      capturedAt: null,
-      isScreenshot: null,
-      mode: "capture",
-    }),
-    itx,
-  );
-  expect(itx.calls.appended).toMatchObject({ payload: { tags: [], transcript: "hi" } });
 });
 
 test("normalizedImageFilename forces the extension to match the payload type", () => {
@@ -275,31 +91,154 @@ test("mediaFilePath sanitizes and bounds the filename", () => {
   expect(mediaFilePath("abc", "x".repeat(200) + ".png")).toMatch(/^.{0,100}\.png$/);
 });
 
-test("deriveMediaList overlays the latest processed result per item, newest first", () => {
+test("deriveMediaList: uploaded rows are pending until a processed settlement overlays them", () => {
   const events: any[] = [
-    {
-      type: MEDIA_CAPTURED_EVENT_TYPE,
-      offset: 1,
-      createdAt: "t1",
-      payload: { stableKey: "a", markdown: "first", transcript: "", tags: ["untagged"] },
-    },
-    {
-      type: MEDIA_CAPTURED_EVENT_TYPE,
-      offset: 2,
-      createdAt: "t2",
-      payload: { stableKey: "b", markdown: "other", transcript: "", tags: [] },
-    },
+    uploadedEvent("a", 1),
+    uploadedEvent("b", 2),
     {
       type: MEDIA_PROCESSED_EVENT_TYPE,
       offset: 3,
       createdAt: "t3",
-      payload: { stableKey: "a", markdown: "better", transcript: "text!", tags: ["receipt"] },
+      payload: {
+        stableKey: "a",
+        title: "Trenitalia ticket",
+        markdown: "A train ticket.",
+        transcript: "Trenitalia 09:45",
+        tags: ["logistics"],
+        processedBy: "m",
+        error: null,
+        requestOffset: 1,
+      },
     },
   ];
   expect(deriveMediaList(events)).toMatchObject([
-    { offset: 2, payload: { markdown: "other" } },
-    { offset: 1, payload: { markdown: "better", transcript: "text!", tags: ["receipt"] } },
+    { offset: 2, analysis: { status: "pending" }, payload: { markdown: "", title: "" } },
+    {
+      offset: 1,
+      analysis: { status: "done" },
+      payload: {
+        title: "Trenitalia ticket",
+        markdown: "A train ticket.",
+        tags: ["logistics"],
+        // file facts from the uploaded event survive the overlay
+        filename: "a.png",
+        path: "/media/a-a.png",
+      },
+    },
   ]);
+});
+
+test("deriveMediaList: a failed settlement keeps the row (and its fields) and shows the error", () => {
+  const events: any[] = [
+    uploadedEvent("a", 1),
+    {
+      type: MEDIA_PROCESSED_EVENT_TYPE,
+      offset: 2,
+      createdAt: "t2",
+      payload: {
+        stableKey: "a",
+        title: "",
+        markdown: "",
+        transcript: "",
+        tags: [],
+        processedBy: "",
+        error: "8005: Internal server error",
+        requestOffset: 1,
+      },
+    },
+  ];
+  expect(deriveMediaList(events)).toMatchObject([
+    {
+      offset: 1,
+      analysis: { status: "failed", error: "8005: Internal server error" },
+      payload: { filename: "a.png" },
+    },
+  ]);
+});
+
+test("deriveMediaList: reanalyze flips a settled row back to pending until the next settlement", () => {
+  const processed = (offset: number, title: string) => ({
+    type: MEDIA_PROCESSED_EVENT_TYPE,
+    offset,
+    createdAt: `t${offset}`,
+    payload: {
+      stableKey: "a",
+      title,
+      markdown: "d",
+      transcript: "",
+      tags: [],
+      processedBy: "m",
+      error: null,
+      requestOffset: null,
+    },
+  });
+  const base: any[] = [
+    uploadedEvent("a", 1),
+    processed(2, "first"),
+    {
+      type: MEDIA_REANALYZE_REQUESTED_EVENT_TYPE,
+      offset: 3,
+      createdAt: "t3",
+      payload: { stableKey: "a" },
+    },
+  ];
+  // Request open: pending, but the previous processing stays visible.
+  expect(deriveMediaList(base)).toMatchObject([
+    { analysis: { status: "pending" }, payload: { title: "first" } },
+  ]);
+  // Settled again: the newer result overlays.
+  expect(deriveMediaList([...base, processed(4, "second")])).toMatchObject([
+    { analysis: { status: "done" }, payload: { title: "second" } },
+  ]);
+});
+
+test("deriveMediaList: legacy captured rows render as before, latest processed overlays", () => {
+  const events: any[] = [
+    capturedEvent("a", 1, { markdown: "first" }),
+    capturedEvent("b", 2, { markdown: "other" }),
+    {
+      type: MEDIA_PROCESSED_EVENT_TYPE,
+      offset: 3,
+      createdAt: "t3",
+      // Legacy phone-scripted re-analysis payload: no error/requestOffset.
+      payload: {
+        stableKey: "a",
+        title: "",
+        markdown: "better",
+        transcript: "text!",
+        tags: ["receipt"],
+        processedBy: "m",
+      },
+    },
+  ];
+  expect(deriveMediaList(events)).toMatchObject([
+    { offset: 2, analysis: { status: "done" }, payload: { markdown: "other" } },
+    {
+      offset: 1,
+      analysis: { status: "done" },
+      payload: { markdown: "better", transcript: "text!", tags: ["receipt"] },
+    },
+  ]);
+});
+
+test("deriveMediaList: one row per stableKey even when captured AND uploaded events exist", () => {
+  const events: any[] = [
+    capturedEvent("a", 1, { markdown: "inline analysis" }),
+    uploadedEvent("a", 2),
+  ];
+  expect(deriveMediaList(events)).toMatchObject([
+    { offset: 1, payload: { markdown: "inline analysis" }, analysis: { status: "done" } },
+  ]);
+});
+
+test("deriveMediaList resets at the last wiped tombstone", () => {
+  const events: any[] = [
+    capturedEvent("old", 1, { markdown: "gone" }),
+    uploadedEvent("pending-old", 2),
+    { type: MEDIA_WIPED_EVENT_TYPE, offset: 3, createdAt: "t3", payload: {} },
+    capturedEvent("new", 4, { markdown: "kept" }),
+  ];
+  expect(deriveMediaList(events)).toMatchObject([{ payload: { stableKey: "new" } }]);
 });
 
 test("filterMedia: terms AND together over markdown+transcript+filename+tags, chips must all match", () => {
@@ -338,42 +277,22 @@ test("mapWithConcurrency bounds in-flight work and preserves order", async () =>
   expect(peak).toBe(2);
 });
 
-test("wipe script deletes every stored file then appends the tombstone", async () => {
+test("wipe script deletes files from BOTH birth event types then appends the tombstone", async () => {
   const itx = fakeItx({
-    toMarkdown: { format: "markdown", data: "unused" },
-    visionAnswer: { choices: [{ message: { content: "{}" } }] },
     streamEvents: [
       { type: MEDIA_CAPTURED_EVENT_TYPE, offset: 1, payload: { path: "/media/a-x.png" } },
-      { type: MEDIA_CAPTURED_EVENT_TYPE, offset: 2, payload: { path: "/media/b-y.png" } },
+      { type: MEDIA_UPLOADED_EVENT_TYPE, offset: 2, payload: { path: "/media/b-y.png" } },
       { type: MEDIA_CAPTURED_EVENT_TYPE, offset: 3, payload: { path: "/media/a-x.png" } },
     ],
   });
   await runScript(buildWipeScript("n1"), itx);
+  expect(itx.calls.eventTypesRead).toEqual([MEDIA_CAPTURED_EVENT_TYPE, MEDIA_UPLOADED_EVENT_TYPE]);
   expect(itx.calls.deletedPaths).toEqual(["/media/a-x.png", "/media/b-y.png"]); // deduped
   expect(itx.calls.appended).toMatchObject({
     type: MEDIA_WIPED_EVENT_TYPE,
     idempotencyKey: "media-wiped-n1",
     payload: { deletedFiles: 2, items: 2 },
   });
-});
-
-test("deriveMediaList resets at the last wiped tombstone", () => {
-  const events: any[] = [
-    {
-      type: MEDIA_CAPTURED_EVENT_TYPE,
-      offset: 1,
-      createdAt: "t1",
-      payload: { stableKey: "old", markdown: "gone", transcript: "", tags: [] },
-    },
-    { type: MEDIA_WIPED_EVENT_TYPE, offset: 2, createdAt: "t2", payload: {} },
-    {
-      type: MEDIA_CAPTURED_EVENT_TYPE,
-      offset: 3,
-      createdAt: "t3",
-      payload: { stableKey: "new", markdown: "kept", transcript: "", tags: [] },
-    },
-  ];
-  expect(deriveMediaList(events)).toMatchObject([{ payload: { stableKey: "new" } }]);
 });
 
 test("wipe generation changes the capture identity so re-captures work after Delete-all", async () => {
@@ -401,10 +320,54 @@ test("extendedSinceIso only ever extends an enabled window backwards", () => {
 
 // --- helpers ---------------------------------------------------------------
 
+function uploadedEvent(stableKey: string, offset: number) {
+  return {
+    type: MEDIA_UPLOADED_EVENT_TYPE,
+    offset,
+    createdAt: `t${offset}`,
+    payload: {
+      stableKey,
+      path: `/media/${stableKey}-${stableKey}.png`,
+      filename: `${stableKey}.png`,
+      contentType: "image/png",
+      width: 100,
+      height: 200,
+      source: "picker",
+      capturedAt: null,
+      isScreenshot: null,
+    },
+  };
+}
+
+function capturedEvent(stableKey: string, offset: number, processing: { markdown: string }) {
+  return {
+    type: MEDIA_CAPTURED_EVENT_TYPE,
+    offset,
+    createdAt: `t${offset}`,
+    payload: {
+      stableKey,
+      path: `/media/${stableKey}-${stableKey}.png`,
+      filename: `${stableKey}.png`,
+      contentType: "image/png",
+      width: 100,
+      height: 200,
+      source: "picker",
+      capturedAt: null,
+      isScreenshot: null,
+      title: "",
+      markdown: processing.markdown,
+      transcript: "",
+      tags: [],
+      processedBy: "m",
+    },
+  };
+}
+
 function item(offset: number, markdown: string, transcript: string, tags: string[]): MediaListItem {
   return {
     offset,
     capturedAt: `2026-08-10T00:00:0${offset}Z`,
+    analysis: { status: "done", error: null },
     payload: {
       stableKey: `k${offset}`,
       path: `/media/k${offset}-f.png`,
@@ -424,20 +387,16 @@ function item(offset: number, markdown: string, transcript: string, tags: string
   };
 }
 
-function fakeItx(behavior: {
-  toMarkdown: any;
-  visionAnswer: any;
-  existingEvent?: any;
-  fileBytes?: Uint8Array;
-  streamEvents?: any[];
-}): any {
+function fakeItx(behavior: { streamEvents: any[] }): any {
   const calls: any = {};
   return {
     calls,
     streams: {
       get: () => ({
-        getEvent: async () => behavior.existingEvent,
-        getEvents: async (args: any) => (args.afterOffset === 0 ? behavior.streamEvents || [] : []),
+        getEvents: async (args: any) => {
+          calls.eventTypesRead = args.eventTypes;
+          return args.afterOffset === 0 ? behavior.streamEvents : [];
+        },
         append: async (event: any) => {
           calls.appended = event;
           return [{ ...event, offset: 1 }];
@@ -449,32 +408,7 @@ function fakeItx(behavior: {
         delete: async () => {
           (calls.deletedPaths ||= []).push(path);
         },
-        bytes: async () => {
-          calls.bytesPath = path;
-          return behavior.fileBytes || new Uint8Array([1, 2, 3]);
-        },
       }),
-    },
-    integrations: {
-      cf: {
-        images: {
-          transformBytes: async (input: any) => {
-            calls.transformInput = input;
-            return { bytes: new Uint8Array([9, 9]), contentType: "image/jpeg" };
-          },
-        },
-      },
-    },
-    ai: {
-      toMarkdown: async (doc: any) => {
-        calls.toMarkdownDoc = doc;
-        return behavior.toMarkdown;
-      },
-      run: async (model: string, body: any) => {
-        calls.visionModel = model;
-        calls.visionBody = body;
-        return behavior.visionAnswer;
-      },
     },
   };
 }

--- a/apps/mobile/src/lib/media.ts
+++ b/apps/mobile/src/lib/media.ts
@@ -1,45 +1,51 @@
 // Media capture pipeline: pure logic only (no Expo imports), so vitest
 // covers it in root CI. The screen (app/project/[projectId]/media.tsx) wires
 // this to the picker and itx. Flow per item: bytes to itx.files at a
-// content-hash path, then ONE capabilityHost.runScript call server-side does
-// files.bytes → ai.toMarkdown (vision model describes the image) → one
-// vision-model call over the actual pixels returning {transcript, tags} →
-// append a media/captured event, idempotency-keyed by the hash so retries
-// and re-picks dedup. "Re-analyze" runs the same pipeline again and appends
-// a media/processed event; the list derivation takes the latest processing
-// per item, so prompt/model improvements apply retroactively. Search is
+// content-hash path, then ONE cheap durable stream append — a
+// media/uploaded event carrying only metadata. Analysis happens SERVER-SIDE:
+// the MediaApp processor (iterate/starter-apps/media) reacts to uploaded
+// events, runs toMarkdown + a vision model, and settles with a
+// media/processed event the list derivation overlays. The phone never holds
+// a socket open for analysis, so locking it mid-pass loses nothing, and an
+// AI failure never loses the item — the row exists from the uploaded event
+// and shows the failure. "Re-analyze" appends media/reanalyze-requested and
+// the same server pipeline overlays the newest result. Search is
 // client-side over description + transcript + tags.
 
 import type { StreamEvent } from "iterate/sdk/itx/react";
 
 export const MEDIA_STREAM_PATH = "/media";
+/** LEGACY birth event (phone-scripted capture+analysis in one) — still
+ * rendered, never appended anymore. */
 export const MEDIA_CAPTURED_EVENT_TYPE = "events.iterate.com/media/captured";
+export const MEDIA_UPLOADED_EVENT_TYPE = "events.iterate.com/media/uploaded";
 export const MEDIA_PROCESSED_EVENT_TYPE = "events.iterate.com/media/processed";
+export const MEDIA_REANALYZE_REQUESTED_EVENT_TYPE = "events.iterate.com/media/reanalyze-requested";
 export const MEDIA_WIPED_EVENT_TYPE = "events.iterate.com/media/wiped";
 export const MEDIA_EVENT_TYPES = [
   MEDIA_CAPTURED_EVENT_TYPE,
+  MEDIA_UPLOADED_EVENT_TYPE,
   MEDIA_PROCESSED_EVENT_TYPE,
+  MEDIA_REANALYZE_REQUESTED_EVENT_TYPE,
   MEDIA_WIPED_EVENT_TYPE,
 ];
-/** Sees the pixels: transcribes text verbatim and picks tags. */
-export const MEDIA_VISION_MODEL = "@cf/meta/llama-4-scout-17b-16e-instruct";
 
 /**
- * Starter taxonomy — expect churn. Multi-tag with overlap allowed; the model
- * may also coin up to two novel kebab-case tags, and returning NO tags is an
- * acceptable answer (deliberately conservative — early dogfood tagged
- * everything `bug-report` on wild guesses).
+ * Display order for tag filter chips. The analysis-owning taxonomy (tags +
+ * model hints + prompt) lives server-side in
+ * iterate/starter-apps/media/analysis.ts (MEDIA_TAG_TAXONOMY) — kept in sync
+ * by hand, same convention as the search semantics.
  */
-export const MEDIA_TAGS: { tag: string; hint: string }[] = [
-  { tag: "screenshot", hint: "a captured device screen: app UI, web page, status bar visible" },
-  { tag: "photo", hint: "a camera photograph of the physical world" },
-  { tag: "transient", hint: "one-off info with no lasting value: OTP codes, confirmations" },
-  { tag: "clipping", hint: "a saved post, article, meme, or quote worth keeping" },
-  { tag: "logistics", hint: "tickets, bookings, schedules, travel details, QR codes" },
-  { tag: "receipt", hint: "proof of purchase, invoices, order confirmations" },
-  { tag: "conversation", hint: "chat threads, DMs, emails, comment sections" },
-  { tag: "code", hint: "code, terminals, dev tools, technical docs" },
-  { tag: "reference", hint: "info to keep long-term: settings, lists, instructions" },
+export const MEDIA_TAGS = [
+  "screenshot",
+  "photo",
+  "transient",
+  "clipping",
+  "logistics",
+  "receipt",
+  "conversation",
+  "code",
+  "reference",
 ];
 
 export type MediaProcessingResult = {
@@ -55,7 +61,8 @@ export type MediaProcessingResult = {
   processedBy: string;
 };
 
-export type MediaCapturedPayload = MediaProcessingResult & {
+/** The cheap durable birth fact: file metadata only, no analysis. */
+export type MediaUploadedPayload = {
   stableKey: string;
   /** itx.files path holding the bytes. */
   path: string;
@@ -72,7 +79,14 @@ export type MediaCapturedPayload = MediaProcessingResult & {
   isScreenshot: boolean | null;
 };
 
-export type MediaProcessedPayload = MediaProcessingResult & { stableKey: string };
+export type MediaCapturedPayload = MediaProcessingResult & MediaUploadedPayload;
+
+export type MediaProcessedPayload = MediaProcessingResult & {
+  stableKey: string;
+  /** Terminal analysis failure, or null/absent on success (absent on legacy
+   * phone-scripted re-analysis events). */
+  error?: string | null;
+};
 
 /**
  * The picker recompresses to JPEG/PNG (quality 0.8) but iOS often keeps the
@@ -102,7 +116,11 @@ export function mediaFilePath(stableKey: string, filename: string): string {
 /**
  * Capture identity = content hash + wipe generation. Without the
  * generation, re-capturing a screenshot after Delete-all would dedup
- * against the pre-wipe event and silently never come back.
+ * against the pre-wipe event and silently never come back. The key spelling
+ * is shared with the legacy media/captured events ON PURPOSE: an item
+ * captured before the uploaded-event split can never re-enter as a
+ * duplicate (the phone's getEvent check hits, and the stream itself rejects
+ * a same-key append).
  */
 export function mediaIdempotencyKey(stableKey: string, wipeGeneration: number): string {
   return wipeGeneration === 0
@@ -134,9 +152,13 @@ export function extendedSinceIso(
   return new Date(Math.min(chosen, existing)).toISOString();
 }
 
-export type ProcessScriptInput = {
+/**
+ * The durable birth append for one captured item — the ENTIRE remote half of
+ * capture now that analysis is server-side. Appended right after files.put;
+ * idempotency-keyed by content hash + wipe generation.
+ */
+export function buildUploadedEvent(input: {
   stableKey: string;
-  /** From readWipeGeneration — capture dedup identity; reprocess ignores it. */
   wipeGeneration: number;
   filename: string;
   contentType: string;
@@ -145,159 +167,47 @@ export type ProcessScriptInput = {
   source: "picker" | "library-sync";
   capturedAt: string | null;
   isScreenshot: boolean | null;
-  /**
-   * "capture" appends the media/captured birth event (idempotent per
-   * stableKey — a re-run returns the existing event). A reprocess appends a
-   * media/processed event instead; the nonce keys each re-run separately.
-   */
-  mode: "capture" | { reprocessNonce: string };
-};
-
-/**
- * The server-side half, as an `async (itx) => {...}` script string for
- * capabilityHost.runScript. Input rides in as one JSON literal — never
- * interpolate fields individually (filenames are attacker-ish data).
- * Returns the appended (or pre-existing) event.
- */
-export function buildProcessScript(input: ProcessScriptInput): string {
-  const scriptInput = {
-    stableKey: input.stableKey,
-    filename: input.filename,
-    contentType: input.contentType,
-    width: input.width,
-    height: input.height,
-    source: input.source,
-    capturedAt: input.capturedAt,
-    isScreenshot: input.isScreenshot,
-    path: mediaFilePath(input.stableKey, input.filename),
-    capture: input.mode === "capture",
-    idempotencyKey:
-      input.mode === "capture"
-        ? mediaIdempotencyKey(input.stableKey, input.wipeGeneration)
-        : `media-processed-${input.stableKey}-${input.mode.reprocessNonce}`,
-    eventType: input.mode === "capture" ? MEDIA_CAPTURED_EVENT_TYPE : MEDIA_PROCESSED_EVENT_TYPE,
-    streamPath: MEDIA_STREAM_PATH,
-    visionModel: MEDIA_VISION_MODEL,
-    visionPrompt: visionPrompt(),
-  };
-  return `async (itx) => {
-  const input = ${asJsLiteral(scriptInput)};
-  const stream = itx.streams.get(input.streamPath);
-  if (input.capture) {
-    const existing = await stream.getEvent({ idempotencyKey: input.idempotencyKey });
-    if (existing) return existing;
-  }
-
-  // blob takes raw bytes (a Blob cannot cross the sandbox RPC boundary);
-  // the extension in \`name\` picks the converter.
-  const bytes = await itx.files.get(input.path).bytes();
-  const described = await itx.ai.toMarkdown({ name: input.filename, blob: bytes });
-  if (described.format === "error") {
-    throw new Error("toMarkdown failed for " + input.filename + ": " + described.error);
-  }
-  const markdown = (described.data || "").trim();
-
-  // Workers AI rejects oversized request bodies (error 3006) — long
-  // full-page screenshots hit it. Downscale for the AI call only (the
-  // stored original is untouched); if the Images binding can't (e.g. some
-  // local dev setups), fall through with the original and let the model
-  // call answer.
-  let visionBytes = bytes;
-  let visionType = input.contentType;
-  if (bytes.length > 1_000_000) {
-    try {
-      const resized = await itx.integrations.cf.images.transformBytes({
-        image: bytes,
-        transforms: [{ width: 1280 }],
-        output: { format: "image/jpeg", quality: 80 },
-      });
-      visionBytes = resized.bytes;
-      visionType = resized.contentType;
-    } catch {}
-  }
-
-  // One vision call over the actual pixels: title + verbatim transcript +
-  // tags in a single JSON answer. Parse defensively — an unparseable answer
-  // degrades to empty title/transcript and ["untagged"] so failures stay
-  // visible.
-  let binary = "";
-  for (let i = 0; i < visionBytes.length; i += 32768) {
-    binary += String.fromCharCode(...visionBytes.subarray(i, i + 32768));
-  }
-  const answer = await itx.ai.run(input.visionModel, {
-    messages: [{
-      role: "user",
-      content: [
-        { type: "text", text: input.visionPrompt },
-        { type: "image_url", image_url: { url: "data:" + visionType + ";base64," + btoa(binary) } },
-      ],
-    }],
-    max_tokens: 1024,
-  });
-  const text = typeof answer?.response === "string"
-    ? answer.response
-    : typeof answer?.choices?.[0]?.message?.content === "string"
-      ? answer.choices[0].message.content
-      : "";
-  let title = "";
-  let transcript = "";
-  let tags = ["untagged"];
-  const match = text.match(/\\{[\\s\\S]*\\}/);
-  if (match) {
-    try {
-      const parsed = JSON.parse(match[0]);
-      if (typeof parsed.title === "string") title = parsed.title.trim().slice(0, 120);
-      if (typeof parsed.transcript === "string") transcript = parsed.transcript.trim();
-      if (Array.isArray(parsed.tags)) {
-        tags = [...new Set(
-          parsed.tags
-            .filter((tag) => typeof tag === "string")
-            .map((tag) => tag.toLowerCase().trim().replace(/[^a-z0-9-]+/g, "-").replace(/^-+|-+$/g, ""))
-            .filter((tag) => tag.length > 0 && tag.length <= 30),
-        )].slice(0, 6);
-      }
-    } catch {}
-  }
-
-  const [event] = await stream.append({
-    type: input.eventType,
-    idempotencyKey: input.idempotencyKey,
+}): { type: string; idempotencyKey: string; payload: MediaUploadedPayload } {
+  return {
+    type: MEDIA_UPLOADED_EVENT_TYPE,
+    idempotencyKey: mediaIdempotencyKey(input.stableKey, input.wipeGeneration),
     payload: {
       stableKey: input.stableKey,
-      title,
-      markdown,
-      transcript,
-      tags,
-      processedBy: input.visionModel,
-      ...(input.capture
-        ? {
-            path: input.path,
-            filename: input.filename,
-            contentType: input.contentType,
-            width: input.width,
-            height: input.height,
-            source: input.source,
-            capturedAt: input.capturedAt,
-            isScreenshot: input.isScreenshot,
-          }
-        : {}),
+      path: mediaFilePath(input.stableKey, input.filename),
+      filename: input.filename,
+      contentType: input.contentType,
+      width: input.width,
+      height: input.height,
+      source: input.source,
+      capturedAt: input.capturedAt,
+      isScreenshot: input.isScreenshot,
     },
-  });
-  return event;
-}`;
+  };
+}
+
+/** Ask the server to re-run analysis; the nonce keys each request separately. */
+export function buildReanalyzeEvent(
+  stableKey: string,
+  nonce: string,
+): { type: string; idempotencyKey: string; payload: { stableKey: string } } {
+  return {
+    type: MEDIA_REANALYZE_REQUESTED_EVENT_TYPE,
+    idempotencyKey: `media-reanalyze-${stableKey}-${nonce}`,
+    payload: { stableKey },
+  };
 }
 
 /**
  * Delete-everything, as a product event on the append-only stream: the
- * script deletes every stored file it can find via the captured events,
- * then appends media/wiped — the tombstone every derivation (phone list,
- * MediaApp fold) resets on. Idempotency-keyed per invocation, not content:
- * each deliberate wipe is its own fact.
+ * script deletes every stored file it can find via the birth events
+ * (uploaded + legacy captured), then appends media/wiped — the tombstone
+ * every derivation (phone list, MediaApp fold) resets on. Idempotency-keyed
+ * per invocation, not content: each deliberate wipe is its own fact.
  */
 export function buildWipeScript(nonce: string): string {
   const scriptInput = {
     streamPath: MEDIA_STREAM_PATH,
-    capturedType: MEDIA_CAPTURED_EVENT_TYPE,
+    birthTypes: [MEDIA_CAPTURED_EVENT_TYPE, MEDIA_UPLOADED_EVENT_TYPE],
     wipedType: MEDIA_WIPED_EVENT_TYPE,
     idempotencyKey: `media-wiped-${nonce}`,
   };
@@ -307,7 +217,7 @@ export function buildWipeScript(nonce: string): string {
   const events = [];
   let cursor = 0;
   while (true) {
-    const page = await stream.getEvents({ afterOffset: cursor, eventTypes: [input.capturedType] });
+    const page = await stream.getEvents({ afterOffset: cursor, eventTypes: input.birthTypes });
     if (page.length === 0) break;
     events.push(...page);
     cursor = page[page.length - 1].offset;
@@ -329,19 +239,6 @@ export function buildWipeScript(nonce: string): string {
 }`;
 }
 
-function visionPrompt(): string {
-  const lines = MEDIA_TAGS.map(({ tag, hint }) => `- "${tag}": ${hint}`);
-  return [
-    'Reply with ONLY a JSON object: {"title": string, "transcript": string, "tags": string[]}.',
-    "title: ONE line saying what the image IS, specific not generic — 'Trenitalia ticket Rome→Florence 09:45', never 'Screenshot' or 'Image Description'.",
-    "transcript: ALL text visible in the image, verbatim, reading order. Empty string if there is none.",
-    "tags: pick from the list below. Include a tag ONLY when the image clearly shows it — no guesses.",
-    "Fewer tags is better; an empty array is a fine answer. Overlap is allowed.",
-    ...lines,
-    "You may add at most 2 extra kebab-case tags if something important has no tag above.",
-  ].join("\n");
-}
-
 /**
  * JSON.stringify is almost a JS literal — U+2028/U+2029 are the exception
  * (legal in JSON strings, line terminators in source). Escape them so a
@@ -351,42 +248,89 @@ function asJsLiteral(value: unknown): string {
   return JSON.stringify(value).replaceAll("\u2028", "\\u2028").replaceAll("\u2029", "\\u2029");
 }
 
+/** Where an item is in its analysis lifecycle — drives the row badge. */
+export type MediaAnalysisState = {
+  status: "pending" | "failed" | "done";
+  /** The terminal failure message when status is "failed". */
+  error: string | null;
+};
+
 export type MediaListItem = {
-  /** The captured event's offset — the item's identity in the list. */
+  /** The birth event's offset (captured or uploaded) — the item's identity
+   * in the list. */
   offset: number;
   capturedAt: string;
   payload: MediaCapturedPayload;
+  analysis: MediaAnalysisState;
 };
 
 /**
- * Captured events → list items, newest first, with the latest media/processed
- * result (by offset) overlaid per stableKey — so a re-analysis updates what
- * you see without rewriting history.
+ * Birth events (uploaded + legacy captured, deduped per stableKey) → list
+ * items, newest first, with the latest successful media/processed result
+ * (by offset) overlaid — so a re-analysis updates what you see without
+ * rewriting history. A failed settlement keeps the previous fields and
+ * surfaces its error; an open request (uploaded or reanalyze newer than the
+ * latest settlement) shows as "pending".
  */
 export function deriveMediaList(events: StreamEvent[]): MediaListItem[] {
   // A wiped tombstone resets everything before it.
   const lastWipeIndex = events.findLastIndex((event) => event.type === MEDIA_WIPED_EVENT_TYPE);
   const liveEvents = lastWipeIndex === -1 ? events : events.slice(lastWipeIndex + 1);
-  const latestProcessed = new Map<string, MediaProcessedPayload>();
+  const latestProcessed = new Map<string, { payload: MediaProcessedPayload; offset: number }>();
+  const latestRequest = new Map<string, number>();
   for (const event of liveEvents) {
     // Events arrive offset-ascending, so later wins by insertion order.
     if (event.type === MEDIA_PROCESSED_EVENT_TYPE) {
       const payload = event.payload as MediaProcessedPayload;
-      latestProcessed.set(payload.stableKey, payload);
+      latestProcessed.set(payload.stableKey, { payload, offset: event.offset });
+    }
+    if (event.type === MEDIA_REANALYZE_REQUESTED_EVENT_TYPE) {
+      const payload = event.payload as { stableKey: string };
+      latestRequest.set(payload.stableKey, event.offset);
     }
   }
-  return liveEvents
-    .filter((event) => event.type === MEDIA_CAPTURED_EVENT_TYPE)
-    .map((event) => {
-      const captured = event.payload as MediaCapturedPayload;
-      const processed = latestProcessed.get(captured.stableKey);
-      return {
-        offset: event.offset,
-        capturedAt: event.createdAt,
-        payload: processed ? { ...captured, ...processed } : captured,
-      };
-    })
-    .sort((a, b) => b.offset - a.offset);
+  const seen = new Set<string>();
+  const items: MediaListItem[] = [];
+  for (const event of liveEvents) {
+    const isCaptured = event.type === MEDIA_CAPTURED_EVENT_TYPE;
+    if (!isCaptured && event.type !== MEDIA_UPLOADED_EVENT_TYPE) continue;
+    const born = event.payload as MediaCapturedPayload;
+    // One row per stableKey even if both a legacy captured and an uploaded
+    // event exist — the first birth wins.
+    if (seen.has(born.stableKey)) continue;
+    seen.add(born.stableKey);
+    // Uploaded births carry no processing fields yet.
+    const base: MediaCapturedPayload = isCaptured
+      ? born
+      : { ...born, title: "", markdown: "", transcript: "", tags: [], processedBy: "" };
+    const processed = latestProcessed.get(born.stableKey);
+    const success = processed !== undefined && !processed.payload.error;
+    const payload: MediaCapturedPayload = success
+      ? {
+          ...base,
+          title: processed.payload.title,
+          markdown: processed.payload.markdown,
+          transcript: processed.payload.transcript,
+          tags: processed.payload.tags,
+          processedBy: processed.payload.processedBy,
+        }
+      : base;
+    // An uploaded birth IS an analysis request; reanalyze events are later
+    // ones. Settled = a processed event newer than the latest request.
+    const requestOffset = Math.max(
+      isCaptured ? 0 : event.offset,
+      latestRequest.get(born.stableKey) || 0,
+    );
+    const settledOffset = processed?.offset || 0;
+    const analysis: MediaAnalysisState =
+      requestOffset > settledOffset
+        ? { status: "pending", error: null }
+        : processed !== undefined && !success
+          ? { status: "failed", error: processed.payload.error || null }
+          : { status: "done", error: null };
+    items.push({ offset: event.offset, capturedAt: event.createdAt, payload, analysis });
+  }
+  return items.sort((a, b) => b.offset - a.offset);
 }
 
 /**
@@ -434,9 +378,9 @@ export async function readAllMediaEvents(stream: {
   }
 }
 
-/** Run `work` over `items` with at most `limit` in flight — the capture
- * pipeline is AI-call-bound (~5-15s per item), so strict sequencing made a
- * 20-item batch crawl. Preserves item order in the result array. */
+/** Run `work` over `items` with at most `limit` in flight — a sync pass
+ * uploads many items and the reads/uploads overlap nicely. Preserves item
+ * order in the result array. */
 export async function mapWithConcurrency<T, R>(
   items: T[],
   limit: number,

--- a/packages/iterate/src/starter-apps/media/analysis.test.ts
+++ b/packages/iterate/src/starter-apps/media/analysis.test.ts
@@ -1,0 +1,160 @@
+// The vision pipeline against a fake itx session (ported from the mobile
+// capture-script tests when analysis moved server-side — the script builder
+// and its injection-safety concerns died with the script).
+import { expect, test } from "vitest";
+import { analyzeMediaImage } from "./analysis.ts";
+
+test("describes, transcribes, and tags: normalized, deduped, chatter-tolerant", async () => {
+  const session = fakeSession({
+    toMarkdown: { format: "markdown", data: "A train ticket from Rome to Florence.\n" },
+    // OpenAI-style answer shape (what llama on Workers AI actually returns),
+    // wrapped in chatter the JSON extractor must see through.
+    visionAnswer: {
+      choices: [
+        {
+          message: {
+            content:
+              'Here is the JSON: {"title": "Trenitalia ticket to Florence", "transcript": "Train to Florence\\nSeat 21A", "tags": ["logistics", "Screenshot!", "screenshot"]}',
+          },
+        },
+      ],
+    },
+  });
+  const result = await analyzeMediaImage(session, {
+    path: "/media/abc123-IMG_0001.PNG",
+    filename: "IMG_0001.PNG",
+    contentType: "image/png",
+  });
+
+  expect(session.calls.bytesPath).toBe("/media/abc123-IMG_0001.PNG");
+  expect(session.calls.visionBody.messages[0].content[1].image_url.url).toMatch(
+    /^data:image\/png;base64,/,
+  );
+  expect(result).toMatchObject({
+    title: "Trenitalia ticket to Florence",
+    markdown: "A train ticket from Rome to Florence.",
+    transcript: "Train to Florence\nSeat 21A",
+    // lowercased, punctuation folded, deduped
+    tags: ["logistics", "screenshot"],
+    processedBy: expect.stringContaining("@cf/"),
+  });
+});
+
+test("oversized images are downscaled for the vision call only", async () => {
+  const session = fakeSession({
+    toMarkdown: { format: "markdown", data: "desc" },
+    visionAnswer: {
+      choices: [{ message: { content: '{"title": "t", "transcript": "", "tags": []}' } }],
+    },
+    fileBytes: new Uint8Array(1_500_000),
+  });
+  await analyzeMediaImage(session, {
+    path: "/media/big-tall.png",
+    filename: "tall.png",
+    contentType: "image/png",
+  });
+
+  expect(session.calls.transformInput).toMatchObject({
+    transforms: [{ width: 1280 }],
+    output: { format: "image/jpeg" },
+  });
+  // The AI call got the small jpeg; the stored original was untouched.
+  expect(session.calls.visionBody.messages[0].content[1].image_url.url).toMatch(
+    /^data:image\/jpeg;base64,/,
+  );
+});
+
+test("unparseable vision output degrades to untagged + empty transcript", async () => {
+  const session = fakeSession({
+    toMarkdown: { format: "markdown", data: "desc" },
+    visionAnswer: { choices: [{ message: { content: "I could not decide, sorry!" } }] },
+  });
+  const result = await analyzeMediaImage(session, {
+    path: "/media/k2-a.png",
+    filename: "a.png",
+    contentType: "image/png",
+  });
+  expect(result).toMatchObject({ tags: ["untagged"], transcript: "", markdown: "desc" });
+});
+
+test("a conversion error throws — the obligation attempt owns retry/settlement", async () => {
+  const session = fakeSession({
+    toMarkdown: { format: "error", error: "unsupported" },
+    visionAnswer: { choices: [{ message: { content: "{}" } }] },
+  });
+  await expect(
+    analyzeMediaImage(session, {
+      path: "/media/k3-b.png",
+      filename: "b.png",
+      contentType: "image/png",
+    }),
+  ).rejects.toThrow(/toMarkdown failed for b.png: unsupported/);
+});
+
+test("empty tags array is preserved — conservative no-tags is a valid answer", async () => {
+  const session = fakeSession({
+    toMarkdown: { format: "markdown", data: "desc" },
+    visionAnswer: { choices: [{ message: { content: '{"transcript": "hi", "tags": []}' } }] },
+  });
+  const result = await analyzeMediaImage(session, {
+    path: "/media/k4-a.png",
+    filename: "a.png",
+    contentType: "image/png",
+  });
+  expect(result).toMatchObject({ tags: [], transcript: "hi" });
+});
+
+test("the bare { response } Workers AI answer shape parses too", async () => {
+  const session = fakeSession({
+    toMarkdown: { format: "markdown", data: "desc" },
+    visionAnswer: { response: '{"title": "plain response", "transcript": "", "tags": []}' },
+  });
+  const result = await analyzeMediaImage(session, {
+    path: "/media/k5-a.png",
+    filename: "a.png",
+    contentType: "image/png",
+  });
+  expect(result).toMatchObject({ title: "plain response" });
+});
+
+// --- helpers ---------------------------------------------------------------
+
+function fakeSession(behavior: {
+  toMarkdown: any;
+  visionAnswer: any;
+  fileBytes?: Uint8Array;
+}): any {
+  const calls: any = {};
+  return {
+    calls,
+    files: {
+      get: (path: string) => ({
+        bytes: async () => {
+          calls.bytesPath = path;
+          return behavior.fileBytes || new Uint8Array([1, 2, 3]);
+        },
+      }),
+    },
+    integrations: {
+      cf: {
+        images: {
+          transformBytes: async (input: any) => {
+            calls.transformInput = input;
+            return { bytes: new Uint8Array([9, 9]), contentType: "image/jpeg" };
+          },
+        },
+      },
+    },
+    ai: {
+      toMarkdown: async (doc: any) => {
+        calls.toMarkdownDoc = doc;
+        return behavior.toMarkdown;
+      },
+      run: async (model: string, body: any) => {
+        calls.visionModel = model;
+        calls.visionBody = body;
+        return behavior.visionAnswer;
+      },
+    },
+  };
+}

--- a/packages/iterate/src/starter-apps/media/analysis.ts
+++ b/packages/iterate/src/starter-apps/media/analysis.ts
@@ -1,0 +1,189 @@
+// The media analysis pipeline: bytes → ai.toMarkdown (vision model describes
+// the image) → one vision call over the actual pixels returning
+// {title, transcript, tags}. Ported from the mobile capture script
+// (apps/mobile/src/lib/media.ts buildProcessScript, PR #2466) when analysis
+// moved server-side: the phone now appends a cheap media/uploaded event and
+// the MediaApp processor (processor.ts) drives this pipeline as an
+// obligation. The server owns the analysis vocabulary — model, taxonomy,
+// prompt; the mobile app keeps a display-only tag list (lib/media.ts
+// MEDIA_TAGS) kept in sync by hand, same convention as search semantics.
+
+/** Sees the pixels: transcribes text verbatim and picks tags. */
+export const MEDIA_VISION_MODEL = "@cf/meta/llama-4-scout-17b-16e-instruct";
+
+/**
+ * Starter taxonomy — expect churn. Multi-tag with overlap allowed; the model
+ * may also coin up to two novel kebab-case tags, and returning NO tags is an
+ * acceptable answer (deliberately conservative — early dogfood tagged
+ * everything `bug-report` on wild guesses).
+ */
+export const MEDIA_TAG_TAXONOMY: { tag: string; hint: string }[] = [
+  { tag: "screenshot", hint: "a captured device screen: app UI, web page, status bar visible" },
+  { tag: "photo", hint: "a camera photograph of the physical world" },
+  { tag: "transient", hint: "one-off info with no lasting value: OTP codes, confirmations" },
+  { tag: "clipping", hint: "a saved post, article, meme, or quote worth keeping" },
+  { tag: "logistics", hint: "tickets, bookings, schedules, travel details, QR codes" },
+  { tag: "receipt", hint: "proof of purchase, invoices, order confirmations" },
+  { tag: "conversation", hint: "chat threads, DMs, emails, comment sections" },
+  { tag: "code", hint: "code, terminals, dev tools, technical docs" },
+  { tag: "reference", hint: "info to keep long-term: settings, lists, instructions" },
+];
+
+export type MediaAnalysisResult = {
+  /** One-line description of what the image IS — the row's bold first line. */
+  title: string;
+  /** The vision model's natural-language description — half the search corpus. */
+  markdown: string;
+  /** Verbatim text visible in the image — the other half. */
+  transcript: string;
+  tags: string[];
+  processedBy: string;
+};
+
+/**
+ * The itx slice the pipeline dials — structural on purpose so the real
+ * `Project` session satisfies it and tests hand in a plain fake.
+ */
+export type MediaAnalysisSession = {
+  files: { get(path: string): { bytes(): Promise<Uint8Array> } };
+  ai: {
+    toMarkdown(document: {
+      name: string;
+      blob: Uint8Array;
+    }): Promise<{ format: string; data?: string; error?: string }>;
+    run(model: string, body: unknown): Promise<unknown>;
+  };
+  integrations: {
+    cf: {
+      images: {
+        transformBytes(input: {
+          image: Uint8Array;
+          transforms: { width: number }[];
+          output: { format: string; quality: number };
+        }): Promise<{ bytes: Uint8Array; contentType: string }>;
+      };
+    };
+  };
+};
+
+/**
+ * One full analysis of a stored media file. Throws on conversion failure so
+ * the caller (the processor's obligation attempt) owns retry/settlement; an
+ * unparseable vision answer degrades to empty title/transcript and
+ * ["untagged"] so failures stay visible instead of hiding an item.
+ */
+export async function analyzeMediaImage(
+  session: MediaAnalysisSession,
+  input: { path: string; filename: string; contentType: string },
+): Promise<MediaAnalysisResult> {
+  // blob takes raw bytes (a Blob cannot cross the RPC boundary); the
+  // extension in `name` picks the converter.
+  const bytes = await session.files.get(input.path).bytes();
+  const described = await session.ai.toMarkdown({ name: input.filename, blob: bytes });
+  if (described.format === "error") {
+    throw new Error(`toMarkdown failed for ${input.filename}: ${described.error}`);
+  }
+  const markdown = (described.data || "").trim();
+
+  // Workers AI rejects oversized request bodies (error 3006) — long
+  // full-page screenshots hit it. Downscale for the AI call only (the
+  // stored original is untouched); if the Images binding can't (e.g. some
+  // local dev setups), fall through with the original and let the model
+  // call answer.
+  let visionBytes = bytes;
+  let visionType = input.contentType;
+  if (bytes.length > 1_000_000) {
+    try {
+      const resized = await session.integrations.cf.images.transformBytes({
+        image: bytes,
+        transforms: [{ width: 1280 }],
+        output: { format: "image/jpeg", quality: 80 },
+      });
+      visionBytes = resized.bytes;
+      visionType = resized.contentType;
+    } catch {}
+  }
+
+  // One vision call over the actual pixels: title + verbatim transcript +
+  // tags in a single JSON answer.
+  let binary = "";
+  for (let i = 0; i < visionBytes.length; i += 32_768) {
+    binary += String.fromCharCode(...visionBytes.subarray(i, i + 32_768));
+  }
+  const answer = await session.ai.run(MEDIA_VISION_MODEL, {
+    messages: [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: mediaVisionPrompt() },
+          {
+            type: "image_url",
+            image_url: { url: `data:${visionType};base64,${btoa(binary)}` },
+          },
+        ],
+      },
+    ],
+    max_tokens: 1024,
+  });
+  return { ...parseVisionAnswer(visionAnswerText(answer)), markdown };
+}
+
+/** Both Workers AI answer shapes: `{ response }` and OpenAI-style choices. */
+function visionAnswerText(answer: unknown): string {
+  const bag = answer as {
+    response?: unknown;
+    choices?: { message?: { content?: unknown } }[];
+  } | null;
+  if (typeof bag?.response === "string") return bag.response;
+  const content = bag?.choices?.[0]?.message?.content;
+  return typeof content === "string" ? content : "";
+}
+
+/** Extract the JSON object from a chatty model answer, defensively. */
+function parseVisionAnswer(text: string): Omit<MediaAnalysisResult, "markdown"> {
+  let title = "";
+  let transcript = "";
+  let tags = ["untagged"];
+  const match = text.match(/\{[\s\S]*\}/);
+  if (match) {
+    try {
+      const parsed = JSON.parse(match[0]) as {
+        title?: unknown;
+        transcript?: unknown;
+        tags?: unknown;
+      };
+      if (typeof parsed.title === "string") title = parsed.title.trim().slice(0, 120);
+      if (typeof parsed.transcript === "string") transcript = parsed.transcript.trim();
+      if (Array.isArray(parsed.tags)) {
+        tags = [
+          ...new Set(
+            parsed.tags
+              .filter((tag): tag is string => typeof tag === "string")
+              .map((tag) =>
+                tag
+                  .toLowerCase()
+                  .trim()
+                  .replace(/[^a-z0-9-]+/g, "-")
+                  .replace(/^-+|-+$/g, ""),
+              )
+              .filter((tag) => tag.length > 0 && tag.length <= 30),
+          ),
+        ].slice(0, 6);
+      }
+    } catch {}
+  }
+  return { title, transcript, tags, processedBy: MEDIA_VISION_MODEL };
+}
+
+function mediaVisionPrompt(): string {
+  const lines = MEDIA_TAG_TAXONOMY.map(({ tag, hint }) => `- "${tag}": ${hint}`);
+  return [
+    'Reply with ONLY a JSON object: {"title": string, "transcript": string, "tags": string[]}.',
+    "title: ONE line saying what the image IS, specific not generic — 'Trenitalia ticket Rome→Florence 09:45', never 'Screenshot' or 'Image Description'.",
+    "transcript: ALL text visible in the image, verbatim, reading order. Empty string if there is none.",
+    "tags: pick from the list below. Include a tag ONLY when the image clearly shows it — no guesses.",
+    "Fewer tags is better; an empty array is a fine answer. Overlap is allowed.",
+    ...lines,
+    "You may add at most 2 extra kebab-case tags if something important has no tag above.",
+  ].join("\n");
+}

--- a/packages/iterate/src/starter-apps/media/analysis.ts
+++ b/packages/iterate/src/starter-apps/media/analysis.ts
@@ -9,7 +9,7 @@
 // MEDIA_TAGS) kept in sync by hand, same convention as search semantics.
 
 /** Sees the pixels: transcribes text verbatim and picks tags. */
-export const MEDIA_VISION_MODEL = "@cf/meta/llama-4-scout-17b-16e-instruct";
+const MEDIA_VISION_MODEL = "@cf/meta/llama-4-scout-17b-16e-instruct";
 
 /**
  * Starter taxonomy — expect churn. Multi-tag with overlap allowed; the model
@@ -17,7 +17,7 @@ export const MEDIA_VISION_MODEL = "@cf/meta/llama-4-scout-17b-16e-instruct";
  * acceptable answer (deliberately conservative — early dogfood tagged
  * everything `bug-report` on wild guesses).
  */
-export const MEDIA_TAG_TAXONOMY: { tag: string; hint: string }[] = [
+const MEDIA_TAG_TAXONOMY: { tag: string; hint: string }[] = [
   { tag: "screenshot", hint: "a captured device screen: app UI, web page, status bar visible" },
   { tag: "photo", hint: "a camera photograph of the physical world" },
   { tag: "transient", hint: "one-off info with no lasting value: OTP codes, confirmations" },
@@ -44,7 +44,7 @@ export type MediaAnalysisResult = {
  * The itx slice the pipeline dials — structural on purpose so the real
  * `Project` session satisfies it and tests hand in a plain fake.
  */
-export type MediaAnalysisSession = {
+type MediaAnalysisSession = {
   files: { get(path: string): { bytes(): Promise<Uint8Array> } };
   ai: {
     toMarkdown(document: {

--- a/packages/iterate/src/starter-apps/media/media-analysis.test.ts
+++ b/packages/iterate/src/starter-apps/media/media-analysis.test.ts
@@ -1,0 +1,283 @@
+// The MediaProcessor's server-side analysis obligations, driven through the
+// real runner + keepalive over an in-memory stream (makeProcessorHarness).
+// The durable story under test: media/uploaded opens an obligation, ONE
+// media/processed event settles it (error field = the result union), and
+// evictions/expiry/replay never lose an item or re-dial the vendor.
+import { expect, test } from "vitest";
+import { makeMemoryProgressStore, makeProcessorHarness } from "../../processors/testing.ts";
+import type { HarnessProcessorDeps } from "../../processors/testing.ts";
+import type { MediaAnalysisResult } from "./analysis.ts";
+import { MediaProcessor, MediaProcessorContract, MEDIA_ANALYSIS_EXPIRY_MS } from "./processor.ts";
+
+const PROCESSED = "events.iterate.com/media/processed";
+
+test("uploaded opens an obligation; analysis settles it with one processed event", async () => {
+  const h = makeHarness(async () => result({ title: "Trenitalia ticket", tags: ["logistics"] }));
+  await h.append(uploaded("k1"));
+
+  expect(h.events(PROCESSED)).toMatchObject([
+    {
+      idempotencyKey: "media/analysis-settled@k1:1",
+      payload: { stableKey: "k1", title: "Trenitalia ticket", error: null, requestOffset: 1 },
+    },
+  ]);
+  expect(h.state()).toMatchObject({
+    items: {
+      k1: {
+        title: "Trenitalia ticket",
+        markdown: "A train ticket.",
+        tags: ["logistics"],
+        analysisError: null,
+        // file facts from the uploaded event survive the overlay
+        filename: "shot.png",
+        path: "/media/k1-shot.png",
+      },
+    },
+    pendingAnalyses: {},
+  });
+});
+
+test("a transient vendor failure is retried in-attempt and still succeeds", async () => {
+  let calls = 0;
+  const h = makeHarness(async () => {
+    calls += 1;
+    if (calls === 1) throw new Error("8005: Internal server error");
+    return result({ title: "second try" });
+  });
+  await h.append(uploaded("k1"));
+  // First try failed; the retry sleeps on virtual time.
+  expect(h.events(PROCESSED)).toEqual([]);
+  await h.advanceTime(2_000);
+
+  expect(calls).toBe(2);
+  expect(h.events(PROCESSED)).toMatchObject([{ payload: { title: "second try", error: null } }]);
+});
+
+test("terminal failure settles with an error and KEEPS the row", async () => {
+  const h = makeHarness(async () => {
+    throw new Error("8005: Internal server error");
+  });
+  await h.append(uploaded("k1"));
+  await h.advanceTime(2_000); // try 2
+  await h.advanceTime(8_000); // try 3 — terminal
+
+  expect(h.events(PROCESSED)).toMatchObject([
+    { payload: { stableKey: "k1", error: "8005: Internal server error", requestOffset: 1 } },
+  ]);
+  expect(h.state()).toMatchObject({
+    items: { k1: { filename: "shot.png", analysisError: "8005: Internal server error" } },
+    pendingAnalyses: {},
+  });
+});
+
+test("eviction mid-attempt: the keepalive revival restarts the obligation", async () => {
+  let calls = 0;
+  const h = makeHarness(async () => {
+    calls += 1;
+    // The first incarnation's attempt hangs forever (vendor never answers).
+    if (calls === 1) return await new Promise<never>(() => {});
+    return result({ title: "after revival" });
+  });
+  await h.append(uploaded("k1"));
+  expect(h.events(PROCESSED)).toEqual([]);
+
+  h.crash();
+  // The parked keepalive alarm fires, appends the revival fact, and the
+  // caught-up pass finds the still-open obligation with an empty live-set.
+  await h.advanceTime(60_000);
+
+  expect(calls).toBe(2);
+  expect(h.events(PROCESSED)).toMatchObject([{ payload: { title: "after revival", error: null } }]);
+  expect(h.state()).toMatchObject({ pendingAnalyses: {} });
+});
+
+test("an expired obligation settles as failed without dialing the vendor", async () => {
+  let calls = 0;
+  const h = makeHarness(async () => {
+    calls += 1;
+    throw new Error("must never be dialed");
+  });
+  // Commit without driving delivery, then wake past the horizon — the
+  // delivery-time state sees an already-expired request.
+  await h.stream.append(uploaded("k1"));
+  await h.advanceTime(MEDIA_ANALYSIS_EXPIRY_MS + 60_000);
+
+  expect(calls).toBe(0);
+  expect(h.events(PROCESSED)).toMatchObject([
+    { payload: { stableKey: "k1", error: expect.stringContaining("expired") } },
+  ]);
+  expect(h.state()).toMatchObject({
+    items: { k1: { analysisError: expect.stringContaining("expired") } },
+    pendingAnalyses: {},
+  });
+});
+
+test("reanalyze-requested re-runs analysis and overlays the newer result", async () => {
+  let calls = 0;
+  const h = makeHarness(async () => {
+    calls += 1;
+    return result({ title: `analysis ${calls}`, tags: calls === 1 ? [] : ["receipt"] });
+  });
+  await h.append(uploaded("k1"));
+  await h.append({
+    type: "events.iterate.com/media/reanalyze-requested",
+    idempotencyKey: "media-reanalyze-k1-n1",
+    payload: { stableKey: "k1" },
+  });
+
+  expect(calls).toBe(2);
+  expect(h.events(PROCESSED)).toMatchObject([
+    { payload: { title: "analysis 1" } },
+    { payload: { title: "analysis 2", tags: ["receipt"] } },
+  ]);
+  expect(h.state()).toMatchObject({
+    items: { k1: { title: "analysis 2", tags: ["receipt"] } },
+    pendingAnalyses: {},
+  });
+});
+
+test("an uploaded event for a legacy-captured stableKey folds to a no-op (no re-analysis)", async () => {
+  let calls = 0;
+  const h = makeHarness(async () => {
+    calls += 1;
+    throw new Error("must never be dialed");
+  });
+  await h.append({
+    type: "events.iterate.com/media/captured",
+    idempotencyKey: "media-captured-k1",
+    payload: {
+      stableKey: "k1",
+      path: "/media/k1-shot.png",
+      filename: "shot.png",
+      contentType: "image/png",
+      width: 100,
+      height: 200,
+      source: "picker",
+      capturedAt: null,
+      isScreenshot: null,
+      title: "already analyzed inline",
+      markdown: "Legacy capture.",
+      transcript: "",
+      tags: ["screenshot"],
+      processedBy: "legacy-model",
+    },
+  });
+  // The shared idempotency-key scheme already rejects a same-key re-upload
+  // at the stream door; this exercises the fold's defense in depth for an
+  // uploaded event that lands under a different key (e.g. a raw append).
+  await h.append({ ...uploaded("k1"), idempotencyKey: "media-captured-k1-raw" });
+
+  expect(calls).toBe(0);
+  expect(h.events(PROCESSED)).toEqual([]);
+  expect(h.state()).toMatchObject({
+    items: { k1: { title: "already analyzed inline" } },
+    pendingAnalyses: {},
+  });
+});
+
+test("a wipe in the same batch cancels the obligation before any attempt starts", async () => {
+  let calls = 0;
+  const h = makeHarness(async () => {
+    calls += 1;
+    throw new Error("must never be dialed");
+  });
+  await h.append(uploaded("k1"), {
+    type: "events.iterate.com/media/wiped",
+    idempotencyKey: "media-wiped-n1",
+    payload: { deletedFiles: 1, items: 1 },
+  });
+
+  expect(calls).toBe(0);
+  expect(h.events(PROCESSED)).toEqual([]);
+  expect(h.state()).toMatchObject({ items: {}, pendingAnalyses: {} });
+});
+
+test("full-stream replay re-executes nothing: no vendor calls, no new events, same items", async () => {
+  const h = makeHarness(async () => result({ title: "Trenitalia ticket" }));
+  await h.append(uploaded("k1"));
+  // Well past every freshness horizon before the replay wakes.
+  await h.advanceTime(MEDIA_ANALYSIS_EXPIRY_MS * 2);
+  const eventsBefore = h.events().length;
+
+  let replayCalls = 0;
+  const replay = makeProcessorHarness<MediaProcessorContract, MediaProcessor>({
+    substrate: {
+      clock: h.clock,
+      stream: h.stream,
+      progress: makeMemoryProgressStore(MediaProcessorContract),
+    },
+    createProcessor: (deps) =>
+      makeProcessor(deps, async () => {
+        replayCalls += 1;
+        throw new Error("replay must never dial the vendor");
+      }),
+  });
+  await replay.settle();
+
+  expect(replayCalls).toBe(0);
+  expect(h.events().length).toBe(eventsBefore);
+  expect(replay.state().items).toEqual(h.state().items);
+  expect(replay.state().pendingAnalyses).toEqual({});
+});
+
+// --- helpers ---------------------------------------------------------------
+
+function uploaded(stableKey: string) {
+  return {
+    type: "events.iterate.com/media/uploaded",
+    idempotencyKey: `media-captured-${stableKey}`,
+    payload: {
+      stableKey,
+      path: `/media/${stableKey}-shot.png`,
+      filename: "shot.png",
+      contentType: "image/png",
+      width: 1170,
+      height: 2532,
+      source: "library-sync",
+      capturedAt: "2026-08-10T09:00:00.000Z",
+      isScreenshot: true,
+    },
+  } as const;
+}
+
+function result(overrides: Partial<MediaAnalysisResult>): MediaAnalysisResult {
+  return {
+    title: "",
+    markdown: "A train ticket.",
+    transcript: "Trenitalia 09:45",
+    tags: ["screenshot"],
+    processedBy: "test-model",
+    ...overrides,
+  };
+}
+
+function makeProcessor(
+  deps: HarnessProcessorDeps<MediaProcessorContract>,
+  analyze: (input: {
+    path: string;
+    filename: string;
+    contentType: string;
+  }) => Promise<MediaAnalysisResult>,
+) {
+  return new MediaProcessor({
+    stream: deps.stream,
+    path: deps.path,
+    projectId: deps.projectId,
+    now: deps.now,
+    sleep: deps.sleep,
+    analyze,
+  });
+}
+
+function makeHarness(
+  analyze: (input: {
+    path: string;
+    filename: string;
+    contentType: string;
+  }) => Promise<MediaAnalysisResult>,
+) {
+  return makeProcessorHarness<MediaProcessorContract, MediaProcessor>({
+    path: "/media",
+    createProcessor: (deps) => makeProcessor(deps, analyze),
+  });
+}

--- a/packages/iterate/src/starter-apps/media/processor.ts
+++ b/packages/iterate/src/starter-apps/media/processor.ts
@@ -1,11 +1,43 @@
-// The media stream processor: folds the mobile app's capture pipeline events
-// (events.iterate.com/media/captured + media/processed on /media — vocab
-// defined by apps/mobile/src/lib/media.ts) into a per-item map, latest
-// processing winning. Pure fold, no side effects; the MediaApp worker layers
-// search/list/get on the reduced state.
+// The media stream processor: folds the mobile app's capture events on
+// /media (vocab shared with apps/mobile/src/lib/media.ts) into a per-item
+// map, latest processing winning — AND owns the server-side analysis
+// reaction. A phone appends a cheap durable media/uploaded event right after
+// the bytes land; this processor treats it as an open obligation, drives the
+// vision pipeline (analysis.ts) via the injected `analyze` dep, and settles
+// with ONE terminal media/processed event whose payload carries the result
+// union (`error: null` on success). Obligation doctrine:
+// docs/writing-stream-processors.md; GithubAiLinterProcessor is the sibling
+// userland precedent. The MediaApp worker hosts this with `recovery = true`,
+// so an eviction mid-analysis is revived by the keepalive and the caught-up
+// pass restarts still-open obligations from reduced state.
 import { z } from "zod";
-import { defineProcessorContract, StreamProcessor } from "../../processors/index.ts";
-import type { ProcessorState, ReduceArgs } from "../../processors/index.ts";
+import {
+  defineProcessorContract,
+  isIdempotencyConflict,
+  StreamProcessor,
+} from "../../processors/index.ts";
+import type {
+  EmittedInput,
+  ProcessEventArgs,
+  ProcessorState,
+  ReduceArgs,
+} from "../../processors/index.ts";
+import type { MediaAnalysisResult } from "./analysis.ts";
+
+/**
+ * An analysis obligation is abandoned (settled as failed, without dialing
+ * the AI) when its requesting event is older than this — the staleness
+ * doctrine's horizon. Generous on purpose: a phone can upload while the
+ * analyzer is broken and still get analyzed when the fix deploys; Re-analyze
+ * covers anything older.
+ */
+export const MEDIA_ANALYSIS_EXPIRY_MS = 24 * 60 * 60 * 1000;
+
+/** Tries per attempt, with backoff between them — covers the transient
+ * Workers AI failure class ("8005: Internal server error") observed in prod
+ * without an extra durable event per retry. */
+const ANALYSIS_TRIES = 3;
+const ANALYSIS_RETRY_BACKOFF_MS = [2_000, 8_000];
 
 const processingFields = {
   title: z.string().default("").meta({
@@ -17,7 +49,7 @@ const processingFields = {
   processedBy: z.string().meta({ description: "Model id that produced this processing." }),
 };
 
-const MediaItem = z.object({
+const fileFields = {
   stableKey: z.string().meta({ description: "Content hash — the item's identity." }),
   path: z.string().meta({ description: "itx.files path holding the bytes." }),
   filename: z.string().meta({ description: "Original filename as picked/synced." }),
@@ -35,37 +67,103 @@ const MediaItem = z.object({
     .nullable()
     .default(null)
     .meta({ description: "iOS mediaSubtypes screenshot flag." }),
+};
+
+const MediaItem = z.object({
+  ...fileFields,
   capturedEventAt: z.string().meta({ description: "Stream time the capture committed." }),
   ...processingFields,
+  analysisError: z
+    .string()
+    .nullable()
+    .default(null)
+    .meta({
+      description:
+        "The latest analysis settlement's failure, or null. Rows born from " +
+        "media/uploaded exist regardless of analysis outcome; a terminal failure lands here.",
+    }),
 });
 
 export type MediaItem = z.infer<typeof MediaItem>;
 
+const PendingAnalysis = z.object({
+  stableKey: z.string(),
+  path: z.string(),
+  filename: z.string(),
+  contentType: z.string(),
+  requestOffset: z.number().meta({
+    description:
+      "Offset of the uploaded/reanalyze event that opened this obligation — the " +
+      "settlement's idempotency identity.",
+  }),
+  expiresAtMs: z.number().meta({
+    description:
+      "Epoch ms (request createdAt + MEDIA_ANALYSIS_EXPIRY_MS); past it the " +
+      "obligation settles as expired without dialing the AI.",
+  }),
+});
+
+type PendingAnalysis = z.infer<typeof PendingAnalysis>;
+
 export const MediaProcessorContract = defineProcessorContract({
   slug: "media",
-  version: "0.1.0",
-  description: "Reduces captured media (screenshots/photos) on /media into a searchable index.",
+  version: "0.2.0",
+  description:
+    "Reduces captured media (screenshots/photos) on /media into a searchable index, and drives " +
+    "server-side vision analysis of uploaded items (obligation pattern).",
   stateSchema: z.object({
     items: z
       .record(z.string(), MediaItem)
       .default({})
       .meta({ description: "Items by stableKey, latest processing overlaid." }),
+    pendingAnalyses: z
+      .record(z.string(), PendingAnalysis)
+      .default({})
+      .meta({
+        description:
+          "Open analysis obligations by stableKey (latest request wins); settled by one " +
+          "media/processed event each.",
+      }),
   }),
   events: {
+    "events.iterate.com/media/uploaded": {
+      description:
+        "A media item's bytes landed in project files: the phone appends this cheap durable " +
+        "fact right after files.put (metadata only — no analysis yet), idempotency-keyed by " +
+        "content hash + wipe generation, sharing the media/captured key scheme so an item " +
+        "already captured never re-uploads as a duplicate. Opens an analysis obligation.",
+      payloadSchema: z.object(fileFields),
+      examples: [
+        {
+          description: "A synced screenshot, uploaded and awaiting analysis.",
+          payload: {
+            stableKey: "abc123",
+            path: "/media/abc123-IMG_0001.png",
+            filename: "IMG_0001.png",
+            contentType: "image/png",
+            width: 1170,
+            height: 2532,
+            source: "library-sync",
+            capturedAt: "2026-08-10T09:00:00.000Z",
+            isScreenshot: true,
+          },
+        },
+      ],
+    },
+    "events.iterate.com/media/reanalyze-requested": {
+      description:
+        "Re-analyze an existing item (the app's Re-analyze button): opens an analysis " +
+        "obligation for it; the settlement overlays the item's processing fields.",
+      payloadSchema: z.object({ stableKey: z.string() }),
+      examples: [{ description: "A user-requested re-run.", payload: { stableKey: "abc123" } }],
+    },
     "events.iterate.com/media/captured": {
       description:
-        "A media item entered the project: bytes stored, first vision processing inline. " +
-        "Appended by the capture pipeline script, idempotency-keyed by content hash.",
+        "LEGACY (pre media/uploaded): a media item entered the project with its first vision " +
+        "processing inline, appended by the old phone-driven capture script. Still folded so " +
+        "history keeps rendering; nothing appends it anymore.",
       payloadSchema: z.object({
-        stableKey: z.string(),
-        path: z.string(),
-        filename: z.string(),
-        contentType: z.string(),
-        width: z.number(),
-        height: z.number(),
-        source: z.string().default("picker"),
-        capturedAt: z.string().nullable().default(null),
-        isScreenshot: z.boolean().nullable().default(null),
+        ...fileFields,
         ...processingFields,
       }),
       examples: [
@@ -103,42 +201,121 @@ export const MediaProcessorContract = defineProcessorContract({
     },
     "events.iterate.com/media/processed": {
       description:
-        "A re-analysis of an existing item (Re-analyze in the app, or batch re-tagging): " +
-        "the latest one supersedes the item's processing fields.",
+        "One analysis settlement (the obligation's single terminal event): on success the " +
+        "processing fields overlay the item's, `error: null`; on terminal failure `error` says " +
+        "why and the item's previous fields stay. Also appended by legacy phone-driven " +
+        "re-analysis (no error/requestOffset).",
       payloadSchema: z.object({
         stableKey: z.string(),
         ...processingFields,
+        error: z.string().nullable().default(null).meta({
+          description: "Terminal analysis failure, or null on success.",
+        }),
+        requestOffset: z.number().nullable().default(null).meta({
+          description: "The uploaded/reanalyze event this settles (null on legacy appends).",
+        }),
       }),
       examples: [
         {
-          description: "A re-tag after a taxonomy improvement.",
+          description: "A successful server-side analysis of an uploaded item.",
           payload: {
             stableKey: "abc123",
+            title: "Trenitalia ticket Rome→Florence 09:45",
             markdown: "A train ticket from Rome to Florence.",
             transcript: "Trenitalia 09:45",
-            tags: ["screenshot", "logistics", "receipt"],
+            tags: ["screenshot", "logistics"],
             processedBy: "@cf/meta/llama-4-scout-17b-16e-instruct",
+            error: null,
+            requestOffset: 12,
           },
         },
       ],
     },
   },
   consumes: [
+    "events.iterate.com/media/uploaded",
+    "events.iterate.com/media/reanalyze-requested",
     "events.iterate.com/media/captured",
     "events.iterate.com/media/processed",
     "events.iterate.com/media/wiped",
   ],
-  emits: [],
+  emits: ["events.iterate.com/media/processed"],
 });
 export type MediaProcessorContract = typeof MediaProcessorContract;
 
 export type MediaState = ProcessorState<MediaProcessorContract>;
 
-export class MediaProcessor extends StreamProcessor<MediaProcessorContract> {
+type MediaProcessorDeps = {
+  /** The vision pipeline (analysis.ts), injected so tests run in plain node. */
+  analyze: (input: {
+    path: string;
+    filename: string;
+    contentType: string;
+  }) => Promise<MediaAnalysisResult>;
+  now: () => number;
+  sleep: (ms: number) => Promise<void>;
+};
+
+export class MediaProcessor extends StreamProcessor<MediaProcessorContract, MediaProcessorDeps> {
   readonly contract = MediaProcessorContract;
+
+  /**
+   * Runtime-only attempts by stableKey. The uploaded/reanalyze +
+   * processed events are the durable truth: after an eviction this set is
+   * empty and the next caught-up pass restarts any still-open obligation.
+   */
+  readonly #liveAnalyses = new Set<string>();
 
   protected override reduce({ event, state }: ReduceArgs<MediaProcessorContract>) {
     switch (event.type) {
+      case "events.iterate.com/media/uploaded": {
+        // A stableKey already present (legacy captured, or a duplicate
+        // upload racing the phone's getEvent check) folds to a no-op — no
+        // duplicate row, no redundant analysis.
+        if (state.items[event.payload.stableKey] !== undefined) return state;
+        return {
+          ...state,
+          items: {
+            ...state.items,
+            [event.payload.stableKey]: {
+              ...event.payload,
+              capturedEventAt: event.createdAt,
+              title: "",
+              markdown: "",
+              transcript: "",
+              tags: [],
+              processedBy: "",
+              analysisError: null,
+            },
+          },
+          pendingAnalyses: {
+            ...state.pendingAnalyses,
+            [event.payload.stableKey]: pendingAnalysisFor(event),
+          },
+        };
+      }
+      case "events.iterate.com/media/reanalyze-requested": {
+        const item = state.items[event.payload.stableKey];
+        // Nothing to re-analyze for an unknown item — skip rather than
+        // invent an obligation with no file behind it.
+        if (item === undefined) return state;
+        return {
+          ...state,
+          pendingAnalyses: {
+            ...state.pendingAnalyses,
+            // Latest request wins: a reanalyze during a pending initial
+            // analysis collapses to one obligation (one settlement key).
+            [item.stableKey]: {
+              stableKey: item.stableKey,
+              path: item.path,
+              filename: item.filename,
+              contentType: item.contentType,
+              requestOffset: event.offset,
+              expiresAtMs: Date.parse(event.createdAt) + MEDIA_ANALYSIS_EXPIRY_MS,
+            },
+          },
+        };
+      }
       case "events.iterate.com/media/captured": {
         // Idempotency-keyed at the source; a duplicate folds to a no-op.
         if (state.items[event.payload.stableKey] !== undefined) return state;
@@ -146,26 +323,164 @@ export class MediaProcessor extends StreamProcessor<MediaProcessorContract> {
           ...state,
           items: {
             ...state.items,
-            [event.payload.stableKey]: { ...event.payload, capturedEventAt: event.createdAt },
+            [event.payload.stableKey]: {
+              ...event.payload,
+              capturedEventAt: event.createdAt,
+              analysisError: null,
+            },
           },
         };
       }
       case "events.iterate.com/media/wiped":
-        return { ...state, items: {} };
+        return { ...state, items: {}, pendingAnalyses: {} };
       case "events.iterate.com/media/processed": {
+        const { [event.payload.stableKey]: _settled, ...pendingAnalyses } = state.pendingAnalyses;
         const existing = state.items[event.payload.stableKey];
         // A processed event for an unknown item (e.g. pre-rename history)
         // has nothing to overlay — skip rather than invent a partial item.
-        if (existing === undefined) return state;
+        if (existing === undefined) return { ...state, pendingAnalyses };
+        // `||` folds legacy payloads (no error field, reduced without the
+        // contract parse in old states) into the success arm.
+        const error = event.payload.error || null;
+        const item =
+          error === null
+            ? {
+                ...existing,
+                title: event.payload.title,
+                markdown: event.payload.markdown,
+                transcript: event.payload.transcript,
+                tags: event.payload.tags,
+                processedBy: event.payload.processedBy,
+                analysisError: null,
+              }
+            : // A failed analysis keeps whatever the item already shows; the
+              // failure itself becomes visible on the row.
+              { ...existing, analysisError: error };
         return {
           ...state,
-          items: { ...state.items, [event.payload.stableKey]: { ...existing, ...event.payload } },
+          items: { ...state.items, [event.payload.stableKey]: item },
+          pendingAnalyses,
         };
       }
       default:
         return state;
     }
   }
+
+  protected override processEvent(args: ProcessEventArgs<MediaProcessorContract>): undefined {
+    // Behind head, a settlement may already sit in an unseen page — acting
+    // early would re-run a settled analysis.
+    if (!args.delivery.caughtUp) return;
+    const now = this.deps.now();
+    const expired: PendingAnalysis[] = [];
+    for (const pending of Object.values(args.state.pendingAnalyses)) {
+      if (this.#liveAnalyses.has(pending.stableKey)) continue;
+      if (now >= pending.expiresAtMs) {
+        expired.push(pending);
+        continue;
+      }
+      // Registered synchronously before any await so this same pass never
+      // classifies its own attempt as undriven.
+      this.#liveAnalyses.add(pending.stableKey);
+      // A dropped attempt is recovered from the still-open obligation on the
+      // next caught-up/revival pass (the worker hosts this with recovery on).
+      args.runInBackground(async () => {
+        try {
+          const settlement = await this.#attemptAnalysis(pending);
+          await this.#appendSettlement(args.append, pending, settlement);
+        } finally {
+          this.#liveAnalyses.delete(pending.stableKey);
+        }
+      });
+    }
+    if (expired.length === 0) return;
+    // Short must-happen appends: an expired obligation's settlement must
+    // land even if this incarnation dies right after the pass — otherwise
+    // the row shows "Analyzing…" forever.
+    args.blockProcessorWhile(async () => {
+      for (const pending of expired) {
+        await this.#appendSettlement(args.append, pending, {
+          error:
+            "analysis window expired before it could run " +
+            `(older than ${MEDIA_ANALYSIS_EXPIRY_MS / 3_600_000}h) — use Re-analyze to retry`,
+        });
+      }
+    });
+  }
+
+  /** One attempt = up to {@link ANALYSIS_TRIES} tries with short backoff. */
+  async #attemptAnalysis(
+    pending: PendingAnalysis,
+  ): Promise<{ result: MediaAnalysisResult } | { error: string }> {
+    let lastError = "analysis failed";
+    for (let tryIndex = 0; tryIndex < ANALYSIS_TRIES; tryIndex++) {
+      if (tryIndex > 0) {
+        await this.deps.sleep(
+          ANALYSIS_RETRY_BACKOFF_MS[Math.min(tryIndex - 1, ANALYSIS_RETRY_BACKOFF_MS.length - 1)]!,
+        );
+      }
+      try {
+        return { result: await this.deps.analyze(pending) };
+      } catch (error) {
+        lastError = error instanceof Error ? error.message : String(error);
+      }
+    }
+    return { error: lastError.slice(0, 2_000) };
+  }
+
+  /**
+   * The obligation's single terminal event. The key is state-derived and
+   * deterministic per obligation (`@<stableKey>:<requestOffset>`); bodies
+   * contain AI output, so two racing incarnations can collide
+   * same-key/different-body — the first committed settlement is the
+   * authority and the loser tolerates the conflict (ai-linter shape).
+   */
+  async #appendSettlement(
+    append: ProcessEventArgs<MediaProcessorContract>["append"],
+    pending: PendingAnalysis,
+    outcome: { result: MediaAnalysisResult } | { error: string },
+  ): Promise<void> {
+    const event: EmittedInput<MediaProcessorContract> = {
+      type: "events.iterate.com/media/processed",
+      idempotencyKey: this.idempotencyKey(
+        `analysis-settled@${pending.stableKey}:${pending.requestOffset}`,
+      ),
+      payload: {
+        stableKey: pending.stableKey,
+        requestOffset: pending.requestOffset,
+        ...("result" in outcome
+          ? { ...outcome.result, error: null }
+          : {
+              title: "",
+              markdown: "",
+              transcript: "",
+              tags: [],
+              processedBy: "",
+              error: outcome.error,
+            }),
+      },
+    };
+    try {
+      await append(event);
+    } catch (error) {
+      if (!isIdempotencyConflict(error)) throw error;
+    }
+  }
+}
+
+function pendingAnalysisFor(event: {
+  createdAt: string;
+  offset: number;
+  payload: { stableKey: string; path: string; filename: string; contentType: string };
+}): PendingAnalysis {
+  return {
+    stableKey: event.payload.stableKey,
+    path: event.payload.path,
+    filename: event.payload.filename,
+    contentType: event.payload.contentType,
+    requestOffset: event.offset,
+    expiresAtMs: Date.parse(event.createdAt) + MEDIA_ANALYSIS_EXPIRY_MS,
+  };
 }
 
 /**

--- a/packages/iterate/src/starter-apps/media/worker.ts
+++ b/packages/iterate/src/starter-apps/media/worker.ts
@@ -1,12 +1,14 @@
-// The MediaApp Durable Object: hosts the media stream processor and exposes
-// the query surface (search/list/get) that gets mounted at `itx.media`.
-// Search returns signed image URLs so an agent's answer can show the actual
+// The MediaApp Durable Object: hosts the media stream processor — the fold
+// AND the server-side analysis obligations (processor.ts) — and exposes the
+// query surface (search/list/get) that gets mounted at `itx.media`. Search
+// returns signed image URLs so an agent's answer can show the actual
 // screenshot. No HTTP page — this app is an API, not a site.
 import {
   StreamProcessorDurableObject,
   type ProcessorHostDeps,
   type StreamEvent,
 } from "../../sdk.ts";
+import { analyzeMediaImage } from "./analysis.ts";
 import { mediaStreamPath } from "./app-ref.ts";
 import { MediaProcessor, searchMediaItems, type MediaItem, type MediaState } from "./processor.ts";
 
@@ -17,8 +19,19 @@ export type MediaSearchHit = MediaItem & {
 
 export class MediaApp extends StreamProcessorDurableObject<MediaState> {
   protected readonly streamPath = mediaStreamPath;
+  /** Analysis obligations must survive eviction: the keepalive revives this
+   * DO and the caught-up pass restarts still-open work from reduced state. */
+  protected override readonly recovery = true;
   protected createProcessor(deps: ProcessorHostDeps) {
-    return new MediaProcessor(deps);
+    return new MediaProcessor({
+      ...deps,
+      now: Date.now,
+      sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+      analyze: async (input) => {
+        using project = await this.env.ITX.get();
+        return await analyzeMediaImage(project, input);
+      },
+    });
   }
 
   /** Project-worker event delivery calls this after a durable /media event

--- a/tasks/media-uploaded-event.md
+++ b/tasks/media-uploaded-event.md
@@ -1,0 +1,151 @@
+---
+status: in-progress
+size: large
+branch: media-uploaded-event
+---
+
+# Media: durable `media/uploaded` event + server-side analysis
+
+## Status summary
+
+Not started yet (spec commit). The design is settled: the phone appends a
+cheap durable `media/uploaded` event right after the bytes land, and analysis
+moves server-side into the userland MediaApp processor (obligation pattern,
+keepalive-recovered). Nothing implemented; checklist below.
+
+## Problem
+
+The mobile Media capture flow (PR #2466) couples the durable record to
+analysis success AND to the phone keeping its capnweb socket open ~5–15s per
+item: after `files.put`, an awaited `capabilityHost.runScript` does
+toMarkdown + vision and only THEN appends the durable `media/captured` event.
+Observed in prod dogfooding:
+
+- locking the phone mid-pass kills every in-flight item ("Peer closed
+  WebSocket: 1001");
+- a transient Workers AI failure ("8005: Internal server error") costs the
+  whole item;
+- failed items re-upload and re-analyze from scratch next pass; two items
+  never came back because no pass completed while foregrounded.
+
+## Design
+
+Split durability from analysis, event-driven and server-side.
+
+### New flow
+
+```
+before (phone drives everything, holds socket open):
+  hash → files.put → runScript(toMarkdown + vision + append captured)   ~5-15s/item
+
+after (phone does the cheap durable part only):
+  phone:  hash → files.put → stream.append(media/uploaded)              ~fast
+  server: MediaApp processor reacts to media/uploaded (obligation) →
+          toMarkdown + vision → append media/processed (error field on
+          terminal failure)
+```
+
+### Event vocabulary (all on `/media`)
+
+- `media/uploaded` (NEW, phone-appended): metadata only — stableKey, path,
+  filename, contentType, width, height, source, capturedAt, isScreenshot.
+  Idempotency key = existing `mediaIdempotencyKey` scheme
+  (`media-captured-<hash>[-g<gen>]`), so wipe-generation semantics are
+  preserved AND a stableKey already recorded as legacy `media/captured`
+  dedups at the phone's existing getEvent check — no duplicate rows.
+- `media/reanalyze-requested` (NEW, phone-appended): `{ stableKey }`, key
+  `media-reanalyze-<stableKey>-<nonce>`. Replaces the phone-driven reprocess
+  script; Re-analyze is now durable too.
+- `media/processed` (EXISTING, now the analysis settlement): gains
+  `error: string | null` (result union in the payload — one terminal event
+  per obligation, per docs/writing-stream-processors.md) and
+  `requestOffset: number | null` (the uploaded/reanalyze event it settles).
+  Success overlays processing fields; failure sets `error` and leaves prior
+  fields alone. Failures never lose the item — the row exists from uploaded.
+- `media/captured` (LEGACY): still folded and rendered everywhere; no longer
+  appended by anything. Old items keep working.
+- `media/wiped`: unchanged, but the wipe script's file sweep now reads
+  uploaded events too.
+
+### Seam: the userland MediaApp processor (starter app), not an OS domain
+
+Considered three homes for the server-side reaction:
+
+1. **OS-side domain processor** (like email): needs per-project subscription
+   wiring at creation for a product-level feature — invasive, and puts a
+   userland concern in the platform.
+2. **Capability-host script re-request**: reuses script obligations but adds
+   a second processor just to request scripts, and retries/settlement
+   semantics don't fit.
+3. **The MediaApp DO itself** (chosen): it already owns the /media vocabulary
+   and fold, already receives committed /media events (project-worker fan-in
+   → `syncEvent` → catchUp), is DO-hosted so alarms + keepalive work
+   (`recovery = true`), and has full project itx (`env.ITX`) for
+   ai.toMarkdown / ai.run / files / images. `GithubAiLinterProcessor` is the
+   exact precedent: a userland starter-app obligation processor doing AI
+   calls with `recovery = true` and injected deps.
+
+The MediaProcessor stops being a pure fold: `reduce` additionally tracks open
+analysis obligations (`pendingAnalyses`), and `processEvent` (under
+`delivery.caughtUp`) starts undriven attempts / settles expired ones,
+following the obligation pattern. Contract/implementation stay in
+processor.ts (existing starter-app shape); the analysis pipeline itself moves
+to a new `analysis.ts` (ported from `buildProcessScript`'s script body), with
+the vision model, taxonomy, and prompt — the server now owns the analysis
+vocabulary (mobile keeps a display-only tag list with a sync note, same
+hand-sync convention as search semantics).
+
+### Obligation semantics (guesses flagged)
+
+- Attempt = up to 3 tries with short backoff (in-attempt retries cover the
+  transient Workers AI 8005 class); final failure settles terminally with
+  `error`. _Guess: 3 tries / 2s+8s backoff._
+- Obligation expiry: 24h from the requesting event's `createdAt` — a wake
+  later than that settles as expired failure without dialing AI (staleness
+  doctrine). Rows stay; Re-analyze works. _Guess: 24h._
+- Settlement idempotency key: `analysis-settled@<stableKey>:<requestOffset>`
+  (state-derived, deterministic per obligation); same-key/different-body
+  races tolerate-as-settlement (`isIdempotencyConflict`), the ai-linter
+  shape.
+- No `…-started` event: analysis is safe to re-run (idempotent appends),
+  like Agent adoption.
+- Eviction recovery: keepalive alarm → revival → caughtUp pass restarts
+  still-open obligations from reduced state.
+
+## Checklist
+
+- [ ] Starter app: `analysis.ts` — pipeline ported from buildProcessScript
+      (bytes → toMarkdown → >1MB downscale → vision JSON parse), owns model +
+      taxonomy + prompt; unit tests ported from the script tests.
+- [ ] Starter app: contract v0.2.0 — consume uploaded + reanalyze-requested,
+      emit processed (with error/requestOffset), state gains pendingAnalyses,
+      MediaItem gains analysisError; reduce dedups uploaded-after-captured;
+      wiped clears obligations.
+- [ ] Starter app: MediaProcessor processEvent obligation branch + worker
+      `recovery = true` + analyze dep wired off env.ITX.
+- [ ] Starter app: harness tests — happy path, terminal failure keeps row,
+      eviction mid-attempt revival, expiry without dialing AI, full-stream
+      replay (throwing fake, zero calls, zero appends), reanalyze, dedup,
+      wipe clears obligations.
+- [ ] Mobile media.ts: uploaded/reanalyze event builders + types,
+      buildProcessScript deleted, wipe script sweeps uploaded too,
+      deriveMediaList births rows from uploaded + overlays processed
+      (error-aware) + analysis status (pending/failed/done), dedup across
+      captured+uploaded.
+- [ ] Mobile media-sync.ts: pass = hash + put + append uploaded (no
+      runScript); progress copy updated.
+- [ ] Mobile media.tsx: capture mutation appends uploaded; rows show
+      "Analyzing…" until processed lands, error state on terminal failure;
+      Re-analyze appends reanalyze-requested. Minimal diff (sibling PR
+      mobile-media-niggles touches the same screen).
+- [ ] Mobile tests: media.test.ts reworked (script tests move to starter
+      app), new derivation/back-compat/wipe coverage.
+- [ ] e2e: media.e2e.test.ts + media-agent-retrieval.e2e.test.ts drive the
+      new flow (put + append uploaded, wait for processed via
+      stream.waitForEvent); media-app.e2e.test.ts (seeded captured) stays as
+      the back-compat lane.
+- [ ] Checks: typecheck, lint, knip, format, vitest.
+
+## Implementation log
+
+(running notes appended during implementation)

--- a/tasks/media-uploaded-event.md
+++ b/tasks/media-uploaded-event.md
@@ -1,17 +1,20 @@
 ---
-status: in-progress
+status: in-review
 size: large
 branch: media-uploaded-event
+pr: https://github.com/iterate/iterate/pull/2482
 ---
 
 # Media: durable `media/uploaded` event + server-side analysis
 
 ## Status summary
 
-Not started yet (spec commit). The design is settled: the phone appends a
-cheap durable `media/uploaded` event right after the bytes land, and analysis
-moves server-side into the userland MediaApp processor (obligation pattern,
-keepalive-recovered). Nothing implemented; checklist below.
+Implemented, all checks green (typecheck, lint, knip, format, vitest across
+os/iterate/mobile). Main pieces: phone appends a cheap durable
+`media/uploaded` event after `files.put`; analysis moved into the userland
+MediaApp processor as an obligation (recovery-enabled); mobile list shows
+Analyzing…/failed states; e2e rewritten for the new flow. Not yet run: the
+live e2e lane (needs a dev server) — CI's preview e2e covers it.
 
 ## Problem
 
@@ -52,7 +55,8 @@ after (phone does the cheap durable part only):
   Idempotency key = existing `mediaIdempotencyKey` scheme
   (`media-captured-<hash>[-g<gen>]`), so wipe-generation semantics are
   preserved AND a stableKey already recorded as legacy `media/captured`
-  dedups at the phone's existing getEvent check — no duplicate rows.
+  dedups at the phone's existing getEvent check (and, failing that, at the
+  stream's same-key rejection) — no duplicate rows.
 - `media/reanalyze-requested` (NEW, phone-appended): `{ stableKey }`, key
   `media-reanalyze-<stableKey>-<nonce>`. Replaces the phone-driven reprocess
   script; Re-analyze is now durable too.
@@ -114,38 +118,61 @@ hand-sync convention as search semantics).
 
 ## Checklist
 
-- [ ] Starter app: `analysis.ts` — pipeline ported from buildProcessScript
+- [x] Starter app: `analysis.ts` — pipeline ported from buildProcessScript
       (bytes → toMarkdown → >1MB downscale → vision JSON parse), owns model +
-      taxonomy + prompt; unit tests ported from the script tests.
-- [ ] Starter app: contract v0.2.0 — consume uploaded + reanalyze-requested,
+      taxonomy + prompt; unit tests ported from the script tests. _In
+      packages/iterate/src/starter-apps/media/analysis.ts + analysis.test.ts;
+      the script-injection tests died with the script._
+- [x] Starter app: contract v0.2.0 — consume uploaded + reanalyze-requested,
       emit processed (with error/requestOffset), state gains pendingAnalyses,
       MediaItem gains analysisError; reduce dedups uploaded-after-captured;
-      wiped clears obligations.
-- [ ] Starter app: MediaProcessor processEvent obligation branch + worker
-      `recovery = true` + analyze dep wired off env.ITX.
-- [ ] Starter app: harness tests — happy path, terminal failure keeps row,
+      wiped clears obligations. _processor.ts._
+- [x] Starter app: MediaProcessor processEvent obligation branch + worker
+      `recovery = true` + analyze dep wired off env.ITX. _worker.ts
+      createProcessor injects analyze/now/sleep; #startOrSettle logic lives
+      in processEvent's caughtUp branch._
+- [x] Starter app: harness tests — happy path, terminal failure keeps row,
       eviction mid-attempt revival, expiry without dialing AI, full-stream
       replay (throwing fake, zero calls, zero appends), reanalyze, dedup,
-      wipe clears obligations.
-- [ ] Mobile media.ts: uploaded/reanalyze event builders + types,
+      wipe clears obligations. _media-analysis.test.ts via
+      makeProcessorHarness; also in-attempt retry on virtual time._
+- [x] Mobile media.ts: uploaded/reanalyze event builders + types,
       buildProcessScript deleted, wipe script sweeps uploaded too,
       deriveMediaList births rows from uploaded + overlays processed
       (error-aware) + analysis status (pending/failed/done), dedup across
-      captured+uploaded.
-- [ ] Mobile media-sync.ts: pass = hash + put + append uploaded (no
-      runScript); progress copy updated.
-- [ ] Mobile media.tsx: capture mutation appends uploaded; rows show
+      captured+uploaded. _MediaListItem.analysis drives the UI badge._
+- [x] Mobile media-sync.ts: pass = hash + put + append uploaded (no
+      runScript); progress copy updated. _"Uploading n of m new…"; failed
+      now counts upload failures only._
+- [x] Mobile media.tsx: capture mutation appends uploaded; rows show
       "Analyzing…" until processed lands, error state on terminal failure;
       Re-analyze appends reanalyze-requested. Minimal diff (sibling PR
-      mobile-media-niggles touches the same screen).
-- [ ] Mobile tests: media.test.ts reworked (script tests move to starter
-      app), new derivation/back-compat/wipe coverage.
-- [ ] e2e: media.e2e.test.ts + media-agent-retrieval.e2e.test.ts drive the
+      mobile-media-niggles touches the same screen). _Pending cards say
+      "Uploading…"; MediaRow renders the analysis badge/error._
+- [x] Mobile tests: media.test.ts reworked (script tests move to starter
+      app), new derivation/back-compat/wipe coverage. _Pending/failed/
+      reanalyze status derivation, captured+uploaded dedup, both-birth-types
+      wipe sweep._
+- [x] e2e: media.e2e.test.ts + media-agent-retrieval.e2e.test.ts drive the
       new flow (put + append uploaded, wait for processed via
       stream.waitForEvent); media-app.e2e.test.ts (seeded captured) stays as
-      the back-compat lane.
-- [ ] Checks: typecheck, lint, knip, format, vitest.
+      the back-compat lane. _120s waits per settlement (same real-time AI
+      cost the awaited-runScript path had; e2e testTimeout is 180s)._
+- [x] Checks: typecheck, lint, knip, format, vitest. _All green; knip
+      required unexporting analysis-internal consts._
 
 ## Implementation log
 
-(running notes appended during implementation)
+- Chose per-stableKey obligation keying (`pendingAnalyses` keyed by
+  stableKey, storing requestOffset) so a reanalyze while an initial analysis
+  is pending collapses to one obligation — latest request wins; the
+  settlement clears the key's entry either way.
+- The harness's MemoryStream rejects same-key/different-body appends exactly
+  like production — the "uploaded after captured" dedup test had to use a
+  distinct key, which documented the real primary dedup (the stream door).
+- deriveMediaList's analysis state: latest request offset (uploaded birth or
+  reanalyze) vs latest settlement offset; request newer → pending; settled
+  with error → failed; else done. Legacy captured rows are born "done".
+- specs/mobile/media.spec.ts untouched: the deterministic lane seeds legacy
+  captured events (now the explicit back-compat surface) and the opt-in AI
+  lane's "Analyzing…" wait still matches the new row badge.


### PR DESCRIPTION
Splits the mobile Media pipeline's durability from its analysis. Before, the phone held a capnweb socket open ~5–15s per item while an awaited `runScript` did toMarkdown + vision and only then appended the durable `media/captured` event — so locking the phone mid-pass killed every in-flight item, and one transient Workers AI error cost the whole item (re-upload + re-analyze next pass; two prod items never came back).

### After this PR

```
phone:  hash → files.put → stream.append(media/uploaded)        # fast, durable
server: MediaApp processor reacts (obligation pattern):
        toMarkdown + vision → append media/processed            # retried server-side
```

- **Sync passes are hash + upload only** — backgrounding mid-pass loses ~nothing; pending cards say "Uploading…" and the row lands as soon as the event commits.
- **Analysis failures never lose the item**: the row exists from `media/uploaded`, shows "Analyzing…" until a `media/processed` settlement overlays it, and a terminal failure renders on the row (`error` field in the settlement — one terminal event per obligation, result union in the payload). Re-analyze retries it.
- **Server-side retries**: 3 tries with backoff per attempt (covers the observed transient `8005` class); eviction mid-analysis is revived by the keepalive (`recovery = true`) and the caught-up pass restarts still-open obligations from reduced state; requests older than 24h settle as expired without dialing the AI.
- **Re-analyze is durable too**: it appends `media/reanalyze-requested` instead of holding a socket open.
- **Seam**: the reaction lives in the userland **MediaApp starter-app processor** (`packages/iterate/src/starter-apps/media`), not a new OS domain — it already owns the /media vocabulary and fold, already receives committed /media events, and is DO-hosted so alarms/keepalive work. `GithubAiLinterProcessor` is the precedent (userland obligation processor doing AI calls). The vision pipeline moved from the phone-generated script into `analysis.ts`, so the server now owns model + taxonomy + prompt. Full decision record: `tasks/media-uploaded-event.md`.
- **Back-compat**: legacy `media/captured` events keep rendering everywhere (the deterministic spec lane seeds them, unchanged); the shared idempotency-key scheme means an item captured pre-split can never re-enter as a duplicate; wipe generations preserved; the wipe sweep covers both birth event types.

### Test coverage

- `media-analysis.test.ts` (node harness, real runner + keepalive): happy path, in-attempt retry on virtual time, terminal failure keeps the row, eviction-mid-attempt revival, expiry without dialing the vendor, reanalyze overlay, dedup, wipe cancelling obligations, and the full-stream replay test (throwing vendor fake, zero calls, zero appends).
- `analysis.test.ts`: the ported vision pipeline (downscale >1MB, chatty-JSON parsing, tag normalization, error propagation).
- Mobile `media.test.ts`: event builders, analysis-state derivation (pending/failed/done), captured+uploaded dedup, both-birth-types wipe sweep.
- e2e (`media.e2e.test.ts`, `media-agent-retrieval.e2e.test.ts`): put + append uploaded, then wait for the server settlement via `stream.waitForEvent` — real AI, real project worker.

All checks green locally: typecheck, lint, knip, format, vitest (os 2780, iterate 385, mobile 120).

Session-Id: bba87654-8592-4e00-8ec7-65d305b59bc2

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +552 -35 | +374 -26 🟩🟩🟩⬜⬜ |
| Mobile | +497 -598 | +360 -397 🟩🟩🟥🟥🟥 |
| Tests | +443 -0 | +369 -0 🟩🟩⬜⬜⬜ |
| Docs | +178 -0 | +155 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+1,670 -633** | **+1,258 -423** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 5a1cdf4 and a436109, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- mobile-pr-preview -->
## 📱 Mobile preview

Channel `media-uploaded-event` · runtime `023cbbc4d` · **JS-only** — the installed app can run it

<details open><summary>OTA — switch the installed app to this PR's channel (`a436109`)</summary>

**[Switch this phone to the PR channel](https://os.iterate.com/m/preview-channel/media-uploaded-event)**

<a href="https://os.iterate.com/m/preview-channel/media-uploaded-event"><img src="https://github.com/iterate/iterate/releases/download/gh-attach-assets/mobile-pr-2482-a43610999-ota-scheme.png" width="90" alt="QR code" /></a>

</details>
<details><summary>Full install — if the app is uninstalled or the runtime differs (`c3b64f8`)</summary>

**[Open the EAS build install page](https://expo.dev/accounts/mishanustom/projects/iterate/builds/3fe243bc-7133-4020-9205-e6b67ab02ece)**

<a href="https://expo.dev/accounts/mishanustom/projects/iterate/builds/3fe243bc-7133-4020-9205-e6b67ab02ece"><img src="https://github.com/iterate/iterate/releases/download/gh-attach-assets/mobile-pr-2482-a43610999-install-3fe243bc.png" width="90" alt="QR code" /></a>

<sub>Installing gets you a compatible binary on the default channel — then use the OTA link above to switch it to this PR's JS.</sub>

</details>

<sub>Back to main inside the app: Build info → Reset to default channel. Republishes on every push to this PR.</sub>
<!-- /mobile-pr-preview -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-12T10:34:16.449Z",
      "deployedAt": "2026-08-12T10:23:14.158Z",
      "headSha": "a4361099928238c9f9dae4b1b72368d69ca61e00",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/78136256990762",
      "shortSha": "a436109",
      "cleanupDurationMs": 13010,
      "deployDurationMs": 57489,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 56442,
      "deployReadinessDurationMs": 1043,
      "deployedWorkerName": "os-preview-6",
      "deployedWorkerVersion": "1747e2b6-0cd8-4482-b56b-5217ab415b62",
      "testDurationMs": 232424,
      "testRetries": null,
      "workerSizeKib": 20777.52,
      "workerGzipKib": 5229.65,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5240.82
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-12T10:34:06.388Z",
      "deployedAt": "2026-08-12T10:22:35.200Z",
      "headSha": "a4361099928238c9f9dae4b1b72368d69ca61e00",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-6.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/78136256990762",
      "shortSha": "a436109",
      "cleanupDurationMs": 2947,
      "deployDurationMs": 17721,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 17481,
      "deployReadinessDurationMs": 236,
      "deployedWorkerName": "docs-preview-6",
      "deployedWorkerVersion": "5481c90a-c359-468d-9623-3f1e1582f35a",
      "testDurationMs": 1877,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-12T10:34:06.977Z",
      "deployedAt": "2026-08-12T10:22:39.612Z",
      "headSha": "a4361099928238c9f9dae4b1b72368d69ca61e00",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/78136256990762",
      "shortSha": "a436109",
      "cleanupDurationMs": 3533,
      "deployDurationMs": 22192,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 21892,
      "deployReadinessDurationMs": 294,
      "deployedWorkerName": "auth-preview-6",
      "deployedWorkerVersion": "6f3f8e1f-9b20-4abf-8380-6c11731a9e47",
      "testDurationMs": 10126,
      "testRetries": null,
      "workerSizeKib": 3983.1,
      "workerGzipKib": 816.06,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-12T10:34:04.023Z",
      "deployedAt": "2026-08-12T10:13:40.014Z",
      "headSha": "a4361099928238c9f9dae4b1b72368d69ca61e00",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/78136256990762",
      "shortSha": "a436109",
      "cleanupDurationMs": 578,
      "deployDurationMs": 68,
      "deployConfigDurationMs": 7,
      "deployReuseProofDurationMs": 9,
      "deployedWorkerName": "dummy-petshop-preview-6",
      "deployedWorkerVersion": "0e9030ef-2ef0-4889-9eb0-09a7661cadc4",
      "testDurationMs": 5807,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `a436109` | [https://auth.iterate-preview-6.com](https://auth.iterate-preview-6.com) | 816.1 KiB | 22.2s | 10.1s |  | 3.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/78136256990762) | 2026-08-12T10:34:06.977Z | Preview app released. |
| Docs | released | `a436109` | [https://docs-preview-6.iterate-dev-preview.workers.dev](https://docs-preview-6.iterate-dev-preview.workers.dev) | 866.2 KiB | 17.7s | 1.9s |  | 2.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/78136256990762) | 2026-08-12T10:34:06.388Z | Preview app released. |
| Dummy Petshop | released | `a436109` | [https://dummy-petshop.iterate-preview-6.com](https://dummy-petshop.iterate-preview-6.com) | 198.3 KiB | 68ms | 5.8s |  | 578ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/78136256990762) | 2026-08-12T10:34:04.023Z | Preview app released. |
| OS | released | `a436109` | [https://os.iterate-preview-6.com](https://os.iterate-preview-6.com) | 5.11 MiB (-11.2 KiB vs main) | 57.5s | 232.4s |  | 13.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/78136256990762) | 2026-08-12T10:34:16.449Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->