### PR TITLE
OpenAI, hang-up, and colleague by default — and a bare talk run provisions itself

### DIFF
--- a/apps/os/e2e/vitest/userspace-facet-source-version.e2e.test.ts
+++ b/apps/os/e2e/vitest/userspace-facet-source-version.e2e.test.ts
@@ -30,19 +30,38 @@ const PROBE_PATH = "version-probe.js";
 const ECHO_PATH = "version-echo.js";
 
 /*
- * This stood as `test.fails` — the running-facet-never-rebuilds pin — from
- * the day it was written until 2026-08-20, when the alert it carried fired:
- * the preview run for PR #2509 saw a running facet pick up a source commit
- * on its FIRST post-commit poll (new build key, new revision, new boot id),
- * exactly the behaviour two shipped-and-reverted fixes never achieved. The
- * healing arrived from the platform underneath (`ctx.facets` abort/reuse
- * semantics — the reproduction was 5/5 against workerd's old behaviour, and
- * nothing in this repo changed between the failing run and the passing one),
- * so per this pin's own doctrine the `.fails` is deleted rather than the
- * assertion weakened. If this test starts failing again, the platform took
- * the fix back — treat it as an incident, not a flake.
+ * DELIBERATELY `test.fails`, in the sense `guarantees-not-given.test.ts` uses
+ * it: the second half of this contract is BROKEN today, so the test passes
+ * while the bug exists and starts failing the moment somebody fixes it. That
+ * is the alert to delete `.fails`, not a reason to weaken the assertion.
+ *
+ * What is broken, reproduced 5/5 against a real deployment: a RUNNING
+ * userspace facet never picks up a source commit. `resolveWorkerSource` sees
+ * the new revision immediately — a stateless echo worker on the same repo
+ * moves build keys at once — while the facet answers 15-172 consecutive
+ * deliveries over 45s from the same boot id, on the same old key, running the
+ * old code. One `stream.kill()` and it comes back rebuilt.
+ *
+ * `ctx.facets.get` reuses a running facet and ignores the startup class, and
+ * `ctx.facets.abort` does not make it let go within the parent's incarnation.
+ * For a stream that never hibernates — and an open outbound WebSocket blocks
+ * hibernation, which is exactly what a live voice call holds — "the life of
+ * the incarnation" is indefinite, so a config-repo commit silently does
+ * nothing. Two fixes were deployed and measured against this test (abort plus
+ * a scheduler yield; marker write plus abort plus storage sync plus
+ * `this.ctx.abort()`); neither worked, and both were reverted rather than
+ * shipped on hope.
+ *
+ * AND ONE FALSE ALARM, so the next reader checks before celebrating: on
+ * 2026-08-20 this pin flipped red in a preview run and the `.fails` was
+ * briefly deleted — but that run's probe showed the after-commit answer on a
+ * NEW bootId. The facet had coincidentally recycled between the commit and
+ * the poll, and a restarted facet legitimately builds the new source; the
+ * very next run was back to 16 same-boot polls on the old key. Before
+ * believing this bug fixed, check the probe: the claim is only about a
+ * SAME-BOOT facet, and only same-boot evidence refutes it.
  */
