### PR TITLE
PR guidance gate: block gh pr mutations until docs/pull-requests.md is in context

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,5 +9,18 @@
         }
       ]
     }
-  ]
+  ],
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR:-$PWD}\"/scripts/hooks/pr-guidance-gate.sh"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/docs/pull-requests.md
+++ b/docs/pull-requests.md
@@ -1,5 +1,11 @@
 # Pull requests
 
+> **Enforcement:** a Claude Code hook ([scripts/hooks/pr-guidance-gate.sh](../scripts/hooks/pr-guidance-gate.sh))
+> blocks PR-mutating `gh` commands until this doc's current content hash appears in the command
+> as a `PR_GUIDANCE_HASH=<hash>` prefix. The deny message contains this whole doc plus the hash,
+> so just follow what it says. Editing this file changes the hash and re-arms the gate for
+> everyone — that's intended.
+
 ## Before open
 
 ```bash

--- a/scripts/hooks/pr-guidance-gate.sh
+++ b/scripts/hooks/pr-guidance-gate.sh
@@ -38,7 +38,7 @@ esac
 {
   echo "BLOCKED: this command mutates a pull request, and the current PR guidance hasn't been through your context yet (or it changed since you last read it)."
   echo
-  echo "Read the guidance below, apply it to your PR, then re-run with the ack prefix (it's string-matched by a hook, not a real env var):"
+  echo "Read the guidance below, and make any changes necessary. You can re-run the command with the ack prefix (it's string-matched by a hook, not a real env var). If changes are substantial or will take a long time, you can first re-run with a note that you are working on the changes based on the pull request guidance:"
   echo
   echo "  PR_GUIDANCE_HASH=$hash gh pr create ..."
   echo

--- a/scripts/hooks/pr-guidance-gate.sh
+++ b/scripts/hooks/pr-guidance-gate.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Claude Code PreToolUse hook (matcher: Bash). Blocks PR-mutating gh commands until the
+# current docs/pull-requests.md has passed through the agent's context: the deny message
+# IS the doc, plus a content hash the agent must echo back as an inline
+# PR_GUIDANCE_HASH=<hash> prefix on gated commands. Doc changes -> new hash -> gate re-fires.
+#
+# Pure bash on purpose: this runs on every Bash tool call, so no jq/node startup cost.
+# Reads must stay ungated (gh pr view/checks, gh api GETs) — PR monitoring runs those
+# constantly. Only create/edit/merge and the REST PATCH escape hatch are gated.
+set -euo pipefail
+
+input=$(cat)
+
+gated=""
+case "$input" in
+  *"gh pr create"* | *"gh pr edit"* | *"gh pr merge"*) gated=1 ;;
+  *"gh api"*)
+    # the REST body-edit escape hatch from docs/pull-requests.md
+    case "$input" in
+      *pulls*)
+        case "$input" in
+          *PATCH*) gated=1 ;;
+        esac
+        ;;
+    esac
+    ;;
+esac
+[ -z "$gated" ] && exit 0
+
+doc="${CLAUDE_PROJECT_DIR:-$PWD}/docs/pull-requests.md"
+[ -f "$doc" ] || exit 0
+
+hash=$(shasum "$doc" | cut -c1-8)
+case "$input" in
+  *"PR_GUIDANCE_HASH=$hash"*) exit 0 ;;
+esac
+
+{
+  echo "BLOCKED: this command mutates a pull request, and the current PR guidance hasn't been through your context yet (or it changed since you last read it)."
+  echo
+  echo "Read the guidance below, apply it to your PR, then re-run with the ack prefix (it's string-matched by a hook, not a real env var):"
+  echo
+  echo "  PR_GUIDANCE_HASH=$hash gh pr create ..."
+  echo
+  echo "----- docs/pull-requests.md -----"
+  cat "$doc"
+} >&2
+exit 2

--- a/scripts/hooks/pr-guidance-gate.test.ts
+++ b/scripts/hooks/pr-guidance-gate.test.ts
@@ -1,0 +1,78 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { expect, test } from "vitest";
+
+const projectDir = join(import.meta.dirname, "..", "..");
+
+test("non-gh commands pass through untouched", () => {
+  expect(runHook("pnpm test")).toMatchObject({ status: 0, stderr: "" });
+  expect(runHook("git push origin my-branch")).toMatchObject({ status: 0, stderr: "" });
+});
+
+test("read-only gh commands pass through — PR monitoring must not be nagged", () => {
+  expect(runHook("gh pr view 123 --json title,body")).toMatchObject({ status: 0 });
+  expect(runHook("gh pr checks 123 --watch")).toMatchObject({ status: 0 });
+  expect(runHook("gh pr list --state open")).toMatchObject({ status: 0 });
+  expect(
+    runHook(
+      `gh api repos/iterate/iterate/pulls/123 -H "Accept: application/vnd.github.html+json" --jq .body_html`,
+    ),
+  ).toMatchObject({ status: 0 });
+});
+
+test("gh pr create without the ack hash is blocked, and the deny message is the guidance doc", () => {
+  const result = runHook(`gh pr create --draft --title "hello" --body "world"`);
+  expect(result).toMatchObject({ status: 2 });
+  const guidance = readFileSync(join(projectDir, "docs", "pull-requests.md"), "utf8");
+  expect(result.stderr).toContain(guidance);
+  expect(result.stderr).toContain(`PR_GUIDANCE_HASH=${currentHash()}`);
+});
+
+test("gh pr edit and merge and the REST PATCH escape hatch are blocked too", () => {
+  expect(runHook("gh pr edit 123 --body-file body.md")).toMatchObject({ status: 2 });
+  expect(runHook("gh pr merge 123 --squash")).toMatchObject({ status: 2 });
+  expect(
+    runHook("gh api -X PATCH repos/iterate/iterate/pulls/123 --input payload.json"),
+  ).toMatchObject({ status: 2 });
+});
+
+test("following the deny message's own instructions unblocks the command", () => {
+  const denied = runHook(`gh pr create --title "hello"`);
+  const ackHash = /PR_GUIDANCE_HASH=([0-9a-f]{8})/.exec(denied.stderr)?.[1];
+  expect(ackHash).toBe(currentHash());
+  expect(runHook(`PR_GUIDANCE_HASH=${ackHash} gh pr create --title "hello"`)).toMatchObject({
+    status: 0,
+    stderr: "",
+  });
+});
+
+test("a stale hash — the doc changed since it was read — is blocked again", () => {
+  expect(runHook(`PR_GUIDANCE_HASH=00000000 gh pr create --title "hello"`)).toMatchObject({
+    status: 2,
+  });
+});
+
+// spawn the real hook script the way Claude Code does: PreToolUse payload on stdin,
+// CLAUDE_PROJECT_DIR in the environment
+function runHook(command: string) {
+  const payload = JSON.stringify({
+    session_id: "test-session",
+    tool_name: "Bash",
+    tool_input: { command, description: "test command" },
+  });
+  const result = spawnSync("bash", [join(import.meta.dirname, "pr-guidance-gate.sh")], {
+    input: payload,
+    encoding: "utf8",
+    env: { ...process.env, CLAUDE_PROJECT_DIR: projectDir },
+  });
+  return { status: result.status, stderr: result.stderr };
+}
+
+// first 8 hex chars of `shasum docs/pull-requests.md` — the ack token the hook expects
+function currentHash() {
+  const doc = readFileSync(join(projectDir, "docs", "pull-requests.md"));
+  return createHash("sha1").update(doc).digest("hex").slice(0, 8);
+}

--- a/tasks/complete/2026-08-12-pr-guidance-gate.md
+++ b/tasks/complete/2026-08-12-pr-guidance-gate.md
@@ -1,5 +1,5 @@
 ---
-status: in-review
+status: done
 size: small
 ---
 
@@ -7,7 +7,7 @@ size: small
 
 ## Status summary
 
-Implemented and tested; PR [#2484](https://github.com/iterate/iterate/pull/2484) awaiting review.
+Implemented and tested; PR [#2484](https://github.com/iterate/iterate/pull/2484) is CI-green and awaiting review.
 Hook + settings wiring + 6 vitest cases + doc note all done. Nothing known missing; possible
 follow-up (out of scope): CI/pullfrog body check to catch non-Claude agents.
 

--- a/tasks/pr-guidance-gate.md
+++ b/tasks/pr-guidance-gate.md
@@ -1,0 +1,73 @@
+---
+status: in-progress
+size: small
+---
+
+# PR guidance gate: force agents to read docs/pull-requests.md before touching PRs
+
+## Status summary
+
+Spec fleshed out, implementation starting. Nothing built yet.
+
+## Problem
+
+Agents keep opening PRs that ignore [docs/pull-requests.md](../docs/pull-requests.md) — no
+screenshots/videos, no risk map, wrong body shape. Global CLAUDE.md is the wrong place to dump
+the guidance: agents skim it at session start and forget it by the time they open a PR, and we
+don't want to bloat it anyway.
+
+## Approach
+
+Just-in-time context injection via a Claude Code `PreToolUse` hook, checked into
+`.claude/settings.json` so every worktree/session gets it:
+
+- The hook watches `Bash` tool calls. When a command mutates a PR (`gh pr create`, `gh pr edit`,
+  `gh pr merge`, or `gh api -X PATCH .../pulls/...`), it blocks (exit 2) and prints the **full
+  contents** of `docs/pull-requests.md` to stderr — which Claude Code feeds back to the model.
+- The deny message ends with a hash of the doc: "re-run with `PR_GUIDANCE_HASH=<hash>` prefixed
+  to your command". The hook lets gated commands through when the current hash appears in the
+  command string.
+- Hashing the doc means the gate self-invalidates whenever the guidance changes: stale hash →
+  blocked again → fresh guidance re-injected.
+- "Gaming" the hash is fine by design: the deny message *is* the doc, so by the time an agent can
+  retry, the guidance is in its context. That's the whole enforcement.
+
+Why a hook and not a `gh` PATH shim:
+
+- Hooks only run under the agent harness — humans in a normal terminal are unaffected, no
+  `isAgent()` env sniffing.
+- Inspects the command string before execution, so it catches `gh` invoked by absolute path.
+- PATH shims are fragile in the sandbox (the pnpm shell wrapper already breaks there).
+- Ships with the repo; no per-machine setup.
+
+## Checklist
+
+- [ ] `scripts/hooks/pr-guidance-gate.sh` — pure bash (no jq/node so every Bash call stays fast):
+      fast-path exit for non-PR commands, `shasum`-based doc hash, exit 2 + guidance on stderr
+      for gated commands missing the current hash
+- [ ] `.claude/settings.json` — add `hooks.PreToolUse` entry (matcher `Bash`)
+- [ ] `scripts/hooks/pr-guidance-gate.test.ts` — vitest in the scripts workspace, spawns the real
+      script: non-gh and read-only `gh pr view`/`gh api` GET pass; create/edit/merge/PATCH
+      blocked without hash; blocked stderr contains the doc + hash; retry with that hash passes;
+      stale hash blocked
+- [ ] Note in `docs/pull-requests.md` mentioning the gate so humans editing the doc know blocking
+      behavior is tied to its hash
+
+## Decisions & assumptions (made while Misha reviews async)
+
+- Gate **mutations only** (create/edit/merge/PATCH). Reads (`gh pr view`, `gh pr checks`,
+  `gh api .../pulls/<n>` GETs) pass freely — gating them would nag constantly during PR
+  monitoring, which the doc itself prescribes.
+- Stateless hash check (no per-session ack marker). The hash rides along as an inline
+  `PR_GUIDANCE_HASH=<hash>` prefix the hook string-matches; it never needs to be a real env var.
+- The existing top-level `SessionStart` key in `.claude/settings.json` is left untouched. It's
+  not under the `"hooks"` key so Claude Code likely never runs it locally — and that's good:
+  `async-coding-agent-setup.sh` does sudo installs and a full test run, clearly meant for cloud
+  agent environments. Flagged for Misha rather than "fixed".
+- Non-Claude agents (Cursor CLI, Codex) don't run Claude hooks. If those turn out to be the
+  offenders too, a follow-up can add a CI/pullfrog check validating PR bodies post-hoc; out of
+  scope here.
+
+## Implementation log
+
+- (empty)

--- a/tasks/pr-guidance-gate.md
+++ b/tasks/pr-guidance-gate.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: in-review
 size: small
 ---
 
@@ -7,7 +7,9 @@ size: small
 
 ## Status summary
 
-Spec fleshed out, implementation starting. Nothing built yet.
+Implemented and tested; PR [#2484](https://github.com/iterate/iterate/pull/2484) awaiting review.
+Hook + settings wiring + 6 vitest cases + doc note all done. Nothing known missing; possible
+follow-up (out of scope): CI/pullfrog body check to catch non-Claude agents.
 
 ## Problem
 
@@ -42,16 +44,18 @@ Why a hook and not a `gh` PATH shim:
 
 ## Checklist
 
-- [ ] `scripts/hooks/pr-guidance-gate.sh` — pure bash (no jq/node so every Bash call stays fast):
+- [x] `scripts/hooks/pr-guidance-gate.sh` — pure bash (no jq/node so every Bash call stays fast):
       fast-path exit for non-PR commands, `shasum`-based doc hash, exit 2 + guidance on stderr
-      for gated commands missing the current hash
-- [ ] `.claude/settings.json` — add `hooks.PreToolUse` entry (matcher `Bash`)
-- [ ] `scripts/hooks/pr-guidance-gate.test.ts` — vitest in the scripts workspace, spawns the real
+      for gated commands missing the current hash _implemented as spec'd; matches on the raw
+      stdin JSON rather than parsing it, which keeps it dependency-free_
+- [x] `.claude/settings.json` — add `hooks.PreToolUse` entry (matcher `Bash`) _added under the
+      proper `"hooks"` key; pre-existing top-level `SessionStart` left untouched, see decisions_
+- [x] `scripts/hooks/pr-guidance-gate.test.ts` — vitest in the scripts workspace, spawns the real
       script: non-gh and read-only `gh pr view`/`gh api` GET pass; create/edit/merge/PATCH
       blocked without hash; blocked stderr contains the doc + hash; retry with that hash passes;
-      stale hash blocked
-- [ ] Note in `docs/pull-requests.md` mentioning the gate so humans editing the doc know blocking
-      behavior is tied to its hash
+      stale hash blocked _6 tests, all passing_
+- [x] Note in `docs/pull-requests.md` mentioning the gate so humans editing the doc know blocking
+      behavior is tied to its hash _blockquote at the top of the doc_
 
 ## Decisions & assumptions (made while Misha reviews async)
 
@@ -70,4 +74,16 @@ Why a hook and not a `gh` PATH shim:
 
 ## Implementation log
 
-- (empty)
+- Hook matches against the raw PreToolUse stdin JSON with bash `case` globs instead of parsing
+  out `.tool_input.command` — avoids a jq/node dependency and startup cost on every Bash call.
+  Accepted tradeoff: a command whose *description* mentions `gh pr create` would also be gated
+  (rare, and the fix is just adding the hash prefix).
+- `gh api` gating is PATCH+`pulls` only. POST to `pulls/.../comments` (review-comment replies)
+  and all GETs stay ungated because PR monitoring — which the guidance itself prescribes — runs
+  those constantly.
+- Hash is `shasum | cut -c1-8` (SHA-1, present on macOS and Linux); test recomputes it with
+  node:crypto and also round-trips the hash extracted from a real deny message.
+- Live-verified both paths: deny prints the full doc + hash and exits 2; hash-prefixed rerun
+  exits 0 silently.
+- `pnpm install && typecheck (scripts) && lint && knip && format && scripts tests` all green
+  locally; full suite left to CI.


### PR DESCRIPTION
Agents keep opening PRs that ignore [docs/pull-requests.md](https://github.com/iterate/iterate/blob/main/docs/pull-requests.md) — no media, no risk map, wrong body shape. Dumping the doc into global CLAUDE.md doesn't work: agents skim it at session start and forget it 200k tokens later.

This adds a `PreToolUse` hook, checked into `.claude/settings.json`, that injects the guidance at the only moment it matters — when a command is about to mutate a PR.

## How it works

`gh pr create` / `gh pr edit` / `gh pr merge` / `gh api -X PATCH .../pulls/...` are blocked with the **full guidance doc as the deny message**, plus an ack token derived from the doc's content:

```
BLOCKED: this command mutates a pull request, and the current PR guidance hasn't
been through your context yet (or it changed since you last read it).

