### PR TITLE
Skip sending PostHog events in non-production environments

### DIFF
--- a/apps/os/src/domains/integrations/posthog.test.ts
+++ b/apps/os/src/domains/integrations/posthog.test.ts
@@ -116,6 +116,19 @@ describe("first-party PostHog stream integration", () => {
     expect(() => CoreProcessorContract.parseEventInput(event)).not.toThrow();
   });
 
+  it.each(["os-preview-3", "os-local"])(
+    "acknowledges without egress on non-production worker %s",
+    async (workerName) => {
+      const captureFetch = acceptingFetch();
+
+      await capturePosthogStreamEventBatch(captureArgs([streamEvent()], workerName), {
+        fetch: captureFetch,
+      });
+
+      expect(captureFetch).not.toHaveBeenCalled();
+    },
+  );
+
   it("captures the raw durable event with only useful indexed dimensions", async () => {
     const durable = streamEvent();
     const requests: CapturedRequest[] = [];

--- a/apps/os/src/domains/integrations/posthog.ts
+++ b/apps/os/src/domains/integrations/posthog.ts
@@ -1,4 +1,5 @@
 import { tracing } from "cloudflare:workers";
+import { shouldSendPosthogEvents } from "@iterate-com/shared/posthog";
 import { v5 as uuidv5 } from "uuid";
 import { z } from "zod";
 import type { StreamDeliveryBatch } from "iterate/processors";
@@ -222,6 +223,11 @@ export async function capturePosthogStreamEventBatch(
 ): Promise<void> {
   if (args.batch.events.length === 0) {
     throw new Error("PostHog stream delivery batch must contain an event");
+  }
+  // Non-production workers never report to PostHog; acknowledging the batch
+  // without egress keeps stream delivery semantics identical across envs.
+  if (!shouldSendPosthogEvents(args.workerName)) {
+    return;
   }
   await tracing.enterSpan("posthog.capture_stream_events", async (span) => {
     const streamPathId = posthogUuid([

--- a/apps/os/src/lib/posthog-url-bootstrap.test.ts
+++ b/apps/os/src/lib/posthog-url-bootstrap.test.ts
@@ -108,7 +108,7 @@ describe("shared PostHog initialization", () => {
     });
 
     const { initPosthog } = await import("@iterate-com/ui/components/posthog");
-    initPosthog({ apiKey: "phc_test" });
+    initPosthog({ apiKey: "phc_test", appStage: "os-prd" });
 
     await vi.waitFor(() => expect(posthogInit).toHaveBeenCalledOnce());
     expect(posthogInit.mock.calls[0]?.[1]).toMatchObject({
@@ -127,7 +127,22 @@ describe("shared PostHog initialization", () => {
       strict_script_versioning: true,
     });
     expect(posthogInit.mock.calls[0]?.[1]).not.toHaveProperty("bootstrap");
+    expect(posthogInit.mock.calls[0]?.[1]).not.toHaveProperty("before_send");
   });
+
+  it.each(["os-preview-3", undefined])(
+    "drops every event and disables replay on non-production stage %s",
+    async (appStage) => {
+      await loadPosthog({ appStage });
+
+      const initOptions = posthogInit.mock.calls[0]?.[1] as {
+        before_send: (event: unknown) => unknown;
+        disable_session_recording: boolean;
+      };
+      expect(initOptions).toMatchObject({ disable_session_recording: true });
+      expect(initOptions.before_send({ event: "$pageview" })).toBeNull();
+    },
+  );
 
   it("supports manual TanStack pageviews and disabling replay", async () => {
     await loadPosthog({ capturePageviews: false, sessionRecording: false });

--- a/apps/os/src/observability/posthog.test.ts
+++ b/apps/os/src/observability/posthog.test.ts
@@ -92,6 +92,22 @@ describe("backend PostHog exception capture", () => {
     expect(sdk.shutdown).toHaveBeenCalledWith(2_000);
   });
 
+  it.each(["os-preview-3", undefined])(
+    "is disabled on non-production workers (%s) even with capture on",
+    (workerName) => {
+      const { input, pending } = captureContext();
+
+      schedulePosthogException({
+        ...input,
+        config: { ...config, cloudflare: { workerName } as AppConfig["cloudflare"] },
+        error: new Error("not sent"),
+      });
+
+      expect(pending).toEqual([]);
+      expect(sdk.construct).not.toHaveBeenCalled();
+    },
+  );
+
   it("is disabled when the public PostHog key is absent", () => {
     const { input, pending } = captureContext();
 

--- a/apps/os/src/observability/posthog.ts
+++ b/apps/os/src/observability/posthog.ts
@@ -1,3 +1,4 @@
+import { shouldSendPosthogEvents } from "@iterate-com/shared/posthog";
 import { PostHog } from "posthog-node";
 import type { AppConfig } from "~/config.ts";
 
@@ -38,6 +39,7 @@ export async function withPosthogExceptionCapture<T>(
 export function schedulePosthogException(input: PosthogExceptionContext & { error: unknown }) {
   try {
     if (input.config.posthog?.capture !== true) return;
+    if (!shouldSendPosthogEvents(input.config.cloudflare.workerName)) return;
     const apiKey = input.config.posthog?.apiKey;
     if (!apiKey || scheduledOperations.has(input.operation)) return;
     scheduledOperations.add(input.operation);

--- a/apps/semaphore/scripts/generate-wrangler-config.ts
+++ b/apps/semaphore/scripts/generate-wrangler-config.ts
@@ -54,6 +54,7 @@ export const REQUIRED_SECRETS = [
 export function envShapedVars(env: SemaphoreEnv) {
   return {
     APP_CONFIG_BASE_URL: env.baseUrl,
+    APP_CONFIG_WORKER_NAME: env.workerName,
     APP_CONFIG_ITERATE_AUTH__ISSUER: `${env.authBaseUrl}/api/auth`,
   };
 }

--- a/apps/semaphore/src/config.ts
+++ b/apps/semaphore/src/config.ts
@@ -23,6 +23,10 @@ export const AppConfig = z.object({
   // generate-wrangler-config.ts), so runtime URL and route can never drift.
   // Optional because local dev has no deployed base URL.
   baseUrl: publicValue(z.url().optional()),
+  // The deployed worker script name (`semaphore-prd`), generated from the same
+  // envs.ts entry as the route. Absent in local dev. The browser PostHog
+  // client uses it as the app stage to decide whether events leave the device.
+  workerName: publicValue(z.string().trim().min(1).optional()),
   logs: AppLogsConfig.default({ stdoutFormat: "pretty", filtering: { rules: [] } }),
   posthog: z.object({
     apiKey: publicValue(z.string().trim().min(1)),

--- a/apps/semaphore/src/routes/__root.tsx
+++ b/apps/semaphore/src/routes/__root.tsx
@@ -59,6 +59,7 @@ function RootComponent() {
   return (
     <AppProviders
       config={config}
+      posthog={{ appStage: config?.workerName }}
       devtools={
         <TanStackDevtools
           config={{ position: "bottom-left" }}

--- a/packages/shared/src/posthog/posthog.test.ts
+++ b/packages/shared/src/posthog/posthog.test.ts
@@ -1,5 +1,18 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { proxyPosthogRequest } from "./posthog.ts";
+import { proxyPosthogRequest, shouldSendPosthogEvents } from "./posthog.ts";
+
+describe("shouldSendPosthogEvents", () => {
+  it.each(["os-prd", "semaphore-prd", "prd"])("sends from production deployment %s", (env) => {
+    expect(shouldSendPosthogEvents(env)).toBe(true);
+  });
+
+  it.each(["os-preview-3", "os-local", "dev", "", undefined])(
+    "drops everything from non-production environment %s",
+    (env) => {
+      expect(shouldSendPosthogEvents(env)).toBe(false);
+    },
+  );
+});
 
 describe("proxyPosthogRequest", () => {
   afterEach(() => vi.unstubAllGlobals());

--- a/packages/shared/src/posthog/posthog.ts
+++ b/packages/shared/src/posthog/posthog.ts
@@ -1,3 +1,14 @@
+/**
+ * Only production deployments report to PostHog — previews, local dev, and CI
+ * produce noise that costs real ingestion money. The environment identifier is
+ * the deployed worker name from envs.ts (`os-prd`, `semaphore-prd`,
+ * `os-preview-3`); local dev has none. Every PostHog client gates its egress
+ * on this one predicate so application code stays unaware of the policy.
+ */
+export function shouldSendPosthogEvents(environment: string | undefined): boolean {
+  return environment === "prd" || Boolean(environment?.endsWith("-prd"));
+}
+
 export interface ProxyPosthogRequestOptions {
   request: Request;
   proxyPrefix: string;

--- a/packages/ui/src/components/posthog.tsx
+++ b/packages/ui/src/components/posthog.tsx
@@ -1,3 +1,5 @@
+import { shouldSendPosthogEvents } from "@iterate-com/shared/posthog";
+
 // posthog-js only ever runs in the browser; the SSR branch keeps it out of the
 // server bundle.
 const loadPosthog = import.meta.env.SSR ? null : () => import("posthog-js");
@@ -52,8 +54,14 @@ function resolveBrowserUrl(url?: string) {
 }
 
 function buildPosthogInitOptions(options: SetupPosthogOptions) {
-  const sessionRecording = options.sessionRecording !== false;
+  // Non-production deployments still initialize the SDK (feature flags,
+  // toolbar) but never send events: `before_send` drops everything at egress,
+  // and session recording is off since its $snapshot events would be dropped
+  // anyway. appStage is the deployed worker name; local dev has none.
+  const sendEvents = shouldSendPosthogEvents(options.appStage);
+  const sessionRecording = options.sessionRecording !== false && sendEvents;
   return {
+    ...(!sendEvents && { before_send: () => null }),
     api_host: resolveBrowserUrl(options.proxyUrl ?? "/e"),
     ui_host: resolveBrowserUrl(options.uiHost ?? "https://eu.posthog.com"),
     defaults: "2026-06-25" as const,

--- a/scripts/ci/posthog-events.test.ts
+++ b/scripts/ci/posthog-events.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "vitest";
-import { postHogEventBatches, systemEvent, type PostHogEvent } from "./posthog-events.ts";
+import { systemEvent } from "./posthog-events.ts";
 
 it("uses a stable top-level PostHog UUID for retry and replay deduplication", () => {
   const first = systemEvent("ci test finished", "stable-source-occurrence", "ci-test:1", {});
@@ -13,39 +13,3 @@ it("uses a stable top-level PostHog UUID for retry and replay deduplication", ()
   );
   expect(first.properties.$insert_id).toBe("stable-source-occurrence");
 });
-
-it("packs capture batches by encoded payload size", () => {
-  const events = [
-    eventWithPayload("a", "1234"),
-    eventWithPayload("b", "5678"),
-    eventWithPayload("c", "9"),
-  ];
-  const oneEventBytes = Buffer.byteLength(JSON.stringify(events[0]));
-
-  expect(postHogEventBatches(events, oneEventBytes * 2 + 1)).toEqual([
-    [events[0], events[1]],
-    [events[2]],
-  ]);
-});
-
-it("keeps an individually oversized event intact for an explicit API failure", () => {
-  const event = eventWithPayload("oversized", "1234567890");
-  expect(postHogEventBatches([event], 1)).toEqual([[event]]);
-});
-
-it.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1])(
-  "rejects an invalid capture batch byte budget (%s)",
-  (budget) => {
-    expect(() => postHogEventBatches([], budget)).toThrow(
-      "PostHog batch event budget must be a positive safe integer",
-    );
-  },
-);
-
-function eventWithPayload(id: string, payload: string): PostHogEvent {
-  return {
-    event: "ci test finished",
-    uuid: id,
-    properties: { distinct_id: `ci-test:${id}`, payload },
-  };
-}

--- a/scripts/ci/posthog-events.ts
+++ b/scripts/ci/posthog-events.ts
@@ -7,75 +7,19 @@ export type PostHogEvent = {
   properties: Record<string, unknown>;
 };
 
-// PostHog accepts batch request bodies up to 20 MB. Keep our event payload at
-// one quarter of that ceiling so the API key/envelope and future event-shape
-// growth retain generous headroom, while avoiding one HTTP round trip per 100
-// test events (the preview suite currently emits roughly 7,000 per run).
-const POSTHOG_BATCH_EVENT_BUDGET_BYTES = 5_000_000;
-
-export function readPostHogConfig(environment = process.env): { apiKey: string; host: string } {
-  const raw = environment.APP_CONFIG_POSTHOG?.trim();
-  if (!raw) throw new Error("APP_CONFIG_POSTHOG is required for CI telemetry");
-  const parsed = JSON.parse(raw) as { apiKey?: unknown; host?: unknown };
-  if (typeof parsed.apiKey !== "string" || parsed.apiKey.length === 0) {
-    throw new Error("APP_CONFIG_POSTHOG.apiKey is required for CI telemetry");
-  }
-  return {
-    apiKey: parsed.apiKey,
-    host:
-      typeof parsed.host === "string" ? parsed.host.replace(/\/$/, "") : "https://eu.i.posthog.com",
-  };
-}
-
-/** Delivers deterministic system events. Callers supply stable identities for backfill safety. */
-export async function sendPostHogEvents(events: PostHogEvent[], config = readPostHogConfig()) {
-  for (const batch of postHogEventBatches(events)) {
-    let lastError: unknown;
-    for (let attempt = 0; attempt < 3; attempt += 1) {
-      try {
-        const response = await fetch(`${config.host}/batch/`, {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ api_key: config.apiKey, batch }),
-          signal: AbortSignal.timeout(15_000),
-        });
-        if (!response.ok)
-          throw new Error(`PostHog returned ${response.status}: ${await response.text()}`);
-        lastError = undefined;
-        break;
-      } catch (error) {
-        lastError = error;
-        if (attempt < 2) await new Promise((resolve) => setTimeout(resolve, 1_000));
-      }
-    }
-    if (lastError) throw new Error("PostHog CI telemetry delivery failed", { cause: lastError });
-  }
-}
-
-export function postHogEventBatches(
-  events: readonly PostHogEvent[],
-  eventBudgetBytes = POSTHOG_BATCH_EVENT_BUDGET_BYTES,
-): PostHogEvent[][] {
-  if (!Number.isSafeInteger(eventBudgetBytes) || eventBudgetBytes <= 0) {
-    throw new TypeError("PostHog batch event budget must be a positive safe integer");
-  }
-
-  const batches: PostHogEvent[][] = [];
-  let batch: PostHogEvent[] = [];
-  let batchBytes = 0;
-  for (const event of events) {
-    const eventBytes = Buffer.byteLength(JSON.stringify(event));
-    const separatorBytes = batch.length === 0 ? 0 : 1;
-    if (batch.length > 0 && batchBytes + separatorBytes + eventBytes > eventBudgetBytes) {
-      batches.push(batch);
-      batch = [];
-      batchBytes = 0;
-    }
-    batch.push(event);
-    batchBytes += (batch.length === 1 ? 0 : 1) + eventBytes;
-  }
-  if (batch.length > 0) batches.push(batch);
-  return batches;
+/**
+ * CI telemetry delivery is downsampled to ZERO: CI test events were 70%+ of
+ * all PostHog ingestion (millions of events per month) and the bill has to
+ * come down. Telemetry artifacts are still written and uploaded to CI storage
+ * — only the PostHog egress is dropped. Every CI event flows through this one
+ * chokepoint, so restoring delivery (ideally sampled) means reverting this
+ * function to its pre-zero implementation in git history (batching, retries,
+ * APP_CONFIG_POSTHOG credentials).
+ */
+export async function sendPostHogEvents(events: PostHogEvent[]) {
+  console.log(
+    `[ci-telemetry] PostHog delivery is downsampled to zero; dropped ${events.length} event(s)`,
+  );
 }
 
 export function systemEvent(

--- a/scripts/ci/sync-ci-telemetry.ts
+++ b/scripts/ci/sync-ci-telemetry.ts
@@ -41,7 +41,7 @@ async function main() {
   console.log(`[ci-telemetry] collected ${events.length} idempotent event(s)`);
   if (dryRun) {
     console.log(JSON.stringify(summarize(events), null, 2));
-  } else if (process.env.CI_TELEMETRY_POSTHOG_ENABLED === "1") await sendPostHogEvents(events);
+  } else await sendPostHogEvents(events);
   if (failures.length > 0) {
     throw new AggregateError(
       failures.map((failure) => failure.error),

--- a/scripts/ci/upload-test-telemetry.test.ts
+++ b/scripts/ci/upload-test-telemetry.test.ts
@@ -5,7 +5,7 @@ import {
   writeTestTelemetryArtifact,
   type TestTelemetryArtifact,
 } from "@iterate-com/shared/test-support/ci-telemetry";
-import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { afterEach, expect, it, vi } from "vitest";
 import { finalizeTestTelemetry, testTelemetryEvents } from "./upload-test-telemetry.ts";
 
 const { sendPostHogEventsMock } = vi.hoisted(() => ({ sendPostHogEventsMock: vi.fn() }));
@@ -14,12 +14,8 @@ vi.mock("./posthog-events.ts", async (importOriginal) => ({
   sendPostHogEvents: sendPostHogEventsMock,
 }));
 
-beforeEach(() => {
-  process.env.CI_TELEMETRY_POSTHOG_ENABLED = "1";
-});
 afterEach(() => {
   sendPostHogEventsMock.mockReset();
-  delete process.env.CI_TELEMETRY_POSTHOG_ENABLED;
 });
 
 const artifact: TestTelemetryArtifact = {

--- a/scripts/ci/upload-test-telemetry.ts
+++ b/scripts/ci/upload-test-telemetry.ts
@@ -101,13 +101,7 @@ export async function finalizeTestTelemetry(options: {
   console.log(
     `[test-telemetry] normalized ${loaded.length} artifact(s) into ${events.length} event(s)`,
   );
-  if (
-    !options.dryRun &&
-    !options.cancelled &&
-    events.length > 0 &&
-    process.env.CI_TELEMETRY_POSTHOG_ENABLED === "1"
-  )
-    await sendPostHogEvents(events);
+  if (!options.dryRun && !options.cancelled && events.length > 0) await sendPostHogEvents(events);
   if (!options.cancelled) {
     const failures = [
       ...(missingWorkspaces.length > 0

--- a/tasks/posthog-skip-nonprod-events.md
+++ b/tasks/posthog-skip-nonprod-events.md
@@ -9,10 +9,17 @@ branch: posthog-skip-nonprod
 ## Status summary
 
 Implemented, all checks green, PR open (draft):
-https://github.com/iterate/iterate/pull/2494. Every PostHog client (browser,
-server exceptions, durable stream events) now gates on one shared
-`shouldSendPosthogEvents(environment)` predicate — non-prod deployments no-op
-at egress. Remaining: review.
+https://github.com/iterate/iterate/pull/2494. Two pieces:
+
+1. Every app PostHog client (browser, server exceptions, durable stream
+   events) gates on one shared `shouldSendPosthogEvents(environment)`
+   predicate — non-prod deployments no-op at egress.
+2. CI telemetry PostHog delivery downsampled to ZERO: `sendPostHogEvents` in
+   `scripts/ci/posthog-events.ts` drops everything (artifacts still written).
+   CI test events were 70%+ of all ingestion (~13M/month at the July run
+   rate); the `CI_TELEMETRY_POSTHOG_ENABLED` escape hatch is gone.
+
+Remaining: review.
 
 ## Motivation
 
@@ -42,9 +49,10 @@ for the browser SDK), so no feature code changes:
 - "Non-production" = anything whose worker name isn't `*-prd`: preview slots,
   local dev (`pnpm dev`), `dev_<you>`, CI e2e runs against previews. Semaphore
   prd counts as production (it's a real deployed surface; its traffic is tiny).
-- CI test telemetry (`scripts/ci/*` → posthog-events.ts etc.) is a deliberate,
-  separate pipeline and stays untouched. If the bill analysis shows it's a big
-  contributor, that's a follow-up task.
+- ~~CI test telemetry (`scripts/ci/*` → posthog-events.ts etc.) is a
+  deliberate, separate pipeline and stays untouched.~~ _Superseded: the bill
+  analysis (PostHog HogQL, 30 days) showed CI telemetry was 71% of all
+  ingestion — Misha asked for it to be downsampled to zero in this PR._
 - We gate in code rather than only flipping `capture`/`sendStreamEvents` in
   non-prd Doppler configs: config-only is invisible, easy to regress, and the
   browser client in semaphore isn't gated by any flag today. The existing
@@ -86,8 +94,28 @@ for the browser SDK), so no feature code changes:
 - **PostHog-side downsampling transformation**: still ingests (billing),
   affects prod data quality, needs PostHog-side config nobody can code-review.
 
+## Bill analysis (2026-08-13, via PostHog HogQL)
+
+30-day org totals: prd project 16.9M events, stg 3.2M, dev 0.19M, ~20.3M
+total. prd breakdown: 71% CI test telemetry, 29% prod stream:append, 0.03%
+browser/product. stg's 3.2M was a one-off July 15–18 burst of preview stream
+events (2.67M on July 17 alone) — the exact accident the code gate prevents.
+Current steady state: non-prod ~11 events/day, CI telemetry bursting only
+from branches that re-enable it (441k on Aug 10–11 from
+`fix/posthog-ci-delivery-fence`).
+
+Note: PR #2446 (Jonas, Aug 6) deliberately removed an earlier worker-name
+gate from `capturePosthogStreamEventBatch` in favor of config flags only.
+This PR re-adds a worker-name gate — deliberately, because the July burst
+shows config flags alone regress silently.
+
 ## Implementation log
 
+- 2026-08-13 (later): CI telemetry downsampled to zero at the
+  `sendPostHogEvents` chokepoint — batching/retry/credential code deleted
+  (recoverable from git history), `CI_TELEMETRY_POSTHOG_ENABLED` checks
+  removed from both callers so the code can't suggest an env var re-enables
+  delivery. Artifact writing and CI-storage upload untouched.
 - 2026-08-13: one shared predicate + four egress gates, ~40 lines of product
   code. Notable deviation from the spec: the stream-event gate lives in
   `capturePosthogStreamEventBatch` rather than the rpc-target, because the

--- a/tasks/posthog-skip-nonprod-events.md
+++ b/tasks/posthog-skip-nonprod-events.md
@@ -1,0 +1,81 @@
+---
+status: in-progress
+size: small
+branch: posthog-skip-nonprod
+---
+
+# PostHog: skip sending all events from non-production environments
+
+## Status summary
+
+Spec fleshed out, implementation not started. Goal: cut the PostHog bill by
+making every PostHog client in the repo a no-op outside production, with one
+shared gate so application code stays unaware.
+
+## Motivation
+
+Our PostHog bill is too high. Preview slots, local dev, and shared dev all
+send real events (pageviews, session recordings, exceptions, durable stream
+events) to the same PostHog project as production. None of that non-prod
+traffic is worth its ingestion cost. Downsampling
+(https://posthog.com/docs/cdp/transformations/downsampling-plugin) was
+considered but is server-side, more involved, and still ingests; client-side
+"don't send" is free and simpler.
+
+## Design
+
+One shared predicate, applied at each client's egress point (`before_send`
+for the browser SDK), so no feature code changes:
+
+- `packages/shared/src/posthog/posthog.ts` gains
+  `shouldSendPosthogEvents(environment: string | undefined): boolean` —
+  true only for production deployments. The environment string is the worker
+  name (`os-prd`, `semaphore-prd`, `os-preview-3`, undefined for local dev).
+  Production = `prd` or `*-prd`.
+- Every client already tags events with `$environment` derived from the same
+  worker name, so the gate input already exists at each site.
+
+### Assumptions (made while fleshing out, AFK-style)
+
+- "Non-production" = anything whose worker name isn't `*-prd`: preview slots,
+  local dev (`pnpm dev`), `dev_<you>`, CI e2e runs against previews. Semaphore
+  prd counts as production (it's a real deployed surface; its traffic is tiny).
+- CI test telemetry (`scripts/ci/*` → posthog-events.ts etc.) is a deliberate,
+  separate pipeline and stays untouched. If the bill analysis shows it's a big
+  contributor, that's a follow-up task.
+- We gate in code rather than only flipping `capture`/`sendStreamEvents` in
+  non-prd Doppler configs: config-only is invisible, easy to regress, and the
+  browser client in semaphore isn't gated by any flag today. The existing
+  config flags remain as-is (they still gate prod behavior).
+- Feature flags / surveys / toolbar still work in non-prod (SDK still
+  initializes); we only drop outgoing capture traffic. Session recording is
+  additionally disabled in non-prod since its `$snapshot` events would be
+  dropped anyway — no point paying the runtime overhead.
+
+## Checklist
+
+- [ ] `shouldSendPosthogEvents(environment)` in `packages/shared/src/posthog/posthog.ts` + unit test
+- [ ] Browser SDK (`packages/ui/src/components/posthog.tsx`): `before_send` hook in
+      `buildPosthogInitOptions` that drops every event when
+      `!shouldSendPosthogEvents(appStage)`; disable session recording in that case too
+- [ ] Semaphore passes an environment identifier (`appStage`) to `AppProviders`
+      so its browser client goes through the same gate
+- [ ] Server exception capture (`apps/os/src/observability/posthog.ts`):
+      early-return in `schedulePosthogException` when the gate says no
+- [ ] Durable stream events (`apps/os/src/rpc-targets.ts`
+      `PostHogIntegrationRpcTarget`): same gate next to the existing
+      `sendStreamEvents` check
+- [ ] Tests: gate behavior covered in existing posthog test files
+- [ ] `pnpm typecheck && pnpm lint && pnpm knip && pnpm format && pnpm test`
+
+## Alternatives considered
+
+- **Doppler config flip only** (set `capture=false`, `sendStreamEvents=false`
+  in non-prd configs): zero code, but silently regressable, doesn't cover
+  semaphore's browser client, and leaves nothing in the repo explaining why.
+- **PostHog-side downsampling transformation**: still ingests (billing),
+  affects prod data quality, needs PostHog-side config nobody can code-review.
+
+## Implementation log
+
+(added as work happens)

--- a/tasks/posthog-skip-nonprod-events.md
+++ b/tasks/posthog-skip-nonprod-events.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: implemented
 size: small
 branch: posthog-skip-nonprod
 ---
@@ -8,9 +8,11 @@ branch: posthog-skip-nonprod
 
 ## Status summary
 
-Spec fleshed out, implementation not started. Goal: cut the PostHog bill by
-making every PostHog client in the repo a no-op outside production, with one
-shared gate so application code stays unaware.
+Implemented, all checks green, PR open (draft):
+https://github.com/iterate/iterate/pull/2494. Every PostHog client (browser,
+server exceptions, durable stream events) now gates on one shared
+`shouldSendPosthogEvents(environment)` predicate — non-prod deployments no-op
+at egress. Remaining: review.
 
 ## Motivation
 
@@ -54,19 +56,27 @@ for the browser SDK), so no feature code changes:
 
 ## Checklist
 
-- [ ] `shouldSendPosthogEvents(environment)` in `packages/shared/src/posthog/posthog.ts` + unit test
-- [ ] Browser SDK (`packages/ui/src/components/posthog.tsx`): `before_send` hook in
+- [x] `shouldSendPosthogEvents(environment)` in `packages/shared/src/posthog/posthog.ts` + unit test
+      _`prd` or `*-prd` only; tested in posthog.test.ts alongside the proxy tests_
+- [x] Browser SDK (`packages/ui/src/components/posthog.tsx`): `before_send` hook in
       `buildPosthogInitOptions` that drops every event when
       `!shouldSendPosthogEvents(appStage)`; disable session recording in that case too
-- [ ] Semaphore passes an environment identifier (`appStage`) to `AppProviders`
+      _both in `buildPosthogInitOptions`; SDK still initializes so flags/toolbar work_
+- [x] Semaphore passes an environment identifier (`appStage`) to `AppProviders`
       so its browser client goes through the same gate
-- [ ] Server exception capture (`apps/os/src/observability/posthog.ts`):
+      _new `workerName` publicValue in semaphore config, emitted as
+      `APP_CONFIG_WORKER_NAME` by generate-wrangler-config, passed in `__root.tsx`_
+- [x] Server exception capture (`apps/os/src/observability/posthog.ts`):
       early-return in `schedulePosthogException` when the gate says no
-- [ ] Durable stream events (`apps/os/src/rpc-targets.ts`
-      `PostHogIntegrationRpcTarget`): same gate next to the existing
-      `sendStreamEvents` check
-- [ ] Tests: gate behavior covered in existing posthog test files
-- [ ] `pnpm typecheck && pnpm lint && pnpm knip && pnpm format && pnpm test`
+- [x] ~~Durable stream events (`apps/os/src/rpc-targets.ts`)~~ gate placed inside
+      `capturePosthogStreamEventBatch` (`apps/os/src/domains/integrations/posthog.ts`)
+      instead — it already receives `workerName` and is directly testable;
+      rpc-targets untouched
+- [x] Tests: gate behavior covered in existing posthog test files
+      _shared predicate, os observability (preview + undefined worker), stream
+      batch no-egress, browser init options in posthog-url-bootstrap.test.ts_
+- [x] `pnpm typecheck && pnpm lint && pnpm knip && pnpm format && pnpm test`
+      _all green locally 2026-08-13_
 
 ## Alternatives considered
 
@@ -78,4 +88,10 @@ for the browser SDK), so no feature code changes:
 
 ## Implementation log
 
-(added as work happens)
+- 2026-08-13: one shared predicate + four egress gates, ~40 lines of product
+  code. Notable deviation from the spec: the stream-event gate lives in
+  `capturePosthogStreamEventBatch` rather than the rpc-target, because the
+  function already takes `workerName` and its test file could cover the gate
+  directly. The os "defaults" browser test
+  (`apps/os/src/lib/posthog-url-bootstrap.test.ts`) now inits with
+  `appStage: "os-prd"` since the no-stage default is deliberately fail-closed.


### PR DESCRIPTION
Cuts the PostHog bill in two moves, sized by a 30-day HogQL analysis of the org's ingestion (~20.3M events/30d): **71% CI test telemetry, 29% prod stream events, 0.03% product/browser** — plus a one-off 3.1M-event burst (July 15–18) when preview stream events got switched on by accident.

Spec + bill analysis: [tasks/posthog-skip-nonprod-events.md](https://github.com/iterate/iterate/blob/posthog-skip-nonprod/tasks/posthog-skip-nonprod-events.md)

## 1. CI telemetry downsampled to ZERO (the 71%)

`sendPostHogEvents` in `scripts/ci/posthog-events.ts` — the single chokepoint every CI event flows through — now drops everything and logs the count. Telemetry artifacts are still written and uploaded to CI storage; only the PostHog egress is gone. The `CI_TELEMETRY_POSTHOG_ENABLED` escape hatch is removed from both callers: since #2446 it defaulted off, but branches kept re-enabling it (441k events on Aug 10–11 alone from one branch). Restoring delivery — ideally sampled — is a deliberate revert of this one function, whose batching/retry implementation lives in git history.

## 2. Non-production environments can't send at all

One predicate in `@iterate-com/shared/posthog`:

```ts
// true only for prd / *-prd worker names (os-prd, semaphore-prd);
// previews (os-preview-3), local dev (undefined) drop everything
shouldSendPosthogEvents(environment: string | undefined): boolean
```

applied at each app client's egress:

- **Browser SDK** (`packages/ui/src/components/posthog.tsx`): non-prod stages init with `before_send: () => null` and session replay disabled. The SDK still initializes, so feature flags and the toolbar keep working in previews.
- **Backend exception capture** (`apps/os/src/observability/posthog.ts`): early-return in `schedulePosthogException`.
- **Durable stream events** (`apps/os/src/domains/integrations/posthog.ts`): `capturePosthogStreamEventBatch` acknowledges without egress.
- **Semaphore** now learns its worker name (new `APP_CONFIG_WORKER_NAME` generated var + `workerName` publicValue) and passes it as the PostHog app stage.

Note for reviewers: #2446 deliberately removed an earlier worker-name gate in favor of Doppler config flags only. This PR re-adds a worker-name gate on purpose — the July burst is what config-only protection regressing looks like, and the Doppler flags stay as the prod-side controls.

## Risk map

- Riskiest part: the fail-closed default. Any client initialized **without** an environment identifier sends nothing. The os browser client passes `config.cloudflare.workerName` (already public config); semaphore's is newly plumbed. Grep for other `initPosthog`/`AppProviders` callers when reviewing.
- On merge: CI telemetry PostHog delivery stops entirely (dashboards fed by `ci test *` events go stale from merge day; artifacts remain for backfill). Preview/dev backend exceptions no longer reach PostHog — preview debugging relies on Cloudflare logs/tracing.
- Review order: `scripts/ci/posthog-events.ts` (delivery removal), `packages/shared/src/posthog/posthog.ts` (predicate), `packages/ui/src/components/posthog.tsx` (before_send + replay), the two os early-returns, then semaphore plumbing and tests.

## Testing

Gate behavior covered in `packages/shared` (predicate), os observability (preview + undefined worker names schedule nothing), stream batch (no fetch on non-prod), browser init options (`before_send` drops, replay disabled), and `scripts/ci` suite passing with delivery removed. Full `typecheck && lint && knip && format && test` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session: 25f6ee70-869e-415b-a15a-f0b0f52a8382

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +24 -0 | +11 -0 🟩⬜⬜⬜⬜ |
| UI components | +9 -1 | +4 -1 🟩⬜⬜⬜⬜ |
| Tests | +61 -44 | +49 -39 🟩🟩🟥🟥⬜ |
| CI & scripts | +16 -77 | +7 -66 🟥🟥🟥🟥⬜ |
| Docs | +125 -0 | +104 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+235 -122** | **+175 -106** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between b90ecb9 and 248378b, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-13T14:52:00.298Z",
      "deployedAt": "2026-08-13T12:45:34.108Z",
      "headSha": "248378be9c8f00a3f03169bb8aad895566bdf3bd",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/284456907350888",
      "shortSha": "248378b",
      "cleanupDurationMs": 15956,
      "deployDurationMs": 72248,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 70341,
      "deployReadinessDurationMs": 1904,
      "deployedWorkerName": "os-preview-2",
      "deployedWorkerVersion": "6f686786-0272-45c7-a04d-a6f763f3d67a",
      "testDurationMs": 245522,
      "testRetries": null,
      "workerSizeKib": 20778.29,
      "workerGzipKib": 5230.57,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5241.05
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-13T14:51:49.171Z",
      "deployedAt": "2026-08-13T12:44:38.838Z",
      "headSha": "248378be9c8f00a3f03169bb8aad895566bdf3bd",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-2.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/284456907350888",
      "shortSha": "248378b",
      "cleanupDurationMs": 4826,
      "deployDurationMs": 15296,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 15069,
      "deployReadinessDurationMs": 223,
      "deployedWorkerName": "docs-preview-2",
      "deployedWorkerVersion": "52a42ba5-268c-4800-b438-1482f3b10fc8",
      "testDurationMs": 2197,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-08-13T14:51:45.234Z",
      "deployedAt": "2026-08-13T12:44:38.440Z",
      "headSha": "248378be9c8f00a3f03169bb8aad895566bdf3bd",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/284456907350888",
      "shortSha": "248378b",
      "cleanupDurationMs": 885,
      "deployDurationMs": 14856,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 14670,
      "deployReadinessDurationMs": 180,
      "deployedWorkerName": "semaphore-preview-2",
      "deployedWorkerVersion": "8420095e-c585-4562-8922-3a9d0b5f9e16",
      "testDurationMs": 49628,
      "testRetries": null,
      "workerSizeKib": 1915.87,
      "workerGzipKib": 441.25,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-13T14:51:50.012Z",
      "deployedAt": "2026-08-13T12:44:45.829Z",
      "headSha": "248378be9c8f00a3f03169bb8aad895566bdf3bd",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/284456907350888",
      "shortSha": "248378b",
      "cleanupDurationMs": 5662,
      "deployDurationMs": 22489,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 22058,
      "deployReadinessDurationMs": 426,
      "deployedWorkerName": "auth-preview-2",
      "deployedWorkerVersion": "e99f4315-d905-4ab9-a8d4-bd923e2c2916",
      "testDurationMs": 17822,
      "testRetries": null,
      "workerSizeKib": 3989.66,
      "workerGzipKib": 817.29,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-08-13T14:51:51.719Z",
      "deployedAt": "2026-08-13T12:44:40.403Z",
      "headSha": "248378be9c8f00a3f03169bb8aad895566bdf3bd",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/284456907350888",
      "shortSha": "248378b",
      "cleanupDurationMs": 7367,
      "deployDurationMs": 24913,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 16631,
      "deployReadinessDurationMs": 8275,
      "deployedWorkerName": "streams-example-app-preview-2",
      "deployedWorkerVersion": "90261d56-1e18-484d-a115-56596b867925",
      "testDurationMs": 82530,
      "testRetries": null,
      "workerSizeKib": 5527.1,
      "workerGzipKib": 1562.14,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-13T14:51:45.986Z",
      "deployedAt": "2026-08-13T12:44:44.214Z",
      "headSha": "248378be9c8f00a3f03169bb8aad895566bdf3bd",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/284456907350888",
      "shortSha": "248378b",
      "cleanupDurationMs": 752,
      "deployDurationMs": 5795,
      "deployConfigDurationMs": 0,
      "deployCommandDurationMs": 5589,
      "deployReadinessDurationMs": 202,
      "deployedWorkerName": "dummy-petshop-preview-2",
      "deployedWorkerVersion": "478cfa80-054a-482e-81f9-41b0398e9779",
      "testDurationMs": 39696,
      "testRetries": null,
      "workerSizeKib": 1115.4,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "b717e505c46472150438e97f994eb4a2c283e0f8+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `248378b` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 817.3 KiB | 22.5s | 17.8s |  | 5.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/284456907350888) | 2026-08-13T14:51:50.012Z | Preview app released. |
| Docs | released | `248378b` | [https://docs-preview-2.iterate-dev-preview.workers.dev](https://docs-preview-2.iterate-dev-preview.workers.dev) | 866.2 KiB | 15.3s | 2.2s |  | 4.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/284456907350888) | 2026-08-13T14:51:49.171Z | Preview app released. |
| Dummy Petshop | released | `248378b` | [https://dummy-petshop.iterate-preview-2.com](https://dummy-petshop.iterate-preview-2.com) | 198.3 KiB | 5.8s | 39.7s |  | 752ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/284456907350888) | 2026-08-13T14:51:45.986Z | Preview app released. |
| OS | released | `248378b` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 5.11 MiB (-10.5 KiB vs main) | 72.2s | 245.5s |  | 16.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/284456907350888) | 2026-08-13T14:52:00.298Z | Preview app released. |
| Semaphore | released | `248378b` | [https://semaphore.iterate-preview-2.com](https://semaphore.iterate-preview-2.com) | 441.3 KiB | 14.9s | 49.6s |  | 885ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/284456907350888) | 2026-08-13T14:51:45.234Z | Preview app released. |
| Streams Example App | released | `248378b` | [https://streams.iterate-preview-2.com](https://streams.iterate-preview-2.com) | 1.53 MiB | 24.9s | 82.5s |  | 7.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/284456907350888) | 2026-08-13T14:51:51.719Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->