### PR TITLE
Fix lint-rule race: main is red on note-composer ?:-spreads

### DIFF
--- a/apps/mobile/src/components/note-composer.tsx
+++ b/apps/mobile/src/components/note-composer.tsx
@@ -157,7 +157,7 @@ async function appendNoteToProject(
     composeNoteFile(
       {
         capturedAt: note.capturedOnDeviceAt,
-        ...(attachments.length > 0 ? { attachments } : {}),
+        ...(attachments.length > 0 && { attachments }),
       },
       note.text,
     ),
@@ -457,7 +457,7 @@ export function NoteCaptureOverlay() {
             onPress={() =>
               router.push({
                 pathname: "/project/[projectId]/notes",
-                params: { projectId, ...(params.slug ? { slug: params.slug } : {}) },
+                params: { projectId, ...(params.slug && { slug: params.slug }) },
               })
             }
           >


### PR DESCRIPTION
Main is red right now: #2487 (the `prefer-logical-and-spread` rule) and #2483 (mobile notes) merged concurrently — each green alone, but the notes PR added two `?:`-spread sites in `note-composer.tsx` that the new rule denies. This applies the rule's own auto-fix to those two lines.

## Risk map

- Two-line mechanical style fix (`...(cond ? {x} : {})` → `...(cond && {x})`), semantically identical. No behavior change.
- On merge: main's lint goes green again; every open PR stops inheriting the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two-line style-only change with no runtime behavior difference.
> 
> **Overview**
> **Unblocks main lint** after `iterate/prefer-logical-and-spread` landed alongside mobile notes work: two object spreads in `note-composer.tsx` still used `...(cond ? { … } : {})`, which the new rule rejects.
> 
> Both sites are updated to the rule’s preferred form—optional `attachments` on the composed note file and optional `slug` in the router `params`—using `...(cond && { … })` instead. Behavior is unchanged; object spread already treats a falsy condition like an empty object.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47e4a93f8ecd7602f0fc420d467d3ea68f8045cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- mobile-pr-preview -->
## 📱 Mobile preview

Channel `fix-lint-rule-race` · runtime `023cbbc4d` · **JS-only** — the installed app can run it

<details open><summary>OTA — switch the installed app to this PR's channel (`47e4a93`)</summary>

**[Switch this phone to the PR channel](https://os.iterate.com/m/preview-channel/fix-lint-rule-race)**

<a href="https://os.iterate.com/m/preview-channel/fix-lint-rule-race"><img src="https://github.com/iterate/iterate/releases/download/gh-attach-assets/mobile-pr-2493-47e4a93f8-ota-scheme.png" width="90" alt="QR code" /></a>

</details>
<details><summary>Full install — if the app is uninstalled or the runtime differs (`c3b64f8`)</summary>

**[Open the EAS build install page](https://expo.dev/accounts/mishanustom/projects/iterate/builds/3fe243bc-7133-4020-9205-e6b67ab02ece)**

<a href="https://expo.dev/accounts/mishanustom/projects/iterate/builds/3fe243bc-7133-4020-9205-e6b67ab02ece"><img src="https://github.com/iterate/iterate/releases/download/gh-attach-assets/mobile-pr-2493-47e4a93f8-install-3fe243bc.png" width="90" alt="QR code" /></a>

<sub>Installing gets you a compatible binary on the default channel — then use the OTA link above to switch it to this PR's JS.</sub>

</details>

<sub>Back to main inside the app: Build info → Reset to default channel. Republishes on every push to this PR.</sub>
<!-- /mobile-pr-preview -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-13T08:54:18.278Z",
      "deployedAt": "2026-08-13T08:45:46.562Z",
      "headSha": "47e4a93f8ecd7602f0fc420d467d3ea68f8045cb",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/130315608289113",
      "shortSha": "47e4a93",
      "cleanupDurationMs": 9540,
      "deployDurationMs": 70445,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 66253,
      "deployReadinessDurationMs": 4189,
      "deployedWorkerName": "os-preview-17",
      "deployedWorkerVersion": "4e4f3f78-af3a-4a73-8568-f9700df93395",
      "testDurationMs": 221792,
      "testRetries": null,
      "workerSizeKib": 20777.4,
      "workerGzipKib": 5229.62,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5241.12
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-13T08:54:10.748Z",
      "deployedAt": "2026-08-13T08:44:51.038Z",
      "headSha": "47e4a93f8ecd7602f0fc420d467d3ea68f8045cb",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-17.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/130315608289113",
      "shortSha": "47e4a93",
      "cleanupDurationMs": 2007,
      "deployDurationMs": 29289,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 10728,
      "deployReadinessDurationMs": 18558,
      "deployedWorkerName": "docs-preview-17",
      "deployedWorkerVersion": "dfdf26a8-447e-4535-b524-af34b0ea7461",
      "testDurationMs": 2869,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-13T08:54:13.291Z",
      "deployedAt": "2026-08-13T08:45:01.175Z",
      "headSha": "47e4a93f8ecd7602f0fc420d467d3ea68f8045cb",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/130315608289113",
      "shortSha": "47e4a93",
      "cleanupDurationMs": 4548,
      "deployDurationMs": 20910,
      "deployConfigDurationMs": 10,
      "deployCommandDurationMs": 20858,
      "deployReadinessDurationMs": 41,
      "deployedWorkerName": "auth-preview-17",
      "deployedWorkerVersion": "ceed0a39-95f9-44ff-b313-62a740e11c76",
      "testDurationMs": 19983,
      "testRetries": null,
      "workerSizeKib": 3988.47,
      "workerGzipKib": 817.43,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-13T08:54:09.459Z",
      "deployedAt": "2026-08-13T08:44:45.885Z",
      "headSha": "47e4a93f8ecd7602f0fc420d467d3ea68f8045cb",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/130315608289113",
      "shortSha": "47e4a93",
      "cleanupDurationMs": 714,
      "deployDurationMs": 5766,
      "deployConfigDurationMs": 10,
      "deployCommandDurationMs": 5525,
      "deployReadinessDurationMs": 188,
      "deployedWorkerName": "dummy-petshop-preview-17",
      "deployedWorkerVersion": "fe4e31b1-e582-482d-9593-9f8912f0fe6e",
      "testDurationMs": 28106,
      "testRetries": null,
      "workerSizeKib": 1115.4,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "b717e505c46472150438e97f994eb4a2c283e0f8+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `47e4a93` | [https://auth.iterate-preview-17.com](https://auth.iterate-preview-17.com) | 817.4 KiB | 20.9s | 20.0s |  | 4.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/130315608289113) | 2026-08-13T08:54:13.291Z | Preview app released. |
| Docs | released | `47e4a93` | [https://docs-preview-17.iterate-dev-preview.workers.dev](https://docs-preview-17.iterate-dev-preview.workers.dev) | 866.2 KiB | 29.3s | 2.9s |  | 2.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/130315608289113) | 2026-08-13T08:54:10.748Z | Preview app released. |
| Dummy Petshop | released | `47e4a93` | [https://dummy-petshop.iterate-preview-17.com](https://dummy-petshop.iterate-preview-17.com) | 198.3 KiB | 5.8s | 28.1s |  | 714ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/130315608289113) | 2026-08-13T08:54:09.459Z | Preview app released. |
| OS | released | `47e4a93` | [https://os.iterate-preview-17.com](https://os.iterate-preview-17.com) | 5.11 MiB (-11.5 KiB vs main) | 70.4s | 221.8s |  | 9.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/130315608289113) | 2026-08-13T08:54:18.278Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Mobile | +2 -2 | +2 -2 🟩🟩🟩🟥🟥 |
| **Total** | **+2 -2** | **+2 -2** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 5837476 and 47e4a93, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->