### PR TITLE
Lint: auto-fixable prefer-logical-and-spread rule

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -122,6 +122,7 @@
     "iterate/no-single-use-helpers": "error",
     "iterate/colocate-single-use-types": "error",
     "iterate/no-single-use-types": "error",
+    "iterate/prefer-logical-and-spread": "error",
     "iterate/typed-no-floating-promises": "off",
     "iterate/mechanical-class-impl": "off",
     "prefer-const": "off",

--- a/apps/auth/e2e/oauth-code-exchange.e2e.test.ts
+++ b/apps/auth/e2e/oauth-code-exchange.e2e.test.ts
@@ -125,7 +125,7 @@ function postJson(cookie: string | null, body: unknown): RequestInit {
     headers: {
       "content-type": "application/json",
       origin: baseUrl,
-      ...(cookie ? { cookie } : {}),
+      ...(cookie && { cookie }),
     },
     body: JSON.stringify(body),
   };
@@ -238,14 +238,12 @@ async function exchangeToken(body: Record<string, string>, origin?: string): Pro
     method: "POST",
     headers: {
       "content-type": "application/x-www-form-urlencoded",
-      ...(origin
-        ? {
-            origin,
-            "sec-fetch-dest": "empty",
-            "sec-fetch-mode": "cors",
-            "sec-fetch-site": "cross-site",
-          }
-        : {}),
+      ...(origin && {
+        origin,
+        "sec-fetch-dest": "empty",
+        "sec-fetch-mode": "cors",
+        "sec-fetch-site": "cross-site",
+      }),
     },
     body: new URLSearchParams(body),
   });

--- a/apps/auth/src/server/email-otp-plugin.ts
+++ b/apps/auth/src/server/email-otp-plugin.ts
@@ -19,7 +19,7 @@ export function createEmailOtpPlugin(options: EmailOtpPluginOptions) {
     // Browser e2e shares one runner IP and deliberately signs up several
     // unique fixed-code users at once. Keep that non-production lane bounded
     // without applying Better Auth's human-facing three-per-minute ceiling.
-    ...(options.fixedTestOtpEnabled ? { rateLimit: { window: 60, max: 100 } } : {}),
+    ...(options.fixedTestOtpEnabled && { rateLimit: { window: 60, max: 100 } }),
     generateOTP: ({ email }) => {
       if (shouldUseTestOtp({ email, fixedTestOtpEnabled: options.fixedTestOtpEnabled })) {
         return TEST_OTP_CODE;

--- a/apps/auth/src/utils/auth-redirect-error.ts
+++ b/apps/auth/src/utils/auth-redirect-error.ts
@@ -24,6 +24,6 @@ export function getLoginRedirectSearch(href: string): LoginRedirectSearch {
   return {
     redirect,
     error,
-    ...(errorDescription ? { error_description: errorDescription } : {}),
+    ...(errorDescription && { error_description: errorDescription }),
   };
 }

--- a/apps/dummy-petshop/src/state.ts
+++ b/apps/dummy-petshop/src/state.ts
@@ -181,8 +181,8 @@ export class PetshopStateDurableObject extends DurableObject {
     state.clients[clientId] = {
       clientSecret,
       accessTokenTtlSeconds: input.accessTokenTtlSeconds ?? DEFAULT_ACCESS_TTL_SECONDS,
-      ...(input.redirectUris ? { redirectUris: input.redirectUris } : {}),
-      ...(input.public ? { public: true } : {}),
+      ...(input.redirectUris && { redirectUris: input.redirectUris }),
+      ...(input.public && { public: true }),
     };
     await this.#save(state);
     return { clientId, clientSecret };

--- a/apps/dummy-petshop/src/worker.ts
+++ b/apps/dummy-petshop/src/worker.ts
@@ -321,7 +321,7 @@ async function mintCodeRedirect(
     clientId: params.clientId,
     redirectUri: params.redirectUri,
     exp: nowSeconds() + CODE_TTL_SECONDS,
-    ...(params.codeChallenge ? { codeChallenge: params.codeChallenge } : {}),
+    ...(params.codeChallenge && { codeChallenge: params.codeChallenge }),
   };
   const target = new URL(params.redirectUri);
   target.searchParams.set("code", await seal(payload, deps.sealKey));
@@ -383,7 +383,7 @@ async function registerOAuthClient(request: Request, deps: PetshopDeps): Promise
   const isPublic = body.token_endpoint_auth_method === "none";
   const { clientId, clientSecret } = await deps.state.createClient({
     redirectUris,
-    ...(isPublic ? { public: true } : {}),
+    ...(isPublic && { public: true }),
   });
   return json(
     {
@@ -1084,9 +1084,10 @@ export async function handlePetshopRequest(request: Request, deps: PetshopDeps):
         tokenExpiresInSeconds: grant.exp - nowSeconds(),
         // An installation token names which GitHub-App installation it acts as,
         // so the OS side can assert it minted the token it expected (§9 P4).
-        ...(grant.t === "installation"
-          ? { installationId: grant.installationId, appId: grant.appId }
-          : {}),
+        ...(grant.t === "installation" && {
+          installationId: grant.installationId,
+          appId: grant.appId,
+        }),
       });
     }
     return json({ owner: grant.sub, pets: deps.pets });

--- a/apps/mobile/src/app/project/[projectId]/chat.tsx
+++ b/apps/mobile/src/app/project/[projectId]/chat.tsx
@@ -170,7 +170,7 @@ export default function ChatScreen() {
           data: base64ToUint8Array(file.base64),
           filename: file.filename,
         })),
-        ...(input.message ? { message: input.message } : {}),
+        ...(input.message && { message: input.message }),
       });
       return added.event.offset;
     },

--- a/apps/mobile/src/app/project/[projectId]/integrations.tsx
+++ b/apps/mobile/src/app/project/[projectId]/integrations.tsx
@@ -81,7 +81,7 @@ export default function IntegrationsScreen() {
       const project = await getProjectItx(baseUrl, projectId);
       return await project.integrations.connectTelegram({
         botToken: input.botToken,
-        ...(input.steal ? { steal: true } : {}),
+        ...(input.steal && { steal: true }),
       });
     },
     onSuccess: async (result, input) => {

--- a/apps/mobile/src/components/activity-card.tsx
+++ b/apps/mobile/src/components/activity-card.tsx
@@ -447,35 +447,32 @@ function metaYaml(
 ): string {
   const seconds = (ms: number) => `${(ms / 1000).toFixed(1)}s`;
   const doc = new Document({
-    ...(llm
-      ? {
-          llm: {
-            ...(llm.model ? { model: llm.model } : {}),
-            ...(llm.durationMs == null ? {} : { duration: seconds(llm.durationMs) }),
-            ...(llm.inputTokens == null ? {} : { inputTokens: llm.inputTokens }),
-            ...(llm.outputTokens == null ? {} : { outputTokens: llm.outputTokens }),
-            ...(llm.outcome && llm.outcome !== "completed" ? { outcome: llm.outcome } : {}),
-            ...(llm.cancelReason ? { cancelReason: llm.cancelReason } : {}),
-          },
-        }
-      : {}),
+    ...(llm && {
+      llm: {
+        ...(llm.model && { model: llm.model }),
+        ...(llm.durationMs == null ? {} : { duration: seconds(llm.durationMs) }),
+        ...(llm.inputTokens == null ? {} : { inputTokens: llm.inputTokens }),
+        ...(llm.outputTokens == null ? {} : { outputTokens: llm.outputTokens }),
+        ...(llm.outcome && llm.outcome !== "completed" && { outcome: llm.outcome }),
+        ...(llm.cancelReason && { cancelReason: llm.cancelReason }),
+      },
+    }),
     code: {
-      ...(code.status === "running" ? { status: "running" } : {}),
+      ...(code.status === "running" && { status: "running" }),
       ...(code.durationMs == null ? {} : { duration: seconds(code.durationMs) }),
-      ...(code.status === "done" && code.success === false ? { failed: true } : {}),
+      ...(code.status === "done" && code.success === false && { failed: true }),
     },
-    ...(promptMessages && promptMessages.length > 0
-      ? {
-          prompt: promptMessages.map((message) => ({
-            role: message.role,
-            content: message.content,
-          })),
-        }
-      : {}),
+    ...(promptMessages &&
+      promptMessages.length > 0 && {
+        prompt: promptMessages.map((message) => ({
+          role: message.role,
+          content: message.content,
+        })),
+      }),
     // The raw model response the round's consequences were derived from —
     // after the prompt, so the doc reads request → answer (parity with the
     // os feed's buildRoundMetaYaml).
-    ...(llm?.responseText ? { response: llm.responseText } : {}),
+    ...(llm?.responseText && { response: llm.responseText }),
   });
   visit(doc, {
     // Multiline strings as |- blocks: readable and highlightable, instead of

--- a/apps/mobile/src/lib/approvals.ts
+++ b/apps/mobile/src/lib/approvals.ts
@@ -186,8 +186,8 @@ export async function decide(input: {
       approvalRequestEventOffset: input.offset,
       verdicts: [...input.verdicts],
       decidedBy: "human",
-      ...(reason ? { reason } : {}),
-      ...(signed ? { keyId: signed.keyId, signature: signed.signature } : {}),
+      ...(reason && { reason }),
+      ...(signed && { keyId: signed.keyId, signature: signed.signature }),
     },
   });
 }

--- a/apps/mobile/src/lib/auth.ts
+++ b/apps/mobile/src/lib/auth.ts
@@ -125,7 +125,7 @@ export async function signIn(baseUrl: string, options: { loginHint?: string } = 
       // which prefills it — and, for `*+test@nustom.com` on deployments with
       // the test OTP enabled, signs in with it automatically (preview QR
       // deep links carry a per-PR test identity).
-      ...(options.loginHint ? { login_hint: options.loginHint } : {}),
+      ...(options.loginHint && { login_hint: options.loginHint }),
     },
   });
   console.log(`[auth] prompting: redirectUri=${REDIRECT_URI} clientId=${clientId}`);

--- a/apps/mobile/src/lib/in-app-links.ts
+++ b/apps/mobile/src/lib/in-app-links.ts
@@ -25,7 +25,7 @@ const SPECIAL_PATHS: {
       const filename = last.replace(/^[0-9a-f]{32,}-/, "");
       return {
         pathname: "/project/[projectId]/media",
-        params: { projectId, ...(filename ? { q: filename } : {}) },
+        params: { projectId, ...(filename && { q: filename }) },
       };
     },
   },

