### PR TITLE
Show chat titles on mobile; expose title from itx.agents.list()

### DIFF
--- a/apps/mobile/src/app/project/[projectId]/chat.tsx
+++ b/apps/mobile/src/app/project/[projectId]/chat.tsx
@@ -56,7 +56,7 @@ import {
   type AgentUiMessageItem,
   type MobileFeedItem,
 } from "../../../lib/feed.ts";
-import { awaitingAgentActivity } from "../../../lib/chat.ts";
+import { awaitingAgentActivity, latestAgentTitle } from "../../../lib/chat.ts";
 import { getProjectItx } from "../../../lib/itx.ts";
 // APPROVAL_STREAM_EVENT_TYPES is module-level (identity-stable) on purpose:
 // useLiveEvents folds eventTypes into its connection-hook deps, so an inline
@@ -233,7 +233,9 @@ export default function ChatScreen() {
     >
       <Stack.Screen
         options={{
-          title: path.replace(/^\/agents\//, ""),
+          // Agent-set title once the first-turn summary lands; the raw path
+          // (still one tap away in the ••• menu) until then.
+          title: latestAgentTitle(events.data || []) || path.replace(/^\/agents\//, ""),
           headerRight: () => (
             <Pressable
               accessibilityLabel="Stream actions"

--- a/apps/mobile/src/app/project/[projectId]/index.tsx
+++ b/apps/mobile/src/app/project/[projectId]/index.tsx
@@ -7,6 +7,7 @@
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { router, Stack, useLocalSearchParams } from "expo-router";
+import { useLiveState } from "iterate/sdk/itx/react";
 import { ActivityIndicator, FlatList, Pressable, StyleSheet, Text, View } from "react-native";
 import { ProjectDrawerButton } from "../../../components/project-drawer.tsx";
 import { newMobileAgentPath } from "../../../lib/chat.ts";
@@ -30,6 +31,28 @@ export default function ChatListScreen() {
       return [...list].sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
     },
   });
+  // The catalog, LIVE: once the query above has painted the first frame (and,
+  // via getProjectItx, configured the shared session this connection reuses),
+  // the collection processor's reduced state takes over the list. Rows then
+  // track pushes — a title lands the moment an agent's first turn sets one,
+  // and chats started elsewhere (web, Slack) appear without any refetch on
+  // navigation, matching the dashboard sidebar.
+  const liveCatalog = useLiveState(
+    (itx) => itx.agents.liveState,
+    (state) => state.agents,
+    [],
+    { slug: projectId, enabled: agents.isSuccess },
+  );
+  const rows =
+    liveCatalog.value === undefined
+      ? agents.data
+      : Object.values(liveCatalog.value)
+          .map((agent) => ({
+            path: agent.path,
+            createdAt: agent.timestamps.createdAt,
+            ...(agent.summary.title === undefined ? {} : { title: agent.summary.title }),
+          }))
+          .sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
   const pushDevice = useQuery({
     queryKey: ["push-device", projectId],
     queryFn: async () => {
@@ -103,7 +126,7 @@ export default function ChatListScreen() {
         </View>
       ) : (
         <FlatList
-          data={agents.data}
+          data={rows}
           keyExtractor={(agent) => agent.path}
           contentContainerStyle={{ padding: spacing.md, gap: spacing.sm }}
           ListEmptyComponent={

--- a/apps/mobile/src/app/project/[projectId]/index.tsx
+++ b/apps/mobile/src/app/project/[projectId]/index.tsx
@@ -135,7 +135,11 @@ export default function ChatListScreen() {
           refreshing={agents.isRefetching}
           onRefresh={() => agents.refetch()}
           renderItem={({ item: agent }) => (
-            <Pressable style={styles.row} onPress={() => openChat(agent.path)}>
+            <Pressable
+              style={styles.row}
+              testID={`chat-list-row:${agent.path}`}
+              onPress={() => openChat(agent.path)}
+            >
               <Text
                 style={agent.title === undefined ? styles.path : styles.title}
                 numberOfLines={2}

--- a/apps/mobile/src/app/project/[projectId]/index.tsx
+++ b/apps/mobile/src/app/project/[projectId]/index.tsx
@@ -113,7 +113,12 @@ export default function ChatListScreen() {
           onRefresh={() => agents.refetch()}
           renderItem={({ item: agent }) => (
             <Pressable style={styles.row} onPress={() => openChat(agent.path)}>
-              <Text style={styles.path}>{agent.path.replace(/^\/agents\//, "")}</Text>
+              <Text
+                style={agent.title === undefined ? styles.path : styles.title}
+                numberOfLines={2}
+              >
+                {agent.title || agent.path.replace(/^\/agents\//, "")}
+              </Text>
               <Text style={styles.date}>{new Date(agent.createdAt).toLocaleString()}</Text>
             </Pressable>
           )}
@@ -149,6 +154,9 @@ const styles = StyleSheet.create({
     padding: spacing.md,
     gap: 2,
   },
+  title: { color: colors.text, fontSize: 15, fontWeight: "500" },
+  // Untitled chats (the agent has not set a summary title yet) fall back to
+  // the raw stream path, shown in mono so it reads as an identifier.
   path: { color: colors.text, fontSize: 14, fontFamily: "Menlo" },
   date: { color: colors.textMuted, fontSize: 12 },
   empty: { color: colors.textMuted, fontSize: 14 },

--- a/apps/mobile/src/components/note-composer.tsx
+++ b/apps/mobile/src/components/note-composer.tsx
@@ -157,7 +157,7 @@ async function appendNoteToProject(
     composeNoteFile(
       {
         capturedAt: note.capturedOnDeviceAt,
-        ...(attachments.length > 0 ? { attachments } : {}),
+        ...(attachments.length > 0 && { attachments }),
       },
       note.text,
     ),
@@ -457,7 +457,7 @@ export function NoteCaptureOverlay() {
             onPress={() =>
               router.push({
                 pathname: "/project/[projectId]/notes",
-                params: { projectId, ...(params.slug ? { slug: params.slug } : {}) },
+                params: { projectId, ...(params.slug && { slug: params.slug }) },
               })
             }
           >

--- a/apps/mobile/src/lib/chat.test.ts
+++ b/apps/mobile/src/lib/chat.test.ts
@@ -3,6 +3,7 @@ import type { StreamEvent } from "iterate/sdk/itx/react";
 import {
   ASSISTANT_MESSAGE_TYPE,
   awaitingAgentActivity,
+  latestAgentTitle,
   mergeEventsByOffset,
   newMobileAgentPath,
   reduceChatEvents,
@@ -171,6 +172,24 @@ test("a null status is provisional until the run settles, immutable after", () =
       executionId: "run-a",
     }),
   ).toEqual({ settled: true, status: null });
+});
+
+test("the chat title is the standing agent-set title, renames included", () => {
+  expect(latestAgentTitle([])).toBeNull();
+  expect(latestAgentTitle([userMessage(1, "hi")])).toBeNull();
+  expect(
+    latestAgentTitle([
+      summaryUpdated(1, { title: "Refund sweep", activity: "Starting work" }),
+      summaryUpdated(2, { activity: "Digging in" }), // activity-only update preserves the title
+      summaryUpdated(3, { title: "Refund sweep for March" }),
+    ]),
+  ).toBe("Refund sweep for March");
+  expect(
+    latestAgentTitle([
+      summaryUpdated(1, { title: "Refund sweep" }),
+      summaryUpdated(2, { title: null }),
+    ]),
+  ).toBeNull();
 });
 
 test("mobile agent paths follow the web slug convention under the mobile channel", () => {

--- a/apps/mobile/src/lib/chat.ts
+++ b/apps/mobile/src/lib/chat.ts
@@ -137,6 +137,23 @@ export function threadContextForScriptRun(
 }
 
 /**
+ * The chat's current agent-set title: the standing `title` after folding
+ * every summary-updated event in offset order (string sets, "" or explicit
+ * null clears, absent preserves — the same per-field semantics as
+ * threadContextForScriptRun, but over the whole stream). Null until the
+ * agent's first-turn summary lands; callers fall back to the path.
+ */
+export function latestAgentTitle(events: StreamEvent[]): string | null {
+  let title: string | null = null;
+  for (const event of [...events].sort((a, b) => a.offset - b.offset)) {
+    if (event.type !== SUMMARY_UPDATED_TYPE) continue;
+    const payload = (event.payload || {}) as { title?: unknown };
+    if (typeof payload.title === "string" || payload.title === null) title = payload.title || null;
+  }
+  return title;
+}
+
+/**
  * Merge a live batch into the events already held, deduping by offset (a
  * replayAfterOffset subscription can overlap the initial page read) and
  * keeping offset order.

--- a/apps/os/e2e/vitest/live-state.e2e.test.ts
+++ b/apps/os/e2e/vitest/live-state.e2e.test.ts
@@ -7,6 +7,7 @@
 import { expect, test } from "vitest";
 import { applyPatch, type LiveUpdate } from "iterate/sdk/capnweb";
 import { LIVE_STATE_PAGER_HEADER } from "../../src/domains/live-state-pager.ts";
+import type { AgentCollectionProcessorState } from "../../src/itx-api.generated.ts";
 import type { ProjectLiveState } from "../../src/domains/projects/project-live-state.ts";
 import { waitForCondition } from "../test-support/wait-for-condition.ts";
 import { adminSecret, withItxSession } from "./test-helpers.ts";
@@ -104,6 +105,55 @@ test("itx.liveState indexes stream activity as a peer slice", async () => {
     path: streamPath,
     eventCount: expect.any(Number),
     lastActivityAt: expect.any(String),
+  });
+  expect(await subscription.ping()).toBe(true);
+});
+
+// The `/agents` collection stream is born on the FIRST agent create(); a live
+// watcher mounted before that (the dashboard sidebar, the mobile chat list on
+// a brand-new project) used to be refused with
+// stream-subscription-unconfigured and stay dead even after chats appeared.
+// The relay now ensures the idempotency-keyed birth batch on exactly that
+// refusal, so the early subscriber gets the empty catalog and then watches
+// the first agent (and its agent-set title) arrive as pushes.
+test("agents.liveState subscribed before any agent exists serves the empty catalog, then pushes the first agent and its title", async () => {
+  const marker = crypto.randomUUID().slice(0, 8);
+  using session = withItxSession();
+  using itx = session.authenticate({ type: "admin-secret", secret: adminSecret() });
+  using project = await itx.projects.get(`agents-live-${RUN_SUFFIX}-${marker}`).create({});
+
+  const track = trackLiveState<AgentCollectionProcessorState>();
+  using subscription = await project.agents.liveState.subscribe(track.onUpdate);
+  await waitForCondition(() => track.state() !== undefined, {
+    description: "the initial (empty) agent catalog snapshot",
+  });
+  // The whole reduced state, exactly: born (birth certificate reduced) with
+  // an EMPTY catalog — toMatchObject({ agents: {} }) would not prove empty.
+  expect(track.state()).toEqual({
+    birthCertificate: {},
+    agents: {},
+    waitingForSinceOffsets: {},
+  });
+
+  const agentPath = `/agents/live-${marker}`;
+  using agent = project.agents.get(agentPath);
+  await agent.create();
+  await waitForCondition(() => track.state()?.agents[agentPath] !== undefined, {
+    description: "the created agent arriving as a push",
+    timeoutMs: 30_000,
+  });
+
+  await project.streams.get(agentPath).append({
+    type: "events.iterate.com/agent/summary-updated",
+    payload: { title: "Live title lands", activity: "first turn" },
+  });
+  await waitForCondition(() => track.state()?.agents[agentPath]?.summary.title !== undefined, {
+    description: "the agent-set title arriving as a push",
+    timeoutMs: 30_000,
+  });
+  expect(track.state()!.agents[agentPath]).toMatchObject({
+    path: agentPath,
+    summary: { title: "Live title lands", activity: "first turn" },
   });
   expect(await subscription.ping()).toBe(true);
 });

--- a/apps/os/src/domains/agents/agent-presence.ts
+++ b/apps/os/src/domains/agents/agent-presence.ts
@@ -142,6 +142,15 @@ export const AgentCatalogRecord = z.strictObject({
 });
 export type AgentCatalogRecord = z.infer<typeof AgentCatalogRecord>;
 
+/** One row of `itx.agents.list()`: stream identity plus the agent-authored
+ * title when one has been set (agents set it on their first turn via
+ * `agent/summary-updated`). Clients fall back to the path when absent. */
+export type AgentListItem = {
+  path: string;
+  createdAt: string;
+  title?: string;
+};
+
 const AgentPresentationTimestamps = AgentCatalogTimestamps.extend({
   runtimeUpdatedAt: z.iso.datetime().optional(),
 });

--- a/apps/os/src/itx-api-graph.generated.ts
+++ b/apps/os/src/itx-api-graph.generated.ts
@@ -407,7 +407,7 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
     name: "AgentCollection",
     kind: "interface",
     sourceText:
-      '/** Agent catalog within one project. */\nexport interface AgentCollection {\n  __describe(): Promise<Description>;\n  processor: StreamProcessorRpc<AgentCollectionProcessorState>;\n  liveState: LiveStateRpc<AgentCollectionProcessorState>;\n  /**\n   * The agent control surface at a path (`"/agents/<name>"`, or relative to\n   * the calling scope — `".."` climbs). The returned handle is a plain,\n   * unproxied RpcTarget ON PURPOSE, so callers can PIPELINE onto this call —\n   * `itx.agents.get(path).message(text)` or `.someTool(args)` in one\n   * expression for an already-created agent — over workerd RPC (the script\n   * lane); dynamic members resolve through the prototype-chain fallback. See\n   * Agent\'s class comment for the mechanism and\n   * `agent-handle-pipelining.itx.e2e.test.ts` for the guard.\n   */\n  get(path: string): Agent;\n  /** Known agents, read from the collection processor\'s reduced database. */\n  list(): Promise<StreamListItem[]>;\n}',
+      '/** Agent catalog within one project. */\nexport interface AgentCollection {\n  __describe(): Promise<Description>;\n  processor: StreamProcessorRpc<AgentCollectionProcessorState>;\n  liveState: LiveStateRpc<AgentCollectionProcessorState>;\n  /**\n   * The agent control surface at a path (`"/agents/<name>"`, or relative to\n   * the calling scope — `".."` climbs). The returned handle is a plain,\n   * unproxied RpcTarget ON PURPOSE, so callers can PIPELINE onto this call —\n   * `itx.agents.get(path).message(text)` or `.someTool(args)` in one\n   * expression for an already-created agent — over workerd RPC (the script\n   * lane); dynamic members resolve through the prototype-chain fallback. See\n   * Agent\'s class comment for the mechanism and\n   * `agent-handle-pipelining.itx.e2e.test.ts` for the guard.\n   */\n  get(path: string): Agent;\n  /** Known agents, read from the collection processor\'s reduced database. */\n  list(): Promise<AgentListItem[]>;\n}',
     summary: "Agent catalog within one project.",
     memberSummaries: {
       get: 'The agent control surface at a path (`"/agents/<name>"`, or relative to the calling scope — `".."` climbs).',
@@ -419,7 +419,7 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
       "AgentCollectionProcessorState",
       "LiveStateRpc",
       "Agent",
-      "StreamListItem",
+      "AgentListItem",
     ],
   },
   {
@@ -1555,6 +1555,16 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
     sourceText:
       '/** The singleton agent collection processor\'s reduced database state. */\nexport type AgentCollectionProcessorState = {\n  birthCertificate: Record<string, never> | null;\n  agents: Record<\n    string,\n    {\n      path: string;\n      summary: {\n        title?: string | undefined;\n        description?: string | undefined;\n        activity?: string | undefined;\n        waitingFor?: "external_event" | "timer" | "user_input" | undefined;\n        pinned: boolean;\n      };\n      timestamps: {\n        createdAt: string;\n        lastWorkAt: string;\n        summaryUpdatedAt?: string | undefined;\n        activityUpdatedAt?: string | undefined;\n      };\n    }\n  >;\n  waitingForSinceOffsets: Record<string, number>;\n};',
     summary: "The singleton agent collection processor's reduced database state.",
+    memberSummaries: {},
+    referencedTypeNames: [],
+  },
+  {
+    name: "AgentListItem",
+    kind: "typeAlias",
+    sourceText:
+      "/** One row of `itx.agents.list()`: stream identity plus the agent-authored\n * title when one has been set (agents set it on their first turn via\n * `agent/summary-updated`). Clients fall back to the path when absent. */\nexport type AgentListItem = {\n  path: string;\n  createdAt: string;\n  title?: string;\n};",
+    summary:
+      "One row of `itx.agents.list()`: stream identity plus the agent-authored title when one has been set (agents set it on their first turn via `agent/summary-updated`).",
     memberSummaries: {},
     referencedTypeNames: [],
   },

--- a/apps/os/src/itx-api.generated.ts
+++ b/apps/os/src/itx-api.generated.ts
@@ -699,7 +699,7 @@ export interface AgentCollection {
    */
   get(path: string): Agent;
   /** Known agents, read from the collection processor's reduced database. */
-  list(): Promise<StreamListItem[]>;
+  list(): Promise<AgentListItem[]>;
 }
 
 /**
@@ -2980,6 +2980,15 @@ export type AgentCollectionProcessorState = {
     }
   >;
   waitingForSinceOffsets: Record<string, number>;
+};
+
+/** One row of `itx.agents.list()`: stream identity plus the agent-authored
+ * title when one has been set (agents set it on their first turn via
+ * `agent/summary-updated`). Clients fall back to the path when absent. */
+export type AgentListItem = {
+  path: string;
+  createdAt: string;
+  title?: string;
 };
 
 /** What `itx.clients.list()` returns per client: the catalog record minus reducer bookkeeping. */

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -2011,9 +2011,8 @@ class AgentCollectionRpcTarget extends IterateRpcTarget<"AgentCollection"> {
   }
 
   get liveState(): LiveStateRpc<AgentCollectionProcessorState> {
-    return facetProcessorLiveStateRelay<AgentCollectionProcessorState>({
-      name: AgentCollectionProcessorContract.slug,
-      path: AGENT_COLLECTION_PATH,
+    return new AgentCollectionLiveStateRpcTarget({
+      auth: this.props.auth,
       projectId: this.props.projectId,
     });
   }
@@ -2073,6 +2072,61 @@ class AgentCollectionRpcTarget extends IterateRpcTarget<"AgentCollection"> {
       createdAt: agent.timestamps.createdAt,
       ...(agent.summary.title === undefined ? {} : { title: agent.summary.title }),
     }));
+  }
+}
+
+/**
+ * The agent catalog's live state, tolerant of the unborn collection. The
+ * `/agents` stream is born on the FIRST agent create(); before that, the
+ * facet relay's subscription lookup refuses with
+ * stream-subscription-unconfigured — which used to error every live watcher
+ * mounted on a fresh project (the dashboard sidebar, the mobile chat list)
+ * and leave it dead even after chats appeared. On exactly that refusal,
+ * append the same idempotency-keyed birth batch agent create() ensures
+ * (repeats are free) and retry once; every other error propagates untouched.
+ * Already-born projects never pay the extra append.
+ */
+class AgentCollectionLiveStateRpcTarget
+  extends IterateRpcRelay<"LiveStateRpc">
+  implements LiveStateRpc<AgentCollectionProcessorState>
+{
+  constructor(readonly props: { auth: ItxAuth; projectId: string }) {
+    super();
+  }
+
+  #relay(): LiveStateRpc<AgentCollectionProcessorState> {
+    return facetProcessorLiveStateRelay<AgentCollectionProcessorState>({
+      name: AgentCollectionProcessorContract.slug,
+      path: AGENT_COLLECTION_PATH,
+      projectId: this.props.projectId,
+    });
+  }
+
+  async #bornThenRetry<T>(operation: () => Promise<T>): Promise<T> {
+    try {
+      return await operation();
+    } catch (error) {
+      if (!isUnconfiguredSubscriptionError(error)) throw error;
+      const collectionStream = new StreamRpcTarget({
+        auth: this.props.auth,
+        projectId: this.props.projectId,
+        path: AGENT_COLLECTION_PATH,
+      });
+      await collectionStream.append(
+        ...agentCollectionCreationEvents({ projectId: this.props.projectId }),
+      );
+      return await operation();
+    }
+  }
+
+  async get(): Promise<AgentCollectionProcessorState> {
+    return await this.#bornThenRetry(() => this.#relay().get());
+  }
+
+  async subscribe(
+    onUpdate: (update: LiveUpdate<AgentCollectionProcessorState>) => unknown,
+  ): Promise<LiveStateSubscriptionHandle> {
+    return await this.#bornThenRetry(() => this.#relay().subscribe(onUpdate));
   }
 }
 

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -97,6 +97,7 @@ import type {
 } from "./domains/streams/core-processor-contract.ts";
 import type { EventFilter } from "./domains/streams/event-filter.ts";
 import { parseAgentPath, resolveAgentPath } from "./domains/agents/utils.ts";
+import type { AgentListItem } from "./domains/agents/agent-presence.ts";
 import {
   AGENT_COLLECTION_PATH,
   AGENT_COLLECTION_SUBSCRIPTION_NAME,
@@ -2065,11 +2066,12 @@ class AgentCollectionRpcTarget extends IterateRpcTarget<"AgentCollection"> {
   }
 
   /** Known agents, read from the collection processor's reduced database. */
-  async list(): Promise<StreamListItem[]> {
+  async list(): Promise<AgentListItem[]> {
     const { state } = await this.processor.snapshot();
     return Object.values(state.agents).map((agent) => ({
       path: agent.path,
       createdAt: agent.timestamps.createdAt,
+      ...(agent.summary.title === undefined ? {} : { title: agent.summary.title }),
     }));
   }
 }

--- a/packages/iterate/src/itx-api.generated.ts
+++ b/packages/iterate/src/itx-api.generated.ts
@@ -699,7 +699,7 @@ export interface AgentCollection {
    */
   get(path: string): Agent;
   /** Known agents, read from the collection processor's reduced database. */
-  list(): Promise<StreamListItem[]>;
+  list(): Promise<AgentListItem[]>;
 }
 
 /**
@@ -2980,6 +2980,15 @@ export type AgentCollectionProcessorState = {
     }
   >;
   waitingForSinceOffsets: Record<string, number>;
+};
+
+/** One row of `itx.agents.list()`: stream identity plus the agent-authored
+ * title when one has been set (agents set it on their first turn via
+ * `agent/summary-updated`). Clients fall back to the path when absent. */
+export type AgentListItem = {
+  path: string;
+  createdAt: string;
+  title?: string;
 };
 
 /** What `itx.clients.list()` returns per client: the catalog record minus reducer bookkeeping. */

--- a/specs/mobile/chat-titles.spec.ts
+++ b/specs/mobile/chat-titles.spec.ts
@@ -57,8 +57,8 @@ test("a chat wears its agent-set title in the thread header and chat list", asyn
   // an async server push, so it gets the repo's 15s cross-server tier.
   await page.goBack(); // chat → chat list: browser history IS the app's back stack on web
   await page.getByText("New chat").waitFor();
-  await expect.poll(() => page.getByText(TITLE).isVisible(), { timeout: 15_000 }).toBe(true);
-  await expect.poll(() => page.getByText(pathFallback).isVisible()).toBe(false);
+  await expect.poll(() => page.getByText(TITLE).count(), { timeout: 15_000 }).toBeGreaterThan(0);
+  await expect.poll(() => page.getByText(pathFallback).count()).toBe(0);
 });
 
 /** Type into the chat composer and send. `insertText` rather than `fill`:

--- a/specs/mobile/chat-titles.spec.ts
+++ b/specs/mobile/chat-titles.spec.ts
@@ -9,7 +9,7 @@
 // ZERO model turns: the script returns nothing, so no context is appended
 // and no LLM request ever opens. Every event in the thread is deterministic.
 
-import { expect, type Page } from "@playwright/test";
+import { type Page } from "@playwright/test";
 import { localOsDevServer } from "../../apps/os/scripts/dev.ts";
 import { signUpWithEmailOtp, uniqueSignupEmail } from "../test-support/email-otp-signup.ts";
 import { test } from "../test-support/test.ts";
@@ -27,12 +27,18 @@ test("a chat wears its agent-set title in the thread header and chat list", asyn
   // OAuth signup ceremony.
   page.videoMode?.setStartTime();
 
-  // ── A brand-new chat: the only name that exists yet is the stream path.
+  // ── A brand-new chat: the only name that exists yet is the stream path,
+  // worn by the thread header (react-navigation renders header titles with
+  // role=heading, which also keeps this from matching message text). The
+  // ••• menu is the thread screen's own header furniture — waiting on it
+  // proves navigation landed (so the URL is readable) while keeping the
+  // rendered cursor at the top of the screen: New chat → ••• → heading,
+  // before it ever descends to the composer.
   await page.getByText("New chat").click();
-  await page.getByPlaceholder("Message").waitFor();
+  await page.getByRole("button", { name: "Stream actions" }).waitFor();
   const agentPath = decodeURIComponent(new URL(page.url()).searchParams.get("path")!);
   const pathFallback = agentPath.replace(/^\/agents\//, "");
-  await page.getByText(pathFallback).first().waitFor();
+  await page.getByRole("heading", { name: pathFallback }).waitFor();
 
   // ── The agent's first turn, minus the model: append the same
   // summary-updated fact a real turn opens with. Returning nothing keeps the
@@ -46,19 +52,25 @@ test("a chat wears its agent-set title in the thread header and chat list", asyn
 
   // The header reads the title live off the thread's own event stream — no
   // refetch, no navigation. The working indicator spins while the script
-  // runs, so this wait rides real product UI.
-  await page.getByText(TITLE).first().waitFor();
+  // runs, so this wait rides real product UI. role=heading scopes it to the
+  // header: the sent /script bubble also contains the title string.
+  await page.getByRole("heading", { name: TITLE }).waitFor();
 
-  // ── Back on the chat list, the row wears the title — served by the live
-  // agent catalog (itx.agents.liveState); the path is demoted to nothing
-  // (it stays reachable from the thread's ••• menu). expect.poll, not a bare
-  // locator wait: the remounted list first paints its cached query data and
-  // the live snapshot arrives over the socket with no spinner in between —
-  // an async server push, so it gets the repo's 15s cross-server tier.
-  await page.goBack(); // chat → chat list: browser history IS the app's back stack on web
-  await page.getByText("New chat").waitFor();
-  await expect.poll(() => page.getByText(TITLE).count(), { timeout: 15_000 }).toBeGreaterThan(0);
-  await expect.poll(() => page.getByText(pathFallback).count()).toBe(0);
+  // ── Back on the chat list (via the header back control — accessible name
+  // "<previous title>, back", and role=link on web where react-navigation
+  // gives it an href), THIS chat's row wears the title — served by the live
+  // agent catalog (itx.agents.liveState), pushed over the socket with no
+  // spinner in between. The row-scoped locator pins which chat got renamed
+  // (and stays unique while the popped thread screen, whose header also
+  // says the title, is still mid-unmount). The annotated waitFor carries
+  // the rendered cursor to the row, holding into the final freeze-frame.
+  // timeout: async server push after first paint — the spinner waiter can't
+  // see it, so this gets the repo's 15s cross-server tier.
+  await page.getByRole("link", { name: /(^Go back$)|(, back$)/ }).click();
+  await page
+    .getByTestId(`chat-list-row:${agentPath}`)
+    .getByText(TITLE)
+    .waitFor({ timeout: 15_000 });
 });
 
 /** Type into the chat composer and send. `insertText` rather than `fill`:
@@ -92,10 +104,16 @@ async function signUpToProject(
     projectSlug,
     testInfo,
   });
-  // timeout: same unwrapped popup — the spinner waiter cannot see it.
-  await popup.getByRole("button", { name: "Continue" }).click({ timeout: 15_000 });
-  // timeout: same unwrapped popup — the spinner waiter cannot see it.
-  await popup.getByRole("button", { name: "Allow access" }).click({ timeout: 15_000 });
+  // A fresh signup re-enters the authorize flow after onboarding, and
+  // re-entries can skip the /project-access "Continue" step (postLogin's
+  // shouldRedirect only fires on the initial authorize) — click it when it
+  // renders, then land on consent's "Allow access" either way. (Same fix as
+  // the other mobile specs; see PR #2492.)
+  const continueButton = popup.getByRole("button", { name: "Continue" });
+  const allowAccessButton = popup.getByRole("button", { name: "Allow access" });
+  await continueButton.or(allowAccessButton).first().waitFor({ timeout: 15_000 }); // timeout: popup page has no spinner-waiter
+  if (await continueButton.isVisible()) await continueButton.click();
+  await allowAccessButton.click({ timeout: 15_000 }); // timeout: popup page has no spinner-waiter
   await page.getByText(projectSlug).click();
   await page.getByText("New chat").waitFor();
 }

--- a/specs/mobile/chat-titles.spec.ts
+++ b/specs/mobile/chat-titles.spec.ts
@@ -10,6 +10,7 @@
 // and no LLM request ever opens. Every event in the thread is deterministic.
 
 import { type Page } from "@playwright/test";
+import { spinnerWaiter } from "middlewright";
 import { localOsDevServer } from "../../apps/os/scripts/dev.ts";
 import { signUpWithEmailOtp, uniqueSignupEmail } from "../test-support/email-otp-signup.ts";
 import { test } from "../test-support/test.ts";
@@ -29,16 +30,14 @@ test("a chat wears its agent-set title in the thread header and chat list", asyn
 
   // ── A brand-new chat: the only name that exists yet is the stream path,
   // worn by the thread header (react-navigation renders header titles with
-  // role=heading, which also keeps this from matching message text). The
-  // ••• menu is the thread screen's own header furniture — waiting on it
-  // proves navigation landed (so the URL is readable) while keeping the
-  // rendered cursor at the top of the screen: New chat → ••• → heading,
-  // before it ever descends to the composer.
+  // role=heading, which also keeps this from matching message text). Read
+  // the path off the screen the way a user would — URLs are an RN-web
+  // artifact, not part of the UI.
   await page.getByText("New chat").click();
-  await page.getByRole("button", { name: "Stream actions" }).waitFor();
-  const agentPath = decodeURIComponent(new URL(page.url()).searchParams.get("path")!);
-  const pathFallback = agentPath.replace(/^\/agents\//, "");
-  await page.getByRole("heading", { name: pathFallback }).waitFor();
+  const pathHeading = page.getByRole("heading", { name: /^mobile\// });
+  await pathHeading.waitFor();
+  const pathFallback = (await pathHeading.textContent())!;
+  const agentPath = `/agents/${pathFallback}`;
 
   // ── The agent's first turn, minus the model: append the same
   // summary-updated fact a real turn opens with. Returning nothing keeps the
@@ -57,20 +56,24 @@ test("a chat wears its agent-set title in the thread header and chat list", asyn
   await page.getByRole("heading", { name: TITLE }).waitFor();
 
   // ── Back on the chat list (via the header back control — accessible name
-  // "<previous title>, back", and role=link on web where react-navigation
-  // gives it an href), THIS chat's row wears the title — served by the live
-  // agent catalog (itx.agents.liveState), pushed over the socket with no
-  // spinner in between. The row-scoped locator pins which chat got renamed
-  // (and stays unique while the popped thread screen, whose header also
-  // says the title, is still mid-unmount). The annotated waitFor carries
-  // the rendered cursor to the row, holding into the final freeze-frame.
-  // timeout: async server push after first paint — the spinner waiter can't
-  // see it, so this gets the repo's 15s cross-server tier.
-  await page.getByRole("link", { name: /(^Go back$)|(, back$)/ }).click();
-  await page
-    .getByTestId(`chat-list-row:${agentPath}`)
-    .getByText(TITLE)
-    .waitFor({ timeout: 15_000 });
+  // "<previous screen title>, back", and role=link on web where
+  // react-navigation gives it an href), THIS chat's row wears the title —
+  // served by the live agent catalog (itx.agents.liveState). The push races
+  // the first paint with no product spinner in between, so the not-yet-
+  // renamed row (still showing the raw path) is taught to the spinner
+  // waiter as loading UI: the wait budget extends while the stale row is
+  // on screen, and no manual timeout is needed. The row-scoped locator
+  // pins which chat got renamed (and stays unique while the popped thread
+  // screen, whose header also says the title, is still mid-unmount); the
+  // annotated waitFor carries the rendered cursor to the row, holding into
+  // the final freeze-frame.
+  await page.getByRole("link", { name: `${projectSlug}, back` }).click();
+  await spinnerWaiter.settings.run(
+    { spinnerSelectors: [`:has-text(${JSON.stringify(pathFallback)})`] },
+    async () => {
+      await page.getByTestId(`chat-list-row:${agentPath}`).getByText(TITLE).waitFor();
+    },
+  );
 });
 
 /** Type into the chat composer and send. `insertText` rather than `fill`:

--- a/specs/mobile/chat-titles.spec.ts
+++ b/specs/mobile/chat-titles.spec.ts
@@ -24,9 +24,6 @@ test("a chat wears its agent-set title in the thread header and chat list", asyn
   const projectSlug = `mobile-chat-titles-${Date.now().toString(36)}`;
 
   await signUpToProject(page, testInfo, osBaseUrl, projectSlug);
-  // Video-mode demos start at the interesting part: the chat list, not the
-  // OAuth signup ceremony.
-  page.videoMode?.setStartTime();
 
   // ── A brand-new chat: the only name that exists yet is the stream path,
   // worn by the thread header (react-navigation renders header titles with
@@ -36,7 +33,7 @@ test("a chat wears its agent-set title in the thread header and chat list", asyn
   await page.getByText("New chat").click();
   const pathHeading = page.getByRole("heading", { name: /^mobile\// });
   await pathHeading.waitFor();
-  const pathFallback = (await pathHeading.textContent())!;
+  const pathFallback = await pathHeading.textContent();
   const agentPath = `/agents/${pathFallback}`;
 
   // ── The agent's first turn, minus the model: append the same
@@ -87,8 +84,8 @@ async function sendChatMessage(page: Page, message: string) {
 }
 
 async function signUpToProject(
-  page: any,
-  testInfo: any,
+  page: test.Page,
+  testInfo: test.TestInfo,
   osBaseUrl: string,
   projectSlug: string,
 ): Promise<void> {
@@ -119,6 +116,9 @@ async function signUpToProject(
   await allowAccessButton.click({ timeout: 15_000 }); // timeout: popup page has no spinner-waiter
   await page.getByText(projectSlug).click();
   await page.getByText("New chat").waitFor();
+  // Video-mode demos start at the interesting part: the chat list, not the
+  // OAuth signup ceremony.
+  page.videoMode?.setStartTime();
 }
 
 async function resolveOsBaseUrl(): Promise<string> {

--- a/specs/mobile/chat-titles.spec.ts
+++ b/specs/mobile/chat-titles.spec.ts
@@ -1,0 +1,108 @@
+// Chat titles through the real phone-sized web build: a fresh chat starts as
+// its raw stream path (mobile/<timestamp> — all the client has before the
+// agent's first turn), then a `/script` maintains the agent status exactly
+// the way a real agent turn would (AGENT_SUMMARY_INSTRUCTION appends
+// agent/summary-updated) — and the title takes over both surfaces this
+// branch teaches to read it: the thread header live off the event stream,
+// and the chat list row via the title now carried by itx.agents.list().
+//
+// ZERO model turns: the script returns nothing, so no context is appended
+// and no LLM request ever opens. Every event in the thread is deterministic.
+
+import { expect, type Page } from "@playwright/test";
+import { localOsDevServer } from "../../apps/os/scripts/dev.ts";
+import { signUpWithEmailOtp, uniqueSignupEmail } from "../test-support/email-otp-signup.ts";
+import { test } from "../test-support/test.ts";
+
+const TITLE = "Refund sweep for March";
+
+test("a chat wears its agent-set title in the thread header and chat list", async ({
+  page,
+}, testInfo) => {
+  const osBaseUrl = await resolveOsBaseUrl();
+  const projectSlug = `mobile-chat-titles-${Date.now().toString(36)}`;
+
+  await signUpToProject(page, testInfo, osBaseUrl, projectSlug);
+  // Video-mode demos start at the interesting part: the chat list, not the
+  // OAuth signup ceremony.
+  page.videoMode?.setStartTime();
+
+  // ── A brand-new chat: the only name that exists yet is the stream path.
+  await page.getByText("New chat").click();
+  await page.getByPlaceholder("Message").waitFor();
+  const agentPath = decodeURIComponent(new URL(page.url()).searchParams.get("path")!);
+  const pathFallback = agentPath.replace(/^\/agents\//, "");
+  await page.getByText(pathFallback).first().waitFor();
+
+  // ── The agent's first turn, minus the model: append the same
+  // summary-updated fact a real turn opens with. Returning nothing keeps the
+  // thread deterministic — no settlement context, no LLM request.
+  await sendChatMessage(
+    page,
+    `/script await itx.agent.append({ type: "events.iterate.com/agent/summary-updated", payload: ${JSON.stringify(
+      { title: TITLE, activity: "Emailing customers about refunds" },
+    )} });`,
+  );
+
+  // The header reads the title live off the thread's own event stream — no
+  // refetch, no navigation. The working indicator spins while the script
+  // runs, so this wait rides real product UI.
+  await page.getByText(TITLE).first().waitFor();
+
+  // ── Back on the chat list, the row wears the title — served by the live
+  // agent catalog (itx.agents.liveState); the path is demoted to nothing
+  // (it stays reachable from the thread's ••• menu). expect.poll, not a bare
+  // locator wait: the remounted list first paints its cached query data and
+  // the live snapshot arrives over the socket with no spinner in between —
+  // an async server push, so it gets the repo's 15s cross-server tier.
+  await page.goBack(); // chat → chat list: browser history IS the app's back stack on web
+  await page.getByText("New chat").waitFor();
+  await expect.poll(() => page.getByText(TITLE).isVisible(), { timeout: 15_000 }).toBe(true);
+  await expect.poll(() => page.getByText(pathFallback).isVisible()).toBe(false);
+});
+
+/** Type into the chat composer and send. `insertText` rather than `fill`:
+ * RN-web's controlled multiline TextInput intermittently fails playwright
+ * fill's post-check under the harness even when visible/enabled/editable all
+ * probe true; typing through the focused element sidesteps that. */
+async function sendChatMessage(page: Page, message: string) {
+  await page.getByPlaceholder("Message").click();
+  await page.keyboard.insertText(message);
+  await page.getByRole("button", { name: "Send" }).click();
+}
+
+async function signUpToProject(
+  page: any,
+  testInfo: any,
+  osBaseUrl: string,
+  projectSlug: string,
+): Promise<void> {
+  await page.goto("/");
+  await page.getByPlaceholder("https://os.iterate.com").fill(osBaseUrl);
+  // timeout: OIDC discovery + client registration have no loading UI for the spinner waiter
+  const popupPromise = page.waitForEvent("popup", { timeout: 15_000 });
+  await page.getByRole("button", { name: "Sign in" }).click();
+  const popup = await popupPromise;
+  // timeout: the popup is outside the wrapped page, so no spinner waiter covers it
+  await popup.getByTestId("email-login-button").click({ timeout: 15_000 });
+  await signUpWithEmailOtp(popup, {
+    // A constant prefix, NOT the slug: the signup display name embeds this,
+    // and a slug-containing name makes getByText(projectSlug) ambiguous.
+    email: uniqueSignupEmail("mobile-chat-titles"),
+    projectSlug,
+    testInfo,
+  });
+  // timeout: same unwrapped popup — the spinner waiter cannot see it.
+  await popup.getByRole("button", { name: "Continue" }).click({ timeout: 15_000 });
+  // timeout: same unwrapped popup — the spinner waiter cannot see it.
+  await popup.getByRole("button", { name: "Allow access" }).click({ timeout: 15_000 });
+  await page.getByText(projectSlug).click();
+  await page.getByText("New chat").waitFor();
+}
+
+async function resolveOsBaseUrl(): Promise<string> {
+  const configured = process.env.APP_CONFIG_BASE_URL?.replace(/\/+$/, "");
+  if (configured) return configured;
+  const target = await localOsDevServer.resolveTarget();
+  return target.baseUrl;
+}

--- a/specs/mobile/notifications.spec.ts
+++ b/specs/mobile/notifications.spec.ts
@@ -330,7 +330,10 @@ test("the approval push is suppressed in the watched thread and sent when you're
     const reason = "not while the spec is watching";
     await rejectFromExpansion(page, reason);
     await page.getByText(`Rejected because: ${reason}`).waitFor();
-    await page.getByText("Sending the launch webhook").waitFor();
+    // The thread-context LINE, by its link role: the chat list mounted-but-
+    // hidden behind this screen now wears the same live title on its row, so
+    // a bare text locator would find that copy too.
+    await page.getByRole("link", { name: /Sending the launch webhook/ }).waitFor();
 
     // ── The orphan lane's payoff: the batch that predates enrollment
     // expands into the SAME detail and decide actions as a journaled row.
@@ -351,8 +354,10 @@ test("the approval push is suppressed in the watched thread and sent when you're
     await page.getByRole("link", { name: "Open thread" }).click();
     // The heading, specifically: expo-router keeps the Notifications screen
     // mounted-but-hidden behind the chat, and its thread-context line also
-    // says "elsewhere-thread" — a bare text locator finds that hidden copy.
-    await page.getByRole("heading", { name: "elsewhere-thread" }).waitFor();
+    // carries this text — a bare text locator finds that hidden copy. The
+    // header wears the thread's agent-set TITLE now, not the raw path
+    // (chat-titles.spec.ts covers that surface on its own).
+    await page.getByRole("heading", { name: "Sending the launch webhook" }).waitFor();
     expect(decodeURIComponent(page.url())).toContain("/agents/elsewhere-thread");
   } finally {
     await echo.close();

--- a/specs/test-support/test.ts
+++ b/specs/test-support/test.ts
@@ -1,4 +1,4 @@
-import { test as base, type Page, type TestInfo } from "@playwright/test";
+import { test as base, type Page, type TestInfo as _TestInfo } from "@playwright/test";
 import {
   CLOUDFLARE_WORKERS_VERSION_OVERRIDES_HEADER,
   cloudflareWorkerVersionOverrideHeaders,
@@ -14,7 +14,7 @@ import { createProjectFixture as createForgedProjectFixture } from "./forged-ses
 import { watchMetroBundles } from "./metro-bundle-spinner.ts";
 import { screenshot } from "./screenshot.ts";
 
-const addPagePlugins = (page: Page, testInfo: TestInfo) => {
+const addPagePlugins = (page: Page, testInfo: _TestInfo) => {
   // Not a middlewright plugin (it listens to network events rather than
   // wrapping actions): holds a [data-spinner] marker while Metro compiles a
   // dev bundle mid-spec, so the spinner-waiter covers those waits too.
@@ -118,3 +118,8 @@ export const test = base.extend<{
     }
   },
 });
+
+export declare namespace test {
+  type Page = Awaited<ReturnType<typeof addPagePlugins>>;
+  type TestInfo = _TestInfo;
+}

--- a/tasks/complete/2026-08-13-mobile-chat-titles.md
+++ b/tasks/complete/2026-08-13-mobile-chat-titles.md
@@ -1,16 +1,17 @@
 ---
-status: in-progress
+status: done
 size: medium
 ---
 
 # Mobile: show chat titles instead of raw stream paths
 
-**Status summary:** implementation complete; PR open (#2490). Server exposes
-agent titles through `itx.agents.list()`, the mobile chat list renders them
-and stays LIVE off the agent catalog's push channel, the thread header folds
-the title from the event stream. Along the way this exposed and fixed a
-pre-existing platform flaw: subscribing to `agents.liveState` on a fresh
-project (zero chats) errored and stayed dead. Remaining: review.
+**Status summary:** done — PR #2490, CI fully green (preview e2e included),
+zero review threads. Server exposes agent titles through
+`itx.agents.list()`, the mobile chat list renders them and stays LIVE off
+the agent catalog's push channel, the thread header folds the title from
+the event stream. Along the way this exposed and fixed a pre-existing
+platform flaw: subscribing to `agents.liveState` on a fresh project (zero
+chats) errored and stayed dead.
 
 Prompted by a screenshot of the mobile chat list showing rows like
 `mobile/2026-08-12t23-27-59-114z` — the raw agent stream path — where a

--- a/tasks/mobile-chat-titles.md
+++ b/tasks/mobile-chat-titles.md
@@ -1,0 +1,52 @@
+---
+status: in-progress
+size: small
+---
+
+# Mobile: show chat titles instead of raw stream paths
+
+**Status summary:** implementation complete; PR open. Server exposes agent
+titles through `itx.agents.list()`, mobile renders them in the chat list and
+thread header. Remaining: review.
+
+Prompted by a screenshot of the mobile chat list showing rows like
+`mobile/2026-08-12t23-27-59-114z` — the raw agent stream path — where a
+human-readable title should be. Agents already set a title on their first
+turn (`agent/summary-updated`, per `AGENT_SUMMARY_INSTRUCTION`), and the web
+sidebar shows it; mobile just had no way to read it: `itx.agents.list()`
+returned only `path` + `createdAt`.
+
+## Checklist
+
+- [x] Expose `title` from `itx.agents.list()` _new `AgentListItem` type in
+      `apps/os/src/domains/agents/agent-presence.ts`; `list()` in
+      `rpc-targets.ts` maps `summary.title` through; regenerated the itx API
+      projections with `pnpm generate:itx-api`_
+- [x] Chat list rows render the title _`apps/mobile/.../index.tsx`: title in
+      normal weight, mono path fallback for chats whose agent has not set one
+      yet_
+- [x] Thread header renders the title _`apps/mobile/.../chat.tsx`: folded
+      from the already-loaded event stream via new `latestAgentTitle` in
+      `lib/chat.ts` (same set/clear/preserve semantics as
+      `threadContextForScriptRun`); raw path stays reachable via the •••
+      menu_
+- [x] Tests _`latestAgentTitle` cases added to
+      `apps/mobile/src/lib/chat.test.ts`_
+
+## Decisions / assumptions
+
+- Fixed the product surface rather than having mobile dig into
+  `agents.liveState`: the title is public catalog data and every list()
+  consumer benefits. `title` is optional on the wire — absent until the
+  agent's first turn lands — so clients keep a path fallback.
+- Chat screen derives its header title client-side from events it already
+  fetches (no extra request, updates live as summary events stream in).
+
+## Implementation log
+
+- `agents.list()` e2e assertions (`itx-agents.e2e.test.ts`) use
+  `objectContaining`/empty-list — tolerant of the added field, no changes
+  needed.
+- Root-worktree typecheck noise encountered along the way, none of it from
+  this change: stale expo route typegen + missing `expo-media-library` in
+  apps/mobile, `*ignoreme*` scratch files in apps/os.

--- a/tasks/mobile-chat-titles.md
+++ b/tasks/mobile-chat-titles.md
@@ -1,13 +1,16 @@
 ---
 status: in-progress
-size: small
+size: medium
 ---
 
 # Mobile: show chat titles instead of raw stream paths
 
-**Status summary:** implementation complete; PR open. Server exposes agent
-titles through `itx.agents.list()`, mobile renders them in the chat list and
-thread header. Remaining: review.
+**Status summary:** implementation complete; PR open (#2490). Server exposes
+agent titles through `itx.agents.list()`, the mobile chat list renders them
+and stays LIVE off the agent catalog's push channel, the thread header folds
+the title from the event stream. Along the way this exposed and fixed a
+pre-existing platform flaw: subscribing to `agents.liveState` on a fresh
+project (zero chats) errored and stayed dead. Remaining: review.
 
 Prompted by a screenshot of the mobile chat list showing rows like
 `mobile/2026-08-12t23-27-59-114z` — the raw agent stream path — where a
@@ -25,28 +28,53 @@ returned only `path` + `createdAt`.
 - [x] Chat list rows render the title _`apps/mobile/.../index.tsx`: title in
       normal weight, mono path fallback for chats whose agent has not set one
       yet_
+- [x] Chat list goes LIVE _`useLiveState((itx) => itx.agents.liveState)`
+      takes over after the `list()` first paint — titles pop in on push, and
+      chats started on web/Slack appear without navigation refetches (the
+      spec exposed that returning from a chat showed a stale list)_
 - [x] Thread header renders the title _`apps/mobile/.../chat.tsx`: folded
       from the already-loaded event stream via new `latestAgentTitle` in
       `lib/chat.ts` (same set/clear/preserve semantics as
       `threadContextForScriptRun`); raw path stays reachable via the •••
       menu_
-- [x] Tests _`latestAgentTitle` cases added to
-      `apps/mobile/src/lib/chat.test.ts`_
+- [x] Platform fix: `agents.liveState` on a fresh project _subscribing
+      before the first agent create() was refused with
+      `stream-subscription-unconfigured` and the watcher stayed dead (latent
+      in the dashboard sidebar too); `AgentCollectionLiveStateRpcTarget` in
+      `rpc-targets.ts` now appends the idempotency-keyed birth batch on
+      exactly that refusal and retries once_
+- [x] Tests _`latestAgentTitle` unit cases in `apps/mobile/src/lib/chat.test.ts`;
+      RN-web spec `specs/mobile/chat-titles.spec.ts` (signup → new chat →
+      path fallback → `/script` appends the summary fact with ZERO model
+      turns → title takes over header and list); e2e
+      `live-state.e2e.test.ts` "subscribed before any agent exists" guards
+      the platform fix; `specs/mobile/notifications.spec.ts` heading
+      assertion updated for the now-titled header_
 
 ## Decisions / assumptions
 
-- Fixed the product surface rather than having mobile dig into
-  `agents.liveState`: the title is public catalog data and every list()
-  consumer benefits. `title` is optional on the wire — absent until the
-  agent's first turn lands — so clients keep a path fallback.
-- Chat screen derives its header title client-side from events it already
-  fetches (no extra request, updates live as summary events stream in).
+- Fixed the product surface rather than having mobile dig into reduced
+  state ad hoc: `title` is public catalog data, every `list()` consumer
+  benefits, and the live list rides the same `useLiveState` primitive the
+  dashboard sidebar uses.
+- `title` is optional on the wire — absent until the agent's first turn
+  lands — so clients keep a path fallback.
+- The platform fix is birth-on-refusal (not birth-on-every-subscribe): the
+  already-born common path pays nothing; only the fresh-project refusal
+  triggers the idempotent birth batch append + one retry.
 
 ## Implementation log
 
 - `agents.list()` e2e assertions (`itx-agents.e2e.test.ts`) use
   `objectContaining`/empty-list — tolerant of the added field, no changes
   needed.
+- The chat-titles spec failed twice before going green: first on the stale
+  list after `goBack` (fixed by the live list), then on the fresh-project
+  liveState refusal (fixed by the platform change). Verified the push
+  mechanics with a throwaway node script before wiring the UI.
+- CI's preview lane failed on `notifications.spec.ts` waiting for a heading
+  named `elsewhere-thread` — that spec seeds a summary title, so the header
+  now (correctly) shows the title instead; assertion updated.
 - Root-worktree typecheck noise encountered along the way, none of it from
   this change: stale expo route typegen + missing `expo-media-library` in
   apps/mobile, `*ignoreme*` scratch files in apps/os.


### PR DESCRIPTION
Mobile chat list and thread header now show the agent-set chat title instead of the raw stream path — and the chat list is live.

Before, the chat list read like a directory dump — `mobile/2026-08-12t23-27-59-114z` — even though agents set a human title on their first turn (`agent/summary-updated`) and the web sidebar already shows it. Mobile had no way to read it: `itx.agents.list()` returned only `path` + `createdAt`.

https://github.com/user-attachments/assets/92a22959-669c-467c-9ef2-d2357fcb29e5

*Recorded from `specs/mobile/chat-titles.spec.ts` (`VIDEO_MODE=1`): a fresh chat starts as its path, a `/script` appends the same summary fact a real agent turn opens with (zero model turns), and the title takes over the thread header and the chat list — ending scoped to the renamed chat's own row (new `chat-list-row:<path>` testID).*

## What changed

**itx surface** — `itx.agents.list()` rows now carry the agent-authored title when one has been set:

```ts
const chats = await itx.agents.list();
// [{ path: "/agents/mobile/2026-08-12t23-27-59-114z",
//    createdAt: "2026-08-12T23:27:59.240Z",
//    title: "Refund sweep for March" }]   // absent until the agent's first turn lands
```

New `AgentListItem` type (`agent-presence.ts`); itx API projections regenerated.

**Mobile chat list — now live** — renders `title` (mono path fallback until the agent sets one), and after the `list()` first paint it overlays `useLiveState((itx) => itx.agents.liveState)` — the same node the dashboard sidebar consumes — so titles pop in on push and chats started on web/Slack appear without navigation refetches. (The spec exposed that the old query-only list stayed stale after `goBack`.)

**Mobile thread header** — folds the title from the event stream the screen already loads (new `latestAgentTitle` in `lib/chat.ts`, same set/clear/preserve semantics as the existing `threadContextForScriptRun`), so it appears/updates live without an extra request. The raw path stays one tap away in the ••• menu.

**Platform fix: `agents.liveState` on a fresh project** — the `/agents` collection stream is born on the first agent `create()`; subscribing before that was refused with `stream-subscription-unconfigured` and the watcher stayed dead even after chats appeared (latent in the dashboard sidebar too). `AgentCollectionLiveStateRpcTarget` now appends the same idempotency-keyed birth batch `create()` ensures — on exactly that refusal, retry once; already-born projects pay nothing. Guarded by a new e2e test (`live-state.e2e.test.ts`).

## Tests

- `specs/mobile/chat-titles.spec.ts` — RN-web spec: signup → new chat shows the path fallback → `/script` sets the summary → title takes over header and list. Zero model turns; fully deterministic.
- `apps/os/e2e/vitest/live-state.e2e.test.ts` — subscribe before any agent exists: empty catalog snapshot, then the first agent and its title arrive as pushes.
- `apps/mobile/src/lib/chat.test.ts` — `latestAgentTitle` fold semantics.
- `specs/mobile/notifications.spec.ts` — updated: its deep-link assertion expected the header to read the raw path; the header now (correctly) wears the seeded title "Sending the launch webhook". This was the one red preview check on the first push.

## Risk map

- Riskiest: `AgentCollectionLiveStateRpcTarget` — a write (idempotent birth batch) triggered from a read path, on the unconfigured-subscription refusal only. Wrong classification would mask real errors; classification uses the platform's own `isUnconfiguredSubscriptionError` prefix check, and every other error propagates untouched.
- `agents.list()` contract change is additive-optional; existing consumers (e2e uses `objectContaining`) are unaffected.
- On merge: no data invalidation, no migration. Old mobile builds keep working (they ignore the new field).
- Review order: `apps/os/src/rpc-targets.ts` (contract + live relay wrapper), `apps/mobile/src/app/project/[projectId]/index.tsx` (live list), `apps/mobile/src/lib/chat.ts` (fold semantics), the specs, then the regenerated `*.generated.ts` files (mechanical).

Task file: `tasks/complete/2026-08-13-mobile-chat-titles.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session id: `58cb8de3-d752-4a49-994b-74b003a11ccd`

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-13T15:07:07.197Z",
      "deployedAt": "2026-08-13T14:52:29.595Z",
      "headSha": "9903ab0889c8e764db5657cace8c419c9c55f65a",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/92212517358817",
      "shortSha": "9903ab0",
      "cleanupDurationMs": 16839,
      "deployDurationMs": 59476,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 58181,
      "deployReadinessDurationMs": 1292,
      "deployedWorkerName": "os-preview-13",
      "deployedWorkerVersion": "f4dd5fc9-0f92-4b1e-8170-476100dcbc46",
      "testDurationMs": 237172,
      "testRetries": null,
      "workerSizeKib": 20780.35,
      "workerGzipKib": 5230.66,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5241.05
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-13T15:06:54.986Z",
      "deployedAt": "2026-08-13T14:51:45.346Z",
      "headSha": "9903ab0889c8e764db5657cace8c419c9c55f65a",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-13.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/92212517358817",
      "shortSha": "9903ab0",
      "cleanupDurationMs": 4620,
      "deployDurationMs": 14162,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 13929,
      "deployReadinessDurationMs": 229,
      "deployedWorkerName": "docs-preview-13",
      "deployedWorkerVersion": "70c37338-d2a0-4a19-bf33-a87901059e8a",
      "testDurationMs": 1862,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-08-13T15:06:50.970Z",
      "deployedAt": "2026-08-13T11:39:00.765Z",
      "headSha": "1a4e77bc129dec2087c48a088724485c32ae83e8",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/92212517358817",
      "shortSha": "1a4e77b",
      "cleanupDurationMs": 600,
      "deployDurationMs": 14774,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 14585,
      "deployReadinessDurationMs": 182,
      "deployedWorkerName": "semaphore-preview-13",
      "deployedWorkerVersion": "6aefed3f-da54-41e9-b21c-f9352ef9080c",
      "testDurationMs": 20779,
      "testRetries": null,
      "workerSizeKib": 1915.76,
      "workerGzipKib": 441.16,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-13T15:06:54.700Z",
      "deployedAt": "2026-08-13T14:51:52.218Z",
      "headSha": "9903ab0889c8e764db5657cace8c419c9c55f65a",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/92212517358817",
      "shortSha": "9903ab0",
      "cleanupDurationMs": 4328,
      "deployDurationMs": 21268,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 20799,
      "deployReadinessDurationMs": 463,
      "deployedWorkerName": "auth-preview-13",
      "deployedWorkerVersion": "fb634143-00f9-4a4f-b8d8-ce4223765742",
      "testDurationMs": 10156,
      "testRetries": null,
      "workerSizeKib": 3983.1,
      "workerGzipKib": 815.71,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-08-13T15:07:00.594Z",
      "deployedAt": "2026-08-13T11:39:11.529Z",
      "headSha": "1a4e77bc129dec2087c48a088724485c32ae83e8",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/92212517358817",
      "shortSha": "1a4e77b",
      "cleanupDurationMs": 10220,
      "deployDurationMs": 39805,
      "deployConfigDurationMs": 7,
      "deployCommandDurationMs": 25347,
      "deployReadinessDurationMs": 14451,
      "deployedWorkerName": "streams-example-app-preview-13",
      "deployedWorkerVersion": "84861cb5-af4f-47b4-8671-d79ad119b7cc",
      "testDurationMs": 54994,
      "testRetries": null,
      "workerSizeKib": 5528.73,
      "workerGzipKib": 1562.47,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-13T15:06:53.515Z",
      "deployedAt": "2026-08-13T11:39:08.001Z",
      "headSha": "9903ab0889c8e764db5657cace8c419c9c55f65a",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/92212517358817",
      "shortSha": "9903ab0",
      "cleanupDurationMs": 2544,
      "deployDurationMs": 83,
      "deployConfigDurationMs": 6,
      "deployReuseProofDurationMs": 45,
      "deployedWorkerName": "dummy-petshop-preview-13",
      "deployedWorkerVersion": "298bfcc0-1611-4ea1-a95e-a393d5c78c08",
      "testDurationMs": 5904,
      "testRetries": null,
      "workerSizeKib": 1115.39,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "c9ab5b52ba7c36918b55d64e903861954487a6b6+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `9903ab0` | [https://auth.iterate-preview-13.com](https://auth.iterate-preview-13.com) | 815.7 KiB | 21.3s | 10.2s |  | 4.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/92212517358817) | 2026-08-13T15:06:54.700Z | Preview app released. |
| Docs | released | `9903ab0` | [https://docs-preview-13.iterate-dev-preview.workers.dev](https://docs-preview-13.iterate-dev-preview.workers.dev) | 866.2 KiB | 14.2s | 1.9s |  | 4.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/92212517358817) | 2026-08-13T15:06:54.986Z | Preview app released. |
| Dummy Petshop | released | `9903ab0` | [https://dummy-petshop.iterate-preview-13.com](https://dummy-petshop.iterate-preview-13.com) | 198.3 KiB | 83ms | 5.9s |  | 2.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/92212517358817) | 2026-08-13T15:06:53.515Z | Preview app released. |
| OS | released | `9903ab0` | [https://os.iterate-preview-13.com](https://os.iterate-preview-13.com) | 5.11 MiB (-10.4 KiB vs main) | 59.5s | 237.2s |  | 16.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/92212517358817) | 2026-08-13T15:07:07.197Z | Preview app released. |
| Semaphore | released | `1a4e77b` | [https://semaphore.iterate-preview-13.com](https://semaphore.iterate-preview-13.com) | 441.2 KiB | 14.8s | 20.8s |  | 600ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/92212517358817) | 2026-08-13T15:06:50.970Z | Preview app released. |
| Streams Example App | released | `1a4e77b` | [https://streams.iterate-preview-13.com](https://streams.iterate-preview-13.com) | 1.53 MiB | 39.8s | 55.0s |  | 10.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/92212517358817) | 2026-08-13T15:07:00.594Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +69 -4 | +40 -4 🟩🟩⬜⬜⬜ |
| Mobile | +80 -7 | +59 -7 🟩🟩🟩⬜⬜ |
| Tests | +187 -3 | +105 -2 🟩🟩🟩🟩🟩 |
| Docs | +81 -0 | +72 -0 🟩🟩🟩⬜⬜ |
| Other | +7 -2 | +2 -2 🟩⬜⬜⬜⬜ |
| Generated | +32 -4 | +12 -2 🟩⬜⬜⬜⬜ |
| **Total** | **+456 -20** | **+290 -17** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 8af5665 and 9903ab0, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- mobile-pr-preview -->
## 📱 Mobile preview

Channel `mobile-chat-titles` · runtime `023cbbc4d` · **JS-only** — the installed app can run it

<details open><summary>OTA — switch the installed app to this PR's channel (`9903ab0`)</summary>

**[Switch this phone to the PR channel](https://os.iterate.com/m/preview-channel/mobile-chat-titles)**

<a href="https://os.iterate.com/m/preview-channel/mobile-chat-titles"><img src="https://github.com/iterate/iterate/releases/download/gh-attach-assets/mobile-pr-2490-9903ab088-ota-scheme.png" width="90" alt="QR code" /></a>

</details>
<details><summary>Full install — if the app is uninstalled or the runtime differs (`c3b64f8`)</summary>

**[Open the EAS build install page](https://expo.dev/accounts/mishanustom/projects/iterate/builds/3fe243bc-7133-4020-9205-e6b67ab02ece)**

<a href="https://expo.dev/accounts/mishanustom/projects/iterate/builds/3fe243bc-7133-4020-9205-e6b67ab02ece"><img src="https://github.com/iterate/iterate/releases/download/gh-attach-assets/mobile-pr-2490-9903ab088-install-3fe243bc.png" width="90" alt="QR code" /></a>

<sub>Installing gets you a compatible binary on the default channel — then use the OTA link above to switch it to this PR's JS.</sub>

</details>

<sub>Back to main inside the app: Build info → Reset to default channel. Republishes on every push to this PR.</sub>
<!-- /mobile-pr-preview -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The live-state wrapper performs a birth-batch append from a subscribe/read path on one classified error; wrong handling could mask failures, though it mirrors existing unborn-stream patterns and only retries once.
> 
> **Overview**
> Mobile chat list and thread header now show the **agent-set title** from `agent/summary-updated` instead of the raw `/agents/...` path, with a mono path fallback until the first turn lands.
> 
> **API:** `itx.agents.list()` returns **`AgentListItem`** rows that optionally include `title` (mapped from reduced catalog `summary.title`); generated ITX types updated.
> 
> **Live catalog:** The mobile project chat list overlays **`useLiveState(itx.agents.liveState)`** after the initial `list()` paint so titles and chats created elsewhere update via push without refetch-on-navigation.
> 
> **Platform:** **`AgentCollectionLiveStateRpcTarget`** wraps the agent catalog live relay: on the specific `stream-subscription-unconfigured` refusal when `/agents` is not yet born, it appends the idempotent birth batch and retries once so early subscribers (fresh projects) get an empty catalog then live updates.
> 
> **Client logic:** New **`latestAgentTitle`** folds summary events on the thread stream for the chat screen header; list rows use `chat-list-row:<path>` testIDs for specs.
> 
> Tests cover fold semantics, live-state before first agent, RN-web chat-titles flow, and notifications header expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9903ab0889c8e764db5657cace8c419c9c55f65a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

