### PR TITLE
Mobile one-tap test sign-in: Continue → consent → in the project

### DIFF
--- a/apps/auth/src/routes/_auth/project-access.tsx
+++ b/apps/auth/src/routes/_auth/project-access.tsx
@@ -41,6 +41,7 @@ import { Input } from "@iterate-com/ui/components/input";
 import { NativeSelect, NativeSelectOption } from "@iterate-com/ui/components/native-select";
 import { z } from "zod/v4";
 import { authClient, useSession } from "../../utils/auth-client.ts";
+import { shouldUseTestOtp } from "../../server/email.ts";
 import {
   oauthClientQueryOptions,
   organizationsQueryOptions,
@@ -53,9 +54,15 @@ import { parseConfig } from "../../config.ts";
 // Runs on the server for both SSR and client navigations. The hostname base
 // is this environment's deployed project domain (e.g. "iterate.app",
 // "iterate-preview-3.app") — onboarding previews "<slug>.<base>" under it.
-const getProjectAccessConfig = createServerFn({ method: "GET" }).handler(({ context }) => ({
-  projectHostnameBase: parseConfig(context.cloudflare.env).projectHostnameBase,
-}));
+// fixedTestOtpEnabled is not a secret (see login.tsx): it gates the test-user
+// auto-continue below.
+const getProjectAccessConfig = createServerFn({ method: "GET" }).handler(({ context }) => {
+  const config = parseConfig(context.cloudflare.env);
+  return {
+    projectHostnameBase: config.projectHostnameBase,
+    fixedTestOtpEnabled: config.fixedTestOtpEnabled,
+  };
+});
 
 export const Route = createFileRoute("/_auth/project-access")({
   component: RouteComponent,
@@ -96,7 +103,7 @@ const CreateProjectInput = z.object({
 
 function RouteComponent() {
   const { client_id, scope, redirect, project_hint } = Route.useSearch();
-  const { projectHostnameBase } = Route.useLoaderData();
+  const { projectHostnameBase, fixedTestOtpEnabled } = Route.useLoaderData();
   // Only a well-formed slug counts; anything else falls back to the derived
   // suggestion as if no hint arrived.
   const hintedProjectSlug = ProjectSlugInput.safeParse(project_hint).success
@@ -224,6 +231,43 @@ function RouteComponent() {
     },
   });
 
+  // Test users sail through project selection: on fixed-test-OTP deployments
+  // (never production — build-time flag) a signed-in `*+test@nustom.com`
+  // user's selection page would only ever be ceremony, so select every
+  // project and continue without a tap. This keeps the protocol shape
+  // identical to real users' (selection row → continue → consent — the
+  // consent screen still shows for untrusted clients); only the tap is gone.
+  // One-tap mobile test sign-in rides this (apps/mobile/src/lib/auth.ts).
+  const autoContinueProjectIds =
+    projectSelectionQuery.data?.flatMap((selection) =>
+      selection.projects.map((project) => project.id),
+    ) ?? [];
+  const testUserAutoContinue = Boolean(
+    hasOAuthClientId &&
+    needsProjectSelection &&
+    fixedTestOtpEnabled &&
+    shouldUseTestOtp({ email: session.user.email, fixedTestOtpEnabled }) &&
+    autoContinueProjectIds.length > 0,
+  );
+  const autoContinue = useQuery({
+    queryKey: ["test-user-auto-continue", client_id],
+    enabled: testUserAutoContinue,
+    retry: false,
+    staleTime: Infinity,
+    gcTime: Infinity,
+    queryFn: async () => {
+      await orpcClient.user.storeOAuthProjectSelection({
+        clientId: client_id!,
+        projectIds: autoContinueProjectIds,
+      });
+      const result = await authClient.oauth2.continue({ postLogin: true });
+      if (!result.url) {
+        throw new Error("Could not continue the OAuth redirect");
+      }
+      return redirectAndStayPending(preserveOAuthResourceSearchParam(result.url));
+    },
+  });
+
   const denyMutation = useMutation({
     mutationFn: async () => {
       const result = await authClient.oauth2.consent({ accept: false });
@@ -246,7 +290,15 @@ function RouteComponent() {
   const isLoadingOAuthClient = hasOAuthClientId && oauthClientQuery.isPending;
   const isLoadingProjectSelection = wantsProjects && projectSelectionQuery.isPending;
 
-  if (isLoadingOAuthClient || organizationsQuery.isPending || isLoadingProjectSelection) {
+  // While the test-user auto-continue is in flight, hold the loading skeleton
+  // so the selection card never flashes (and can't be double-submitted). If
+  // it errors, fall through to the normal interactive page.
+  if (
+    isLoadingOAuthClient ||
+    organizationsQuery.isPending ||
+    isLoadingProjectSelection ||
+    (testUserAutoContinue && !autoContinue.isError)
+  ) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-muted/20 p-4">
         <Card className="w-full max-w-xl">

--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -19,7 +19,6 @@ import {
   clearLastProject,
   getLastProject,
   getServerBaseUrl,
-  setLastProject,
   setServerBaseUrl,
 } from "../lib/storage.ts";
 import { colors, radius, spacing } from "../lib/theme.ts";
@@ -92,37 +91,17 @@ export default function SignInScreen() {
           ? { loginHint: hintedEmail }
           : {};
       await signIn(baseUrl, loginHint);
-      reconnectItxSession(baseUrl);
-      // An account with exactly one project (every CI-seeded test identity,
-      // and plenty of real ones) skips the picker: a single-item list is a
-      // pointless tap. The picker stays one Back away, and multi-project
-      // accounts land on it as before.
-      let onlyProject: { id: string; slug: string } | null = null;
-      try {
-        const itx = await getItxSession(baseUrl);
-        const entries = await itx.projects.list({ scope: "mine" });
-        if (entries.length === 1) {
-          await backfillProjectIfMissing(itx, entries[0]);
-          onlyProject = { id: entries[0].id, slug: entries[0].slug };
-          await setLastProject(baseUrl, onlyProject);
-        }
-      } catch {
-        // The picker owns list/backfill error states — fall through to it.
-        onlyProject = null;
-      }
-      return { baseUrl, onlyProject };
+      return baseUrl;
     },
-    onSuccess: ({ onlyProject }) => {
+    onSuccess: (baseUrl) => {
       setEditedServer(null);
+      reconnectItxSession(baseUrl);
       queryClient.clear();
-      if (onlyProject) {
-        router.replace({
-          pathname: "/project/[projectId]",
-          params: { projectId: onlyProject.id, slug: onlyProject.slug },
-        });
-      } else {
-        router.replace("/projects");
-      }
+      // autoOpen: fresh sign-ins skip the picker when the account has exactly
+      // one project (projects.tsx) — the first list can ride a cold itx
+      // WebSocket, so the decision lives in the picker's retrying query, not
+      // here. Plain /projects visits (Back from a project) never auto-open.
+      router.replace({ pathname: "/projects", params: { autoOpen: "1" } });
     },
   });
 

--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -19,6 +19,7 @@ import {
   clearLastProject,
   getLastProject,
   getServerBaseUrl,
+  setLastProject,
   setServerBaseUrl,
 } from "../lib/storage.ts";
 import { colors, radius, spacing } from "../lib/theme.ts";
@@ -91,13 +92,37 @@ export default function SignInScreen() {
           ? { loginHint: hintedEmail }
           : {};
       await signIn(baseUrl, loginHint);
-      return baseUrl;
-    },
-    onSuccess: (baseUrl) => {
-      setEditedServer(null);
       reconnectItxSession(baseUrl);
+      // An account with exactly one project (every CI-seeded test identity,
+      // and plenty of real ones) skips the picker: a single-item list is a
+      // pointless tap. The picker stays one Back away, and multi-project
+      // accounts land on it as before.
+      let onlyProject: { id: string; slug: string } | null = null;
+      try {
+        const itx = await getItxSession(baseUrl);
+        const entries = await itx.projects.list({ scope: "mine" });
+        if (entries.length === 1) {
+          await backfillProjectIfMissing(itx, entries[0]);
+          onlyProject = { id: entries[0].id, slug: entries[0].slug };
+          await setLastProject(baseUrl, onlyProject);
+        }
+      } catch {
+        // The picker owns list/backfill error states — fall through to it.
+        onlyProject = null;
+      }
+      return { baseUrl, onlyProject };
+    },
+    onSuccess: ({ onlyProject }) => {
+      setEditedServer(null);
       queryClient.clear();
-      router.replace("/projects");
+      if (onlyProject) {
+        router.replace({
+          pathname: "/project/[projectId]",
+          params: { projectId: onlyProject.id, slug: onlyProject.slug },
+        });
+      } else {
+        router.replace("/projects");
+      }
     },
   });
 

--- a/apps/mobile/src/app/preview-channel/[channel].tsx
+++ b/apps/mobile/src/app/preview-channel/[channel].tsx
@@ -65,9 +65,17 @@ export default function PreviewChannelScreen() {
     mutationFn: async () => {
       // The Switch tap IS the consent for the whole plan (channel + backend +
       // test identity): mark it before the reload wipes this process, so the
-      // re-opened screen continues without a second tap.
+      // re-opened screen continues without a second tap. A real reload never
+      // returns from switchChannelAndReload — reaching the line below means
+      // the OLD bundle is still running ("no-update": nothing published, or
+      // the PR has native changes), where auto-continuing would both hide
+      // that message and apply the old bundle's plan. Take the consent back.
       await setAutoContinueChannel(channel);
-      return switchChannelAndReload(channel);
+      const result = await switchChannelAndReload(channel);
+      if (result === "no-update") {
+        await clearAutoContinueChannel();
+      }
+      return result;
     },
     // Only reaches onSuccess without a reload ("no-update"); the invalidate
     // flips `current` and the button below becomes "Continue". After a real

--- a/apps/mobile/src/app/preview-channel/[channel].tsx
+++ b/apps/mobile/src/app/preview-channel/[channel].tsx
@@ -12,7 +12,10 @@
 // - Backend/identity differences from the running bundle's expectation are
 //   SHOWN, and the fix rides Continue as a default-checked checkbox — wanting
 //   the PR's JS almost always means wanting its backend + test identity too,
-//   but unticking keeps the plain channel switch. Never applied silently.
+//   but unticking keeps the plain channel switch. Never applied from a bare
+//   scan — but a Switch TAP consents to the whole plan, so the post-switch
+//   re-entry continues by itself (the one-shot marker in
+//   lib/preview-channel.ts) instead of asking for a second tap.
 //   The stamp resolves against the preset list only (lib/expected-backend.ts),
 //   so a poisoned bundle stamp can't name an arbitrary server.
 import { useState } from "react";
@@ -30,8 +33,11 @@ import {
 } from "../../lib/expected-backend.ts";
 import { reconnectItxSession } from "../../lib/itx.ts";
 import {
+  clearAutoContinueChannel,
   fetchLatestUpdateAndReload,
+  getAutoContinueChannel,
   getPreviewChannelOverride,
+  setAutoContinueChannel,
   switchChannelAndReload,
 } from "../../lib/preview-channel.ts";
 import { DEFAULT_SERVER } from "../../lib/servers.ts";
@@ -56,7 +62,13 @@ export default function PreviewChannelScreen() {
   const recommendedServer = expectation.server;
 
   const switchChannel = useMutation({
-    mutationFn: () => switchChannelAndReload(channel),
+    mutationFn: async () => {
+      // The Switch tap IS the consent for the whole plan (channel + backend +
+      // test identity): mark it before the reload wipes this process, so the
+      // re-opened screen continues without a second tap.
+      await setAutoContinueChannel(channel);
+      return switchChannelAndReload(channel);
+    },
     // Only reaches onSuccess without a reload ("no-update"); the invalidate
     // flips `current` and the button below becomes "Continue". After a real
     // reload the deep link re-opens this screen in the NEW bundle.
@@ -125,12 +137,49 @@ export default function PreviewChannelScreen() {
       return input.baseUrl;
     },
     // Mirrors the sign-in screen's login mutation: reconnect on the new
-    // deployment, drop every cached read, land on the boot path (which
-    // fast-forwards to the remembered project or the picker).
-    onSuccess: (baseUrl) => {
+    // deployment, drop every cached read, and land where it does — fresh
+    // sign-ins go to the picker with autoOpen so a single-project account
+    // (every per-PR test identity) skips it; a plain server switch takes the
+    // boot path (remembered project or picker).
+    onSuccess: (baseUrl, input) => {
       reconnectItxSession(baseUrl);
       queryClient.clear();
-      router.replace("/");
+      if (input.type === "sign-in") {
+        router.replace({ pathname: "/projects", params: { autoOpen: "1" } });
+      } else {
+        router.replace("/");
+      }
+    },
+  });
+
+  // The post-switch auto-continue: once the switch-reload has re-opened this
+  // screen and everything has settled (freshness verdict in, phone state
+  // read), do exactly what the Continue button would — but only when the
+  // one-shot marker from the Switch tap is present. Fresh scans of a channel
+  // the app is already on have no marker and keep the reassurance screen.
+  // A query rather than an effect, like the freshness check above.
+  useQuery({
+    queryKey: ["qr-channel-auto-continue", channel],
+    enabled:
+      alreadyOnTarget &&
+      !reloadImminent &&
+      (!canOta || freshness.isSuccess || freshness.isError) &&
+      (recommendedServer === null || phoneState.isSuccess || phoneState.isError),
+    staleTime: Infinity,
+    refetchOnMount: "always",
+    retry: false,
+    queryFn: async () => {
+      const pending = await getAutoContinueChannel();
+      if (pending !== channel) {
+        return "none" as const;
+      }
+      await clearAutoContinueChannel();
+      if (plan !== null) {
+        await applyPlan.mutateAsync(plan);
+      } else {
+        router.replace("/");
+      }
+      return "continued" as const;
     },
   });
 

--- a/apps/mobile/src/app/projects.tsx
+++ b/apps/mobile/src/app/projects.tsx
@@ -5,7 +5,7 @@
 // own their teardown when sign-out replaces this route.
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { router, Stack } from "expo-router";
+import { router, Stack, useLocalSearchParams } from "expo-router";
 import { ActivityIndicator, FlatList, Pressable, StyleSheet, Text, View } from "react-native";
 import type { ProjectListEntry } from "iterate/sdk/itx/react";
 import { AppDrawerButton } from "../components/project-drawer.tsx";
@@ -19,13 +19,30 @@ import { colors, radius, spacing } from "../lib/theme.ts";
 
 export default function ProjectsScreen() {
   const queryClient = useQueryClient();
+  // Set by the sign-in screen's post-login navigation: an account with
+  // exactly one project skips the picker — a single-item list is a pointless
+  // tap. Only fresh sign-ins carry it, so Back from a project (plain
+  // /projects) always shows the picker.
+  const { autoOpen } = useLocalSearchParams<{ autoOpen?: string }>();
   const projects = useQuery({
-    queryKey: ["projects"],
+    queryKey: ["projects", { autoOpen: Boolean(autoOpen) }],
     queryFn: async () => {
       const baseUrl = (await getServerBaseUrl()) || DEFAULT_SERVER;
       try {
         const itx = await getItxSession(baseUrl);
         const list = await itx.projects.list({ scope: "mine" });
+        // Navigate from the query, not render (same rationale as the
+        // sign-in redirect below) — and from HERE rather than the sign-in
+        // mutation so the cold-itx first list gets this query's retries.
+        if (autoOpen && list.length === 1) {
+          const project = list[0];
+          await backfillProjectIfMissing(itx, project);
+          await setLastProject(baseUrl, { id: project.id, slug: project.slug });
+          router.replace({
+            pathname: "/project/[projectId]",
+            params: { projectId: project.id, slug: project.slug },
+          });
+        }
         return { baseUrl, list };
       } catch (error) {
         // Redirect from the async failure, not render: render-time

--- a/apps/mobile/src/lib/auth.ts
+++ b/apps/mobile/src/lib/auth.ts
@@ -137,14 +137,24 @@ export async function signIn(baseUrl: string, options: { loginHint?: string } = 
   // fixed-OTP sign-in server-side and bounces straight into this same
   // authorize URL with the session cookie set. The user's first page is the
   // consent screen — deliberately kept, since the app is a userland client.
+  // Probed first: a param-less GET answers 400 ("email must be…") exactly
+  // where the endpoint exists and is enabled, without signing anything in —
+  // anywhere else (stale deployment, prod, network trouble) the wrap is
+  // skipped and the plain authorize URL still carries the login_hint, so the
+  // fallback is the prefilled login page rather than a 404.
   const testLoginHint =
     options.loginHint && /\+test@nustom\.com$/i.test(options.loginHint) ? options.loginHint : null;
   const promptUrl = testLoginHint
     ? await (async () => {
-        const url = new URL("/test-login", issuer);
-        url.searchParams.set("email", testLoginHint);
-        url.searchParams.set("return_to", await request.makeAuthUrlAsync(discovery));
-        return url.toString();
+        const testLoginUrl = new URL("/test-login", issuer);
+        const probe = await fetch(testLoginUrl).catch(() => null);
+        if (probe?.status !== 400) {
+          console.log(`[auth] /test-login unavailable (${probe?.status}); using the login page`);
+          return undefined;
+        }
+        testLoginUrl.searchParams.set("email", testLoginHint);
+        testLoginUrl.searchParams.set("return_to", await request.makeAuthUrlAsync(discovery));
+        return testLoginUrl.toString();
       })()
     : undefined;
   console.log(`[auth] prompting: redirectUri=${REDIRECT_URI} clientId=${clientId}`);

--- a/apps/mobile/src/lib/auth.ts
+++ b/apps/mobile/src/lib/auth.ts
@@ -122,16 +122,33 @@ export async function signIn(baseUrl: string, options: { loginHint?: string } = 
     extraParams: {
       resource,
       // Rides the OAuth authorize request into the auth worker's login page,
-      // which prefills it — and, for `*+test@nustom.com` on deployments with
-      // the test OTP enabled, signs in with it automatically (preview QR
-      // deep links carry a per-PR test identity).
+      // which prefills it (preview QR deep links carry a per-PR test
+      // identity). For test addresses the browser doesn't even land there —
+      // see the /test-login wrap below — but the hint stays on the authorize
+      // request so the fallback (endpoint missing on a stale deployment) is
+      // the prefilled login page, not a blank one.
       ...(options.loginHint ? { login_hint: options.loginHint } : {}),
     },
   });
+  const discovery = { authorizationEndpoint: config.authorization_endpoint };
+  // Test identities skip the login screen entirely: route the browser through
+  // the auth worker's /test-login (fixed-test-OTP deployments only — 404 in
+  // production, apps/auth/src/server/test-login.ts), which completes the
+  // fixed-OTP sign-in server-side and bounces straight into this same
+  // authorize URL with the session cookie set. The user's first page is the
+  // consent screen — deliberately kept, since the app is a userland client.
+  const testLoginHint =
+    options.loginHint && /\+test@nustom\.com$/i.test(options.loginHint) ? options.loginHint : null;
+  const promptUrl = testLoginHint
+    ? await (async () => {
+        const url = new URL("/test-login", issuer);
+        url.searchParams.set("email", testLoginHint);
+        url.searchParams.set("return_to", await request.makeAuthUrlAsync(discovery));
+        return url.toString();
+      })()
+    : undefined;
   console.log(`[auth] prompting: redirectUri=${REDIRECT_URI} clientId=${clientId}`);
-  const result = await request.promptAsync({
-    authorizationEndpoint: config.authorization_endpoint,
-  });
+  const result = await request.promptAsync(discovery, promptUrl ? { url: promptUrl } : {});
   console.log(
     `[auth] prompt result: type=${result.type}` +
       (result.type === "success" ? ` params=${JSON.stringify(Object.keys(result.params))}` : "") +

--- a/apps/mobile/src/lib/preview-channel.ts
+++ b/apps/mobile/src/lib/preview-channel.ts
@@ -23,6 +23,27 @@ export async function getPreviewChannelOverride() {
   return AsyncStorage.getItem(STORAGE_KEY);
 }
 
+// One-shot marker: the user tapped "Switch to <channel>", which already says
+// "run this PR's JS against its backend as its identity" — the confirm screen
+// re-opened by the switch-reload applies the bundle's recommended setup
+// without a second Continue tap. Persisted (not JS state) because the reload
+// wipes the process; consumed by the ACTION, not the read, so an intervening
+// freshness reload doesn't drop the intent. Fresh scans of a channel the app
+// is already on never set it — those keep the reassurance screen.
+const AUTO_CONTINUE_KEY = "preview-channel-auto-continue";
+
+export async function setAutoContinueChannel(channel: string) {
+  await AsyncStorage.setItem(AUTO_CONTINUE_KEY, channel);
+}
+
+export async function getAutoContinueChannel() {
+  return AsyncStorage.getItem(AUTO_CONTINUE_KEY);
+}
+
+export async function clearAutoContinueChannel() {
+  await AsyncStorage.removeItem(AUTO_CONTINUE_KEY);
+}
+
 /** Switch channel, then pull whatever it has. Returns what happened so the
  * caller can show it; only "reloading" actually restarts the app. */
 export async function switchChannelAndReload(channel: string | null) {

--- a/specs/mobile/approvals.spec.ts
+++ b/specs/mobile/approvals.spec.ts
@@ -74,7 +74,7 @@ test("approve and reject script bursts from inside the chat thread", async ({ pa
     // separate Page outside the plugged middleware (no spinner-waiter to
     // extend), and these clicks land after auth-worker navigations that run
     // cold on fresh preview deploys — CI-proven >1s.
-    await popup.getByRole("button", { name: "Continue" }).click({ timeout: 15_000 });
+    // Project selection auto-continues for test identities (project-access.tsx).
     await popup.getByRole("button", { name: "Allow access" }).click({ timeout: 15_000 });
 
     // Opening the project auto-enrolls this browser's approval key — no
@@ -82,7 +82,7 @@ test("approve and reject script bursts from inside the chat thread", async ({ pa
     // itx WebSocket to the deployment (~20-30s against preview slots) — a
     // product-latency problem worth fixing at the source, not something more
     // spinner UI can paper over.
-    await page.getByText(projectSlug).click();
+    // The app auto-opens the account's only project — no picker tap.
     await page.getByText("New chat").waitFor();
     const projectId = new URL(page.url()).pathname.split("/")[2]!;
 

--- a/specs/mobile/expected-backend-signin.spec.ts
+++ b/specs/mobile/expected-backend-signin.spec.ts
@@ -1,9 +1,11 @@
-// Proof that the bundle's baked-in expectation reaches a REAL deployed auth
-// screen: the sign-in screen shows the expected backend, Sign in opens the
-// deployment's actual /oauth2/authorize (whose signed /login redirect must
-// carry the login_hint — the @better-auth/oauth-provider patch), and the
-// login page offers "Continue as <test email>" with the fixed test OTP
-// prefilled after one press.
+// Proof that the bundle's baked-in expectation drives a one-tap sign-in
+// against a REAL deployed auth worker: the sign-in screen shows the expected
+// backend, Sign in routes the browser through the deployment's /test-login
+// (apps/auth/src/server/test-login.ts — server-side fixed-OTP sign-in, then
+// straight into the authorize URL), project selection auto-continues for the
+// test identity, and the first interactive page is the consent screen — the
+// deliberate "userland client" moment. Allowing access completes the code
+// exchange and the app lands in the identity's only project, no picker.
 //
 // The expectation is stamped into build-info.json at publish time
 // (apps/mobile/scripts/write-build-info.mjs); the web dev bundle here is
@@ -16,7 +18,6 @@
 // Skipped otherwise — the stamp must name an envs.ts preset, and prd keeps
 // the fixed test OTP off.
 
-import { expect } from "@playwright/test";
 import { deployedPreviewEnvs } from "../../envs.ts";
 import { test } from "../test-support/test.ts";
 
@@ -53,7 +54,7 @@ test("scanning the channel you're already on shows the bundle's expected backend
   await page.getByText(`test sign-in as ${HINT_EMAIL}`).waitFor();
 });
 
-test("the bundle's expectation survives to a real auth screen with the test OTP prefilled", async ({
+test("one tap signs the test identity in: consent is the only stop before the project", async ({
   page,
   context,
 }) => {
@@ -77,27 +78,23 @@ test("the bundle's expectation survives to a real auth screen with the test OTP 
   await page.locator(`input[value="${target!.baseUrl}"]`).waitFor();
 
   // Sign in opens the REAL auth deployment in a popup (OIDC discovery +
-  // client registration + authorize happen live against the slot).
+  // client registration happen live against the slot) — routed through
+  // /test-login, so the login page and OTP screen never appear.
   // timeout: cold cross-server auth navigation — no loading UI for the spinner waiter
   const popupPromise = context.waitForEvent("page", { timeout: 45_000 });
   await page.getByRole("button", { name: "Sign in" }).click();
   const popup = await popupPromise;
 
-  // The signed /login redirect carried the login_hint: the page offers the
-  // hinted identity as its primary action.
-  const continueAs = popup.getByRole("button", { name: `Continue as ${HINT_EMAIL}` });
-  // timeout: the popup is outside the wrapped page, so no spinner waiter covers it
-  await continueAs.waitFor({ timeout: 45_000 });
-  await continueAs.click();
+  // First interactive page: consent, already signed in as the hinted
+  // identity with project selection auto-continued behind the scenes. This
+  // stop is deliberate — the mobile app is an untrusted userland client.
+  // timeout: unwrapped popup (no spinner waiter) + first-visit /test-login seeding
+  await popup.getByText("Allow Iterate (iOS)?").waitFor({ timeout: 45_000 });
+  await popup.getByRole("button", { name: "Allow access" }).click();
 
-  // One press later: the normal OTP screen, code already filled with the
-  // fixed test OTP. The user only confirms.
-  await popup
-    .getByText(`Enter the 6-digit code sent to ${HINT_EMAIL}`)
-    // timeout: unwrapped popup — the spinner waiter cannot see it
-    .waitFor({ timeout: 30_000 });
-  await expect
-    // timeout: unwrapped popup — the spinner waiter cannot see it
-    .poll(() => popup.getByTestId("email-otp-input").inputValue(), { timeout: 10_000 })
-    .toBe("424242");
+  // Allowing access finishes the code exchange; the app opens the identity's
+  // only project directly ("New chat" is the project chat screen) — no
+  // project picker for a single-project account.
+  // timeout: popup handoff + cold OS-side backfill create, both outside the spinner waiter
+  await page.getByText("New chat").waitFor({ timeout: 90_000 });
 });

--- a/specs/mobile/integrations.spec.ts
+++ b/specs/mobile/integrations.spec.ts
@@ -29,12 +29,12 @@ test("opens the project integration catalogue from the mobile drawer", async ({
     projectSlug,
     testInfo,
   });
-  // timeout: same unwrapped popup — the spinner waiter cannot see it.
-  await popup.getByRole("button", { name: "Continue" }).click({ timeout: 15_000 });
+  // Project selection auto-continues for test identities (project-access.tsx)
+  // — consent is the next interactive page.
   // timeout: same unwrapped popup — the spinner waiter cannot see it.
   await popup.getByRole("button", { name: "Allow access" }).click({ timeout: 15_000 });
 
-  await page.getByText(projectSlug).click();
+  // The app auto-opens the account's only project — no picker tap.
   await page.getByText("New chat").waitFor();
   await page.getByLabel("Open project menu").filter({ visible: true }).click();
   await page.getByRole("button", { name: "/agents" }).waitFor();

--- a/specs/mobile/media.spec.ts
+++ b/specs/mobile/media.spec.ts
@@ -151,11 +151,11 @@ async function signUpToProject(
     projectSlug,
     testInfo,
   });
-  // timeout: same unwrapped popup — the spinner waiter cannot see it.
-  await popup.getByRole("button", { name: "Continue" }).click({ timeout: 15_000 });
+  // Project selection auto-continues for test identities (project-access.tsx)
+  // — consent is the next interactive page.
   // timeout: same unwrapped popup — the spinner waiter cannot see it.
   await popup.getByRole("button", { name: "Allow access" }).click({ timeout: 15_000 });
-  await page.getByText(projectSlug).click();
+  // The app auto-opens the account's only project — no picker tap.
   await page.getByText("New chat").waitFor();
 }
 

--- a/specs/mobile/notes.spec.ts
+++ b/specs/mobile/notes.spec.ts
@@ -97,11 +97,11 @@ async function signUpToProject(
     projectSlug,
     testInfo,
   });
-  // timeout: same unwrapped popup — the spinner waiter cannot see it.
-  await popup.getByRole("button", { name: "Continue" }).click({ timeout: 15_000 });
+  // Project selection auto-continues for test identities (project-access.tsx)
+  // — consent is the next interactive page.
   // timeout: same unwrapped popup — the spinner waiter cannot see it.
   await popup.getByRole("button", { name: "Allow access" }).click({ timeout: 15_000 });
-  await page.getByText(projectSlug).click();
+  // The app auto-opens the account's only project — no picker tap.
   await page.getByText("New chat").waitFor();
 }
 

--- a/specs/mobile/notifications.spec.ts
+++ b/specs/mobile/notifications.spec.ts
@@ -79,9 +79,9 @@ test("the approval push is suppressed in the watched thread and sent when you're
     // separate Page outside the plugged middleware (no spinner-waiter to
     // extend), and these clicks land after auth-worker navigations that run
     // cold on fresh preview deploys — CI-proven >1s.
-    await popup.getByRole("button", { name: "Continue" }).click({ timeout: 15_000 });
+    // Project selection auto-continues for test identities (project-access.tsx).
     await popup.getByRole("button", { name: "Allow access" }).click({ timeout: 15_000 });
-    await page.getByText(projectSlug).click();
+    // The app auto-opens the account's only project — no picker tap.
     await page.getByText("New chat").waitFor();
     const projectId = new URL(page.url()).pathname.split("/")[2]!;
 

--- a/tasks/mobile-one-tap-login.md
+++ b/tasks/mobile-one-tap-login.md
@@ -1,0 +1,53 @@
+---
+status: in-progress
+size: small
+base: preview-one-click-login (#2485)
+---
+
+# Mobile one-tap test sign-in
+
+## Status summary
+
+Implemented, awaiting preview CI (the rewritten mobile spec runs in the
+preview lane). Stacked on [#2485](https://github.com/iterate/iterate/pull/2485).
+
+## Ask
+
+Mobile preview sign-in took 7 taps. Decision from discussion: keep the
+consent screen ("the mobile app is effectively a userland app/client") and
+the unavoidable native ASWebAuthenticationSession dialog; kill everything
+else. 7 → 3 (or "2 that count": Continue + Allow access).
+
+| Old tap | Fate | How |
+| --- | --- | --- |
+| 1 Continue | stays | — |
+| 2 native dialog | stays | iOS requirement of ASWebAuthenticationSession |
+| 3 Continue with email | gone | browser routed through `/test-login?email=…&return_to=<authorize URL>` |
+| 4 OTP submit | gone | same |
+| 5 project-access Accept | gone | page auto-selects all + continues for test users (fixed-OTP deployments only) |
+| 6 consent Authorize | **kept deliberately** | mobile stays an untrusted dynamically-registered client |
+| 7 in-app project picker | gone | auto-open when the account has exactly one project (general UX win, not test-only) |
+
+## Checklist
+
+- [x] mobile: route test-identity sign-ins through `/test-login` — _apps/mobile/src/lib/auth.ts: `makeAuthUrlAsync` + `promptAsync(discovery, {url})`; gated on the hint matching `+test@nustom.com`; fallback (stale deployment without the endpoint) is the old prefilled login page since login_hint still rides the authorize URL_
+- [x] auth: project-access auto-continue for test users — _apps/auth/src/routes/_auth/project-access.tsx: gated on build-time `fixedTestOtpEnabled` + `shouldUseTestOtp(session email)` + OAuth flow with projects; selects every project, stores selection, `oauth2.continue`; holds the loading skeleton while in flight; falls back to the interactive page on error_
+- [x] mobile: auto-open single project after sign-in — _apps/mobile/src/app/index.tsx login mutation: list projects post-signin, exactly one → backfill + setLastProject + straight to `/project/[projectId]`_
+- [x] spec: pin the new flow — _specs/mobile/expected-backend-signin.spec.ts: popup's first interactive page is consent ("Allow Iterate (iOS)?"), Allow access → app lands on the project chat screen ("New chat"), no login/OTP/selection/picker anywhere_
+
+## Implementation log
+
+- expo-auth-session supports the wrap cleanly: `AuthRequest.makeAuthUrlAsync`
+  builds the real authorize URL (PKCE intact), `promptAsync(discovery, {url})`
+  opens the wrapper instead. `/test-login` already accepts same-origin
+  absolute `return_to` (the authorize endpoint is on the auth origin), so no
+  endpoint changes were needed.
+- project-access auto-continue uses a gated `useQuery` (no useEffect) that
+  performs the same store-selection + continue the manual button does, and
+  never resolves (redirect keeps it pending) — mirroring the page's
+  `redirectAndStayPending` convention.
+- Kept the protocol shape identical for test users: selection row →
+  consentReferenceId narrowing → project-scoped token. Only the tap is gone.
+- Auto-open single project is deliberately NOT test-gated: a one-item picker
+  is a pointless tap for real users too. The picker remains reachable (Back,
+  and multi-project accounts land on it as before).

--- a/tasks/mobile-one-tap-login.md
+++ b/tasks/mobile-one-tap-login.md
@@ -37,6 +37,18 @@ else. 7 → 3 (or "2 that count": Continue + Allow access).
 
 ## Implementation log
 
+- Misha's phone test exposed two QR-flow gaps (the QR confirm screen has its
+  own sign-in path, separate from the sign-in screen): its `applyPlan`
+  landed on the boot path with no `autoOpen`, so the picker still demanded a
+  tap; and the post-switch re-entry waited for a second "Continue" even
+  though the Switch tap already said everything. Fixed: `applyPlan`
+  navigates to the picker with `autoOpen` for sign-in plans, and the Switch
+  tap persists a one-shot marker (AsyncStorage — the reload wipes JS state)
+  that the re-opened screen consumes to continue by itself once freshness
+  and phone-state settle. Bare rescans of the current channel set no marker
+  and keep the reassurance screen, so the untick affordance and existing
+  specs stay intact. QR flow is now: Switch → native dialog → Allow access.
+
 - expo-auth-session supports the wrap cleanly: `AuthRequest.makeAuthUrlAsync`
   builds the real authorize URL (PKCE intact), `promptAsync(discovery, {url})`
   opens the wrapper instead. `/test-login` already accepts same-origin

--- a/tasks/mobile-one-tap-login.md
+++ b/tasks/mobile-one-tap-login.md
@@ -51,3 +51,11 @@ else. 7 → 3 (or "2 that count": Continue + Allow access).
 - Auto-open single project is deliberately NOT test-gated: a one-item picker
   is a pointless tap for real users too. The picker remains reachable (Back,
   and multi-project accounts land on it as before).
+- First CI round: four older mobile specs still tapped "Continue" on
+  project-access and the project in the picker — removed both (that's the
+  feature). Auto-open initially lived in the sign-in mutation with a single
+  attempt; the first project list rides a cold itx WebSocket (~20-30s on
+  preview slots) so it sometimes fell back to the picker. Moved it into the
+  picker's own retrying query, keyed by an `autoOpen` param only the sign-in
+  navigation sets — deterministic, and Back-to-picker never auto-bounces.
+  Verified against preview-5 locally: 8 passed / 1 skipped, approvals green.


### PR DESCRIPTION
Stacked on #2485 (base branch `preview-one-click-login` — merge that first).

Mobile preview sign-in was 7 taps. Now it's tap **Continue**, accept the native browser dialog, tap **Allow access** — and you're in the project. Per discussion: the consent screen stays **on purpose** (the mobile app is a userland client — dynamically registered, untrusted, and should feel like one), and the native ASWebAuthenticationSession dialog is an iOS requirement.

| Old tap | Now |
| --- | --- |
| Continue | ✅ stays |
| native browser dialog | stays (iOS requirement) |
| "Continue with \<email\>" | gone — browser routes through `/test-login`, which signs in server-side and lands on the authorize URL |
| OTP submit | gone — same |
| project-access "Accept" | gone — auto-selects + continues for test users on fixed-OTP deployments (never prod; build-time flag). Protocol shape unchanged: selection row → consent → project-scoped token |
| consent "Allow access" | ✅ **kept deliberately** |
| in-app project picker | gone when the account has exactly one project (not test-gated — a one-item picker is a pointless tap for real users too; multi-project accounts see it as before) |

Fallback: on a deployment without `/test-login` (stale auth), the login_hint still rides the authorize URL, so the browser falls back to the old prefilled login page rather than breaking.

The deployed-slot mobile spec now pins the whole flow: popup's first interactive page is consent, Allow access lands on the project chat screen — login page, OTP, selection page, and picker never appear.

See [tasks/mobile-one-tap-login.md](tasks/mobile-one-tap-login.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-13T08:55:43.440Z",
      "deployedAt": "2026-08-13T08:43:54.023Z",
      "headSha": "e4930e24270b879e16761b72459a5a1d877c177e",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/4415125275036",
      "shortSha": "e4930e2",
      "cleanupDurationMs": 15879,
      "deployDurationMs": 65185,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 63417,
      "deployReadinessDurationMs": 1764,
      "deployedWorkerName": "os-preview-5",
      "deployedWorkerVersion": "39091072-91de-49a6-b2ca-5ba64484b7bf",
      "testDurationMs": 224608,
      "testRetries": null,
      "workerSizeKib": 20777.4,
      "workerGzipKib": 5229.62,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5241.12
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-13T08:55:31.135Z",
      "deployedAt": "2026-08-13T08:43:02.212Z",
      "headSha": "e4930e24270b879e16761b72459a5a1d877c177e",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-5.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/4415125275036",
      "shortSha": "e4930e2",
      "cleanupDurationMs": 3572,
      "deployDurationMs": 11798,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 11603,
      "deployReadinessDurationMs": 190,
      "deployedWorkerName": "docs-preview-5",
      "deployedWorkerVersion": "0efec3ee-c334-4a59-add6-f89a85754e79",
      "testDurationMs": 1889,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-13T08:55:31.604Z",
      "deployedAt": "2026-08-13T08:43:09.332Z",
      "headSha": "e4930e24270b879e16761b72459a5a1d877c177e",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/4415125275036",
      "shortSha": "e4930e2",
      "cleanupDurationMs": 4040,
      "deployDurationMs": 19055,
      "deployConfigDurationMs": 7,
      "deployCommandDurationMs": 18720,
      "deployReadinessDurationMs": 328,
      "deployedWorkerName": "auth-preview-5",
      "deployedWorkerVersion": "ab6bdc63-224b-44f1-a9f4-d9390dc203f4",
      "testDurationMs": 16528,
      "testRetries": null,
      "workerSizeKib": 3989.66,
      "workerGzipKib": 817.25,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-13T08:55:28.647Z",
      "deployedAt": "2026-08-13T08:43:07.940Z",
      "headSha": "e4930e24270b879e16761b72459a5a1d877c177e",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/4415125275036",
      "shortSha": "e4930e2",
      "cleanupDurationMs": 1081,
      "deployDurationMs": 5730,
      "deployConfigDurationMs": 1,
      "deployCommandDurationMs": 5533,
      "deployReadinessDurationMs": 193,
      "deployedWorkerName": "dummy-petshop-preview-5",
      "deployedWorkerVersion": "1635f826-c71c-4bad-9b8d-14a9bea3a95e",
      "testDurationMs": 44544,
      "testRetries": null,
      "workerSizeKib": 1115.4,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "b717e505c46472150438e97f994eb4a2c283e0f8+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-08-13T08:55:28.234Z",
      "deployedAt": "2026-08-13T08:43:05.471Z",
      "headSha": "e4930e24270b879e16761b72459a5a1d877c177e",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/4415125275036",
      "shortSha": "e4930e2",
      "cleanupDurationMs": 665,
      "deployDurationMs": 15052,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 14860,
      "deployReadinessDurationMs": 186,
      "deployedWorkerName": "semaphore-preview-5",
      "deployedWorkerVersion": "f78d316c-cc51-42be-82de-17c61ae3b193",
      "testDurationMs": 61154,
      "testRetries": null,
      "workerSizeKib": 1915.75,
      "workerGzipKib": 441.16,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-08-13T08:55:40.129Z",
      "deployedAt": "2026-08-13T08:43:05.567Z",
      "headSha": "e4930e24270b879e16761b72459a5a1d877c177e",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/4415125275036",
      "shortSha": "e4930e2",
      "cleanupDurationMs": 11895,
      "deployDurationMs": 15738,
      "deployConfigDurationMs": 47,
      "deployCommandDurationMs": 14914,
      "deployReadinessDurationMs": 777,
      "deployedWorkerName": "streams-example-app-preview-5",
      "deployedWorkerVersion": "ca86ddbf-59da-443b-83e1-b2c9b6f8cd9d",
      "testDurationMs": 87413,
      "testRetries": null,
      "workerSizeKib": 5526.48,
      "workerGzipKib": 1561.93,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `e4930e2` | [https://auth.iterate-preview-5.com](https://auth.iterate-preview-5.com) | 817.3 KiB | 19.1s | 16.5s |  | 4.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/4415125275036) | 2026-08-13T08:55:31.604Z | Preview app released. |
| Docs | released | `e4930e2` | [https://docs-preview-5.iterate-dev-preview.workers.dev](https://docs-preview-5.iterate-dev-preview.workers.dev) | 866.2 KiB | 11.8s | 1.9s |  | 3.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/4415125275036) | 2026-08-13T08:55:31.135Z | Preview app released. |
| Dummy Petshop | released | `e4930e2` | [https://dummy-petshop.iterate-preview-5.com](https://dummy-petshop.iterate-preview-5.com) | 198.3 KiB | 5.7s | 44.5s |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/4415125275036) | 2026-08-13T08:55:28.647Z | Preview app released. |
| OS | released | `e4930e2` | [https://os.iterate-preview-5.com](https://os.iterate-preview-5.com) | 5.11 MiB (-11.5 KiB vs main) | 65.2s | 224.6s |  | 15.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/4415125275036) | 2026-08-13T08:55:43.440Z | Preview app released. |
| Semaphore | released | `e4930e2` | [https://semaphore.iterate-preview-5.com](https://semaphore.iterate-preview-5.com) | 441.2 KiB | 15.1s | 61.2s |  | 665ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/4415125275036) | 2026-08-13T08:55:28.234Z | Preview app released. |
| Streams Example App | released | `e4930e2` | [https://streams.iterate-preview-5.com](https://streams.iterate-preview-5.com) | 1.53 MiB | 15.7s | 87.4s |  | 11.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/4415125275036) | 2026-08-13T08:55:40.129Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +57 -5 | +44 -5 🟩🟩🟩⬜⬜ |
| Mobile | +143 -17 | +83 -11 🟩🟩🟩🟩🟥 |
| Tests | +35 -38 | +4 -21 🟥⬜⬜⬜⬜ |
| Docs | +73 -0 | +62 -0 🟩🟩🟩⬜⬜ |
| **Total** | **+308 -60** | **+193 -37** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 5837476 and e4930e2, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- mobile-pr-preview -->
## 📱 Mobile preview

Channel `mobile-one-tap-login` · runtime `023cbbc4d` · **JS-only** — the installed app can run it

<details open><summary>OTA — switch the installed app to this PR's channel (`e4930e2`)</summary>

**[Switch this phone to the PR channel](https://os.iterate.com/m/preview-channel/mobile-one-tap-login)**

<a href="https://os.iterate.com/m/preview-channel/mobile-one-tap-login"><img src="https://github.com/iterate/iterate/releases/download/gh-attach-assets/mobile-pr-2488-e4930e242-ota-scheme.png" width="90" alt="QR code" /></a>

</details>
<details><summary>Full install — if the app is uninstalled or the runtime differs (`c3b64f8`)</summary>

**[Open the EAS build install page](https://expo.dev/accounts/mishanustom/projects/iterate/builds/3fe243bc-7133-4020-9205-e6b67ab02ece)**

<a href="https://expo.dev/accounts/mishanustom/projects/iterate/builds/3fe243bc-7133-4020-9205-e6b67ab02ece"><img src="https://github.com/iterate/iterate/releases/download/gh-attach-assets/mobile-pr-2488-e4930e242-install-3fe243bc.png" width="90" alt="QR code" /></a>

<sub>Installing gets you a compatible binary on the default channel — then use the OTA link above to switch it to this PR's JS.</sub>

</details>

<sub>Back to main inside the app: Build info → Reset to default channel. Republishes on every push to this PR.</sub>
<!-- /mobile-pr-preview -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth sign-in routing, server-side auto-continue on project-access, and navigation after auth—auth-critical paths but gated to fixed-test-OTP preview identities with explicit fallbacks and consent retained.
> 
> **Overview**
> Cuts mobile preview sign-in from **7 taps to ~3** (Continue → native browser → **Allow access** → in the project) by removing login, OTP, project-access, and single-project picker steps while **keeping consent** on purpose for the dynamically registered client.
> 
> **Auth (`project-access`)** — On fixed-test-OTP deployments only, `*+test@nustom.com` users in an OAuth flow with project selection **auto-select all projects**, store selection, and `oauth2.continue` without showing the page (loading skeleton while in flight; errors fall back to the normal UI).
> 
> **Mobile sign-in** — Test hints matching `+test@nustom.com` open **`/test-login`** (probed via GET → 400) with `return_to` set to the real authorize URL (PKCE intact); stale/prod deployments fall back to the prefilled login page via `login_hint`.
> 
> **Post-login navigation** — Fresh sign-ins route to `/projects` with **`autoOpen`**; the projects query **retries** and, when exactly one project exists, **backfills and opens it** (not test-gated). QR preview flow: **Switch** sets a one-shot AsyncStorage marker so after channel reload the screen **auto-continues** the switch plan without a second Continue tap; bare rescans still show the reassurance screen.
> 
> Specs and task doc updated to assert consent-first flow and no picker for single-project test accounts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c985574b3e849f5412dcadc81170694d4c9d571. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->