Read the guidance below, apply it to your PR, then re-run with the ack prefix
(it's string-matched by a hook, not a real env var):

  PR_GUIDANCE_HASH=ddfa7254 gh pr create ...

----- docs/pull-requests.md -----
# Pull requests
...
```

The agent re-runs with `PR_GUIDANCE_HASH=ddfa7254 gh pr create ...` and it goes through. Editing the doc changes the hash, which re-arms the gate for every agent — guidance updates propagate on the next PR touch, not on the next session start.

"Gaming" the hash is fine by design: the deny message *is* the doc, so by the time an agent can retry, the guidance has passed through its context. That's the whole enforcement.

Reads (`gh pr view/checks/list`, `gh api` GETs) stay ungated — PR monitoring, which the guidance itself prescribes, runs those constantly.

## Risk map

- **Riskiest part:** the hook fires on *every* Bash tool call, so a bug that false-positives (or exits non-zero unexpectedly under `set -euo pipefail`) would degrade every agent session in the repo. Mitigations: pure bash with `case` globs (no jq/node dependency or startup cost), fast-path `exit 0` for anything that doesn't smell like a PR mutation, and `exit 0` when `docs/pull-requests.md` is missing.
- **Known accepted false positive:** the hook matches the raw PreToolUse JSON, so a command whose text merely *contains* e.g. `gh pr create` (heredoc writing docs, say) gets gated too. Cost is one retry with the hash prefix.
- **What changes on merge:** Claude Code sessions pick the hook up at session start (existing sessions unaffected). Non-Claude agents (Cursor CLI, Codex) don't run Claude hooks — if they're offenders too, a follow-up CI/pullfrog body check is the complement.
- **Deliberately not touched:** the pre-existing top-level `SessionStart` key in `.claude/settings.json` sits outside the `"hooks"` key, so Claude Code likely never runs it locally — and activating it would be wrong (`async-coding-agent-setup.sh` does sudo installs and a full test run; it's meant for cloud agent envs). Left as-is, flagged here.
- **Review order:** `scripts/hooks/pr-guidance-gate.sh` (the logic), `pr-guidance-gate.test.ts` (the contract, including the deny→ack round-trip), then `.claude/settings.json` and the doc note (mechanical).

Task file: [tasks/pr-guidance-gate.md](https://github.com/iterate/iterate/blob/pr-guidance-gate/tasks/complete/2026-08-12-pr-guidance-gate.md)

Session id: `7c06a252-6e92-4ace-ab55-b45ee6547dd8`

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +78 -0 | +65 -0 🟩🟩🟩🟩⬜ |
| CI & scripts | +48 -0 | +43 -0 🟩🟩🟩⬜⬜ |
| Docs | +95 -0 | +78 -0 🟩🟩🟩🟩🟩 |
| Other | +14 -1 | +14 -1 🟩⬜⬜⬜⬜ |
| **Total** | **+235 -1** | **+200 -1** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 5a1cdf4 and b95a3e4, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The hook runs on every Bash tool call in Claude sessions; a false positive or unexpected exit would affect all agent work, though fast-path exits and tests mitigate that. Scope is agent harness only—humans and non-Claude agents are unaffected.
> 
> **Overview**
> Adds a **Claude Code `PreToolUse` hook** on Bash that blocks PR-mutating `gh` commands (`gh pr create` / `edit` / `merge`, and `gh api -X PATCH` on `pulls`) until the agent echoes the current **`docs/pull-requests.md` content hash** as an inline `PR_GUIDANCE_HASH=<hash>` prefix. On block, stderr is the full guidance doc plus the hash—so guidance lands in context at the moment a PR would be touched, not at session start.
> 
> **Read-only** `gh` usage (`pr view`, `checks`, `list`, GET `gh api`) stays ungated so PR monitoring isn’t nagged. Wiring lives in `.claude/settings.json`; `docs/pull-requests.md` documents the enforcement. **`scripts/hooks/pr-guidance-gate.test.ts`** covers pass-through, block, deny→ack unblock, and stale-hash behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b95a3e49beffdd6449f20fbae5a794ba3b8ed2b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->