### PR TITLE
Dynamic worker loads: bare stable identity, nonce only for recovery

### DIFF
--- a/apps/os/src/domains/itx/itx-entrypoint.ts
+++ b/apps/os/src/domains/itx/itx-entrypoint.ts
@@ -79,7 +79,7 @@ export class ItxEntrypoint extends WorkerEntrypoint<Env, ItxEntrypointProps> {
     const runner = new DynamicWorkerRunner({
       streamContext,
       exports: this.ctx.exports,
-      loaderNonceScope: "parent-isolate",
+      loaderScope: "shared",
       projectId,
       scopePath: taken.dispatch.ref.path,
     });

--- a/apps/os/src/domains/itx/itx-entrypoint.ts
+++ b/apps/os/src/domains/itx/itx-entrypoint.ts
@@ -79,6 +79,7 @@ export class ItxEntrypoint extends WorkerEntrypoint<Env, ItxEntrypointProps> {
     const runner = new DynamicWorkerRunner({
       streamContext,
       exports: this.ctx.exports,
+      loaderNonceScope: "parent-isolate",
       projectId,
       scopePath: taken.dispatch.ref.path,
     });

--- a/apps/os/src/domains/processor-facet-durable-object.ts
+++ b/apps/os/src/domains/processor-facet-durable-object.ts
@@ -464,6 +464,7 @@ export class ProcessorFacet extends ProcessorFacetBase<Env> {
           new DynamicWorkerRunner({
             streamContext: { kind: "scope", scopePath: "/" },
             exports: this.ctx.exports,
+            loaderNonceScope: "parent-isolate",
             projectId,
             scopePath: "/",
           }).fetch({

--- a/apps/os/src/domains/processor-facet-durable-object.ts
+++ b/apps/os/src/domains/processor-facet-durable-object.ts
@@ -464,7 +464,7 @@ export class ProcessorFacet extends ProcessorFacetBase<Env> {
           new DynamicWorkerRunner({
             streamContext: { kind: "scope", scopePath: "/" },
             exports: this.ctx.exports,
-            loaderNonceScope: "parent-isolate",
+            loaderScope: "shared",
             projectId,
             scopePath: "/",
           }).fetch({

--- a/apps/os/src/domains/workers/worker-loader.serve.test.ts
+++ b/apps/os/src/domains/workers/worker-loader.serve.test.ts
@@ -429,6 +429,42 @@ describe("resolveWorkerSource", () => {
     ]);
   });
 
+  test("loads the bare identity when no instance nonce is supplied", async () => {
+    const resolved = sourceFrom(
+      await resolveWorkerSource({
+        projectId: "prj_bare",
+        source: {
+          createWorker: {
+            files: { files: { "main.js": "export default {};" }, type: "inline" },
+          },
+        },
+      }),
+    );
+    const load = () =>
+      loadResolvedWorker({
+        bindings: {},
+        globalOutbound: {} as Fetcher,
+        loaderInstanceNonce: undefined,
+        mode: "cached",
+        projectId: "prj_bare",
+        resolved,
+        scopePath: "/",
+        streamContext: { kind: "scope", scopePath: "/" },
+      });
+
+    load();
+    load();
+
+    const [first, second] = h.state.loaderCalls.map(({ key }) => key);
+    // Every distinct key is a billable Dynamic Worker per day: without a
+    // nonce the key ends at the content hash, so repeat loads anywhere in
+    // the deployment converge on one identity.
+    expect(first).toBe(
+      `worker-loader:os-test:version-1:prj_bare:/:{"kind":"scope","scopePath":"/"}:${resolved.cacheKey}`,
+    );
+    expect(second).toBe(first);
+  });
+
   test("scopes loaded workers to the runner that minted their RPC bindings", async () => {
     const resolved = sourceFrom(
       await resolveWorkerSource({

--- a/apps/os/src/domains/workers/worker-loader.ts
+++ b/apps/os/src/domains/workers/worker-loader.ts
@@ -213,8 +213,9 @@ export function loadResolvedWorker({
 }: {
   bindings: WorkerBindings;
   globalOutbound: Fetcher;
-  /** The runner lifetime that minted these loopback RPC bindings. */
-  loaderInstanceNonce: string;
+  /** Extra key component partitioning the loader cache by binding lifetime.
+   * Undefined loads under the bare identity — the cheap steady state. */
+  loaderInstanceNonce: string | undefined;
   /** Reusable apps keep a content-addressed isolate warm; one-off code-mode
    * executions must not leave a cache entry behind after every unique run. */
   mode: "cached" | "one-off";
@@ -238,18 +239,18 @@ export function loadResolvedWorker({
   // the key's cardinality is a direct dollar amount: a per-request component
   // here turned ordinary traffic into ~3.9M billable identities (~$7.8k) in
   // three weeks (2026-08), while also forcing a cold isolate build on every
-  // request and every stream delivery. Never add a component that varies more
-  // often than parent-isolate lifetime without pricing it first.
+  // request and every stream delivery. Never add a key component without
+  // pricing its cardinality first.
   //
-  // Loader isolates capture the minting runner's loopback RPC bindings; using
-  // them from a mismatched lifetime fails with "Unable to deserialize cloned
-  // data due to invalid or unsupported version". The nonce scopes that
-  // lifetime (see DynamicWorkerRunner's loaderNonceScope): parent-isolate for
-  // request-scoped lanes so warm isolates are reused instead of billed and
-  // cold-started per request, per-runner for Durable Object incarnations.
-  // Build artifacts remain content-addressed and shared; only the loaded
-  // isolate is nonce-scoped. The deployment id still keeps identities easy
-  // to attribute and guarantees separation across a rollout.
+  // Loader isolates capture loopback RPC bindings minted by whoever loaded
+  // them first; using those from a mismatched lifetime fails with "Unable to
+  // deserialize cloned data due to invalid or unsupported version". The
+  // request-scoped lanes load under the bare identity below and recover from
+  // that skew reactively (see DynamicWorkerRunner's loaderScope: the retry
+  // supplies a recovery nonce); Durable Object hosts pass a per-runner nonce
+  // so an incarnation's facet isolate is never reused by its successor. Build
+  // artifacts remain content-addressed and shared. The deployment id keeps
+  // identities easy to attribute and guarantees separation across a rollout.
   const loaderIdentity = [
     "worker-loader",
     env.WORKER_SELF,
@@ -259,6 +260,9 @@ export function loadResolvedWorker({
     JSON.stringify(StreamContext.parse(streamContext)),
     resolved.cacheKey,
   ].join(":");
-  const cacheKey = [loaderIdentity, loaderInstanceNonce].join(":");
+  const cacheKey =
+    loaderInstanceNonce === undefined
+      ? loaderIdentity
+      : [loaderIdentity, loaderInstanceNonce].join(":");
   return env.LOADER.get(cacheKey, () => workerCode);
 }

--- a/apps/os/src/domains/workers/worker-loader.ts
+++ b/apps/os/src/domains/workers/worker-loader.ts
@@ -233,13 +233,22 @@ export function loadResolvedWorker({
   };
   if (mode === "one-off") return env.LOADER.load(workerCode);
 
-  // Loader isolates capture this runner's loopback RPC bindings. They must not
-  // survive the runner that minted them: a stateless ingress runner lives for
-  // one request, while a Durable Object runner lives for one incarnation.
-  // Crossing orphaned bindings from a later runner fails with
-  // "Unable to deserialize cloned data due to invalid or unsupported version".
-  // Build artifacts remain content-addressed and shared; only the cheap loaded
-  // isolate is runner-scoped. The deployment id still keeps identities easy
+  // THIS KEY IS UNBELIEVABLY EXPENSIVE TO GET WRONG. Cloudflare bills every
+  // distinct value ever passed to LOADER.get as a Dynamic Worker per day, so
+  // the key's cardinality is a direct dollar amount: a per-request component
+  // here turned ordinary traffic into ~3.9M billable identities (~$7.8k) in
+  // three weeks (2026-08), while also forcing a cold isolate build on every
+  // request and every stream delivery. Never add a component that varies more
+  // often than parent-isolate lifetime without pricing it first.
+  //
+  // Loader isolates capture the minting runner's loopback RPC bindings; using
+  // them from a mismatched lifetime fails with "Unable to deserialize cloned
+  // data due to invalid or unsupported version". The nonce scopes that
+  // lifetime (see DynamicWorkerRunner's loaderNonceScope): parent-isolate for
+  // request-scoped lanes so warm isolates are reused instead of billed and
+  // cold-started per request, per-runner for Durable Object incarnations.
+  // Build artifacts remain content-addressed and shared; only the loaded
+  // isolate is nonce-scoped. The deployment id still keeps identities easy
   // to attribute and guarantees separation across a rollout.
   const loaderIdentity = [
     "worker-loader",

--- a/apps/os/src/domains/workers/worker-runner.test.ts
+++ b/apps/os/src/domains/workers/worker-runner.test.ts
@@ -191,7 +191,7 @@ it("reuses a loaded worker within one runner but not across runner lifetimes", a
   expect(loaderNonces[2]).not.toBe(loaderNonces[0]);
 });
 
-it("shares one loaded worker across parent-isolate-scoped runners", async () => {
+it("loads shared-scope runners under the bare identity, with no nonce at all", async () => {
   h.resolveWorkerSource.mockResolvedValue({
     ok: true,
     source: {
@@ -208,31 +208,34 @@ it("shares one loaded worker across parent-isolate-scoped runners", async () => 
   h.loadResolvedWorker.mockImplementation(() => ({
     getEntrypoint: () => ({ fetch: () => Promise.resolve(new Response("ok")) }),
   }));
-  const createRunner = (loaderNonceScope?: "parent-isolate" | "runner") =>
+  const createRunner = (loaderScope?: "shared" | "runner") =>
     new DynamicWorkerRunner({
       streamContext: { kind: "scope", scopePath: inlineRef.path },
       exports: {} as ExecutionContext["exports"],
-      loaderNonceScope,
+      loaderScope,
       projectId: "prj_private",
       scopePath: inlineRef.path,
     });
 
-  await createRunner("parent-isolate").fetch({
+  await createRunner("shared").fetch({
     ref: inlineRef,
     request: new Request("https://example.com/1"),
   });
-  await createRunner("parent-isolate").fetch({
+  await createRunner("shared").fetch({
     ref: inlineRef,
     request: new Request("https://example.com/2"),
   });
   await createRunner().fetch({ ref: inlineRef, request: new Request("https://example.com/3") });
 
   const loaderNonces = h.loadResolvedWorker.mock.calls.map(([input]) => input.loaderInstanceNonce);
-  expect(loaderNonces[0]).toBe(loaderNonces[1]);
-  expect(loaderNonces[2]).not.toBe(loaderNonces[0]);
+  // Undefined IS the design: the bare identity is the key, so parent isolates
+  // coming and going mint no new billable Dynamic Workers.
+  expect(loaderNonces[0]).toBeUndefined();
+  expect(loaderNonces[1]).toBeUndefined();
+  expect(loaderNonces[2]).toEqual(expect.any(String));
 });
 
-it("moves later parent-isolate runners off a clone-skew-replaced loader", async () => {
+it("moves every later shared-scope runner onto the clone-skew recovery nonce", async () => {
   const workerFetch = vi
     .fn()
     .mockRejectedValueOnce(
@@ -259,7 +262,7 @@ it("moves later parent-isolate runners off a clone-skew-replaced loader", async 
     new DynamicWorkerRunner({
       streamContext: { kind: "scope", scopePath: inlineRef.path },
       exports: {} as ExecutionContext["exports"],
-      loaderNonceScope: "parent-isolate",
+      loaderScope: "shared",
       projectId: "prj_private",
       scopePath: inlineRef.path,
     });
@@ -269,9 +272,11 @@ it("moves later parent-isolate runners off a clone-skew-replaced loader", async 
 
   const loaderNonces = h.loadResolvedWorker.mock.calls.map(([input]) => input.loaderInstanceNonce);
   expect(loaderNonces).toHaveLength(3);
-  // The skew retry replaced the shared nonce; the next runner must reuse the
-  // replacement, never return to the known-stale shared loader.
-  expect(loaderNonces[1]).not.toBe(loaderNonces[0]);
+  // Steady state loads the bare identity; the skew retry mints a recovery
+  // nonce, and the next runner must reuse that replacement rather than
+  // return to the known-stale shared entry.
+  expect(loaderNonces[0]).toBeUndefined();
+  expect(loaderNonces[1]).toEqual(expect.any(String));
   expect(loaderNonces[2]).toBe(loaderNonces[1]);
 });
 

--- a/apps/os/src/domains/workers/worker-runner.test.ts
+++ b/apps/os/src/domains/workers/worker-runner.test.ts
@@ -191,6 +191,90 @@ it("reuses a loaded worker within one runner but not across runner lifetimes", a
   expect(loaderNonces[2]).not.toBe(loaderNonces[0]);
 });
 
+it("shares one loaded worker across parent-isolate-scoped runners", async () => {
+  h.resolveWorkerSource.mockResolvedValue({
+    ok: true,
+    source: {
+      assetConfig: undefined,
+      assetManifest: {},
+      assets: {},
+      cacheKey: "build-key",
+      commitOid: "commit-1",
+      mainModule: "worker.js",
+      modules: {},
+      wranglerConfig: undefined,
+    },
+  });
+  h.loadResolvedWorker.mockImplementation(() => ({
+    getEntrypoint: () => ({ fetch: () => Promise.resolve(new Response("ok")) }),
+  }));
+  const createRunner = (loaderNonceScope?: "parent-isolate" | "runner") =>
+    new DynamicWorkerRunner({
+      streamContext: { kind: "scope", scopePath: inlineRef.path },
+      exports: {} as ExecutionContext["exports"],
+      loaderNonceScope,
+      projectId: "prj_private",
+      scopePath: inlineRef.path,
+    });
+
+  await createRunner("parent-isolate").fetch({
+    ref: inlineRef,
+    request: new Request("https://example.com/1"),
+  });
+  await createRunner("parent-isolate").fetch({
+    ref: inlineRef,
+    request: new Request("https://example.com/2"),
+  });
+  await createRunner().fetch({ ref: inlineRef, request: new Request("https://example.com/3") });
+
+  const loaderNonces = h.loadResolvedWorker.mock.calls.map(([input]) => input.loaderInstanceNonce);
+  expect(loaderNonces[0]).toBe(loaderNonces[1]);
+  expect(loaderNonces[2]).not.toBe(loaderNonces[0]);
+});
+
+it("moves later parent-isolate runners off a clone-skew-replaced loader", async () => {
+  const workerFetch = vi
+    .fn()
+    .mockRejectedValueOnce(
+      new Error("Unable to deserialize cloned data due to invalid or unsupported version."),
+    )
+    .mockResolvedValue(new Response("ok"));
+  h.resolveWorkerSource.mockResolvedValue({
+    ok: true,
+    source: {
+      assetConfig: undefined,
+      assetManifest: {},
+      assets: {},
+      cacheKey: "build-key",
+      commitOid: "commit-1",
+      mainModule: "worker.js",
+      modules: {},
+      wranglerConfig: undefined,
+    },
+  });
+  h.loadResolvedWorker.mockImplementation(() => ({
+    getEntrypoint: () => ({ fetch: workerFetch }),
+  }));
+  const createRunner = () =>
+    new DynamicWorkerRunner({
+      streamContext: { kind: "scope", scopePath: inlineRef.path },
+      exports: {} as ExecutionContext["exports"],
+      loaderNonceScope: "parent-isolate",
+      projectId: "prj_private",
+      scopePath: inlineRef.path,
+    });
+
+  await createRunner().fetch({ ref: inlineRef, request: new Request("https://example.com/1") });
+  await createRunner().fetch({ ref: inlineRef, request: new Request("https://example.com/2") });
+
+  const loaderNonces = h.loadResolvedWorker.mock.calls.map(([input]) => input.loaderInstanceNonce);
+  expect(loaderNonces).toHaveLength(3);
+  // The skew retry replaced the shared nonce; the next runner must reuse the
+  // replacement, never return to the known-stale shared loader.
+  expect(loaderNonces[1]).not.toBe(loaderNonces[0]);
+  expect(loaderNonces[2]).toBe(loaderNonces[1]);
+});
+
 it("loads runScript workers once and releases both native handles", async () => {
   h.resolveWorkerSource.mockResolvedValue({
     ok: true,

--- a/apps/os/src/domains/workers/worker-runner.ts
+++ b/apps/os/src/domains/workers/worker-runner.ts
@@ -31,14 +31,15 @@ export type DynamicWorkerTraceRole = "project_config" | "run_script" | "schedule
 const WORKERS_RPC_CLONE_VERSION_ERROR =
   "Unable to deserialize cloned data due to invalid or unsupported version.";
 
-// Loader nonce shared by every parent-isolate-scoped runner in this parent
-// isolate. Cloudflare bills each distinct Worker Loader key as a Dynamic
-// Worker per day, so a per-runner nonce on the request-scoped lanes turned
-// every project-host request and every stream delivery into a new billable
-// identity AND a cold isolate (2026-08: ~3.9M identities ≈ $7.8k). Lazy so an
-// isolate that never loads dynamic code mints nothing; replaced after
-// clone-version skew so later loads abandon the stale isolate.
-let parentIsolateLoaderNonce: string | undefined;
+// Recovery nonce for the shared-scope lanes in this parent isolate. Undefined
+// in steady state ON PURPOSE: shared-scope loads then ride the bare loader
+// identity, so parent isolates coming and going mint NO new billable Dynamic
+// Workers (a per-runner nonce turned every project-host request and every
+// stream delivery into a new identity and a cold isolate — 2026-08: ~3.9M
+// identities ≈ $7.8k). Set only when a clone-version skew proves the cached
+// isolate stale; every shared-scope load in this parent isolate then abandons
+// it for the replacement.
+let sharedLoaderRecoveryNonce: string | undefined;
 
 // Structural shadow of StatefulWorkerDurableObject.invokeCapability instead
 // of the DO's own type: the DO imports this module (cycle), and a typed
@@ -70,7 +71,7 @@ export class DynamicWorkerRunner {
   readonly #bindings: WorkerBindings;
   readonly #globalOutbound: Fetcher;
   #loaderInstanceNonce: string | undefined;
-  readonly #loaderNonceScope: "parent-isolate" | "runner";
+  readonly #loaderScope: "shared" | "runner";
   readonly #projectId: string;
   readonly #scopePath: string;
   readonly #streamContext: StreamContext;
@@ -83,18 +84,20 @@ export class DynamicWorkerRunner {
     /**
      * Which lifetime keys this runner's loaded isolates in the Worker Loader
      * cache. Every distinct key is a billable Dynamic Worker per day, so the
-     * choice is a dollar cost, not bookkeeping. "parent-isolate" shares warm
-     * loaded isolates across runners in this parent isolate — the
-     * request-scoped lanes (ingress, itx dispatch, stream delivery) use it,
-     * because a per-runner key minted a new billable identity and a cold
-     * isolate per request. A shared isolate can outlive the runner whose
-     * loopback bindings it captured; the clone-version retry then replaces
-     * the shared nonce for the whole parent isolate. "runner" (default) keys
-     * loads to this runner alone — Durable Object hosts keep it so a fresh
-     * incarnation never reuses a facet isolate holding the previous
-     * incarnation's bindings (that lane has no clone-skew retry).
+     * choice is a dollar cost, not bookkeeping. "shared" loads under the bare
+     * content-and-scope identity — no nonce at all in steady state, so warm
+     * isolates are reused across requests, deliveries, and parent isolates
+     * alike; the request-scoped lanes (ingress, itx dispatch, stream
+     * delivery) use it, because a per-runner key minted a new billable
+     * identity and a cold isolate per request. A shared isolate can outlive
+     * the lifetime that minted its captured loopback bindings; the
+     * clone-version retry then moves this parent isolate's shared loads onto
+     * a recovery nonce. "runner" (default) keys loads to this runner alone —
+     * Durable Object hosts keep it so a fresh incarnation never reuses a
+     * facet isolate holding the previous incarnation's bindings (that lane
+     * has no clone-skew retry).
      */
-    loaderNonceScope?: "parent-isolate" | "runner";
+    loaderScope?: "shared" | "runner";
     projectId: string;
     /** The itx scope the loaded code runs in (its `env.ITX` answers here). */
     scopePath: string;
@@ -111,7 +114,7 @@ export class DynamicWorkerRunner {
       props.projectId,
       props.streamContext,
     );
-    this.#loaderNonceScope = props.loaderNonceScope ?? "runner";
+    this.#loaderScope = props.loaderScope ?? "runner";
     this.#projectId = props.projectId;
     this.#scopePath = props.scopePath;
     this.#streamContext = props.streamContext;
@@ -459,8 +462,8 @@ export class DynamicWorkerRunner {
       // A clone-skew replacement must retire the stale isolate for every load
       // that would have shared it, not just this runner's — going back to a
       // known-stale shared key re-fails every later call.
-      if (this.#loaderNonceScope === "parent-isolate") {
-        parentIsolateLoaderNonce = freshInstanceNonce;
+      if (this.#loaderScope === "shared") {
+        sharedLoaderRecoveryNonce = freshInstanceNonce;
       } else {
         this.#loaderInstanceNonce = freshInstanceNonce;
       }
@@ -468,9 +471,10 @@ export class DynamicWorkerRunner {
     return loadResolvedWorker({
       bindings: this.#bindings,
       globalOutbound: this.#globalOutbound,
+      // Shared scope: usually undefined — the bare identity IS the key.
       loaderInstanceNonce:
-        this.#loaderNonceScope === "parent-isolate"
-          ? (parentIsolateLoaderNonce ??= crypto.randomUUID())
+        this.#loaderScope === "shared"
+          ? sharedLoaderRecoveryNonce
           : (this.#loaderInstanceNonce ??= crypto.randomUUID()),
       mode,
       projectId: this.#projectId,

--- a/apps/os/src/domains/workers/worker-runner.ts
+++ b/apps/os/src/domains/workers/worker-runner.ts
@@ -31,6 +31,15 @@ export type DynamicWorkerTraceRole = "project_config" | "run_script" | "schedule
 const WORKERS_RPC_CLONE_VERSION_ERROR =
   "Unable to deserialize cloned data due to invalid or unsupported version.";
 
+// Loader nonce shared by every parent-isolate-scoped runner in this parent
+// isolate. Cloudflare bills each distinct Worker Loader key as a Dynamic
+// Worker per day, so a per-runner nonce on the request-scoped lanes turned
+// every project-host request and every stream delivery into a new billable
+// identity AND a cold isolate (2026-08: ~3.9M identities ≈ $7.8k). Lazy so an
+// isolate that never loads dynamic code mints nothing; replaced after
+// clone-version skew so later loads abandon the stale isolate.
+let parentIsolateLoaderNonce: string | undefined;
+
 // Structural shadow of StatefulWorkerDurableObject.invokeCapability instead
 // of the DO's own type: the DO imports this module (cycle), and a typed
 // DurableObjectStub of it deep-instantiates the stub's self-referential type
@@ -60,7 +69,8 @@ type StatefulWorkerRpc = {
 export class DynamicWorkerRunner {
   readonly #bindings: WorkerBindings;
   readonly #globalOutbound: Fetcher;
-  #loaderInstanceNonce: string = crypto.randomUUID();
+  #loaderInstanceNonce: string | undefined;
+  readonly #loaderNonceScope: "parent-isolate" | "runner";
   readonly #projectId: string;
   readonly #scopePath: string;
   readonly #streamContext: StreamContext;
@@ -70,6 +80,21 @@ export class DynamicWorkerRunner {
     /** The hosting context's `ctx.exports` — loopback entrypoints are minted
      * from it, so the isolate's authority is the host's, never the ref's. */
     exports: ExecutionContext["exports"];
+    /**
+     * Which lifetime keys this runner's loaded isolates in the Worker Loader
+     * cache. Every distinct key is a billable Dynamic Worker per day, so the
+     * choice is a dollar cost, not bookkeeping. "parent-isolate" shares warm
+     * loaded isolates across runners in this parent isolate — the
+     * request-scoped lanes (ingress, itx dispatch, stream delivery) use it,
+     * because a per-runner key minted a new billable identity and a cold
+     * isolate per request. A shared isolate can outlive the runner whose
+     * loopback bindings it captured; the clone-version retry then replaces
+     * the shared nonce for the whole parent isolate. "runner" (default) keys
+     * loads to this runner alone — Durable Object hosts keep it so a fresh
+     * incarnation never reuses a facet isolate holding the previous
+     * incarnation's bindings (that lane has no clone-skew retry).
+     */
+    loaderNonceScope?: "parent-isolate" | "runner";
     projectId: string;
     /** The itx scope the loaded code runs in (its `env.ITX` answers here). */
     scopePath: string;
@@ -86,6 +111,7 @@ export class DynamicWorkerRunner {
       props.projectId,
       props.streamContext,
     );
+    this.#loaderNonceScope = props.loaderNonceScope ?? "runner";
     this.#projectId = props.projectId;
     this.#scopePath = props.scopePath;
     this.#streamContext = props.streamContext;
@@ -430,12 +456,22 @@ export class DynamicWorkerRunner {
     freshInstanceNonce?: string,
   ): WorkerStub {
     if (freshInstanceNonce !== undefined) {
-      this.#loaderInstanceNonce = freshInstanceNonce;
+      // A clone-skew replacement must retire the stale isolate for every load
+      // that would have shared it, not just this runner's — going back to a
+      // known-stale shared key re-fails every later call.
+      if (this.#loaderNonceScope === "parent-isolate") {
+        parentIsolateLoaderNonce = freshInstanceNonce;
+      } else {
+        this.#loaderInstanceNonce = freshInstanceNonce;
+      }
     }
     return loadResolvedWorker({
       bindings: this.#bindings,
       globalOutbound: this.#globalOutbound,
-      loaderInstanceNonce: this.#loaderInstanceNonce,
+      loaderInstanceNonce:
+        this.#loaderNonceScope === "parent-isolate"
+          ? (parentIsolateLoaderNonce ??= crypto.randomUUID())
+          : (this.#loaderInstanceNonce ??= crypto.randomUUID()),
       mode,
       projectId: this.#projectId,
       resolved,

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -5437,7 +5437,7 @@ class DynamicWorkerRpcTarget extends IterateRpcRelay<"DynamicWorkerCapability"> 
     this.#lazyRunner ??= new DynamicWorkerRunner({
       streamContext: this.#props.streamContext,
       exports: this.#props.ctx.exports,
-      loaderNonceScope: "parent-isolate",
+      loaderScope: "shared",
       projectId: this.#props.projectId,
       scopePath: this.#ref.path,
     });

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -5437,6 +5437,7 @@ class DynamicWorkerRpcTarget extends IterateRpcRelay<"DynamicWorkerCapability"> 
     this.#lazyRunner ??= new DynamicWorkerRunner({
       streamContext: this.#props.streamContext,
       exports: this.#props.ctx.exports,
+      loaderNonceScope: "parent-isolate",
       projectId: this.#props.projectId,
       scopePath: this.#ref.path,
     });

--- a/apps/os/src/worker.ts
+++ b/apps/os/src/worker.ts
@@ -201,6 +201,7 @@ async function apiFetch(
     const runner = new DynamicWorkerRunner({
       streamContext: { kind: "scope", scopePath: ref.path },
       exports: ctx.exports,
+      loaderNonceScope: "parent-isolate",
       projectId: route.resolved.projectId,
       scopePath: ref.path,
     });

--- a/apps/os/src/worker.ts
+++ b/apps/os/src/worker.ts
@@ -201,7 +201,7 @@ async function apiFetch(
     const runner = new DynamicWorkerRunner({
       streamContext: { kind: "scope", scopePath: ref.path },
       exports: ctx.exports,
-      loaderNonceScope: "parent-isolate",
+      loaderScope: "shared",
       projectId: route.resolved.projectId,
       scopePath: ref.path,
     });


### PR DESCRIPTION
## What

Dynamic Worker Loader cache keys on the request-scoped lanes (project-host ingress, `env.ITX.fetch` dispatch, itx worker capability dispatch — which includes every itx-call stream delivery — and the project processor's `workerFetch` probe) now load under the **bare content-and-scope identity: no nonce at all in steady state**. Parent isolates, requests, and deliveries coming and going mint **zero** new Dynamic Worker identities. A nonce exists only in two places:

- **Recovery**: when the existing clone-version-skew retry fires, it installs a recovery nonce for the whole parent isolate, so every later load abandons the stale cached isolate instead of re-failing against it.
- **Durable Object hosts** (stream facet runner, stateful worker DO, scheduler — 41 loads/day in prd): they keep per-runner nonces via the new `loaderScope` option (default `"runner"`), because an incarnation's facet isolate must never be reused by its successor and that lane has no clone-skew retry.

## Why: the loader key is unbelievably expensive to get wrong

Cloudflare bills **every distinct value ever passed to `LOADER.get` as a Dynamic Worker, at $0.002 per worker per day** ([pricing](https://developers.cloudflare.com/dynamic-workers/pricing/)). The key's cardinality is a direct dollar amount, not bookkeeping.

Since #2330 (2026-07-29), the key carried a per-`DynamicWorkerRunner` random UUID, and a runner is created per HTTP request on ingress, per `env.ITX.fetch` hop, and per itx capability traversal (so per stream-delivery batch too). Net effect over ~3 weeks:

- **~3.9M unique loader identities ≈ $7.8k billed** — one identity per request/batch, each alive for one billed worker-day.
- **A cold isolate on every dispatch**: the whole project worker bundle transferred, parsed, and executed per request and per event batch. Warm reuse never happened — 8 sequential curls to the same prd project host each took 1.2–2.0s.
- Most of the paying traffic is garbage: **52,957 of 69,838 project-host fetches in 24h (76%) returned 404**, overwhelmingly crawler/scanner hits on resolving hosts (custom domains like `george.iterate.com` plus `*.iterate.app`).

The key-construction site now carries a comment stating the cost constraint explicitly so no future change re-adds a high-cardinality component unpriced.

## Why the nonce existed, and the experiment that shows steady state doesn't need it

The nonce was the correctness fix from the 2026-07-29 incident chain (#2323 → #2328 → #2329 → #2330). Loaded isolates capture loopback RPC stubs minted from the loading runner's `ctx.exports` (`env.ITX` and the egress `globalOutbound`); a cached isolate reused after those stubs die fails with `Unable to deserialize cloned data due to invalid or unsupported version.` — production 500s on `www.iterate.com`. #2330's model was that these stubs die with the runner (one request), which forced per-request keys — and the billing catastrophe.

That model is disproven by direct experiment on real workerd (local dev, this branch): a committed `/__spike` route that calls `this.itx.identity()` **and** an external `fetch` on every request — i.e. exercises both captured stubs — answered `{"slug":"spike","egress":200}` on **11 consecutive requests through one shared warm isolate, each request a distinct runner**, at ~25ms per request, with zero clone-version log lines. Captured stubs survive their minting request; they die on the rare events the incident chain actually documented (parent-isolate death with the loader cache surviving, deploy skew — ~11 recovered retries per observation window under #2329's per-isolate keys, not one per request).

So the design is: optimistic bare identity, plus the already-existing skew retry as reactive recovery, with two lessons from the chain kept intact — #2328's (a successful recovery must replace the *shared* nonce, or later loads return to the known-stale entry and re-fail) and #2330's (lanes with no transparent retry must not share: the DO facet lanes keep per-runner keys).

## Prior art: this matches Cloudflare's own practice

Researched cloudflare-os (the workshop product), workerd internals, vibesdk, and the Dynamic Workers docs:

- **Every first-party Cloudflare user of Worker Loader keys deterministically, never with a nonce**: cloudflare-os keys `<DO id>.<monotonic codeVersion>[.<chat>.<sequence>].<gadgetId>` (`overseer.ts`); vibesdk keys `<space>-<branch>-<commitHash>`; the playground hashes files+options; one-shot code-mode uses anonymous `.load()` specifically because "`get` with a random id would only churn the loader's isolate cache". The docs recommend exactly our shape: "compute IDs based on a hash of the code and config".
- **Our env bindings are already the sanctioned pattern.** workerd only allows props-specialized `ctx.exports.Class({props})` loopback stubs (plain-data props) in a dynamic worker's env — which is precisely what `itxEntrypointBinding` and `projectEgressFetcher` produce. At load, workerd hoists these env capabilities into the *child worker's own channel table* (`rewriteCaps` in `server.c++`), giving them **worker lifetime, not request lifetime** — the runtime-level explanation for why the spike's warm isolate kept working across requests. Plain RPC stubs in env are explicitly unsupported (kentonv, workerd PR #6316: "Eventually we might support plain RPC stubs in `env`… a deep change which I'm not going to attempt right now").
- cloudflare-os's refinement — the loopback target re-resolves live authority from props **per method call** (their `GatekeeperLoopback`) — is also how our `ItxEntrypoint.get()` already works.

So the bare stable key + props-specialized loopback env is not just empirically fine; it is the pattern Cloudflare's own products ship, with the binding lifetime guaranteed by the runtime's env-capability hoisting rather than by luck.

## Baseline to beat (prd, 24h to 2026-08-18 ~12:50 UTC)

Captured via the Workers Observability query API before this change; re-measure after deploy.

| Span | Count/24h | p50 | p90 | p99 |
|---|---|---|---|---|
| `dynamic_worker.project_config.fetch` | 69,838 | 155ms | 270ms | 536ms |
| `dynamic_worker.project_config.call` (processEventBatch) | 2,537 | 100ms | 969ms | 2,352ms |
| `dynamic_worker.scheduler_action.call` | 289 | 1,048ms | 1,821ms | 2,504ms |

End-to-end probe (sequential GETs to one prd project host, 404 path): 1.98s, 1.16s, 1.38s, 1.40s, 1.59s, 1.27s, 1.48s, 0.15s — repeats should converge toward the ~150ms floor once isolates stay warm; the local-dev equivalent of the same lane runs at 5–25ms warm. (Aside spotted while measuring: ~20% of `project_config.call` spans report ~2³² ms durations — a wraparound telemetry bug, excluded above, not addressed here.)

## Preview verification (slot 3, this PR's final commit only)

Cloudflare's deployment history for `os-preview-3` shows the last upload at 12:30:39Z (this PR's HEAD) with nothing deployed after it, so the window below is exclusively this code — the slot's previous occupant (deployed 11:30Z) is excluded.

- Sequential requests to a freshly created project host over one reused connection: **84ms first, then 28–61ms per request** through the full dynamic-worker lane (worker-serve header verified). Separate fresh connections show the designed cold pattern: each edge process pays one ~1.2s cold load per identity, then serves warm — versus prd today, where **every** request pays ~1.2–2.0s.
- From 12:30:40Z through measurement: **13,901 `processEventBatch` calls, 385 project fetches, 338 run-script executions — zero `iterate.worker.rpc_clone_version_retry` spans**, across the full preview e2e suite plus manual probing.

## Risk map

- **Riskiest part**: a stale cached isolate (its minting parent isolate died but the Worker Loader cache entry survived, or a deploy left version skew) serving a non-retryable dispatch — POST bodies and WebSocket upgrades cannot ride the transparent retry, so those fail once per stale entry per parent isolate before the recovery nonce takes over. The incident-chain evidence puts this at ~11 events per observation window, always recovered on the retryable lanes; the local spike shows the steady state is clean. **Watch `iterate.worker.rpc_clone_version_retry` after deploy**: a rate near the request rate would mean stub lifetime behaves differently in production than in local workerd — then revert and take the per-call-props design instead.
- **Expect on merge** (prd auto-deploys): daily unique Dynamic Workers drop from ~200k/day to roughly (projects × scopes × content versions × deploys) — hundreds; repeat project-host requests and stream deliveries go warm; occasional single clone-skew retries reappear in logs (recovered, by design).
- **Review order**: `worker-runner.ts` (the `loaderScope` split and recovery-nonce semantics), `worker-loader.ts` (bare-identity key + the cost-constraint comment), the four one-line call-site diffs, then the tests (`worker-runner.test.ts` pins "no nonce in steady state" and recovery propagation; `worker-loader.serve.test.ts` pins the bare key shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {},
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

No preview apps recorded.

</details>
<!-- /CLOUDFLARE_PREVIEW -->