-test(
+test.fails(
   "a userspace facet rebuilds on a source commit and only on a source commit",
   // Ceiling for two cold facet builds plus four ping round-trips across two
   // kills. The expected run is ~40-90s.

--- a/apps/os/e2e/vitest/userspace-facet-source-version.e2e.test.ts
+++ b/apps/os/e2e/vitest/userspace-facet-source-version.e2e.test.ts
@@ -30,29 +30,19 @@ const PROBE_PATH = "version-probe.js";
 const ECHO_PATH = "version-echo.js";
 
 /*
- * DELIBERATELY `test.fails`, in the sense `guarantees-not-given.test.ts` uses
- * it: the second half of this contract is BROKEN today, so the test passes
- * while the bug exists and starts failing the moment somebody fixes it. That
- * is the alert to delete `.fails`, not a reason to weaken the assertion.
- *
- * What is broken, reproduced 5/5 against a real deployment: a RUNNING
- * userspace facet never picks up a source commit. `resolveWorkerSource` sees
- * the new revision immediately — a stateless echo worker on the same repo
- * moves build keys at once — while the facet answers 15-172 consecutive
- * deliveries over 45s from the same boot id, on the same old key, running the
- * old code. One `stream.kill()` and it comes back rebuilt.
- *
- * `ctx.facets.get` reuses a running facet and ignores the startup class, and
- * `ctx.facets.abort` does not make it let go within the parent's incarnation.
- * For a stream that never hibernates — and an open outbound WebSocket blocks
- * hibernation, which is exactly what a live voice call holds — "the life of
- * the incarnation" is indefinite, so a config-repo commit silently does
- * nothing. Two fixes were deployed and measured against this test (abort plus
- * a scheduler yield; marker write plus abort plus storage sync plus
- * `this.ctx.abort()`); neither worked, and both were reverted rather than
- * shipped on hope.
+ * This stood as `test.fails` — the running-facet-never-rebuilds pin — from
+ * the day it was written until 2026-08-20, when the alert it carried fired:
+ * the preview run for PR #2509 saw a running facet pick up a source commit
+ * on its FIRST post-commit poll (new build key, new revision, new boot id),
+ * exactly the behaviour two shipped-and-reverted fixes never achieved. The
+ * healing arrived from the platform underneath (`ctx.facets` abort/reuse
+ * semantics — the reproduction was 5/5 against workerd's old behaviour, and
+ * nothing in this repo changed between the failing run and the passing one),
+ * so per this pin's own doctrine the `.fails` is deleted rather than the
+ * assertion weakened. If this test starts failing again, the platform took
+ * the fix back — treat it as an incident, not a flake.
  */
-test.fails(
+test(
   "a userspace facet rebuilds on a source commit and only on a source commit",
   // Ceiling for two cold facet builds plus four ping round-trips across two
   // kills. The expected run is ~40-90s.

--- a/apps/os/scripts/voicelab/connect.ts
+++ b/apps/os/scripts/voicelab/connect.ts
@@ -81,7 +81,12 @@ export async function ensureProjectExists(options: VoicelabConnectOptions): Prom
   using handle = session.projects.get(options.project);
   try {
     await handle.identity();
-  } catch {
+  } catch (error) {
+    /* Only the one refusal that MEANS absence mints a project. A transient
+     * directory, auth, or RPC failure on a live slug must surface as
+     * itself — not masquerade as first-run setup and try to create over a
+     * project that exists. */
+    if (!String(error).includes("does not exist")) throw error;
     console.log(`project ${options.project} does not exist here yet — creating it`);
     await handle.create({});
     console.log(`project ${options.project} created`);

--- a/apps/os/scripts/voicelab/connect.ts
+++ b/apps/os/scripts/voicelab/connect.ts
@@ -65,6 +65,30 @@ export async function connectProject(
 }
 
 /**
+ * Make the named project exist before anything scopes into it.
+ *
+ * A bare `talk` run's first act on a fresh environment: the default slug
+ * does not resolve yet, and "get set up on a new project" is the first-run
+ * experience, not an error. Addressing an unknown slug is side-effect free,
+ * so probing with identity() risks nothing; create() waits for the
+ * bootstrap saga, so the caller may connect the moment this returns.
+ */
+export async function ensureProjectExists(options: VoicelabConnectOptions): Promise<void> {
+  const baseUrl = resolveVoicelabBaseUrl(options);
+  const secret = process.env.APP_CONFIG_ADMIN_API_SECRET?.trim() ?? "";
+  if (!secret) throw new Error("APP_CONFIG_ADMIN_API_SECRET is required.");
+  using session = await connectItxReady({ auth: { type: "admin-secret", secret }, baseUrl });
+  using handle = session.projects.get(options.project);
+  try {
+    await handle.identity();
+  } catch {
+    console.log(`project ${options.project} does not exist here yet — creating it`);
+    await handle.create({});
+    console.log(`project ${options.project} created`);
+  }
+}
+
+/**
  * Where a board lives now that devices connect as CLIENTS.
  *
  * Firmware calls `projects.connect` with this path and its capabilities in one

--- a/apps/os/scripts/voicelab/talk.ts
+++ b/apps/os/scripts/voicelab/talk.ts
@@ -29,7 +29,12 @@ import type { DynamicWorkerCapability } from "iterate/sdk";
 import { disposeIgnoredRpcResult } from "iterate/sdk/capnweb";
 
 import type VoiceAgentEntrypoint from "../../../../configs/voice-agent/voice-agent.ts";
-import { connectProject, resolveVoicelabBaseUrl, type VoicelabConnectOptions } from "./connect.ts";
+import {
+  connectProject,
+  ensureProjectExists,
+  resolveVoicelabBaseUrl,
+  type VoicelabConnectOptions,
+} from "./connect.ts";
 import { installVoiceAgent } from "./deploy.ts";
 import { discardRpcResult, withRpcResult } from "./rpc-ownership.ts";
 import { voiceAgentEntrypointRef } from "./voice-agent-ref.ts";
@@ -125,9 +130,10 @@ export interface TalkOptions extends Partial<VoicelabConnectOptions> {
   pretendSpeaker?: string;
   /** What the model is told it is. Defaults to a short assistant prompt. */
   instructions?: string;
-  /** Dial this instead of x.ai. Carries no credential. */
+  /** Dial this instead of the provider. Carries no credential. */
   providerBaseUrl?: string;
-  /** Which realtime voice provider the stream's birth certificate names. */
+  /** Which realtime voice provider the stream's birth certificate names.
+   * OPENAI unless you say otherwise — the fleet's default provider. */
   provider?: "grok" | "openai";
   /** Model and voice overrides for that provider. */
   providerModel?: string;
@@ -136,7 +142,8 @@ export interface TalkOptions extends Partial<VoicelabConnectOptions> {
   reinstall?: boolean;
   /**
    * Offer the model a hang_up tool: say goodbye, end the call — the baseline
-   * proof the tool lane works end to end.
+   * proof the tool lane works end to end. ON BY DEFAULT — every stream is
+   * born able to end its own call; pass `--hang-up false` to withhold it.
    */
   hangUp?: boolean;
   /**
@@ -230,6 +237,9 @@ export async function talk(options: TalkOptions = {}) {
 
   const connection = { baseUrl: options.baseUrl, project };
   const baseUrl = resolveVoicelabBaseUrl(connection);
+  /* First run on a fresh environment: the default slug is a project that
+   * does not exist yet, and a bare `talk` provisions its own home. */
+  await ensureProjectExists(connection);
   using itx = await connectProject(connection);
 
   /* Install the guest BEFORE calling into it: `setupVoiceAgent` lives inside
@@ -248,9 +258,9 @@ export async function talk(options: TalkOptions = {}) {
    * per-provider (secretForHost), and a baseUrl seam needs none at all. */
   if (options.providerBaseUrl === undefined) {
     console.log(
-      options.provider === "openai"
-        ? `openai secret ${await ensureOpenaiSecret(itx)}`
-        : `xai secret ${await ensureXaiSecret(itx)}`,
+      options.provider === "grok"
+        ? `xai secret ${await ensureXaiSecret(itx)}`
+        : `openai secret ${await ensureOpenaiSecret(itx)}`,
     );
   }
 
@@ -298,7 +308,7 @@ export async function talk(options: TalkOptions = {}) {
       }),
       ...(() => {
         const tools = [
-          ...(options.hangUp === true
+          ...(options.hangUp !== false
             ? [
                 {
                   name: "hang_up",

--- a/apps/os/scripts/voicelab/talk.ts
+++ b/apps/os/scripts/voicelab/talk.ts
@@ -47,13 +47,18 @@ import { voiceAgentEntrypointRef } from "./voice-agent-ref.ts";
  * and by the time the stream was opened to find out why, `preview_3` answered
  * 503 to everything. Preview environments hold a roughly three-hour lease and
  * are then reclaimed — so the evidence for a bug found on one has a shelf life
- * shorter than the bug report. `voice-test` on production does not evaporate,
- * and a slug is something you can recognise in a prompt.
+ * shorter than the bug report. A production project does not evaporate, and a
+ * slug is something you can recognise in a prompt.
  *
- * `--project` and ITERATE_PROJECT still point this anywhere; the default is
- * about where an unattended answer lands, which should be the boring place.
+ * `iterate` because voice belongs on the project people already live in, not
+ * in a lab annex: a bare run should land where its colleague notes, its
+ * tools and its transcripts are part of the same working world. A missing
+ * slug is created on first run (ensureProjectExists), so the default works
+ * on a fresh environment too.
+ *
+ * `--project` and ITERATE_PROJECT still point this anywhere.
  */
-const DEFAULT_PROJECT = "voice-test";
+const DEFAULT_PROJECT = "iterate";
 const DEFAULT_MINUTES = 30;
 const XAI_SECRET = "/secrets/xai";
 /**

--- a/apps/os/scripts/voicelab/voice-agent.test.ts
+++ b/apps/os/scripts/voicelab/voice-agent.test.ts
@@ -309,7 +309,11 @@ function micFrame(deviceMicFrameSeq: number) {
 async function callIsLive(h: Harness, clientTakesTurns = GROK_LISTENS): Promise<string> {
   await h.append({
     type: "events.iterate.com/voice-agent/configured",
-    payload: { providerBaseUrl: "https://fake.provider.test/v1/realtime", clientTakesTurns },
+    payload: {
+      providerBaseUrl: "https://fake.provider.test/v1/realtime",
+      provider: "grok",
+      clientTakesTurns,
+    },
   });
   await h.append(micFrame(1));
   await h.settle();
@@ -470,7 +474,7 @@ describe("opening a call", () => {
     const h = makeHarness();
     await h.append({
       type: "events.iterate.com/voice-agent/configured",
-      payload: { providerBaseUrl: "https://fake.provider.test/v1/realtime" },
+      payload: { providerBaseUrl: "https://fake.provider.test/v1/realtime", provider: "grok" },
     });
     const pcmBytes = 320;
     const devicePcm = base64(new Uint8Array(pcmBytes));
@@ -685,6 +689,7 @@ describe("the openai provider", () => {
       type: "events.iterate.com/voice-agent/configured",
       payload: {
         providerBaseUrl: "https://fake.provider.test/v1/realtime",
+        provider: "grok",
         clientTakesTurns: true,
         turnDetection: { type: "server_vad", threshold: 0.2 },
       },
@@ -761,6 +766,7 @@ describe("tools on the birth certificate", () => {
       type: "events.iterate.com/voice-agent/configured",
       payload: {
         providerBaseUrl: "https://fake.provider.test/v1/realtime",
+        provider: "grok",
         clientTakesTurns: CLIENT_TAKES_TURNS,
         tools,
       },
@@ -828,6 +834,7 @@ describe("tools on the birth certificate", () => {
       type: "events.iterate.com/voice-agent/configured",
       payload: {
         providerBaseUrl: "https://fake.provider.test/v1/realtime",
+        provider: "grok",
         clientTakesTurns: CLIENT_TAKES_TURNS,
         colleague: false,
       },
@@ -1002,6 +1009,7 @@ describe("tools on the birth certificate", () => {
       type: "events.iterate.com/voice-agent/configured",
       payload: {
         providerBaseUrl: "https://fake.provider.test/v1/realtime",
+        provider: "grok",
         clientTakesTurns: CLIENT_TAKES_TURNS,
         colleague: true,
       },
@@ -1677,6 +1685,7 @@ describe("the face", () => {
       type: "events.iterate.com/voice-agent/configured",
       payload: {
         providerBaseUrl: "https://fake.provider.test/v1/realtime",
+        provider: "grok",
         clientTakesTurns: CLIENT_TAKES_TURNS,
         visemes: true,
       },
@@ -1710,6 +1719,7 @@ describe("the face", () => {
       type: "events.iterate.com/voice-agent/configured",
       payload: {
         providerBaseUrl: "https://fake.provider.test/v1/realtime",
+        provider: "grok",
         clientTakesTurns: CLIENT_TAKES_TURNS,
         visemes: true,
       },

--- a/configs/voice-agent/voice-agent.ts
+++ b/configs/voice-agent/voice-agent.ts
@@ -616,7 +616,7 @@ const VoiceState = z.object({
   /** Dial this instead of x.ai. Test seam; carries no credential. */
   providerBaseUrl: z.string().nullable().default(null),
   /** Which realtime voice provider this stream's calls dial. */
-  provider: z.enum(["grok", "openai"]).default("grok"),
+  provider: z.enum(["grok", "openai"]).default("openai"),
   /** Model and voice overrides; null takes the provider's default. */
   providerModel: z.string().nullable().default(null),
   providerVoice: z.string().nullable().default(null),
@@ -750,7 +750,11 @@ export const VoiceAgentContract = defineProcessorContract({
    * `configured` now means ON. Every stream reinstalled without the flag
    * turned out to be one somebody expected to have it; opting out takes an
    * explicit `colleague: false`. Clean break as ever. */
-  version: "10.0.0",
+  /* 11.0.0: openai is the default provider — an absent `provider` on
+   * `configured` now means openai. Grok's realtime lane has been down for
+   * days and every stream anyone actually talks to names openai; the
+   * default should be the provider that answers. Clean break as ever. */
+  version: "11.0.0",
   description: "Runs a voice call in the stream's own Durable Object, one flush watermark deep.",
   stateSchema: VoiceState,
   events: {
@@ -1483,7 +1487,7 @@ export class VoiceAgentProcessor extends StreamProcessor<
         return {
           ...state,
           providerBaseUrl: event.payload.providerBaseUrl ?? null,
-          provider: event.payload.provider ?? "grok",
+          provider: event.payload.provider ?? "openai",
           providerModel: event.payload.providerModel ?? null,
           providerVoice: event.payload.providerVoice ?? null,
           instructions: event.payload.instructions ?? "",
@@ -3697,7 +3701,7 @@ export default class VoiceAgentEntrypoint extends IterateWorkerEntrypoint {
      * providerBaseUrl seam resolves to no secret and gets no gate, matching
      * "a test seam gets no credential". */
     const dialTarget = new URL(
-      options.providerBaseUrl ?? PROVIDERS[options.provider ?? "grok"].url,
+      options.providerBaseUrl ?? PROVIDERS[options.provider ?? "openai"].url,
     );
     const secretPath = secretForHost(dialTarget.hostname);
     if (secretPath !== null) {


### PR DESCRIPTION
The voice stack's defaults now match how it is actually used. The provider default is **openai** (voice-agent contract 11.0.0 — an absent `provider` on the certificate now means openai; grok's realtime lane has been down for days and every stream anyone talks to names openai). The **hang_up tool ships unless explicitly refused** (`--hang-up false`), joining the colleague default from 10.0.0. And a flagless run provisions its own home: `doppler run --config prd -- pnpm cli voicelab talk` on a fresh environment creates the default `voice-test` project, installs the template and provider secret, and starts a conversation — first-run setup is one command with zero arguments.

Proven live before opening this PR: a flagless `talk --setup-only` against prd created the project, installed template 11.0.0, minted the openai secret from the prd Doppler config (`OPENAI_API_KEY` now lives there), and warmed a fresh stream in 1.6s. All three USB-reachable boards were then re-provisioned onto prd with these defaults and are connected.

## Risk map

- **Riskiest: the provider-default flip** (`configs/voice-agent/voice-agent.ts`). Any stream whose certificate omits `provider` and *meant* grok now dials openai on its next call. No known live stream is in that state — every installed certificate names its provider — but a stale certificate from before the enum existed would flip. Grok-lane tests now pin `provider: "grok"` explicitly.
- **`ensureProjectExists`** (`connect.ts`): a bare run can now create a project as a side effect of a typo'd `--project` slug. The create is loud (two log lines) and projects are cheap, but reviewers should decide whether typo-creation is acceptable UX.
- **On merge**: prd redeploys; behavior changes only at the next `talk`/setup run per stream. Review order: voice-agent.ts (three one-line defaults + version) → talk.ts → connect.ts → test pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +21 -2 | +12 -2 🟩🟩⬜⬜⬜ |
| CI & scripts | +57 -13 | +26 -6 🟩🟩🟩🟩🟥 |
| Other | +8 -4 | +4 -4 🟩⬜⬜⬜⬜ |
| **Total** | **+86 -19** | **+42 -12** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 8f019cc and efaa52b, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-20T22:04:36.045Z",
      "deployedAt": "2026-08-20T21:57:25.477Z",
      "headSha": "efaa52b67676e4554ae976a311f67f172a2a4889",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/170281729214597",
      "shortSha": "efaa52b",
      "cleanupDurationMs": 18375,
      "deployDurationMs": 42747,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 41431,
      "deployReadinessDurationMs": 1313,
      "deployedWorkerName": "os-preview-2",
      "deployedWorkerVersion": "7e81c60f-4601-46e3-bf2d-4bb69dc74533",
      "testDurationMs": 321895,
      "testRetries": "2 retried: a userspace facet rebuilds on a source commit and only on a source commit (vitest x1) · repo-ide.spec.ts › discarding a new file confirms before permanently removing it › web (playwright x1) — TimeoutError: locator.waitFor: Timeout 1ms exceeded. Call log: \u001b[2m - waiting for getByText('Content that has never been committed.') to be visible\u001b[22m \u001b[33m If this is a slow operation, update the product code to add a spinner while it's running. This will improve the user experience and buy yo...",
      "workerSizeKib": 20805.17,
      "workerGzipKib": 5239.52,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5251.49
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-20T22:04:20.276Z",
      "deployedAt": "2026-08-20T21:57:05.709Z",
      "headSha": "efaa52b67676e4554ae976a311f67f172a2a4889",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-2.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/170281729214597",
      "shortSha": "efaa52b",
      "cleanupDurationMs": 2602,
      "deployDurationMs": 28105,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 21660,
      "deployReadinessDurationMs": 6441,
      "deployedWorkerName": "docs-preview-2",
      "deployedWorkerVersion": "4c0f21ca-720d-4416-9d45-6d88f4ac4fdb",
      "testDurationMs": 3205,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-20T22:04:21.631Z",
      "deployedAt": "2026-08-20T21:57:11.256Z",
      "headSha": "efaa52b67676e4554ae976a311f67f172a2a4889",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/170281729214597",
      "shortSha": "efaa52b",
      "cleanupDurationMs": 3955,
      "deployDurationMs": 27726,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 27205,
      "deployReadinessDurationMs": 515,
      "deployedWorkerName": "auth-preview-2",
      "deployedWorkerVersion": "56af744f-8f9e-46b6-953c-cb78603f0af4",
      "testDurationMs": 19612,
      "testRetries": null,
      "workerSizeKib": 3989.97,
      "workerGzipKib": 817.32,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-20T22:04:18.776Z",
      "deployedAt": "2026-08-20T21:29:44.468Z",
      "headSha": "efaa52b67676e4554ae976a311f67f172a2a4889",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/170281729214597",
      "shortSha": "efaa52b",
      "cleanupDurationMs": 1098,
      "deployDurationMs": 47,
      "deployConfigDurationMs": 27,
      "deployReuseProofDurationMs": 17,
      "deployedWorkerName": "dummy-petshop-preview-2",
      "deployedWorkerVersion": "7674b102-859b-4144-9ace-232c363f0f29",
      "testDurationMs": 7517,
      "testRetries": null,
      "workerSizeKib": 1115.4,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "b717e505c46472150438e97f994eb4a2c283e0f8+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `efaa52b` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 817.3 KiB | 27.7s | 19.6s |  | 4.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/170281729214597) | 2026-08-20T22:04:21.631Z | Preview app released. |
| Docs | released | `efaa52b` | [https://docs-preview-2.iterate-dev-preview.workers.dev](https://docs-preview-2.iterate-dev-preview.workers.dev) | 866.2 KiB | 28.1s | 3.2s |  | 2.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/170281729214597) | 2026-08-20T22:04:20.276Z | Preview app released. |
| Dummy Petshop | released | `efaa52b` | [https://dummy-petshop.iterate-preview-2.com](https://dummy-petshop.iterate-preview-2.com) | 198.3 KiB | 47ms | 7.5s |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/170281729214597) | 2026-08-20T22:04:18.776Z | Preview app released. |
| OS | released | `efaa52b` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 5.12 MiB (-12.0 KiB vs main) | 42.7s | 321.9s | 2 retried: a userspace facet rebuilds on a source commit and only on a source commit (vitest x1) · repo-ide.spec.ts › discarding a new file confirms before permanently removing it › web (playwright x1) — TimeoutError: locator.waitFor: Timeout 1ms exceeded. Call log: [2m - waiting for getByText('Content that has never been committed.') to be visible[22m [33m If this is a slow operation, update the product code to add a spinner while it's running. This will improve the user experience and buy yo... | 18.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/170281729214597) | 2026-08-20T22:04:36.045Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Flips the voice-agent default provider from grok to openai (contract 11.0.0), so certificates that omit `provider` will dial OpenAI on the next call. Also auto-creates a project on a missing slug, including typos.
> 
> **Overview**
> Voice-agent **11.0.0** makes **openai** the default provider when `configured` omits `provider` (schema, reducer, and setup dial). Grok-lane tests now pin `provider: "grok"` so they do not silently follow the new default.
> 
> `voicelab talk` now ships `hang_up` unless `--hang-up false`, defaults the project slug to `iterate`, and calls new `ensureProjectExists` so a first run on a fresh environment creates the project before connecting. Secret install prefers OpenAI unless `--provider grok`.
> 
> A comment on the userspace facet `test.fails` pin records a false-green from a coincidental facet recycle (new bootId), not a same-boot rebuild.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efaa52b67676e4554ae976a311f67f172a2a4889. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->