--- a/apps/mobile/src/lib/oauth-connect.ts
+++ b/apps/mobile/src/lib/oauth-connect.ts
@@ -42,8 +42,8 @@ export async function connectMobileOAuth(input: {
     const code = callback.searchParams.get("oauthCode");
     const installationId = callback.searchParams.get("oauthInstallationId");
     const completion = await input.project.integrations.completeConnect({
-      ...(code ? { code } : {}),
-      ...(installationId ? { installationId } : {}),
+      ...(code && { code }),
+      ...(installationId && { installationId }),
       provider: input.provider,
       state,
     });

--- a/apps/mobile/src/lib/open-project.ts
+++ b/apps/mobile/src/lib/open-project.ts
@@ -29,6 +29,6 @@ export async function backfillProjectIfMissing(
   if (project.deploymentStatus !== "missing") return;
   await itx.projects.get(project.slug).create({
     projectId: project.id,
-    ...(project.organizationSlug ? { organizationSlug: project.organizationSlug } : {}),
+    ...(project.organizationSlug && { organizationSlug: project.organizationSlug }),
   });
 }

--- a/apps/os/e2e/vitest/onboarding-smoke.ts
+++ b/apps/os/e2e/vitest/onboarding-smoke.ts
@@ -209,7 +209,7 @@ function writeSmokeTelemetry(input: {
     attempts: input.attempts,
     phases: [],
     errors: input.errors,
-    ...(input.errors[0] ? { firstFailure: input.errors[0].message.slice(0, 300) } : {}),
+    ...(input.errors[0] && { firstFailure: input.errors[0].message.slice(0, 300) }),
   };
   writeTestTelemetryArtifact({
     artifactSchemaVersion: 1,
@@ -223,7 +223,7 @@ function writeSmokeTelemetry(input: {
       startedAt: new Date(runStartedAt).toISOString(),
       finishedAt: new Date(finishedAtMs).toISOString(),
       durationMs: input.durationMs,
-      ...(input.state === "failed" && input.errors.at(-1) ? { error: input.errors.at(-1) } : {}),
+      ...(input.state === "failed" && input.errors.at(-1) && { error: input.errors.at(-1) }),
     },
     lanes: [
       {

--- a/apps/os/scripts/generate-itx-api.ts
+++ b/apps/os/scripts/generate-itx-api.ts
@@ -117,7 +117,7 @@ const AMBIENT_NAMES = new Set([
 function openProject(fsOverlay?: Map<string, string>) {
   const api = new API({
     cwd: projectDir,
-    ...(fsOverlay ? { fs: { readFile: (fileName) => fsOverlay.get(path.resolve(fileName)) } } : {}),
+    ...(fsOverlay && { fs: { readFile: (fileName) => fsOverlay.get(path.resolve(fileName)) } }),
   });
   const snapshot = api.updateSnapshot({ openProjects: [tsconfigPath] });
   const project = snapshot.getProject(tsconfigPath);

--- a/apps/os/scripts/generate-wrangler-config.test.ts
+++ b/apps/os/scripts/generate-wrangler-config.test.ts
@@ -105,7 +105,7 @@ it("binds local OS to the selected auth worker's default entrypoint", () => {
   expect(auth).toEqual({
     binding: "AUTH",
     service: selected.authWorkerName,
-    ...(selected.authRemote ? { remote: true } : {}),
+    ...(selected.authRemote && { remote: true }),
   });
 });
 

--- a/apps/os/scripts/generate-wrangler-config.ts
+++ b/apps/os/scripts/generate-wrangler-config.ts
@@ -329,7 +329,7 @@ function workerBindings(input: {
       {
         binding: "AUTH",
         service: input.authWorkerName,
-        ...(input.authRemote ? { remote: true } : {}),
+        ...(input.authRemote && { remote: true }),
       },
       // The typechecker sidecar (src/typechecker.ts,
       // wrangler.typechecker.jsonc): the one script carrying the TypeScript
@@ -525,23 +525,19 @@ function localDevBindings() {
       // local dev has no envs.ts entry.
       APP_CONFIG_CLOUDFLARE_AI_GATEWAY__TRANSPORT: "byok",
       APP_CONFIG_CLOUDFLARE_AI_GATEWAY__RESPONSE_CACHE_TTL_SECONDS: String(7 * 24 * 60 * 60),
-      ...(process.env.PORT ? { APP_CONFIG_BASE_URL: `http://localhost:${process.env.PORT}` } : {}),
-      ...(process.env.APP_CONFIG_ITERATE_REPO_PKG_REF?.trim()
-        ? {
-            APP_CONFIG_ITERATE_REPO_PKG_REF: process.env.APP_CONFIG_ITERATE_REPO_PKG_REF.trim(),
-          }
-        : {}),
+      ...(process.env.PORT && { APP_CONFIG_BASE_URL: `http://localhost:${process.env.PORT}` }),
+      ...(process.env.APP_CONFIG_ITERATE_REPO_PKG_REF?.trim() && {
+        APP_CONFIG_ITERATE_REPO_PKG_REF: process.env.APP_CONFIG_ITERATE_REPO_PKG_REF.trim(),
+      }),
       // Local dev's SDK tarball lockstep (dev.ts + lib/dev-sdk-tarball.ts).
-      ...(process.env.APP_CONFIG_ITERATE_REPO_PKG_SPEC_OVERRIDES?.trim()
-        ? {
-            APP_CONFIG_ITERATE_REPO_PKG_SPEC_OVERRIDES:
-              process.env.APP_CONFIG_ITERATE_REPO_PKG_SPEC_OVERRIDES.trim(),
-          }
-        : {}),
+      ...(process.env.APP_CONFIG_ITERATE_REPO_PKG_SPEC_OVERRIDES?.trim() && {
+        APP_CONFIG_ITERATE_REPO_PKG_SPEC_OVERRIDES:
+          process.env.APP_CONFIG_ITERATE_REPO_PKG_SPEC_OVERRIDES.trim(),
+      }),
       // Local dev trusts forge-minted sessions by deriving the public key from
       // AUTH_FORGE_ES256_PRIVATE_JWK. Do not read APP_CONFIG_ITERATE_AUTH__JWKS
       // from Doppler here: stale snapshots caused login verification failures.
-      ...(localAuthJwks ? { APP_CONFIG_ITERATE_AUTH__JWKS: localAuthJwks } : {}),
+      ...(localAuthJwks && { APP_CONFIG_ITERATE_AUTH__JWKS: localAuthJwks }),
     },
   };
 }

--- a/apps/os/scripts/project-seed.ts
+++ b/apps/os/scripts/project-seed.ts
@@ -906,7 +906,7 @@ function asGoogleToken(value: unknown) {
   }
   return {
     refreshToken: value.refreshToken,
-    ...(typeof value.accessToken === "string" ? { accessToken: value.accessToken } : {}),
+    ...(typeof value.accessToken === "string" && { accessToken: value.accessToken }),
   };
 }
 

--- a/apps/os/scripts/session.ts
+++ b/apps/os/scripts/session.ts
@@ -67,15 +67,15 @@ export async function create(options: CreateOptions = {}) {
     ? {
         kind: "admin" as const,
         operatorId,
-        ...(options.returnTo ? { returnTo: options.returnTo } : {}),
-        ...(options.ttlSeconds ? { ttlSeconds: options.ttlSeconds } : {}),
+        ...(options.returnTo && { returnTo: options.returnTo }),
+        ...(options.ttlSeconds && { ttlSeconds: options.ttlSeconds }),
       }
     : {
         kind: "project" as const,
         operatorId,
         project: project!,
-        ...(options.returnTo ? { returnTo: options.returnTo } : {}),
-        ...(options.ttlSeconds ? { ttlSeconds: options.ttlSeconds } : {}),
+        ...(options.returnTo && { returnTo: options.returnTo }),
+        ...(options.ttlSeconds && { ttlSeconds: options.ttlSeconds }),
       };
 
   const response = await fetch(new URL("/api/operator-sessions", baseUrl), {

--- a/apps/os/src/auth/operator-session.test.ts
+++ b/apps/os/src/auth/operator-session.test.ts
@@ -43,7 +43,7 @@ async function issue(
     headers: {
       authorization: options.authorization ?? `Bearer ${ADMIN_SECRET}`,
       "content-type": "application/json",
-      ...(options.origin ? { origin: options.origin } : {}),
+      ...(options.origin && { origin: options.origin }),
     },
     method: "POST",
   });

--- a/apps/os/src/components/create-project-form.tsx
+++ b/apps/os/src/components/create-project-form.tsx
@@ -78,7 +78,7 @@ export function CreateProjectForm({
       // server-side nudge, and the project home plays it from live pushes.
       const project = session.projects.get(input.slug).create(
         {
-          ...(input.organizationSlug ? { organizationSlug: input.organizationSlug } : {}),
+          ...(input.organizationSlug && { organizationSlug: input.organizationSlug }),
           ...(input.configRepoTemplate === undefined
             ? {}
             : { configRepoTemplate: input.configRepoTemplate }),
@@ -129,7 +129,7 @@ export function CreateProjectForm({
     onSubmit: async ({ value }) => {
       const parsed = CreateProjectInput.parse(value);
       await createProject.mutateAsync({
-        ...(parsed.configRepoTemplate ? { configRepoTemplate: parsed.configRepoTemplate } : {}),
+        ...(parsed.configRepoTemplate && { configRepoTemplate: parsed.configRepoTemplate }),
         slug: parsed.slug,
         organizationSlug: parsed.organizationSlug,
       });

--- a/apps/os/src/components/stream-state-panel.tsx
+++ b/apps/os/src/components/stream-state-panel.tsx
@@ -795,7 +795,7 @@ function readSubscriptionRow(
       ? {
           afterOffset: haltedAfterOffset,
           attempts: haltedAttempts,
-          ...(typeof haltedRecord?.error === "string" ? { error: haltedRecord.error } : {}),
+          ...(typeof haltedRecord?.error === "string" && { error: haltedRecord.error }),
         }
       : undefined;
 
@@ -848,7 +848,7 @@ function readSubscriptionRow(
   return {
     name,
     kind,
-    ...(kind === "processor-wake" ? { processorSlug: name } : {}),
+    ...(kind === "processor-wake" && { processorSlug: name }),
     facet,
     // Durable facts (reduced from committed events) outrank the mirrored
     // runtime row, which may not have loaded yet.
@@ -882,7 +882,7 @@ function buildConnectionRows(
     rows.set(entry.connectionKey, {
       key: entry.connectionKey,
       kind: runtime?.kind ?? entry.connectionKind ?? "session",
-      ...(runtime?.kind === "hosted" ? { subscriptionName: runtime.name } : {}),
+      ...(runtime?.kind === "hosted" && { subscriptionName: runtime.name }),
       // The pushed runtime table is authoritative once it has loaded. Before
       // that first snapshot, keep the reduced presence entry visible instead
       // of making every open session disappear from the panel.
@@ -905,9 +905,9 @@ function buildConnectionRows(
     rows.set(key, {
       key,
       kind: runtime.kind,
-      ...(runtime.kind === "hosted" ? { subscriptionName: runtime.name } : {}),
+      ...(runtime.kind === "hosted" && { subscriptionName: runtime.name }),
       connected: true,
-      ...(typeof openedBy?.description === "string" ? { description: openedBy.description } : {}),
+      ...(typeof openedBy?.description === "string" && { description: openedBy.description }),
       ...(user === undefined ? {} : { user }),
       ...(announcement == null ? {} : { processor: announcement }),
       runtime,
@@ -1216,9 +1216,7 @@ function readAnnouncement(value: unknown): AgentUiProcessorAnnouncement | null {
           ? [
               {
                 type: event.type,
-                ...(typeof event.description === "string"
-                  ? { description: event.description }
-                  : {}),
+                ...(typeof event.description === "string" && { description: event.description }),
               },
             ]
           : [];
@@ -1231,10 +1229,10 @@ function readSubscriberUser(value: unknown): AgentUiPresenceEntry["user"] {
   const user = readRuntimeRecord(value);
   if (typeof user?.email !== "string") return undefined;
   return {
-    ...(typeof user.id === "string" ? { id: user.id } : {}),
+    ...(typeof user.id === "string" && { id: user.id }),
     email: user.email,
-    ...(typeof user.name === "string" ? { name: user.name } : {}),
-    ...(typeof user.picture === "string" ? { picture: user.picture } : {}),
+    ...(typeof user.name === "string" && { name: user.name }),
+    ...(typeof user.picture === "string" && { picture: user.picture }),
   };
 }
 

--- a/apps/os/src/domains/agents/agent-collection-processor-implementation.ts
+++ b/apps/os/src/domains/agents/agent-collection-processor-implementation.ts
@@ -99,9 +99,10 @@ export class AgentCollectionStreamProcessor extends StreamProcessor<AgentCollect
               timestamps: {
                 ...previous.timestamps,
                 summaryUpdatedAt: source.createdAt,
-                ...(activityChanged
-                  ? { activityUpdatedAt: source.createdAt, lastWorkAt: source.createdAt }
-                  : {}),
+                ...(activityChanged && {
+                  activityUpdatedAt: source.createdAt,
+                  lastWorkAt: source.createdAt,
+                }),
               },
             },
           },

--- a/apps/os/src/domains/agents/agent-prompt-fold.ts
+++ b/apps/os/src/domains/agents/agent-prompt-fold.ts
@@ -139,13 +139,11 @@ function reduceAgentEventCore(input: {
         },
         // Fresh external input is a fresh start: the autonomous-turn budget
         // and the failure streak both reset.
-        ...(trigger === "external"
-          ? {
-              autonomousTurnCount: 0,
-              consecutiveLlmFailures: 0,
-              latestExternalTriggerOffset: event.offset,
-            }
-          : {}),
+        ...(trigger === "external" && {
+          autonomousTurnCount: 0,
+          consecutiveLlmFailures: 0,
+          latestExternalTriggerOffset: event.offset,
+        }),
       };
     }
     case "events.iterate.com/agent/llm-request-requested": {
@@ -192,17 +190,15 @@ function reduceAgentEventCore(input: {
         // Under the retry cap the failure itself is the next trigger — the
         // retry is pure reduce arithmetic, no wake event, no rendered nudge.
         // At the cap the conversation waits for fresh input.
-        ...(failures < state.config.llmRequestRetryPolicy.maxAttempts
-          ? {
-              pendingLlmRequestTrigger: {
-                offset: event.offset,
-                atMs: Date.parse(event.createdAt),
-                // as const: inside the conditional spread the literal would
-                // widen to string and fall out of the trigger-source union.
-                source: "agent-loop" as const,
-              },
-            }
-          : {}),
+        ...(failures < state.config.llmRequestRetryPolicy.maxAttempts && {
+          pendingLlmRequestTrigger: {
+            offset: event.offset,
+            atMs: Date.parse(event.createdAt),
+            // as const: inside the conditional spread the literal would
+            // widen to string and fall out of the trigger-source union.
+            source: "agent-loop" as const,
+          },
+        }),
       };
     }
     case "events.iterate.com/agent/token-usage-reported":

--- a/apps/os/src/domains/devices/device-processor-implementation.ts
+++ b/apps/os/src/domains/devices/device-processor-implementation.ts
@@ -366,9 +366,9 @@ export class DeviceProcessor extends StreamProcessor<DeviceProcessorContract, De
                 ? {}
                 : { agentReplyEventOffset: event.payload.agentReplyEventOffset }),
               ...(approvalRequestEventOffset === undefined ? {} : { approvalRequestEventOffset }),
-              ...(approvalPresentedAt || claimed?.claimedAt
-                ? { presentedAt: approvalPresentedAt || claimed?.claimedAt }
-                : {}),
+              ...((approvalPresentedAt || claimed?.claimedAt) && {
+                presentedAt: approvalPresentedAt || claimed?.claimedAt,
+              }),
               body: event.payload.body,
               destination: event.payload.destination,
               expiresAt: event.payload.expiresAt,

--- a/apps/os/src/domains/email/email-agent-processor-implementation.ts
+++ b/apps/os/src/domains/email/email-agent-processor-implementation.ts
@@ -150,9 +150,9 @@ export class EmailAgentProcessor extends StreamProcessor<
                 // Automated mail (Auto-Submitted, bulk precedence,
                 // mailer-daemon) is recorded but never triggers a reply —
                 // the classic mail-loop guard.
-                ...(event.payload.automated
-                  ? { llmRequestPolicy: { behaviour: "dont-trigger-request" as const } }
-                  : {}),
+                ...(event.payload.automated && {
+                  llmRequestPolicy: { behaviour: "dont-trigger-request" as const },
+                }),
               },
             });
           } catch (error) {
@@ -289,9 +289,9 @@ function inboundEmailAgentInput(payload: InboundEmailPayload): string {
     subject: message.subject ?? "",
     ...(message.messageId == null ? {} : { messageId: message.messageId }),
     ...(message.text === undefined ? {} : { text: message.text }),
-    ...(message.text === undefined && message.html !== undefined ? { html: message.html } : {}),
+    ...(message.text === undefined && message.html !== undefined && { html: message.html }),
     ...(attachments.length === 0 ? {} : { attachments }),
-    ...(payload.automated ? { automated: true } : {}),
+    ...(payload.automated && { automated: true }),
   };
   return [
     "`events.iterate.com/email/received` event received",

--- a/apps/os/src/domains/email/utils.ts
+++ b/apps/os/src/domains/email/utils.ts
@@ -506,17 +506,17 @@ export function buildProjectEmailMessage(input: {
   });
   const references = (request.references ?? []).map(angleBracketed).join(" ");
   const headers: Record<string, string> = {
-    ...(request.inReplyTo ? { "In-Reply-To": angleBracketed(request.inReplyTo) } : {}),
-    ...(references ? { References: references } : {}),
+    ...(request.inReplyTo && { "In-Reply-To": angleBracketed(request.inReplyTo) }),
+    ...(references && { References: references }),
   };
   return {
     from: { email: from, name: projectName },
     to: request.to,
     subject: request.subject,
-    ...(request.text ? { text: request.text } : {}),
-    ...(request.html ? { html: request.html } : {}),
-    ...(replyTo ? { replyTo } : {}),
-    ...(Object.keys(headers).length > 0 ? { headers } : {}),
-    ...(attachments.length > 0 ? { attachments } : {}),
+    ...(request.text && { text: request.text }),
+    ...(request.html && { html: request.html }),
+    ...(replyTo && { replyTo }),
+    ...(Object.keys(headers).length > 0 && { headers }),
+    ...(attachments.length > 0 && { attachments }),
   };
 }

--- a/apps/os/src/domains/integrations/connect-flows.ts
+++ b/apps/os/src/domains/integrations/connect-flows.ts
@@ -621,7 +621,7 @@ async function recordConnection(input: {
     const secretInput = {
       egress: { urls: [...secret.egressUrls] },
       material: secret.material,
-      ...(secret.refresh ? { refresh: secret.refresh } : {}),
+      ...(secret.refresh && { refresh: secret.refresh }),
     };
     if ((await secretStub.describe()).created) await secretStub.update(secretInput);
     else await secretStub.create(secretInput);
@@ -1135,7 +1135,7 @@ async function recordGithubConnection(input: {
       },
     ],
     connectedEvent: githubConnectedEvent(input),
-    ...(input.directoryClaim ? { directoryClaim: input.directoryClaim } : {}),
+    ...(input.directoryClaim && { directoryClaim: input.directoryClaim }),
   });
 }
 
@@ -1359,7 +1359,7 @@ async function completeGoogleConnect(input: {
         egressUrls: GOOGLE_CONNECTION_EGRESS_URLS,
         material: {
           accessToken: tokenData.access_token,
-          ...(tokenData.refresh_token ? { refreshToken: tokenData.refresh_token } : {}),
+          ...(tokenData.refresh_token && { refreshToken: tokenData.refresh_token }),
         },
         path: googleConnectionSecretPath(connection),
         refresh: {

--- a/apps/os/src/domains/integrations/github-api.ts
+++ b/apps/os/src/domains/integrations/github-api.ts
@@ -36,7 +36,7 @@ export function connectionOctokit(input: {
   const placeholder = `Bearer ${githubAccessTokenPlaceholder(input.connection)}`;
   const egress = projectStub(itxEnv.PROJECT, input.projectId);
   return new Octokit({
-    ...(input.baseUrl ? { baseUrl: input.baseUrl } : {}),
+    ...(input.baseUrl && { baseUrl: input.baseUrl }),
     // Disable Octokit's own retry paths: replaying an opaque write after a
     // 5xx/429/408 can duplicate a comment or review. The connection Secret DO
     // may still refresh credentials and repeat once after a 401; that narrow

--- a/apps/os/src/domains/integrations/integration-api.ts
+++ b/apps/os/src/domains/integrations/integration-api.ts
@@ -179,7 +179,7 @@ async function handleMcpOAuthCallback(input: {
     });
     const result = await completeMcpOAuth(state, {
       code,
-      ...(iss ? { iss } : {}),
+      ...(iss && { iss }),
       fetchFn: fetchLikeFromFetcher(egress),
     });
     const secret = itxEnv.SECRET.getByName(

--- a/apps/os/src/domains/integrations/slack-agent-processor-implementation.ts
+++ b/apps/os/src/domains/integrations/slack-agent-processor-implementation.ts
@@ -414,7 +414,7 @@ export class SlackAgentProcessor extends StreamProcessor<
           channel: target.channel,
           ...(channelType == null ? {} : { channelType }),
           conversationActive: state.conversationActive || mentioned,
-          ...(getsEyesReaction ? { eyesReactionMessageTs: target.messageTs } : {}),
+          ...(getsEyesReaction && { eyesReactionMessageTs: target.messageTs }),
           threadTs: target.threadTs,
         };
       }

--- a/apps/os/src/domains/integrations/slack-runtime-presentation.test.ts
+++ b/apps/os/src/domains/integrations/slack-runtime-presentation.test.ts
@@ -35,9 +35,9 @@ async function setup({
         slackTeamId: "T1",
         body: {
           type: "event_callback",
-          ...(mentionBot
-            ? { authorizations: [{ is_bot: true, user_id: "UBOT", bot_id: "BBOT" }] }
-            : {}),
+          ...(mentionBot && {
+            authorizations: [{ is_bot: true, user_id: "UBOT", bot_id: "BBOT" }],
+          }),
           event: {
             type: "message",
             channel,

--- a/apps/os/src/domains/integrations/telegram-agent-processor-implementation.ts
+++ b/apps/os/src/domains/integrations/telegram-agent-processor-implementation.ts
@@ -227,9 +227,9 @@ export class TelegramAgentProcessor extends StreamProcessor<
         content: telegramWebhookAgentInput(event.payload, { newCommand }),
         actor: {
           type: "telegram",
-          ...(typeof senderId === "number" || typeof senderId === "string"
-            ? { userId: String(senderId) }
-            : {}),
+          ...((typeof senderId === "number" || typeof senderId === "string") && {
+            userId: String(senderId),
+          }),
           ...(senderUsername == null ? {} : { username: senderUsername }),
         },
         refs: [
@@ -456,9 +456,9 @@ export class TelegramAgentProcessor extends StreamProcessor<
             : { messageThreadId: target.messageThreadId }),
           // Half of the deterministic reply_to_message_id rule: the newest
           // human message on this session.
-          ...(target.kind === "message" && !target.fromIsBot && target.messageId !== undefined
-            ? { latestInboundMessageId: target.messageId }
-            : {}),
+          ...(target.kind === "message" &&
+            !target.fromIsBot &&
+            target.messageId !== undefined && { latestInboundMessageId: target.messageId }),
         };
       }
       case "events.iterate.com/agent/llm-request-requested":
@@ -633,7 +633,7 @@ function telegramUpdateTarget(body: unknown): TelegramUpdateTarget | null {
       chatId,
       fromIsBot: from?.is_bot === true,
       kind,
-      ...(typeof messageId === "number" ? { messageId } : {}),
+      ...(typeof messageId === "number" && { messageId }),
       ...(messageThreadId === undefined ? {} : { messageThreadId }),
     };
   }

--- a/apps/os/src/domains/itx/mcp-oauth.test.ts
+++ b/apps/os/src/domains/itx/mcp-oauth.test.ts
@@ -83,7 +83,7 @@ function makeFakeServer(opts: { protectedResource?: boolean; registration?: bool
         issuer: ORIGIN,
         authorization_endpoint: `${ORIGIN}/oauth/authorize`,
         token_endpoint: `${ORIGIN}/oauth/token`,
-        ...(registration ? { registration_endpoint: `${ORIGIN}/oauth/register` } : {}),
+        ...(registration && { registration_endpoint: `${ORIGIN}/oauth/register` }),
         response_types_supported: ["code"],
         grant_types_supported: ["authorization_code", "refresh_token"],
         code_challenge_methods_supported: ["S256"],
@@ -117,7 +117,7 @@ function makeFakeServer(opts: { protectedResource?: boolean; registration?: bool
       }
       const code = `code-${codes.size + 1}`;
       const challenge = url.searchParams.get("code_challenge") ?? undefined;
-      codes.set(code, { clientId, redirectUri, ...(challenge ? { challenge } : {}) });
+      codes.set(code, { clientId, redirectUri, ...(challenge && { challenge }) });
       const target = new URL(redirectUri);
       target.searchParams.set("code", code);
       const state = url.searchParams.get("state");

--- a/apps/os/src/domains/itx/mcp-oauth.ts
+++ b/apps/os/src/domains/itx/mcp-oauth.ts
@@ -153,9 +153,9 @@ export async function beginMcpOAuth(input: BeginMcpOAuthInput): Promise<BeginMcp
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
       token_endpoint_auth_method: "none",
-      ...(input.scope ? { scope: input.scope } : {}),
+      ...(input.scope && { scope: input.scope }),
     },
-    ...(input.scope ? { scope: input.scope } : {}),
+    ...(input.scope && { scope: input.scope }),
     fetchFn,
   }).catch((cause: unknown) => {
     throw new McpOAuthError(
@@ -170,17 +170,17 @@ export async function beginMcpOAuth(input: BeginMcpOAuthInput): Promise<BeginMcp
     metadata: authMetadata,
     clientInformation: clientInfo,
     redirectUrl: input.redirectUri,
-    ...(input.scope ? { scope: input.scope } : {}),
-    ...(resource ? { resource } : {}),
+    ...(input.scope && { scope: input.scope }),
+    ...(resource && { resource }),
   });
 
   const state: MCPOAuthState = {
     v: "mcp-oauth-1",
     projectId: input.projectId,
     path: input.path,
-    ...(input.notify ? { notify: input.notify } : {}),
+    ...(input.notify && { notify: input.notify }),
     mcpUrl: input.mcpUrl,
-    ...(resource ? { resource: resource.toString() } : {}),
+    ...(resource && { resource: resource.toString() }),
     redirectUri: input.redirectUri,
     authServerUrl,
     clientId: clientInfo.client_id,
@@ -225,8 +225,8 @@ export async function completeMcpOAuth(
     authorizationCode: input.code,
     codeVerifier: state.codeVerifier,
     redirectUri: state.redirectUri,
-    ...(state.resource ? { resource: new URL(state.resource) } : {}),
-    ...(input.iss ? { iss: input.iss } : {}),
+    ...(state.resource && { resource: new URL(state.resource) }),
+    ...(input.iss && { iss: input.iss }),
     fetchFn: input.fetchFn,
   }).catch((cause: unknown) => {
     throw new McpOAuthError(`token exchange failed: ${errorText(cause)}`);
@@ -238,12 +238,12 @@ export async function completeMcpOAuth(
 
   return {
     path: state.path,
-    ...(state.notify ? { notify: state.notify } : {}),
+    ...(state.notify && { notify: state.notify }),
     mcpUrl: state.mcpUrl,
     secret: {
       material: {
         accessToken: tokens.access_token,
-        ...(tokens.refresh_token ? { refreshToken: tokens.refresh_token } : {}),
+        ...(tokens.refresh_token && { refreshToken: tokens.refresh_token }),
         // client_id is required to refresh a public client (RFC 6749 §6).
         clientId: state.clientId,
       },

--- a/apps/os/src/domains/projects/openai-ai-gateway-egress.ts
+++ b/apps/os/src/domains/projects/openai-ai-gateway-egress.ts
@@ -81,7 +81,7 @@ export function openAiAiGatewayBindingHeaders(input: {
     "cf-aig-metadata": JSON.stringify({
       projectId: input.projectId,
       source: "project-egress",
-      ...(caller !== undefined ? { caller } : {}),
+      ...(caller !== undefined && { caller }),
     }),
   };
   for (const [name, value] of input.requestHeaders.entries()) {
@@ -110,9 +110,9 @@ export function openAiAiGatewayRoutingFromConfig(config: AppConfig): {
   return {
     gatewayId: config.cloudflareAiGateway.id,
     openaiApiKey: config.openAiApiKey.exposeSecret(),
-    ...(config.cloudflareAiGateway.responseCacheTtlSeconds !== undefined
-      ? { responseCacheTtlSeconds: config.cloudflareAiGateway.responseCacheTtlSeconds }
-      : {}),
+    ...(config.cloudflareAiGateway.responseCacheTtlSeconds !== undefined && {
+      responseCacheTtlSeconds: config.cloudflareAiGateway.responseCacheTtlSeconds,
+    }),
   };
 }
 

--- a/apps/os/src/domains/secrets/secret-durable-object.ts
+++ b/apps/os/src/domains/secrets/secret-durable-object.ts
@@ -628,7 +628,7 @@ export class SecretDurableObject extends DurableObject<Env> {
         ...material,
         accessToken: data.access_token,
         // Providers may rotate the refresh token on use; keep the newest.
-        ...(typeof data.refresh_token === "string" ? { refreshToken: data.refresh_token } : {}),
+        ...(typeof data.refresh_token === "string" && { refreshToken: data.refresh_token }),
       },
       snapshot,
     );

--- a/apps/os/src/domains/streams/client-libraries/browser/catch-up-page.test.ts
+++ b/apps/os/src/domains/streams/client-libraries/browser/catch-up-page.test.ts
@@ -57,7 +57,7 @@ describe("catchUpAvailableHistory", () => {
       offset,
       createdAt: new Date(offset).toISOString(),
       path: "/tests/catch-up",
-      ...(ephemeral ? { ephemeral: true as const } : {}),
+      ...(ephemeral && { ephemeral: true as const }),
     });
     const serverEvents = [event(1), event(2, true), event(3), event(4, true)];
     const reads: Array<{ afterOffset: number; beforeOffset: number; limit: number }> = [];

--- a/apps/os/src/domains/streams/client-libraries/processors/browser-feed/implementation.test.ts
+++ b/apps/os/src/domains/streams/client-libraries/processors/browser-feed/implementation.test.ts
@@ -46,7 +46,7 @@ function event(
     payload,
     path: "/tests/live-feed",
     createdAt: new Date(offset * 1_000).toISOString(),
-    ...(ephemeral ? { ephemeral: true as const } : {}),
+    ...(ephemeral && { ephemeral: true as const }),
   };
 }
 

--- a/apps/os/src/domains/streams/stream-durable-object.ts
+++ b/apps/os/src/domains/streams/stream-durable-object.ts
@@ -1469,9 +1469,9 @@ export class StreamDurableObject extends DurableObject<Env> {
         // the parent-held Capability Provider Pager wiring — that is the one
         // facet whose live mounts have runtime state (sockets, provider legs)
         // living on this parent.
-        ...(name === CapabilityHostProcessorContract.slug
-          ? { capabilityHost: this.#capabilityHostFacadeWiring() }
-          : {}),
+        ...(name === CapabilityHostProcessorContract.slug && {
+          capabilityHost: this.#capabilityHostFacadeWiring(),
+        }),
       });
     }
     return new ExpressionProcessorFacadeRpcTarget({
@@ -1782,7 +1782,7 @@ export class StreamDurableObject extends DurableObject<Env> {
         return {
           name,
           action: receiver.action,
-          ...(receiver.action === "facet-processor" ? { placement: "facet" as const } : {}),
+          ...(receiver.action === "facet-processor" && { placement: "facet" as const }),
           configuredAtOffset: entry.configuredAtOffset,
           status:
             row?.status ??

--- a/apps/os/src/domains/streams/stream-event-sender.ts
+++ b/apps/os/src/domains/streams/stream-event-sender.ts
@@ -2475,13 +2475,11 @@ function parseWakeDeliveryResult(
     outcome: "error",
     error: Object.assign(error, {
       ...(typeof serialized.itxCallId === "string" &&
-      serialized.itxCallId.length > 0 &&
-      serialized.itxCallId.length <= 200
-        ? { itxCallId: serialized.itxCallId }
-        : {}),
-      ...(serialized.durableObjectReset === true ? { durableObjectReset: true } : {}),
-      ...(serialized.overloaded === true ? { overloaded: true } : {}),
-      ...(serialized.retryable === true ? { retryable: true } : {}),
+        serialized.itxCallId.length > 0 &&
+        serialized.itxCallId.length <= 200 && { itxCallId: serialized.itxCallId }),
+      ...(serialized.durableObjectReset === true && { durableObjectReset: true }),
+      ...(serialized.overloaded === true && { overloaded: true }),
+      ...(serialized.retryable === true && { retryable: true }),
     }),
   };
 }

--- a/apps/os/src/domains/streams/stream-subscriber-pager.ts
+++ b/apps/os/src/domains/streams/stream-subscriber-pager.ts
@@ -229,8 +229,8 @@ export class StreamSubscriberPagerRegistry {
         v: 1,
         connectionKey: args.connectionKey,
         pagerId: claimed.attachment.pagerId,
-        ...(hasFilter ? { filter: args.filter } : {}),
-        ...(args.events === false ? { events: false as const } : {}),
+        ...(hasFilter && { filter: args.filter }),
+        ...(args.events === false && { events: false as const }),
       });
     }
   }

--- a/apps/os/src/domains/workers/worker-build-coordinator.ts
+++ b/apps/os/src/domains/workers/worker-build-coordinator.ts
@@ -144,7 +144,7 @@ export class WorkerBuildCoordinator {
   ) {
     this.#observe({
       buildKey: flight.buildKey,
-      ...(kind === "settled" ? { durationMs: this.#now() - flight.startedAt } : {}),
+      ...(kind === "settled" && { durationMs: this.#now() - flight.startedAt }),
       kind,
       ...(outcome === undefined ? {} : { outcome }),
       ...(sizes === undefined ? {} : { sizes }),

--- a/apps/os/src/lib/agent-round-meta-yaml.ts
+++ b/apps/os/src/lib/agent-round-meta-yaml.ts
@@ -38,37 +38,32 @@ export function buildRoundMetaYaml(
   promptMessages: { role: string; content: string }[] | null,
 ) {
   const doc = new Document({
-    ...(llm
-      ? {
-          llm: {
-            ...(llm.model ? { model: llm.model } : {}),
-            ...(llm.durationMs == null
-              ? {}
-              : { duration: `${(llm.durationMs / 1000).toFixed(1)}s` }),
-            ...(llm.inputTokens == null ? {} : { inputTokens: llm.inputTokens }),
-            ...(llm.outputTokens == null ? {} : { outputTokens: llm.outputTokens }),
-            ...(llm.outcome && llm.outcome !== "completed" ? { outcome: llm.outcome } : {}),
-            ...(llm.cancelReason ? { cancelReason: llm.cancelReason } : {}),
-          },
-        }
-      : {}),
+    ...(llm && {
+      llm: {
+        ...(llm.model && { model: llm.model }),
+        ...(llm.durationMs == null ? {} : { duration: `${(llm.durationMs / 1000).toFixed(1)}s` }),
+        ...(llm.inputTokens == null ? {} : { inputTokens: llm.inputTokens }),
+        ...(llm.outputTokens == null ? {} : { outputTokens: llm.outputTokens }),
+        ...(llm.outcome && llm.outcome !== "completed" && { outcome: llm.outcome }),
+        ...(llm.cancelReason && { cancelReason: llm.cancelReason }),
+      },
+    }),
     code: {
-      ...(code.status === "running" ? { status: "running" } : {}),
+      ...(code.status === "running" && { status: "running" }),
       started: formatClockTime(code.startedAtMs),
       ...(code.durationMs == null ? {} : { duration: `${(code.durationMs / 1000).toFixed(1)}s` }),
-      ...(code.status === "done" && code.success === false ? { failed: true } : {}),
+      ...(code.status === "done" && code.success === false && { failed: true }),
     },
-    ...(promptMessages && promptMessages.length > 0
-      ? {
-          prompt: promptMessages.map((message) => ({
-            role: message.role,
-            content: message.content,
-          })),
-        }
-      : {}),
+    ...(promptMessages &&
+      promptMessages.length > 0 && {
+        prompt: promptMessages.map((message) => ({
+          role: message.role,
+          content: message.content,
+        })),
+      }),
     // The raw model response the round's consequences were derived from —
     // after the prompt, so the doc reads request → answer.
-    ...(llm?.responseText ? { response: llm.responseText } : {}),
+    ...(llm?.responseText && { response: llm.responseText }),
   });
   visit(doc, {
     // Multiline strings as |- blocks: readable and highlightable, instead of

--- a/apps/os/src/lib/web-agent.ts
+++ b/apps/os/src/lib/web-agent.ts
@@ -45,7 +45,7 @@ export async function sendAgentFirstTurn(
   if (files.length > 0) {
     await agent.addFiles({
       files: await filesToAgentPayload(files),
-      ...(trimmed ? { message: trimmed } : {}),
+      ...(trimmed && { message: trimmed }),
     });
   } else {
     await agent.message(trimmed);

--- a/apps/os/src/observability/posthog.ts
+++ b/apps/os/src/observability/posthog.ts
@@ -79,7 +79,7 @@ async function capturePosthogException(
   const removeErrorListener = client.on("error", reportDeliveryFailure);
   const properties: Record<string, unknown> = {
     $environment: input.config.cloudflare.workerName ?? "os-local",
-    ...(input.projectId ? { $groups: { project: input.projectId } } : {}),
+    ...(input.projectId && { $groups: { project: input.projectId } }),
     ...requestProperties(input.request),
     ...input.properties,
   };
@@ -113,6 +113,6 @@ function requestProperties(request?: Request) {
   return {
     $current_url: `${url.origin}${url.pathname}`,
     http_method: request.method,
-    ...(request.headers.get("cf-ray") ? { cf_ray: request.headers.get("cf-ray") } : {}),
+    ...(request.headers.get("cf-ray") && { cf_ray: request.headers.get("cf-ray") }),
   };
 }

--- a/apps/os/src/observability/wide-log.ts
+++ b/apps/os/src/observability/wide-log.ts
@@ -151,7 +151,7 @@ function boundedEvent(event: WideLogEvent): WideLogEvent {
     message: event.message,
     log: event.log,
     outcome: event.outcome,
-    ...(event.error ? { error: event.error } : {}),
+    ...(event.error && { error: event.error }),
     dropped: { eventBytes },
   };
 }
@@ -197,7 +197,7 @@ export async function runWideLog<T>(
       log: {
         id: `log_${crypto.randomUUID().replaceAll("-", "")}`,
         kind,
-        ...(parentId ? { parentId } : {}),
+        ...(parentId && { parentId }),
         start: new Date(startedAt).toISOString(),
       },
       outcome: "unknown",

--- a/apps/os/src/routes/_app/projects/$projectSlug/agents/streams/$.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/agents/streams/$.tsx
@@ -125,7 +125,7 @@ function ProjectAgentDetailContent() {
     // feed shows a single message and the agent gets one turn trigger.
     const { event } = await itx.agents.get(streamPath).addFiles({
       files: await filesToAgentPayload(files),
-      ...(message ? { message } : {}),
+      ...(message && { message }),
     });
     return event;
   }

--- a/apps/os/src/routes/index.tsx
+++ b/apps/os/src/routes/index.tsx
@@ -30,7 +30,7 @@ export const Route = createFileRoute("/")({
         search: decision.welcome
           ? {
               welcome: true,
-              ...(decision.ensureBirth ? { ensureBirth: true } : {}),
+              ...(decision.ensureBirth && { ensureBirth: true }),
             }
           : {},
         replace: true,

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -1203,7 +1203,7 @@ export class StreamRpcTarget extends IterateRpcTarget<"Stream"> {
         ...(args.idempotencyKey === undefined ? {} : { idempotencyKey: args.idempotencyKey }),
         configuration: {
           ...(args.name === undefined ? {} : { name: args.name }),
-          ...(args.description?.trim() ? { description: args.description.trim() } : {}),
+          ...(args.description?.trim() && { description: args.description.trim() }),
           ...(args.filter === undefined ? {} : { filter: args.filter }),
           receiver: {
             action: "copy-to-stream",
@@ -2942,7 +2942,7 @@ class SecretCollectionRpcTarget extends IterateRpcTarget<"SecretCollection"> {
         path,
         egress: egressOrigins,
         ...(input.description === undefined ? {} : { description: input.description }),
-        ...(scopePath.startsWith("/agents/") ? { notify: scopePath } : {}),
+        ...(scopePath.startsWith("/agents/") && { notify: scopePath }),
       },
     });
     return { path, url };
@@ -4447,7 +4447,7 @@ class EmailCapabilityRpcTarget extends IterateRpcTarget<"EmailCapability"> {
       request: {
         ...input,
         attachments,
-        ...(thread !== null && input.replyTo === undefined ? { replyTo: thread.replyTo } : {}),
+        ...(thread !== null && input.replyTo === undefined && { replyTo: thread.replyTo }),
       },
     });
     const { from, messageId } = await this.#deliver({
@@ -6795,12 +6795,10 @@ export class ProjectRpcTarget extends IterateRpcTarget<"Project"> {
       }).sourceText,
       children: {
         ...PROJECT_BUILTIN_BLIPS,
-        ...(scopePath.startsWith("/agents/")
-          ? {
-              agent: "THIS agent's control surface (present because this is an agent scope).",
-              chat: "THIS agent's web-chat door.",
-            }
-          : {}),
+        ...(scopePath.startsWith("/agents/") && {
+          agent: "THIS agent's control surface (present because this is an agent scope).",
+          chat: "THIS agent's web-chat door.",
+        }),
       },
       parent: scopePath === "/" ? "session.projects" : `the project-root itx (scope "/")`,
       // Dynamic mounts only: the builtins are already the `children` map, and
@@ -8909,9 +8907,9 @@ class McpClientCollectionRpcTarget extends IterateRpcTarget<"McpClientCollection
       mcpUrl: input.url,
       path,
       redirectUri: `${baseUrl.replace(/\/$/, "")}/api/mcp-oauth/callback`,
-      ...(input.scope ? { scope: input.scope } : {}),
+      ...(input.scope && { scope: input.scope }),
       // An agent scope gets messaged when the user finishes signing in.
-      ...(this.props.scopePath.startsWith("/agents/") ? { notify: this.props.scopePath } : {}),
+      ...(this.props.scopePath.startsWith("/agents/") && { notify: this.props.scopePath }),
       projectId: this.props.projectId,
       encryptionKey: env.SECRET_ENCRYPTION_KEY,
       fetchFn: fetchLikeFromFetcher(this.props.egress),
@@ -8928,7 +8926,7 @@ class McpClientCollectionRpcTarget extends IterateRpcTarget<"McpClientCollection
   get exa(): McpClientRpc {
     const hasPlatformKey = parseConfig(env).integrations.exa !== undefined;
     return McpClientRpcTarget.createLazyClient(
-      { url: EXA_MCP_URL, ...(hasPlatformKey ? { headers: EXA_PLATFORM_KEY_HEADER } : {}) },
+      { url: EXA_MCP_URL, ...(hasPlatformKey && { headers: EXA_PLATFORM_KEY_HEADER }) },
       {
         description: {
           instructions:

--- a/apps/os/src/worker.ts
+++ b/apps/os/src/worker.ts
@@ -292,20 +292,16 @@ function ingressLogFields(request: Request, route: Awaited<ReturnType<typeof dec
   return {
     ingress: {
       lane: route.lane,
-      ...((route.lane === "api" && path === "/api") || route.lane === "project"
-        ? {
-            transport:
-              request.headers.get("upgrade")?.toLowerCase() === "websocket"
-                ? ("websocket" as const)
-                : ("http" as const),
-          }
-        : {}),
-      ...(route.lane === "project"
-        ? {
-            projectId: route.resolved.projectId,
-            appSlug: route.resolved.appSlug ?? undefined,
-          }
-        : {}),
+      ...(((route.lane === "api" && path === "/api") || route.lane === "project") && {
+        transport:
+          request.headers.get("upgrade")?.toLowerCase() === "websocket"
+            ? ("websocket" as const)
+            : ("http" as const),
+      }),
+      ...(route.lane === "project" && {
+        projectId: route.resolved.projectId,
+        appSlug: route.resolved.appSlug ?? undefined,
+      }),
     },
   };
 }

--- a/lint/oxlint-plugin-iterate.ts
+++ b/lint/oxlint-plugin-iterate.ts
@@ -299,6 +299,21 @@ function hasTypePredicateReturnType(sourceCode: SourceCode, fn: any) {
   const returnTypeText = sourceCode.getText(returnType);
   return /\basserts\b/.test(returnTypeText) || /\bis\b/.test(returnTypeText);
 }
+/** Expression types that bind looser than `&&`, so they need wrapping parens
+ * when placed on either side of it. `??` may not even mix with `&&`
+ * unparenthesized (SyntaxError), and `a || b && c` / `f && a ? b : c` parse
+ * with different groupings than the pre-fix code meant. */
+function needsParensInsideLogicalAnd(node: any) {
+  if (node.type === "LogicalExpression") return node.operator !== "&&";
+  return (
+    node.type === "ConditionalExpression" ||
+    node.type === "AssignmentExpression" ||
+    node.type === "ArrowFunctionExpression" ||
+    node.type === "YieldExpression" ||
+    node.type === "SequenceExpression"
+  );
+}
+
 function findVariableInScopeChain(scope: Scope.Scope | null, name: string) {
   for (let current = scope; current; current = current.upper) {
     const variable = current.variables.find((v: any) => v.name === name);
@@ -759,6 +774,50 @@ const plugin: StrictPlugin = {
                 ],
               });
             }
+          },
+        };
+      },
+    },
+    "prefer-logical-and-spread": {
+      meta: {
+        type: "suggestion",
+        fixable: "code",
+        docs: {
+          description:
+            "Prefer ...(cond && obj) over ...(cond ? obj : {}) in object literals. Object spread " +
+            "treats any falsy value like {}, so the empty-object arm is dead weight.",
+        },
+      },
+      create(context) {
+        return {
+          "ObjectExpression > SpreadElement > ConditionalExpression": (node: any) => {
+            const { test, consequent, alternate } = node;
+            if (alternate.type !== "ObjectExpression" || alternate.properties.length > 0) return;
+
+            // Comments living inside the ternary but outside the parts we keep
+            // (e.g. `f ? /* why */ {…} : {}`) would be dropped by the rewrite —
+            // report without a fix in that case.
+            const wouldDropComment = context.sourceCode.getAllComments().some((comment: any) => {
+              if (!comment.range || !node.range) return false;
+              const inside = (range: [number, number]) =>
+                comment.range[0] >= range[0] && comment.range[1] <= range[1];
+              return inside(node.range) && !inside(test.range) && !inside(consequent.range);
+            });
+
+            const wrap = (child: any) => {
+              const text = context.sourceCode.getText(child);
+              return needsParensInsideLogicalAnd(child) ? `(${text})` : text;
+            };
+            context.report({
+              node,
+              message:
+                "Spreading a falsy value into an object literal is a no-op, same as spreading {}. " +
+                "Use ...(cond && obj) instead of ...(cond ? obj : {}).",
+              ...(!wouldDropComment && {
+                fix: (fixer: Rule.RuleFixer) =>
+                  fixer.replaceText(node, `${wrap(test)} && ${wrap(consequent)}`),
+              }),
+            });
           },
         };
       },

--- a/lint/oxlint-plugin-logical-and-spread.test.ts
+++ b/lint/oxlint-plugin-logical-and-spread.test.ts
@@ -1,0 +1,166 @@
+// Tests for iterate/prefer-logical-and-spread: object spread treats any falsy
+// value like {}, so `...(cond ? obj : {})` is just `...(cond && obj)` with a
+// dead empty-object arm. The rule is auto-fixable, and the fix must be
+// parse-preserving (parens around `||`/`??`/ternary operands) — most of the
+// tests here run the real oxlint binary with --fix and assert the output.
+
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import assert from "node:assert/strict";
+
+import { test } from "vitest";
+
+test("fixes the basic pattern", () => {
+  using fixture = createOxlintFixture();
+  fixture.write(
+    "basic.ts",
+    [
+      "declare const f: { def: string } | undefined;",
+      "export const x = {",
+      "  ...(f ? { abc: f.def } : {}),",
+      "};",
+      "",
+    ].join("\n"),
+  );
+
+  fixture.runOxlint(["--fix", "basic.ts"]);
+  assert.match(fixture.read("basic.ts"), /\.\.\.\(f && \{ abc: f\.def \}\),/);
+});
+
+test("parenthesizes operands that bind looser than &&", () => {
+  using fixture = createOxlintFixture();
+  fixture.write(
+    "precedence.ts",
+    [
+      "declare const a: boolean, b: boolean, f: boolean;",
+      "declare const left: object | null, right: object;",
+      "export const x = {",
+      "  ...(a || b ? { x: 1 } : {}),",
+      "  ...(f ? (left ?? right) : {}),",
+      "};",
+      "",
+    ].join("\n"),
+  );
+
+  fixture.runOxlint(["--fix", "precedence.ts"]);
+  const fixed = fixture.read("precedence.ts");
+  assert.match(fixed, /\.\.\.\(\(a \|\| b\) && \{ x: 1 \}\),/);
+  assert.match(fixed, /\.\.\.\(f && \(left \?\? right\)\),/);
+});
+
+test("fixes non-literal consequents too", () => {
+  using fixture = createOxlintFixture();
+  fixture.write(
+    "reference.ts",
+    [
+      "declare const f: { extras: object } | undefined;",
+      "export const x = {",
+      "  ...(f ? f.extras : {}),",
+      "};",
+      "",
+    ].join("\n"),
+  );
+
+  fixture.runOxlint(["--fix", "reference.ts"]);
+  assert.match(fixture.read("reference.ts"), /\.\.\.\(f && f\.extras\),/);
+});
+
+test("reports without fixing when the rewrite would drop a comment", () => {
+  using fixture = createOxlintFixture();
+  const source = [
+    "declare const f: { def: string } | undefined;",
+    "export const x = {",
+    "  ...(f ? /* keep me */ { abc: f.def } : {}),",
+    "};",
+    "",
+  ].join("\n");
+  fixture.write("commented.ts", source);
+
+  const result = fixture.runOxlint(["--fix", "commented.ts"], { expectFailure: true });
+  assert.match(result.stdout + result.stderr, /Spreading a falsy value/);
+  assert.equal(fixture.read("commented.ts"), source);
+});
+
+test("leaves non-matching spreads alone", () => {
+  using fixture = createOxlintFixture();
+  fixture.write(
+    "ok.ts",
+    [
+      "declare const f: boolean, g: { a: number };",
+      "export const objects = {",
+      "  ...(f ? { a: 1 } : { b: 2 }),", // both arms meaningful
+      "  ...(f ? {} : { a: 1 }),", // mirrored form: fix would add a negation
+      "  ...(f && g),", // already idiomatic
+      "};",
+      "export const array = [...(f ? [1] : [])];", // array spread of falsy throws
+      "",
+    ].join("\n"),
+  );
+
+  fixture.runOxlint(["ok.ts"]);
+});
+
+const repoRoot = resolve(import.meta.dirname, "..");
+const pluginPath = join(repoRoot, "lint", "oxlint-plugin-iterate.ts");
+const oxlintBin = join(repoRoot, "node_modules", ".bin", "oxlint");
+
+/** Same fixture shape as oxlint-plugin-icon-button.test.ts: a temp project
+ * with the real plugin armed, linted by the real oxlint binary. */
+function createOxlintFixture() {
+  const root = mkdtempSync(join(tmpdir(), "iterate-oxlint-logical-and-spread-"));
+  const configPath = join(root, ".oxlintrc.json");
+
+  writeFileSync(
+    configPath,
+    JSON.stringify(
+      {
+        categories: {
+          correctness: "off",
+          nursery: "off",
+          pedantic: "off",
+          perf: "off",
+          restriction: "off",
+          style: "off",
+          suspicious: "off",
+        },
+        env: {
+          builtin: true,
+          node: true,
+        },
+        jsPlugins: [pluginPath],
+        rules: { "iterate/prefer-logical-and-spread": "error" },
+      },
+      null,
+      2,
+    ),
+  );
+
+  return {
+    root,
+    [Symbol.dispose]() {
+      rmSync(root, { force: true, recursive: true });
+    },
+    read(path: string) {
+      return readFileSync(join(root, path), "utf8");
+    },
+    runOxlint(args: string[], options: { expectFailure?: boolean } = {}) {
+      const result = spawnSync(
+        oxlintBin,
+        [...args, "--config", configPath, "--threads", "1", "--format", "stylish"],
+        { cwd: root, encoding: "utf8" },
+      );
+      if (options.expectFailure) {
+        assert.notEqual(result.status, 0, result.stderr || result.stdout);
+      } else {
+        assert.equal(result.status, 0, result.stderr || result.stdout);
+      }
+      return result;
+    },
+    write(path: string, contents: string) {
+      mkdirSync(dirname(join(root, path)), { recursive: true });
+      writeFileSync(join(root, path), contents);
+    },
+  };
+}

--- a/packages/iterate/src/approve-core.ts
+++ b/packages/iterate/src/approve-core.ts
@@ -190,8 +190,8 @@ export async function decide(input: {
     approvalRequestEventOffset: input.offset,
     verdicts: [...input.verdicts],
     decidedBy: "human" as const,
-    ...(reason ? { reason } : {}),
-    ...(signs ? { keyId: input.key!.keyId, signature } : {}),
+    ...(reason && { reason }),
+    ...(signs && { keyId: input.key!.keyId, signature }),
   };
   // The exact submission is replay-safe, while a corrected verdict, key, or
   // signature remains a new attempt after the door ignores an invalid one.

--- a/packages/iterate/src/approve-json.ts
+++ b/packages/iterate/src/approve-json.ts
@@ -208,7 +208,7 @@ export async function runApprovalJson(input: {
       const offsetOnly = z.object({ offset: z.number() }).loose().safeParse(json);
       emit({
         type: "error",
-        ...(offsetOnly.success ? { offset: offsetOnly.data.offset } : {}),
+        ...(offsetOnly.success && { offset: offsetOnly.data.offset }),
         message: `malformed decision line: ${z.prettifyError(line.error)}`,
       });
       return;
@@ -313,7 +313,7 @@ function dispatch(
         offset,
         outcome: "rejected",
         reason: payload.decidedBy === "expiry" ? "expiry" : "human",
-        ...(typeof payload.reason === "string" ? { humanReason: payload.reason } : {}),
+        ...(typeof payload.reason === "string" && { humanReason: payload.reason }),
       });
       return;
     }

--- a/packages/iterate/src/cli.ts
+++ b/packages/iterate/src/cli.ts
@@ -370,7 +370,7 @@ const setupMissingProjectForChat = async (session: RpcStub<Session>, project: Pr
   try {
     projectItx = (await session.projects.get(project.slug).create({
       projectId: project.id,
-      ...(project.organizationSlug ? { organizationSlug: project.organizationSlug } : {}),
+      ...(project.organizationSlug && { organizationSlug: project.organizationSlug }),
     })) as unknown as RpcStub<Project>;
   } catch (error) {
     throw new Error(

--- a/packages/iterate/src/processors/stream-processor-registry.ts
+++ b/packages/iterate/src/processors/stream-processor-registry.ts
@@ -211,13 +211,11 @@ function serializeWakeDeliveryError(error: unknown): StreamWakeDeliveryError {
         ? candidate.message
         : String(error) || "unknown delivery failure",
     ...(typeof candidate?.itxCallId === "string" &&
-    candidate.itxCallId.length > 0 &&
-    candidate.itxCallId.length <= 200
-      ? { itxCallId: candidate.itxCallId }
-      : {}),
-    ...(candidate?.durableObjectReset === true ? { durableObjectReset: true as const } : {}),
-    ...(candidate?.overloaded === true ? { overloaded: true as const } : {}),
-    ...(candidate?.retryable === true ? { retryable: true as const } : {}),
+      candidate.itxCallId.length > 0 &&
+      candidate.itxCallId.length <= 200 && { itxCallId: candidate.itxCallId }),
+    ...(candidate?.durableObjectReset === true && { durableObjectReset: true as const }),
+    ...(candidate?.overloaded === true && { overloaded: true as const }),
+    ...(candidate?.retryable === true && { retryable: true as const }),
   };
 }
 

--- a/packages/iterate/src/processors/stream-processor-runner.ts
+++ b/packages/iterate/src/processors/stream-processor-runner.ts
@@ -831,7 +831,7 @@ export class StreamProcessorRunner<
       const newestEventCreatedAtMs = Date.parse(committedEvents.at(-1)!.createdAt);
       this.hooks.noteBatchIngested({
         ingestedThroughOffset: next.processing.acknowledgedThroughOffset,
-        ...(Number.isFinite(newestEventCreatedAtMs) ? { newestEventCreatedAtMs } : {}),
+        ...(Number.isFinite(newestEventCreatedAtMs) && { newestEventCreatedAtMs }),
         eventCount: committedEvents.length,
         ingestStartedAtMs: ctx.ingestStartedAtMs,
         atMs: this.now(),

--- a/packages/shared/src/evlog/orpc-plugin.ts
+++ b/packages/shared/src/evlog/orpc-plugin.ts
@@ -27,7 +27,7 @@ function setOrpcRequestLogContext(options: {
   const logRequestId = options.context.log.getContext().requestId;
 
   options.context.log.set({
-    ...(requestId !== undefined && requestId !== logRequestId ? { requestId } : {}),
+    ...(requestId !== undefined && requestId !== logRequestId && { requestId }),
     rpc: options.context.rawRequest
       ? {
           url: options.context.rawRequest.url,

--- a/packages/shared/src/evlog/runtime.ts
+++ b/packages/shared/src/evlog/runtime.ts
@@ -25,12 +25,10 @@ export function createNitroEvlogModuleOptions(options: { context: AppLoggingCont
       appName: options.context.manifest.packageName,
       version: options.context.manifest.version,
     },
-    ...(options.context.config.logs.stdoutFormat === "pretty"
-      ? {
-          pretty: false,
-          stringify: false,
-        }
-      : {}),
+    ...(options.context.config.logs.stdoutFormat === "pretty" && {
+      pretty: false,
+      stringify: false,
+    }),
   };
 }
 

--- a/packages/shared/src/posthog/posthog.ts
+++ b/packages/shared/src/posthog/posthog.ts
@@ -30,6 +30,6 @@ export async function proxyPosthogRequest(options: ProxyPosthogRequestOptions): 
     body,
     redirect: options.request.redirect,
     // Node's fetch requires this for stream bodies; Workers harmlessly ignore it.
-    ...(body ? { duplex: "half" as const } : {}),
+    ...(body && { duplex: "half" as const }),
   });
 }

--- a/packages/shared/src/test-support/ci-telemetry.ts
+++ b/packages/shared/src/test-support/ci-telemetry.ts
@@ -228,8 +228,8 @@ export function normalizeTestTelemetryError(
   const candidate = error as { message?: unknown; name?: unknown; stack?: unknown };
   return {
     message: typeof candidate.message === "string" ? candidate.message : fallbackMessage,
-    ...(typeof candidate.name === "string" ? { name: candidate.name } : {}),
-    ...(typeof candidate.stack === "string" ? { stack: candidate.stack } : {}),
+    ...(typeof candidate.name === "string" && { name: candidate.name }),
+    ...(typeof candidate.stack === "string" && { stack: candidate.stack }),
   };
 }
 
@@ -359,39 +359,37 @@ export function ciTelemetrySourceFromEnvironment(
   const runId = environment.GITHUB_RUN_ID ?? fallbackRunId;
   return {
     repository,
-    ...(environment.TEST_TELEMETRY_HEAD_SHA || environment.GITHUB_SHA
-      ? { headSha: environment.TEST_TELEMETRY_HEAD_SHA || environment.GITHUB_SHA }
-      : {}),
-    ...(environment.TEST_TELEMETRY_BRANCH ||
-    environment.GITHUB_HEAD_REF ||
-    environment.GITHUB_REF_NAME
-      ? {
-          branch:
-            environment.TEST_TELEMETRY_BRANCH ||
-            environment.GITHUB_HEAD_REF ||
-            environment.GITHUB_REF_NAME,
-        }
-      : {}),
+    ...((environment.TEST_TELEMETRY_HEAD_SHA || environment.GITHUB_SHA) && {
+      headSha: environment.TEST_TELEMETRY_HEAD_SHA || environment.GITHUB_SHA,
+    }),
+    ...((environment.TEST_TELEMETRY_BRANCH ||
+      environment.GITHUB_HEAD_REF ||
+      environment.GITHUB_REF_NAME) && {
+      branch:
+        environment.TEST_TELEMETRY_BRANCH ||
+        environment.GITHUB_HEAD_REF ||
+        environment.GITHUB_REF_NAME,
+    }),
     ...optionalPullRequestNumber(
       environment.TEST_TELEMETRY_PULL_REQUEST_NUMBER,
       environment.GITHUB_REF,
     ),
-    ...(environment.GITHUB_WORKFLOW ? { workflowName: environment.GITHUB_WORKFLOW } : {}),
+    ...(environment.GITHUB_WORKFLOW && { workflowName: environment.GITHUB_WORKFLOW }),
     workflowRunId: runId,
     workflowRunAttempt: environment.GITHUB_RUN_ATTEMPT ?? "1",
-    ...(environment.GITHUB_SERVER_URL && environment.GITHUB_REPOSITORY && environment.GITHUB_RUN_ID
-      ? {
-          workflowRunUrl: `${environment.GITHUB_SERVER_URL}/${environment.GITHUB_REPOSITORY}/actions/runs/${environment.GITHUB_RUN_ID}`,
-        }
-      : {}),
-    ...(environment.GITHUB_JOB ? { jobName: environment.GITHUB_JOB } : {}),
+    ...(environment.GITHUB_SERVER_URL &&
+      environment.GITHUB_REPOSITORY &&
+      environment.GITHUB_RUN_ID && {
+        workflowRunUrl: `${environment.GITHUB_SERVER_URL}/${environment.GITHUB_REPOSITORY}/actions/runs/${environment.GITHUB_RUN_ID}`,
+      }),
+    ...(environment.GITHUB_JOB && { jobName: environment.GITHUB_JOB }),
     workspaceRoot: environment.GITHUB_WORKSPACE ?? process.cwd(),
     runnerProvider: environment.DEPOT_JOB_URL
       ? "depot"
       : environment.GITHUB_RUN_ID
         ? "github-actions"
         : "local",
-    ...(environment.DEPOT_JOB_URL ? { depotJobUrl: environment.DEPOT_JOB_URL } : {}),
+    ...(environment.DEPOT_JOB_URL && { depotJobUrl: environment.DEPOT_JOB_URL }),
     executionContext: environment.GITHUB_RUN_ID ? "ci" : "local",
   };
 }

--- a/packages/shared/src/test-support/e2e-policy/retry-telemetry-reporter.ts
+++ b/packages/shared/src/test-support/e2e-policy/retry-telemetry-reporter.ts
@@ -219,27 +219,26 @@ export class RetryTelemetryReporter {
           tests.push({
             fullName: test.fullName,
             moduleId: testModule.moduleId,
-            ...(test.location
-              ? { testLine: test.location.line, testColumn: test.location.column }
-              : {}),
-            ...(test.id ? { runnerTestId: test.id } : {}),
-            ...(test.options
-              ? {
-                  expectedState:
-                    test.options.mode === "skip" || test.options.mode === "todo"
-                      ? test.options.mode
-                      : test.options.fails
-                        ? "failed"
-                        : "passed",
-                }
-              : {}),
+            ...(test.location && {
+              testLine: test.location.line,
+              testColumn: test.location.column,
+            }),
+            ...(test.id && { runnerTestId: test.id }),
+            ...(test.options && {
+              expectedState:
+                test.options.mode === "skip" || test.options.mode === "todo"
+                  ? test.options.mode
+                  : test.options.fails
+                    ? "failed"
+                    : "passed",
+            }),
             ...(test.options?.timeout === undefined
               ? {}
               : { configuredTimeoutMs: test.options.timeout }),
             tags: [...(test.tags ?? [])],
             annotations: annotations.map(({ type, message }) => ({
               type,
-              ...(message ? { description: message } : {}),
+              ...(message && { description: message }),
             })),
             ...(diagnostic?.repeatCount === undefined
               ? {}
@@ -274,7 +273,7 @@ export class RetryTelemetryReporter {
             attempts: [],
             phases: parseTelemetryPhases(annotations),
             errors,
-            ...(firstFailure ? { firstFailure } : {}),
+            ...(firstFailure && { firstFailure }),
           });
         }
       }
@@ -304,7 +303,7 @@ export class RetryTelemetryReporter {
           startedAt: new Date(this.runStartedAtMs).toISOString(),
           finishedAt: new Date(finishedAtMs).toISOString(),
           durationMs: Math.max(0, finishedAtMs - this.runStartedAtMs),
-          ...(unhandled[0] ? { error: unhandled[0] } : {}),
+          ...(unhandled[0] && { error: unhandled[0] }),
         },
         lanes: [
           {
@@ -371,8 +370,8 @@ function parseTelemetryPhases(
         {
           name: parsed.name,
           durationMs: Math.round(parsed.durationMs),
-          ...(typeof parsed.category === "string" ? { category: parsed.category } : {}),
-          ...(typeof parsed.startedAt === "string" ? { startedAt: parsed.startedAt } : {}),
+          ...(typeof parsed.category === "string" && { category: parsed.category }),
+          ...(typeof parsed.startedAt === "string" && { startedAt: parsed.startedAt }),
         },
       ];
     } catch {

--- a/packages/ui/src/components/events/agent-ui-reducer.ts
+++ b/packages/ui/src/components/events/agent-ui-reducer.ts
@@ -791,9 +791,8 @@ function reduceAgentUiEvent(
               status: "done",
               outcome:
                 status === "succeeded" ? "completed" : status === "failed" ? "failed" : "cancelled",
-              ...(partialText !== null && step.responseText === ""
-                ? { responseText: partialText }
-                : {}),
+              ...(partialText !== null &&
+                step.responseText === "" && { responseText: partialText }),
               ...(typeof payload.durationMs === "number"
                 ? { durationMs: payload.durationMs }
                 : status === "cancelled"
@@ -991,17 +990,17 @@ function reduceAgentUiEvent(
       const user =
         typeof openerUser?.email === "string"
           ? {
-              ...(typeof openerUser.id === "string" ? { id: openerUser.id } : {}),
+              ...(typeof openerUser.id === "string" && { id: openerUser.id }),
               email: openerUser.email,
-              ...(typeof openerUser.name === "string" ? { name: openerUser.name } : {}),
-              ...(typeof openerUser.picture === "string" ? { picture: openerUser.picture } : {}),
+              ...(typeof openerUser.name === "string" && { name: openerUser.name }),
+              ...(typeof openerUser.picture === "string" && { picture: openerUser.picture }),
             }
           : undefined;
       const entry: AgentUiPresenceEntry = {
         connectionKey,
         connectionKind,
         connected: true,
-        ...(typeof openedBy?.description === "string" ? { description: openedBy.description } : {}),
+        ...(typeof openedBy?.description === "string" && { description: openedBy.description }),
         ...(user === undefined ? {} : { user }),
         ...(announcement == null ? {} : { processor: announcement }),
       };
@@ -1408,7 +1407,7 @@ function readCodeOutcome(payload: Record<string, unknown>): Partial<AgentUiCodeS
   if (settlement.status === "succeeded") {
     return {
       success: true,
-      ...(Object.hasOwn(settlement, "result") ? { result: settlement.result } : {}),
+      ...(Object.hasOwn(settlement, "result") && { result: settlement.result }),
     };
   }
   return { success: false, errorMessage: settlement.error };
@@ -1418,8 +1417,8 @@ function readUsageTokens(usage: unknown): { input?: number; output?: number } {
   if (!isRecord(usage)) return {};
   // The settled event's normalized usage (the contract's camelCase shape).
   return {
-    ...(typeof usage.inputTokens === "number" ? { input: usage.inputTokens } : {}),
-    ...(typeof usage.outputTokens === "number" ? { output: usage.outputTokens } : {}),
+    ...(typeof usage.inputTokens === "number" && { input: usage.inputTokens }),
+    ...(typeof usage.outputTokens === "number" && { output: usage.outputTokens }),
   };
 }
 
@@ -1440,7 +1439,7 @@ function readProcessorAnnouncement(value: unknown): AgentUiProcessorAnnouncement
           .filter((owned) => typeof owned.type === "string")
           .map((owned) => ({
             type: owned.type as string,
-            ...(typeof owned.description === "string" ? { description: owned.description } : {}),
+            ...(typeof owned.description === "string" && { description: owned.description }),
           }))
       : [],
   };

--- a/packages/ui/src/components/posthog.tsx
+++ b/packages/ui/src/components/posthog.tsx
@@ -70,16 +70,14 @@ function buildPosthogInitOptions(options: SetupPosthogOptions) {
     mask_all_element_attributes: true,
     mask_all_text: true,
     strict_script_versioning: true,
-    ...(sessionRecording
-      ? {
-          session_recording: {
-            maskAllInputs: true,
-            maskTextSelector: "*",
-            recordBody: false,
-            recordHeaders: false,
-          },
-        }
-      : {}),
+    ...(sessionRecording && {
+      session_recording: {
+        maskAllInputs: true,
+        maskTextSelector: "*",
+        recordBody: false,
+        recordHeaders: false,
+      },
+    }),
     loaded: options.appStage
       ? (client: import("posthog-js").PostHogInterface) => {
           client.register({

--- a/scripts/ci/node-test-telemetry-reporter.ts
+++ b/scripts/ci/node-test-telemetry-reporter.ts
@@ -96,9 +96,9 @@ export default async function* nodeTestTelemetryReporter(source: AsyncIterable<T
               {
                 name: event.data.details.error.name,
                 message: String(event.data.details.error.message),
-                ...(event.data.details.error.stack
-                  ? { stack: String(event.data.details.error.stack) }
-                  : {}),
+                ...(event.data.details.error.stack && {
+                  stack: String(event.data.details.error.stack),
+                }),
               },
             ]
           : [],
@@ -137,23 +137,21 @@ export default async function* nodeTestTelemetryReporter(source: AsyncIterable<T
             startedAt: new Date(startedAtMs).toISOString(),
             startedAtSource: "inferred",
             scheduleDelayMs: Math.max(0, startedAtMs - previousFinishedAtMs),
-            ...(event.type === "test:fail"
-              ? {
-                  error: {
-                    name: event.data.details.error.name,
-                    message: String(event.data.details.error.message),
-                    ...(event.data.details.error.stack
-                      ? { stack: String(event.data.details.error.stack) }
-                      : {}),
-                  },
-                }
-              : {}),
+            ...(event.type === "test:fail" && {
+              error: {
+                name: event.data.details.error.name,
+                message: String(event.data.details.error.message),
+                ...(event.data.details.error.stack && {
+                  stack: String(event.data.details.error.stack),
+                }),
+              },
+            }),
             phases: [],
           };
         }),
         phases: [],
         errors,
-        ...(errors[0] ? { firstFailure: errors[0].message.slice(0, 300) } : {}),
+        ...(errors[0] && { firstFailure: errors[0].message.slice(0, 300) }),
         ...(final.data.testNumber === undefined ? {} : { testNumber: final.data.testNumber }),
         ...(final.data.line === undefined ? {} : { testLine: final.data.line }),
         ...(final.data.column === undefined ? {} : { testColumn: final.data.column }),

--- a/scripts/ci/playwright-telemetry-reporter.ts
+++ b/scripts/ci/playwright-telemetry-reporter.ts
@@ -79,7 +79,7 @@ export default class PlaywrightTelemetryReporter implements Reporter {
         startedAt: result.startTime.toISOString(),
         finishedAt: new Date(finishedAtMs).toISOString(),
         durationMs,
-        ...(this.globalErrors[0] ? { error: this.globalErrors[0] } : {}),
+        ...(this.globalErrors[0] && { error: this.globalErrors[0] }),
       },
       lanes: [
         {
@@ -120,7 +120,7 @@ function toTestRecord(test: TestCase, runStartedAtMs: number): TestTelemetryReco
       attachmentCount: result.attachments?.length ?? 0,
       stdoutBytes: outputSize(result.stdout ?? []),
       stderrBytes: outputSize(result.stderr ?? []),
-      ...(error ? { error } : {}),
+      ...(error && { error }),
       phases: flattenSteps(result.steps),
     };
   });
@@ -147,22 +147,22 @@ function toTestRecord(test: TestCase, runStartedAtMs: number): TestTelemetryReco
     tags: test.tags ?? [],
     annotations: (test.annotations ?? []).map(({ type, description }) => ({
       type,
-      ...(description ? { description } : {}),
+      ...(description && { description }),
     })),
-    ...(testProject ? { context: { testProject } } : {}),
+    ...(testProject && { context: { testProject } }),
     retryCount,
     passedAfterRetry: test.outcome() === "flaky",
     state: finalAttempt?.state ?? "skipped",
     outcome: test.outcome(),
     durationMs: attempts.reduce((total, attempt) => total + attempt.durationMs, 0),
     attemptDetail: "complete",
-    ...(firstStartedAt ? { startedAt: firstStartedAt } : {}),
-    ...(firstStartedAt ? { startedAtSource: "runner" as const } : {}),
-    ...(attempts[0] ? { scheduleDelayMs: attempts[0].scheduleDelayMs } : {}),
+    ...(firstStartedAt && { startedAt: firstStartedAt }),
+    ...(firstStartedAt && { startedAtSource: "runner" as const }),
+    ...(attempts[0] && { scheduleDelayMs: attempts[0].scheduleDelayMs }),
     attempts,
     phases: [],
     errors,
-    ...(errors[0] ? { firstFailure: errors[0].message.slice(0, 300) } : {}),
+    ...(errors[0] && { firstFailure: errors[0].message.slice(0, 300) }),
   };
 }
 
@@ -174,15 +174,13 @@ function flattenSteps(steps: readonly TestStep[]): TestTelemetryPhase[] {
         name: step.titlePath().filter(Boolean).join(" › "),
         category: step.category,
         durationMs: nonnegativeDuration(step.duration),
-        ...(step.startTime ? { startedAt: step.startTime.toISOString() } : {}),
+        ...(step.startTime && { startedAt: step.startTime.toISOString() }),
         attachmentCount: step.attachments?.length ?? 0,
-        ...(step.location
-          ? {
-              sourceFile: step.location.file,
-              sourceLine: step.location.line,
-              sourceColumn: step.location.column,
-            }
-          : {}),
+        ...(step.location && {
+          sourceFile: step.location.file,
+          sourceLine: step.location.line,
+          sourceColumn: step.location.column,
+        }),
         ...(step.error
           ? { error: normalizePlaywrightError(step.error) }
           : unfinished
@@ -219,6 +217,6 @@ function firstResultError(errors: readonly TestError[], error: TestError | undef
 function normalizePlaywrightError(error: TestError): TestTelemetryError {
   return {
     message: error.message ?? error.value ?? "Unknown Playwright error",
-    ...(error.stack ? { stack: error.stack } : {}),
+    ...(error.stack && { stack: error.stack }),
   };
 }

--- a/scripts/ci/posthog-events.ts
+++ b/scripts/ci/posthog-events.ts
@@ -87,7 +87,7 @@ export function systemEvent(
 ): PostHogEvent {
   return {
     event,
-    ...(timestamp ? { timestamp } : {}),
+    ...(timestamp && { timestamp }),
     uuid: deterministicEventUuid(insertId),
     properties: {
       distinct_id: distinctId,

--- a/scripts/ci/pr-dashboard.ts
+++ b/scripts/ci/pr-dashboard.ts
@@ -173,7 +173,7 @@ export async function findDashboardState(
           ((parent.bot_id && message.bot_id === parent.bot_id) ||
             (parent.user && message.user === parent.user)),
       );
-      return { ts: parent.ts, ...(details?.ts ? { detailsTs: details.ts } : {}) };
+      return { ts: parent.ts, ...(details?.ts && { detailsTs: details.ts }) };
     }
 
     cursor = history.response_metadata?.next_cursor || undefined;

--- a/scripts/lib/do-reset.ts
+++ b/scripts/lib/do-reset.ts
@@ -439,7 +439,7 @@ export async function resetWorkerDurableObjects(input: {
         // them also names them here.
         containers: kept.map((className) => ({ class_name: className })),
         migrations: {
-          ...(script.migration_tag ? { old_tag: script.migration_tag } : {}),
+          ...(script.migration_tag && { old_tag: script.migration_tag }),
           new_tag: `do-reset-${tagHash([script.migration_tag ?? null, deletedClasses])}`,
           steps: [{ deleted_classes: deletedClasses }],
         },
@@ -739,7 +739,7 @@ export async function ensureContainerClasses(input: {
       // what container-enables their namespaces.
       containers: missing.map((className) => ({ class_name: className })),
       migrations: {
-        ...(script?.migration_tag ? { old_tag: script.migration_tag } : {}),
+        ...(script?.migration_tag && { old_tag: script.migration_tag }),
         new_tag: `container-bootstrap-${tagHash([script?.migration_tag ?? null, missing])}`,
         steps: [{ new_sqlite_classes: missing }],
       },

--- a/scripts/lib/env-context.ts
+++ b/scripts/lib/env-context.ts
@@ -106,9 +106,8 @@ export async function resolveEnvContext<E extends DeployableEnv>(options: {
           ...init,
           headers: {
             authorization: `Bearer ${secrets.CLOUDFLARE_API_TOKEN}`,
-            ...(init?.body && typeof init.body === "string"
-              ? { "content-type": "application/json" }
-              : {}),
+            ...(init?.body &&
+              typeof init.body === "string" && { "content-type": "application/json" }),
             ...init?.headers,
           },
         }),

--- a/scripts/preview/e2e-telemetry.ts
+++ b/scripts/preview/e2e-telemetry.ts
@@ -49,10 +49,10 @@ export class PreviewE2eTelemetryArtifact {
     );
     this.ci = {
       ...ci,
-      ...(context.branch ? { branch: context.branch } : {}),
+      ...(context.branch && { branch: context.branch }),
       headSha: context.headSha,
       pullRequestNumber: context.pullRequestNumber,
-      ...(context.runUrl ? { workflowRunUrl: context.runUrl } : {}),
+      ...(context.runUrl && { workflowRunUrl: context.runUrl }),
     };
     this.artifactId = testTelemetryArtifactId(
       "preview",
@@ -92,7 +92,7 @@ export class PreviewE2eTelemetryArtifact {
   }) {
     this.deploymentLanes.push({
       app: input.app,
-      ...(input.slot ? { previewSlot: input.slot } : {}),
+      ...(input.slot && { previewSlot: input.slot }),
       status: input.status,
       durationMs: input.durationMs,
       finishedAt: input.finishedAt,
@@ -126,8 +126,8 @@ export class PreviewE2eTelemetryArtifact {
       startedAt: new Date(startedAtMs).toISOString(),
       finishedAt,
       durationMs: input.durationMs,
-      ...(previewSlot ? { previewSlot } : {}),
-      ...(input.error ? { error: normalizeTestTelemetryError(input.error) } : {}),
+      ...(previewSlot && { previewSlot }),
+      ...(!!input.error && { error: normalizeTestTelemetryError(input.error) }),
       lanes: this.deploymentLanes,
     };
   }
@@ -148,7 +148,7 @@ export class PreviewE2eTelemetryArtifact {
         testKind: "e2e",
         lane: "preview",
         app: input.app,
-        ...(input.slot ? { previewSlot: input.slot } : {}),
+        ...(input.slot && { previewSlot: input.slot }),
       },
       status: input.status,
       durationMs: input.durationMs,
@@ -170,7 +170,7 @@ export class PreviewE2eTelemetryArtifact {
       startedAt: new Date(this.startedAtMs).toISOString(),
       finishedAt,
       durationMs: input.durationMs,
-      ...(input.error ? { error: normalizeTestTelemetryError(input.error) } : {}),
+      ...(!!input.error && { error: normalizeTestTelemetryError(input.error) }),
     };
   }
 
@@ -208,7 +208,7 @@ export class PreviewE2eTelemetryArtifact {
       context: this.context,
       expectedArtifactSources: this.expectedArtifactSources,
       run: this.runResult,
-      ...(this.deploymentResult ? { deployment: this.deploymentResult } : {}),
+      ...(this.deploymentResult && { deployment: this.deploymentResult }),
       lanes: this.lanes,
       tests: [],
       modules: [],

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -306,7 +306,7 @@ async function withPreviewE2eTelemetry<T>(
   telemetry.runFinished({
     status: operationError ? "failed" : previewOperationWasSkipped(result) ? "skipped" : "passed",
     durationMs: Date.now() - startedAt,
-    ...(operationError ? { error: operationError } : {}),
+    ...(!!operationError && { error: operationError }),
   });
   let telemetryError: unknown;
   try {
@@ -546,9 +546,8 @@ async function deployPreviewApps({
             // are moving targets, while the sha pins the exact builds this
             // deploy shipped.
             PREVIEW_PULL_REQUEST_HEAD_SHA: context.pullRequestHeadSha,
-            ...(app.slug === "os" && osContainerRollout
-              ? { OS_CONTAINERS_ROLLOUT: osContainerRollout.mode }
-              : {}),
+            ...(app.slug === "os" &&
+              osContainerRollout && { OS_CONTAINERS_ROLLOUT: osContainerRollout.mode }),
           },
           dopplerConfig: environmentConfigLease.dopplerConfig,
           mainWorkerSize: workerSizeBaselines[app.slug] ?? null,
@@ -970,9 +969,9 @@ async function testPreviewApps({
           context,
           previewSlot: environmentConfigLease.slug,
         }),
-        ...(telemetryArtifactDirectory
-          ? { TEST_TELEMETRY_ARTIFACT_DIR: telemetryArtifactDirectory }
-          : {}),
+        ...(telemetryArtifactDirectory && {
+          TEST_TELEMETRY_ARTIFACT_DIR: telemetryArtifactDirectory,
+        }),
       },
       signal: runtime.signal,
       workingDirectory: resolve(runtime.repositoryRoot, app.appPath),
@@ -1827,7 +1826,7 @@ async function readCanonicalTestTelemetry(
         name: record.fullName,
         retryCount: record.retryCount,
         passedAfterRetry: record.passedAfterRetry,
-        ...(record.firstFailure ? { firstFailure: record.firstFailure } : {}),
+        ...(record.firstFailure && { firstFailure: record.firstFailure }),
       })),
     collectionErrors: [],
   };
@@ -1886,7 +1885,7 @@ async function readPlaywrightTestTelemetry(
               .join(" › "),
             retryCount,
             passedAfterRetry: test.status === "flaky" || finalResult?.status === "passed",
-            ...(firstFailureSummary ? { firstFailure: firstFailureSummary } : {}),
+            ...(firstFailureSummary && { firstFailure: firstFailureSummary }),
           });
         }
       }
@@ -2756,9 +2755,9 @@ function resolvePreviewTestTelemetryEnvironment(input: {
     TEST_TELEMETRY_KIND: "e2e",
     TEST_TELEMETRY_APP: input.app,
     TEST_TELEMETRY_HEAD_SHA: input.context.pullRequestHeadSha,
-    ...(input.context.pullRequestHeadRef
-      ? { TEST_TELEMETRY_BRANCH: input.context.pullRequestHeadRef }
-      : {}),
+    ...(input.context.pullRequestHeadRef && {
+      TEST_TELEMETRY_BRANCH: input.context.pullRequestHeadRef,
+    }),
     TEST_TELEMETRY_PULL_REQUEST_NUMBER: String(input.context.pullRequestNumber),
     TEST_TELEMETRY_PREVIEW_SLOT: input.previewSlot,
   };

--- a/tasks/complete/2026-08-12-prefer-logical-and-spread.md
+++ b/tasks/complete/2026-08-12-prefer-logical-and-spread.md
@@ -1,5 +1,5 @@
 ---
-status: done-pending-review
+status: done
 size: small
 ---
 

--- a/tasks/prefer-logical-and-spread.md
+++ b/tasks/prefer-logical-and-spread.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done-pending-review
 size: small
 ---
 
@@ -7,8 +7,8 @@ size: small
 
 ## Status
 
-Spec committed first; implementation follows in this branch. PR contains the
-rule + test, then a separate `--fix` commit applying it across the repo.
+Done, pending review. Rule + tests in commit 2; repo-wide `--fix` in commit 3.
+PR: https://github.com/iterate/iterate/pull/2487
 
 ## Summary
 
@@ -50,7 +50,18 @@ ternary's `: {}` arm is dead weight.
 
 ## Checklist
 
-- [ ] add `iterate/prefer-logical-and-spread` rule to `lint/oxlint-plugin-iterate.ts`
-- [ ] enable it as `error` in `.oxlintrc.json`
-- [ ] test file `lint/oxlint-plugin-logical-and-spread.test.ts` covering report, fix output (incl. precedence parens), and non-matches
-- [ ] run `pnpm lint:fix` across the repo, commit the mechanical fixes separately
+- [x] add `iterate/prefer-logical-and-spread` rule to `lint/oxlint-plugin-iterate.ts` _implemented with a `needsParensInsideLogicalAnd` precedence helper; reports fix-less when the rewrite would drop a comment_
+- [x] enable it as `error` in `.oxlintrc.json` _alongside the other `iterate/*` rules_
+- [x] test file `lint/oxlint-plugin-logical-and-spread.test.ts` covering report, fix output (incl. precedence parens), and non-matches _5 tests, runs the real oxlint binary with `--fix` and asserts the rewritten files_
+- [x] run `pnpm lint:fix` across the repo, commit the mechanical fixes separately _71 files; see notes_
+
+## Implementation notes
+
+- `oxlint --fix` needed two passes: fixes for conditional spreads *nested
+  inside* another conditional spread's consequent overlap the outer fix, so
+  oxlint defers them to the next run (7 such sites, e.g.
+  `apps/os/src/lib/agent-round-meta-yaml.ts`).
+- Three sites in `scripts/preview/{e2e-telemetry,preview}.ts` spread on an
+  `unknown`-typed test (caught errors), and `...(unknown && {…})` is TS2698.
+  Hand-tweaked to `...(!!input.error && {…})` — identical runtime semantics,
+  and `!!` makes the spread type `false | {…}`.

--- a/tasks/prefer-logical-and-spread.md
+++ b/tasks/prefer-logical-and-spread.md
@@ -1,0 +1,56 @@
+---
+status: in-progress
+size: small
+---
+
+# Lint rule: prefer `...(cond && obj)` over `...(cond ? obj : {})`
+
+## Status
+
+Spec committed first; implementation follows in this branch. PR contains the
+rule + test, then a separate `--fix` commit applying it across the repo.
+
+## Summary
+
+Add a deterministic, auto-fixable custom oxlint rule (`iterate/prefer-logical-and-spread`)
+that rewrites
+
+```ts
+const x = {
+  ...(f ? { abc: f.def } : {}),
+};
+```
+
+to
+
+```ts
+const x = {
+  ...(f && { abc: f.def }),
+};
+```
+
+Object spread of any falsy value is a no-op (same as spreading `{}`), so the
+ternary's `: {}` arm is dead weight.
+
+## Decisions (assumptions, made while Misha is AFK)
+
+- Scope: only spreads inside **object literals** (`SpreadElement` whose parent
+  is an `ObjectExpression`). Array spread of falsy throws, so it's excluded.
+  JSX spread attributes left out to keep the rule tight.
+- Only the exact stated direction: alternate must be an empty object literal
+  `{}`. The mirrored `cond ? {} : obj` form is NOT rewritten to `!cond && obj`
+  (adds a negation, less obviously a pure win).
+- The consequent can be any expression (e.g. `f ? f.extras : {}` →
+  `f && f.extras`) — same falsy-spread reasoning applies.
+- Fix wraps the test/consequent in parens when precedence demands it
+  (`a || b ? x : {}` → `(a || b) && x`; `f ? (a ?? b) : {}` → `f && (a ?? b)`),
+  so the fix is always parse- and semantics-preserving.
+- If comments live inside the ternary but outside the test/consequent nodes,
+  report without a fix rather than silently dropping them.
+
+## Checklist
+
+- [ ] add `iterate/prefer-logical-and-spread` rule to `lint/oxlint-plugin-iterate.ts`
+- [ ] enable it as `error` in `.oxlintrc.json`
+- [ ] test file `lint/oxlint-plugin-logical-and-spread.test.ts` covering report, fix output (incl. precedence parens), and non-matches
+- [ ] run `pnpm lint:fix` across the repo, commit the mechanical fixes separately


### PR DESCRIPTION
Adds \`iterate/prefer-logical-and-spread\`, a deterministic auto-fixable oxlint rule for conditional object spreads.

Object spread treats any falsy value exactly like \`{}\`, so the empty-object arm of a ternary spread is dead weight:

\`\`\`ts
// before
const x = {
  ...(f ? { abc: f.def } : {}),
};

// after --fix
const x = {
  ...(f && { abc: f.def }),
};
\`\`\`

Details:

- Object literals only — array spread of a falsy value throws, so \`[...(f ? [1] : [])]\` is untouched.
- The fix is parse-preserving: operands that bind looser than \`&&\` get parens (\`a || b ? x : {}\` → \`(a || b) && x\`; \`f ? a ?? b : {}\` → \`f && (a ?? b)\`, which would otherwise be a SyntaxError).
- If a comment lives inside the ternary but outside the kept operands, the rule reports without fixing rather than silently dropping it.
- The mirrored form \`cond ? {} : obj\` is deliberately not rewritten to \`!cond && obj\` — adding a negation isn't a pure win.

The second commit is the repo-wide \`oxlint --fix\` output (71 files), kept separate so the rule itself is easy to review in isolation. Two hand-tweaks in that commit: \`scripts/preview/{e2e-telemetry,preview}.ts\` spread on \`unknown\`-typed caught errors, where bare \`...(unknown && {…})\` is a TS2698 — those became \`...(!!input.error && {…})\` (identical runtime semantics, and \`!!\` makes the spread type \`false | {…}\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session: 2cf22af6-07ec-4d92-903d-9e3ca84d6682

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-13T07:37:51.178Z",
      "deployedAt": "2026-08-12T22:52:25.772Z",
      "headSha": "c6d5e43e8fcc34c4b89abe083b5765d013ea6744",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/521143544750980",
      "shortSha": "c6d5e43",
      "cleanupDurationMs": 14206,
      "deployDurationMs": 35331,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 33487,
      "deployReadinessDurationMs": 1841,
      "deployedWorkerName": "os-preview-12",
      "deployedWorkerVersion": "1bc42b35-9894-4f44-a8c3-9f4ddc59dd76",
      "testDurationMs": 229910,
      "testRetries": null,
      "workerSizeKib": 20777.26,
      "workerGzipKib": 5229.78,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5240.79
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-13T07:37:40.450Z",
      "deployedAt": "2026-08-12T22:52:02.554Z",
      "headSha": "c6d5e43e8fcc34c4b89abe083b5765d013ea6744",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-12.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/521143544750980",
      "shortSha": "c6d5e43",
      "cleanupDurationMs": 3475,
      "deployDurationMs": 10602,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 10266,
      "deployReadinessDurationMs": 332,
      "deployedWorkerName": "docs-preview-12",
      "deployedWorkerVersion": "f54664d2-f28c-4aa7-9886-f3f21e7a6969",
      "testDurationMs": 1887,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-08-13T07:37:38.231Z",
      "deployedAt": "2026-08-12T21:17:41.383Z",
      "headSha": "74cb49f0f73774ff9e592ab8aaae81d78575379d",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/521143544750980",
      "shortSha": "74cb49f",
      "cleanupDurationMs": 1254,
      "deployDurationMs": 18660,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 18493,
      "deployReadinessDurationMs": 163,
      "deployedWorkerName": "semaphore-preview-12",
      "deployedWorkerVersion": "9ee5d814-af85-408d-a653-7d663199b665",
      "testDurationMs": 20752,
      "testRetries": null,
      "workerSizeKib": 1915.75,
      "workerGzipKib": 441.16,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-13T07:37:41.481Z",
      "deployedAt": "2026-08-12T22:52:08.164Z",
      "headSha": "c6d5e43e8fcc34c4b89abe083b5765d013ea6744",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/521143544750980",
      "shortSha": "c6d5e43",
      "cleanupDurationMs": 4503,
      "deployDurationMs": 16208,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 15875,
      "deployReadinessDurationMs": 328,
      "deployedWorkerName": "auth-preview-12",
      "deployedWorkerVersion": "2228a6eb-a51a-4b1c-a9ad-86c47cafb924",
      "testDurationMs": 10107,
      "testRetries": null,
      "workerSizeKib": 3983.09,
      "workerGzipKib": 815.76,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-08-13T07:37:45.332Z",
      "deployedAt": "2026-08-12T21:17:42.143Z",
      "headSha": "74cb49f0f73774ff9e592ab8aaae81d78575379d",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/521143544750980",
      "shortSha": "74cb49f",
      "cleanupDurationMs": 8352,
      "deployDurationMs": 20189,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 19251,
      "deployReadinessDurationMs": 931,
      "deployedWorkerName": "streams-example-app-preview-12",
      "deployedWorkerVersion": "9d2df964-672d-4742-ac0a-023278145d69",
      "testDurationMs": 51177,
      "testRetries": null,
      "workerSizeKib": 5526.34,
      "workerGzipKib": 1561.9,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-13T07:37:39.631Z",
      "deployedAt": "2026-08-12T21:17:46.435Z",
      "headSha": "c6d5e43e8fcc34c4b89abe083b5765d013ea6744",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/521143544750980",
      "shortSha": "c6d5e43",
      "cleanupDurationMs": 1399,
      "deployDurationMs": 82,
      "deployConfigDurationMs": 7,
      "deployReuseProofDurationMs": 29,
      "deployedWorkerName": "dummy-petshop-preview-12",
      "deployedWorkerVersion": "187b760c-7c42-4872-b1d9-f17e9da6cade",
      "testDurationMs": 5593,
      "testRetries": null,
      "workerSizeKib": 1115.4,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "b717e505c46472150438e97f994eb4a2c283e0f8+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `c6d5e43` | [https://auth.iterate-preview-12.com](https://auth.iterate-preview-12.com) | 815.8 KiB | 16.2s | 10.1s |  | 4.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/521143544750980) | 2026-08-13T07:37:41.481Z | Preview app released. |
| Docs | released | `c6d5e43` | [https://docs-preview-12.iterate-dev-preview.workers.dev](https://docs-preview-12.iterate-dev-preview.workers.dev) | 866.2 KiB | 10.6s | 1.9s |  | 3.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/521143544750980) | 2026-08-13T07:37:40.450Z | Preview app released. |
| Dummy Petshop | released | `c6d5e43` | [https://dummy-petshop.iterate-preview-12.com](https://dummy-petshop.iterate-preview-12.com) | 198.3 KiB | 82ms | 5.6s |  | 1.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/521143544750980) | 2026-08-13T07:37:39.631Z | Preview app released. |
| OS | released | `c6d5e43` | [https://os.iterate-preview-12.com](https://os.iterate-preview-12.com) | 5.11 MiB (-11.0 KiB vs main) | 35.3s | 229.9s |  | 14.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/521143544750980) | 2026-08-13T07:37:51.178Z | Preview app released. |
| Semaphore | released | `74cb49f` | [https://semaphore.iterate-preview-12.com](https://semaphore.iterate-preview-12.com) | 441.2 KiB | 18.7s | 20.8s |  | 1.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/521143544750980) | 2026-08-13T07:37:38.231Z | Preview app released. |
| Streams Example App | released | `74cb49f` | [https://streams.iterate-preview-12.com](https://streams.iterate-preview-12.com) | 1.53 MiB | 20.2s | 51.2s |  | 8.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/521143544750980) | 2026-08-13T07:37:45.332Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +186 -208 | +184 -206 🟩🟩🟥🟥🟥 |
| Mobile | +29 -32 | +29 -32 🟥⬜⬜⬜⬜ |
| UI components | +29 -34 | +29 -34 🟥⬜⬜⬜⬜ |
| Tests | +184 -20 | +161 -20 🟩🟩⬜⬜⬜ |
| CI & scripts | +69 -79 | +69 -79 🟩🟥⬜⬜⬜ |
| Docs | +67 -0 | +52 -0 🟩⬜⬜⬜⬜ |
| Other | +60 -0 | +50 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+624 -373** | **+574 -371** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 258795c and c6d5e43, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- mobile-pr-preview -->
## 📱 Mobile preview

Channel `prefer-logical-and-spread` · runtime `023cbbc4d` · **JS-only** — the installed app can run it

<details open><summary>OTA — switch the installed app to this PR's channel (`c6d5e43`)</summary>

**[Switch this phone to the PR channel](https://os.iterate.com/m/preview-channel/prefer-logical-and-spread)**

<a href="https://os.iterate.com/m/preview-channel/prefer-logical-and-spread"><img src="https://github.com/iterate/iterate/releases/download/gh-attach-assets/mobile-pr-2487-c6d5e43e8-ota-scheme.png" width="90" alt="QR code" /></a>

</details>
<details><summary>Full install — if the app is uninstalled or the runtime differs (`c3b64f8`)</summary>

**[Open the EAS build install page](https://expo.dev/accounts/mishanustom/projects/iterate/builds/3fe243bc-7133-4020-9205-e6b67ab02ece)**

<a href="https://expo.dev/accounts/mishanustom/projects/iterate/builds/3fe243bc-7133-4020-9205-e6b67ab02ece"><img src="https://github.com/iterate/iterate/releases/download/gh-attach-assets/mobile-pr-2487-c6d5e43e8-install-3fe243bc.png" width="90" alt="QR code" /></a>

<sub>Installing gets you a compatible binary on the default channel — then use the OTA link above to switch it to this PR's JS.</sub>

</details>

<sub>Back to main inside the app: Build info → Reset to default channel. Republishes on every push to this PR.</sub>
<!-- /mobile-pr-preview -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical style refactor with parse-preserving fixes and no intended runtime behavior change; preview OS e2e failure on stream DO reset appears unrelated to spread rewrites.
> 
> **Overview**
> Introduces **`iterate/prefer-logical-and-spread`**, an auto-fixable oxlint rule that rewrites conditional object spreads from `...(cond ? obj : {})` to **`...(cond && obj)`**, because spreading any falsy value is already a no-op like `{}`.
> 
> The rule is enabled as **error** in `.oxlintrc.json`, implemented in `lint/oxlint-plugin-iterate.ts` with precedence-safe parentheses and fix-less reporting when comments would be dropped. **`lint/oxlint-plugin-logical-and-spread.test.ts`** exercises the real oxlint binary with `--fix`.
> 
> A separate mechanical pass updates **~71 files** across auth, OS, mobile, packages, and CI scripts. Three preview telemetry sites use `!!` on caught `unknown` errors so TypeScript accepts the spread after the rewrite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6d5e43e8fcc34c4b89abe083b5765d013ea6744. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->