### PR TITLE
Reproify: the facet source-version pin cannot see a coincidental recycle

### DIFF
--- a/apps/os/e2e/vitest/facet-version-probe.ts
+++ b/apps/os/e2e/vitest/facet-version-probe.ts
@@ -1,0 +1,101 @@
+/**
+ * The instrument both facet-source-version suites use: a userspace facet that
+ * reports which instance answered, which build it was loaded from, and which
+ * source revision that build came from.
+ *
+ * Shared rather than copied so `userspace-facet-source-version.e2e.test.ts`
+ * (the pin) and `userspace-facet-recycle-false-alarm.e2e.test.ts` (why the pin
+ * false-alarms) measure the same facet the same way — the only difference
+ * between them is what they DO to it.
+ */
+
+export const PING = "events.iterate.test/facet-version/ping";
+export const SEEN = "events.iterate.test/facet-version/seen";
+
+export const PROBE_PATH = "version-probe.js";
+
+/** One `SEEN` payload: who answered, on which build, from which source. */
+export type FacetProbeAnswer = { id: string; bootId: string; buildKey: string; revision: string };
+
+/**
+ * The probe facet, committed to the project's config repo. Plain JavaScript
+ * (the platform bundles it; TS syntax fails the build as a
+ * `subscription-delivery-halted` event) — so `#private` fields and plain
+ * assignment instead of type annotations.
+ *
+ * It owes no background work, so `recovery` stays off: this probe is about
+ * facet IDENTITY across incarnations, and a keepalive alarm would add a second
+ * thing that revives the facet.
+ */
+export const probeFacetSource = (revision: string) => `
+import { StreamProcessorFacet } from "iterate/sdk";
+import { defineProcessorContract, StreamProcessor } from "iterate/processors";
+import { z } from "zod";
+
+export const VersionProbeContract = defineProcessorContract({
+  slug: "facet-version",
+  version: "1.0.0",
+  description: "Reports which facet instance and which loaded build handled each ping.",
+  stateSchema: z.object({ seen: z.array(z.string()).default([]) }),
+  events: {
+    "${PING}": {
+      description: "Ask the facet to identify itself.",
+      payloadSchema: z.object({ id: z.string() }),
+    },
+    "${SEEN}": {
+      description: "The answering facet instance, its build key, and its source revision.",
+      payloadSchema: z.object({
+        id: z.string(),
+        bootId: z.string(),
+        buildKey: z.string(),
+        revision: z.string(),
+      }),
+    },
+  },
+  consumes: ["${PING}"],
+  emits: ["${SEEN}"],
+});
+
+class VersionProbeProcessor extends StreamProcessor {
+  contract = VersionProbeContract;
+  // Set by the facet below, once per created processor.
+  bootId = "unset";
+  buildKey = "unset";
+
+  reduce({ state, event }) {
+    return { ...state, seen: [...state.seen, event.payload.id] };
+  }
+
+  processEvent({ event, append, blockProcessorWhile }) {
+    if (event === null || event.type !== "${PING}") return;
+    const id = event.payload.id;
+    const bootId = this.bootId;
+    const buildKey = this.buildKey;
+    // Per-event work the cursor must not outrun: the answer IS the measurement.
+    blockProcessorWhile(async () => {
+      await append({
+        type: "${SEEN}",
+        idempotencyKey: "seen@" + id,
+        // Baked into the SOURCE, so the answer says which build actually ran.
+        payload: { id, bootId, buildKey, revision: "${revision}" },
+      });
+    });
+  }
+}
+
+export class VersionProbeFacet extends StreamProcessorFacet {
+  // One per FACET INSTANCE: a new value proves the facet was torn down and
+  // started again (the base rebuilds its host per incarnation, but this field
+  // lives on the Durable Object instance itself).
+  #bootId = crypto.randomUUID();
+
+  createProcessor(deps) {
+    const processor = new VersionProbeProcessor(deps);
+    processor.bootId = this.#bootId;
+    // The build key the Stream DO resolved for this load — verbatim the
+    // cacheKey half of the facetSourceVersion marker that drives the abort.
+    processor.buildKey = String(this.env.ITERATE_WORKER_VERSION ?? "missing");
+    return processor;
+  }
+}
+`;

--- a/apps/os/e2e/vitest/facet-version-probe.ts
+++ b/apps/os/e2e/vitest/facet-version-probe.ts
@@ -14,6 +14,14 @@ export const SEEN = "events.iterate.test/facet-version/seen";
 
 export const PROBE_PATH = "version-probe.js";
 
+/**
+ * The probe processor contract's slug, and therefore the only subscription
+ * name that can receive anything: a facet-processor subscription whose name
+ * differs from its contract slug is delivered NOTHING, with no error and no
+ * halted-delivery event. Both suites name their subscription after this.
+ */
+export const PROBE_CONTRACT_SLUG = "facet-version";
+
 /** One `SEEN` payload: who answered, on which build, from which source. */
 export type FacetProbeAnswer = { id: string; bootId: string; buildKey: string; revision: string };
 
@@ -33,7 +41,7 @@ import { defineProcessorContract, StreamProcessor } from "iterate/processors";
 import { z } from "zod";
 
 export const VersionProbeContract = defineProcessorContract({
-  slug: "facet-version",
+  slug: "${PROBE_CONTRACT_SLUG}",
   version: "1.0.0",
   description: "Reports which facet instance and which loaded build handled each ping.",
   stateSchema: z.object({ seen: z.array(z.string()).default([]) }),

--- a/apps/os/e2e/vitest/userspace-facet-recycle-false-alarm.e2e.test.ts
+++ b/apps/os/e2e/vitest/userspace-facet-recycle-false-alarm.e2e.test.ts
@@ -11,7 +11,7 @@ import {
 import { adminSecret, withItxSession } from "./test-helpers.ts";
 
 /*
- * Why the pin next door goes red for no reason.
+ * Why the adjacent pin goes red for no reason.
  *
  * `userspace-facet-source-version.e2e.test.ts` is a `test.fails`: it asserts
  * the FIX ("a source commit reaches the RUNNING facet") and stays green only

--- a/apps/os/e2e/vitest/userspace-facet-recycle-false-alarm.e2e.test.ts
+++ b/apps/os/e2e/vitest/userspace-facet-recycle-false-alarm.e2e.test.ts
@@ -4,6 +4,7 @@ import { waitForCondition } from "../test-support/wait-for-condition.ts";
 import {
   type FacetProbeAnswer,
   PING,
+  PROBE_CONTRACT_SLUG,
   PROBE_PATH,
   probeFacetSource,
   SEEN,
@@ -47,19 +48,19 @@ import { adminSecret, withItxSession } from "./test-helpers.ts";
  * the commit is what replaced the facet. That is a separate change; this test
  * only holds the bug still.
  *
- * Needs a real deployment, like the pin: against local dev the facet never
- * builds at all and the first ping times out, which `test.fails` absorbs into
- * a vacuous pass. Hence the `[facet-recycle]` phase log — `test.fails` hides
- * WHICH throw ended the run, so a run that proves anything is one whose log
- * reaches `verdict`.
+ * The `[facet-recycle]` phase log is not decoration. `test.fails` reports
+ * every throw as the expected one, so a green pin says nothing about whether
+ * the pinned thing happened — the same blind spot this file is about. Three
+ * runs of this test "passed" while never reaching the assertion at all. A run
+ * proves something only if its log reaches `verdict`.
  */
 test.fails(
   "the source-version pin tells a facet that recycled from one the commit rebuilt",
-  // Ceiling, not an expectation: the run is ~60-90s against an idle
-  // deployment. 150s was not enough on a fully loaded preview run (the first
-  // attempt of the run described above timed out), and a ceiling only costs
-  // wall time when it is actually hit.
-  { timeout: 240_000 },
+  // Ceiling, not an expectation: ~6s against a warm local deployment, and the
+  // pin's comparable scenario takes 50-75s on a busy preview. Matched to the
+  // pin's ceiling because a ceiling costs wall time only when it is hit, and
+  // hitting it here would be absorbed as a vacuous pass rather than reported.
+  { timeout: 180_000 },
   async () => {
     // `test.fails` reports every throw as the expected one, so the phase log
     // is the only way to tell a run that measured something from one that
@@ -75,7 +76,10 @@ test.fails(
     log("project created", await project.projectId);
 
     const streamPath = "/facet-recycle";
-    const subscriptionName = "facet-recycle";
+    // Must equal the probe contract's slug: a facet-processor subscription
+    // named anything else is silently delivered nothing — no error, no
+    // halted-delivery event, just a facet that never answers.
+    const subscriptionName = PROBE_CONTRACT_SLUG;
 
     await project.repo.commitFiles({
       changes: [{ content: probeFacetSource("v1"), path: PROBE_PATH }],

--- a/apps/os/e2e/vitest/userspace-facet-recycle-false-alarm.e2e.test.ts
+++ b/apps/os/e2e/vitest/userspace-facet-recycle-false-alarm.e2e.test.ts
@@ -56,7 +56,7 @@ import { adminSecret, withItxSession } from "./test-helpers.ts";
 test.fails(
   "the source-version pin tells a facet that recycled from one the commit rebuilt",
   // Ceiling, not an expectation: the run is ~60-90s against an idle
-  // deployment. 150s was not enough on a saturated preview lane (the first
+  // deployment. 150s was not enough on a fully loaded preview run (the first
   // attempt of the run described above timed out), and a ceiling only costs
   // wall time when it is actually hit.
   { timeout: 240_000 },

--- a/apps/os/e2e/vitest/userspace-facet-recycle-false-alarm.e2e.test.ts
+++ b/apps/os/e2e/vitest/userspace-facet-recycle-false-alarm.e2e.test.ts
@@ -14,27 +14,31 @@ import { adminSecret, withItxSession } from "./test-helpers.ts";
  * Why the adjacent pin goes red for no reason.
  *
  * `userspace-facet-source-version.e2e.test.ts` is a `test.fails`: it asserts
- * the FIX ("a source commit reaches the RUNNING facet") and stays green only
- * while the bug survives. Its entire verdict is four comparisons between the
- * probe answer from before the commit and the one from after it:
+ * the FIX ("a source commit reaches the RUNNING facet"), so it stays green
+ * only while the bug survives and goes red the moment somebody fixes it. Its
+ * whole verdict is four comparisons between the probe answer from before the
+ * commit and the one from after it:
  *
  *     revision === "v2" && buildKey !== before.buildKey
  *       && /^[0-9a-f]{64}$/.test(buildKey) && bootId !== before.bootId
  *
- * None of those says WHY the facet changed. A facet that recycles for its own
+ * None of them says WHY the facet changed. A facet that recycles for its own
  * reasons — eviction, a redeploy rolling the isolate, a crash — comes back
  * building the newest source, because a facet that starts cold always does. So
  * a recycle that happens to land inside the pin's 45s poll window produces all
  * four, the pinned expectation passes, and vitest turns that into
- * `Error: Expect test to fail`. That has cost at least five red CI runs:
- * several during #2512, then #2516 at `1906b2aee` and again at `9bc655d82`
- * (Depot run 97mhddbj6d, job 7dm8bqj38b — 1 failed / 202 passed / 1 expected
- * fail, the failure being only the pin).
+ * `Error: Expect test to fail`.
  *
- * So this test stops waiting for the coincidence and CAUSES it: commit the new
- * source, then kill the stream, so the facet that answers is provably a fresh
- * one and provably not a running facet that picked the commit up. The pin's
- * four comparisons should not all hold on that answer. They all hold.
+ * It is not rare. The pin false-alarmed on the preview run of the very PR that
+ * added this file, and printed the proof: `third` answered v1 on boot
+ * `7c3831dc` and the FIRST poll after the commit answered v2 on boot
+ * `20bc97b2`. The facet had recycled in between, so the pin never observed a
+ * running facet at all.
+ *
+ * This test therefore stops waiting for the coincidence and CAUSES it: commit
+ * the new source, then kill the stream, so the facet that answers is provably
+ * a fresh one and provably not a running facet that picked the commit up. The
+ * pin's four comparisons should not all hold on that answer. They all hold.
  *
  * Note what the fix cannot be: a cleverer comparison over these same two
  * answers. A real in-place rebuild lands on a new boot id too (the abort
@@ -45,21 +49,30 @@ import { adminSecret, withItxSession } from "./test-helpers.ts";
  *
  * Needs a real deployment, like the pin: against local dev the facet never
  * builds at all and the first ping times out, which `test.fails` absorbs into
- * a vacuous pass. The `console.log` below is the receipt — if it is not in
- * the run output, the run proved nothing.
+ * a vacuous pass. Hence the `[facet-recycle]` phase log — `test.fails` hides
+ * WHICH throw ended the run, so a run that proves anything is one whose log
+ * reaches `verdict`.
  */
 test.fails(
   "the source-version pin tells a facet that recycled from one the commit rebuilt",
-  // Ceiling for the cold facet build, the post-kill rebuild, and their pings.
-  // The expected run is ~30-60s.
-  { timeout: 150_000 },
+  // Ceiling, not an expectation: the run is ~60-90s against an idle
+  // deployment. 150s was not enough on a saturated preview lane (the first
+  // attempt of the run described above timed out), and a ceiling only costs
+  // wall time when it is actually hit.
+  { timeout: 240_000 },
   async () => {
+    // `test.fails` reports every throw as the expected one, so the phase log
+    // is the only way to tell a run that measured something from one that
+    // fell over on the way. Every step announces itself.
+    const log = (phase: string, detail?: unknown) =>
+      console.log(`[facet-recycle] ${phase}`, detail ?? "");
+
     using session = withItxSession();
     using itx = session.authenticate({ type: "admin-secret", secret: adminSecret() });
     using project = await itx.projects
       .get(`facet-recycle-${crypto.randomUUID().slice(0, 8)}`)
       .create({});
-    await project.projectId;
+    log("project created", await project.projectId);
 
     const streamPath = "/facet-recycle";
     const subscriptionName = "facet-recycle";
@@ -68,6 +81,7 @@ test.fails(
       changes: [{ content: probeFacetSource("v1"), path: PROBE_PATH }],
       message: "A userspace facet processor that reports its instance, build key and revision",
     });
+    log("committed v1");
 
     const stream = project.streams.get(streamPath);
 
@@ -95,6 +109,7 @@ test.fails(
         },
       },
     } satisfies StreamEventInput);
+    log("subscription configured");
 
     const answers = async (): Promise<FacetProbeAnswer[]> => {
       const events = await stream.getEvents({ eventTypes: [SEEN] });
@@ -104,38 +119,51 @@ test.fails(
     /** Ping the facet and return the answer it committed. */
     const identify = async (label: string, timeoutMs: number): Promise<FacetProbeAnswer> => {
       const id = `${label}-${crypto.randomUUID().slice(0, 8)}`;
-      await stream.append({ type: PING, payload: { id } } satisfies StreamEventInput);
+      // A ping issued just after a kill can land while the Durable Object is
+      // still being reset. That is the platform, not the measurement, so give
+      // the append a few goes before giving up on the whole run.
+      for (let attempt = 0; ; attempt++) {
+        try {
+          await stream.append({ type: PING, payload: { id } } satisfies StreamEventInput);
+          break;
+        } catch (error) {
+          if (attempt === 4) throw error;
+          log(`ping "${id}" did not append, retrying`, String(error));
+          await new Promise((resolve) => setTimeout(resolve, 2_000));
+        }
+      }
       await waitForCondition(async () => (await answers()).some((answer) => answer.id === id), {
+        // A build failure surfaces as a `subscription-delivery-halted` event on
+        // the stream — read it if this ever times out.
         description: `the userspace facet to answer ping "${id}"`,
         timeoutMs,
       });
       const answer = (await answers()).find((entry) => entry.id === id);
       if (answer === undefined) throw new Error(`no answer for ping "${id}"`);
+      log(`answered ${label}`, answer);
       return answer;
     };
 
     // The facet the commit below will not reach: cold-built from v1, running.
-    const beforeCommit = await identify("before-commit", 90_000);
+    const beforeCommit = await identify("before-commit", 120_000);
     expect(beforeCommit).toMatchObject({ revision: "v1" });
 
     await project.repo.commitFiles({
       changes: [{ content: probeFacetSource("v2"), path: PROBE_PATH }],
       message: "Change the probe facet's source",
     });
+    log("committed v2");
 
     // THE COINCIDENCE, forced. In CI this is an eviction or a redeploy landing
     // inside the pin's poll window; here it is a kill, which is the same event
     // as far as the facet is concerned — the parent incarnation goes and takes
     // the facet with it. Nothing about the commit caused it.
     await stream.kill().catch(() => undefined);
+    log("killed the stream");
 
-    // Its replacement cold-builds, hence the cold-build budget. Polling rather
-    // than pinging once is also what keeps THIS test from becoming the next
-    // false alarm: every way of not reaching the pin's four comparisons ends
-    // in a throw, which `test.fails` absorbs. The only way it can go red is by
-    // reaching the bottom and finding the bug gone.
+    // Its replacement cold-builds, hence the cold-build budget.
     const deadline = Date.now() + 60_000;
-    let recycled = await identify("after-recycle-0", 90_000);
+    let recycled = await identify("after-recycle-0", 120_000);
     for (let attempt = 1; recycled.revision !== "v2"; attempt++) {
       if (Date.now() > deadline) {
         throw new Error(`the restarted facet never built v2: ${JSON.stringify(recycled)}`);
@@ -149,7 +177,7 @@ test.fails(
     // picked the commit up.
     expect(recycled).not.toMatchObject({ bootId: beforeCommit.bootId });
 
-    console.log("facet recycle false alarm", { beforeCommit, recycled });
+    log("verdict", { beforeCommit, recycled });
 
     // The pin's verdict, its four comparisons verbatim (the block under
     // "THE BUG" in userspace-facet-source-version.e2e.test.ts), applied to a

--- a/apps/os/e2e/vitest/userspace-facet-recycle-false-alarm.e2e.test.ts
+++ b/apps/os/e2e/vitest/userspace-facet-recycle-false-alarm.e2e.test.ts
@@ -132,12 +132,22 @@ test.fails(
           await new Promise((resolve) => setTimeout(resolve, 2_000));
         }
       }
-      await waitForCondition(async () => (await answers()).some((answer) => answer.id === id), {
+      try {
+        await waitForCondition(async () => (await answers()).some((answer) => answer.id === id), {
+          description: `the userspace facet to answer ping "${id}"`,
+          timeoutMs,
+        });
+      } catch (error) {
         // A build failure surfaces as a `subscription-delivery-halted` event on
-        // the stream — read it if this ever times out.
-        description: `the userspace facet to answer ping "${id}"`,
-        timeoutMs,
-      });
+        // the stream. `test.fails` would swallow that silently, so make the
+        // stream give its own account of the run before rethrowing.
+        const events = await stream.getEvents({});
+        log(
+          "stream events at timeout",
+          events.slice(-25).map((event) => ({ type: event.type, payload: event.payload })),
+        );
+        throw error;
+      }
       const answer = (await answers()).find((entry) => entry.id === id);
       if (answer === undefined) throw new Error(`no answer for ping "${id}"`);
       log(`answered ${label}`, answer);

--- a/apps/os/e2e/vitest/userspace-facet-recycle-false-alarm.e2e.test.ts
+++ b/apps/os/e2e/vitest/userspace-facet-recycle-false-alarm.e2e.test.ts
@@ -1,0 +1,168 @@
+import { expect, test } from "vitest";
+import type { StreamEventInput } from "iterate/processors";
+import { waitForCondition } from "../test-support/wait-for-condition.ts";
+import {
+  type FacetProbeAnswer,
+  PING,
+  PROBE_PATH,
+  probeFacetSource,
+  SEEN,
+} from "./facet-version-probe.ts";
+import { adminSecret, withItxSession } from "./test-helpers.ts";
+
+/*
+ * Why the pin next door goes red for no reason.
+ *
+ * `userspace-facet-source-version.e2e.test.ts` is a `test.fails`: it asserts
+ * the FIX ("a source commit reaches the RUNNING facet") and stays green only
+ * while the bug survives. Its entire verdict is four comparisons between the
+ * probe answer from before the commit and the one from after it:
+ *
+ *     revision === "v2" && buildKey !== before.buildKey
+ *       && /^[0-9a-f]{64}$/.test(buildKey) && bootId !== before.bootId
+ *
+ * None of those says WHY the facet changed. A facet that recycles for its own
+ * reasons — eviction, a redeploy rolling the isolate, a crash — comes back
+ * building the newest source, because a facet that starts cold always does. So
+ * a recycle that happens to land inside the pin's 45s poll window produces all
+ * four, the pinned expectation passes, and vitest turns that into
+ * `Error: Expect test to fail`. That has cost at least five red CI runs:
+ * several during #2512, then #2516 at `1906b2aee` and again at `9bc655d82`
+ * (Depot run 97mhddbj6d, job 7dm8bqj38b — 1 failed / 202 passed / 1 expected
+ * fail, the failure being only the pin).
+ *
+ * So this test stops waiting for the coincidence and CAUSES it: commit the new
+ * source, then kill the stream, so the facet that answers is provably a fresh
+ * one and provably not a running facet that picked the commit up. The pin's
+ * four comparisons should not all hold on that answer. They all hold.
+ *
+ * Note what the fix cannot be: a cleverer comparison over these same two
+ * answers. A real in-place rebuild lands on a new boot id too (the abort
+ * REPLACES the facet), so the recycle and the fix are the same tuple. On
+ * seeing a new boot id the pin has to go back and re-probe for evidence that
+ * the commit is what replaced the facet. That is a separate change; this test
+ * only holds the bug still.
+ */
+test.fails(
+  "the source-version pin tells a facet that recycled from one the commit rebuilt",
+  // Ceiling for the cold facet build, the post-kill rebuild, and their pings.
+  // The expected run is ~30-60s.
+  { timeout: 150_000 },
+  async () => {
+    using session = withItxSession();
+    using itx = session.authenticate({ type: "admin-secret", secret: adminSecret() });
+    using project = await itx.projects
+      .get(`facet-recycle-${crypto.randomUUID().slice(0, 8)}`)
+      .create({});
+    await project.projectId;
+
+    const streamPath = "/facet-recycle";
+    const subscriptionName = "facet-recycle";
+
+    await project.repo.commitFiles({
+      changes: [{ content: probeFacetSource("v1"), path: PROBE_PATH }],
+      message: "A userspace facet processor that reports its instance, build key and revision",
+    });
+
+    const stream = project.streams.get(streamPath);
+
+    await stream.append({
+      type: "events.iterate.com/stream/subscription-configured",
+      payload: {
+        name: subscriptionName,
+        receiver: {
+          action: "facet-processor",
+          source: {
+            kind: "userspace",
+            worker: {
+              type: "stateful",
+              path: streamPath,
+              className: "VersionProbeFacet",
+              durableWorkerKey: "version-probe",
+              source: {
+                createWorker: {
+                  entryPoint: PROBE_PATH,
+                  files: { type: "repo", repoPath: "/repos/config" },
+                },
+              },
+            },
+          },
+        },
+      },
+    } satisfies StreamEventInput);
+
+    const answers = async (): Promise<FacetProbeAnswer[]> => {
+      const events = await stream.getEvents({ eventTypes: [SEEN] });
+      return events.map((event) => event.payload as FacetProbeAnswer);
+    };
+
+    /** Ping the facet and return the answer it committed. */
+    const identify = async (label: string, timeoutMs: number): Promise<FacetProbeAnswer> => {
+      const id = `${label}-${crypto.randomUUID().slice(0, 8)}`;
+      await stream.append({ type: PING, payload: { id } } satisfies StreamEventInput);
+      await waitForCondition(async () => (await answers()).some((answer) => answer.id === id), {
+        description: `the userspace facet to answer ping "${id}"`,
+        timeoutMs,
+      });
+      const answer = (await answers()).find((entry) => entry.id === id);
+      if (answer === undefined) throw new Error(`no answer for ping "${id}"`);
+      return answer;
+    };
+
+    // The facet the commit below will not reach: cold-built from v1, running.
+    const beforeCommit = await identify("before-commit", 90_000);
+    expect(beforeCommit).toMatchObject({ revision: "v1" });
+
+    await project.repo.commitFiles({
+      changes: [{ content: probeFacetSource("v2"), path: PROBE_PATH }],
+      message: "Change the probe facet's source",
+    });
+
+    // THE COINCIDENCE, forced. In CI this is an eviction or a redeploy landing
+    // inside the pin's poll window; here it is a kill, which is the same event
+    // as far as the facet is concerned — the parent incarnation goes and takes
+    // the facet with it. Nothing about the commit caused it.
+    await stream.kill().catch(() => undefined);
+
+    // Its replacement cold-builds, hence the cold-build budget. Polling rather
+    // than pinging once is also what keeps THIS test from becoming the next
+    // false alarm: every way of not reaching the pin's four comparisons ends
+    // in a throw, which `test.fails` absorbs. The only way it can go red is by
+    // reaching the bottom and finding the bug gone.
+    const deadline = Date.now() + 60_000;
+    let recycled = await identify("after-recycle-0", 90_000);
+    for (let attempt = 1; recycled.revision !== "v2"; attempt++) {
+      if (Date.now() > deadline) {
+        throw new Error(`the restarted facet never built v2: ${JSON.stringify(recycled)}`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 3_000));
+      recycled = await identify(`after-recycle-${attempt}`, 60_000);
+    }
+
+    // Ground truth, and the whole point: this is a NEW facet. It was created
+    // after the kill, it never ran the v1 build, and no running facet ever
+    // picked the commit up.
+    expect(recycled).not.toMatchObject({ bootId: beforeCommit.bootId });
+
+    console.log("facet recycle false alarm", { beforeCommit, recycled });
+
+    // The pin's verdict, its four comparisons verbatim (the block under
+    // "THE BUG" in userspace-facet-source-version.e2e.test.ts), applied to a
+    // facet that demonstrably did not rebuild in place. One of them has to be
+    // the one that notices. None is — and the fourth is worse than blind: a
+    // moved boot id is the very thing that PROVES this was a recycle, and the
+    // pin reads it as evidence for the rebuild.
+    const pinVerdict = {
+      revisionIsNewSource: recycled.revision === "v2",
+      buildKeyMoved: recycled.buildKey !== beforeCommit.buildKey,
+      buildKeyWellFormed: /^[0-9a-f]{64}$/.test(recycled.buildKey),
+      bootIdMoved: recycled.bootId !== beforeCommit.bootId,
+    };
+    expect(pinVerdict).not.toMatchObject({
+      revisionIsNewSource: true,
+      buildKeyMoved: true,
+      buildKeyWellFormed: true,
+      bootIdMoved: true,
+    });
+  },
+);

--- a/apps/os/e2e/vitest/userspace-facet-recycle-false-alarm.e2e.test.ts
+++ b/apps/os/e2e/vitest/userspace-facet-recycle-false-alarm.e2e.test.ts
@@ -42,6 +42,11 @@ import { adminSecret, withItxSession } from "./test-helpers.ts";
  * seeing a new boot id the pin has to go back and re-probe for evidence that
  * the commit is what replaced the facet. That is a separate change; this test
  * only holds the bug still.
+ *
+ * Needs a real deployment, like the pin: against local dev the facet never
+ * builds at all and the first ping times out, which `test.fails` absorbs into
+ * a vacuous pass. The `console.log` below is the receipt — if it is not in
+ * the run output, the run proved nothing.
  */
 test.fails(
   "the source-version pin tells a facet that recycled from one the commit rebuilt",

--- a/apps/os/e2e/vitest/userspace-facet-source-version.e2e.test.ts
+++ b/apps/os/e2e/vitest/userspace-facet-source-version.e2e.test.ts
@@ -4,6 +4,7 @@ import { waitForCondition } from "../test-support/wait-for-condition.ts";
 import {
   type FacetProbeAnswer,
   PING,
+  PROBE_CONTRACT_SLUG,
   PROBE_PATH,
   probeFacetSource,
   SEEN,
@@ -82,7 +83,9 @@ test.fails(
     await project.projectId;
 
     const streamPath = "/facet-version";
-    const subscriptionName = "facet-version";
+    // Must equal the probe contract's slug: a facet-processor subscription
+    // named anything else is silently delivered nothing.
+    const subscriptionName = PROBE_CONTRACT_SLUG;
 
     await project.repo.commitFiles({
       changes: [

--- a/apps/os/e2e/vitest/userspace-facet-source-version.e2e.test.ts
+++ b/apps/os/e2e/vitest/userspace-facet-source-version.e2e.test.ts
@@ -1,6 +1,13 @@
 import { expect, test } from "vitest";
 import type { StreamEventInput } from "iterate/processors";
 import { waitForCondition } from "../test-support/wait-for-condition.ts";
+import {
+  type FacetProbeAnswer,
+  PING,
+  PROBE_PATH,
+  probeFacetSource,
+  SEEN,
+} from "./facet-version-probe.ts";
 import { adminSecret, withItxSession } from "./test-helpers.ts";
 
 // The source-change contract for a userspace processor FACET, in both
@@ -22,11 +29,8 @@ import { adminSecret, withItxSession } from "./test-helpers.ts";
 // half of the marker — plus a per-instance boot id and the source revision it
 // was built from.
 
-const PING = "events.iterate.test/facet-version/ping";
-const SEEN = "events.iterate.test/facet-version/seen";
 const WOKEN = "events.iterate.com/stream/woken";
 
-const PROBE_PATH = "version-probe.js";
 const ECHO_PATH = "version-echo.js";
 
 /*
@@ -59,7 +63,10 @@ const ECHO_PATH = "version-echo.js";
  * the poll, and a restarted facet legitimately builds the new source; the
  * very next run was back to 16 same-boot polls on the old key. Before
  * believing this bug fixed, check the probe: the claim is only about a
- * SAME-BOOT facet, and only same-boot evidence refutes it.
+ * SAME-BOOT facet, and only same-boot evidence refutes it. Every red run
+ * since has been the same coincidence, and the four comparisons below
+ * cannot see it: `userspace-facet-recycle-false-alarm.e2e.test.ts` forces
+ * the recycle instead of waiting for it and pins that blind spot.
  */
 test.fails(
   "a userspace facet rebuilds on a source commit and only on a source commit",
@@ -128,14 +135,13 @@ test.fails(
       },
     } satisfies StreamEventInput);
 
-    type Answer = { id: string; bootId: string; buildKey: string; revision: string };
-    const answers = async (): Promise<Answer[]> => {
+    const answers = async (): Promise<FacetProbeAnswer[]> => {
       const events = await stream.getEvents({ eventTypes: [SEEN] });
-      return events.map((event) => event.payload as Answer);
+      return events.map((event) => event.payload as FacetProbeAnswer);
     };
 
     /** Ping the facet and return the answer it committed. */
-    const identify = async (label: string, timeoutMs: number): Promise<Answer> => {
+    const identify = async (label: string, timeoutMs: number): Promise<FacetProbeAnswer> => {
       const id = `${label}-${crypto.randomUUID().slice(0, 8)}`;
       await stream.append({ type: PING, payload: { id } } satisfies StreamEventInput);
       await waitForCondition(
@@ -192,7 +198,7 @@ test.fails(
     // Poll rather than ping once: a rebuild that merely LAGS the commit is a
     // different (and much milder) thing than one that never happens, and only
     // a repeated ping tells them apart.
-    const afterCommitAnswers: Answer[] = [];
+    const afterCommitAnswers: FacetProbeAnswer[] = [];
     const deadline = Date.now() + 45_000;
     let afterCommit = await identify("after-commit-0", 90_000);
     afterCommitAnswers.push(afterCommit);
@@ -239,89 +245,6 @@ test.fails(
     expect(afterCommit).not.toMatchObject({ bootId: third.bootId });
   },
 );
-
-/**
- * The probe facet, committed to the project's config repo. Plain JavaScript
- * (the platform bundles it; TS syntax fails the build as a
- * `subscription-delivery-halted` event) — so `#private` fields and plain
- * assignment instead of type annotations.
- *
- * It owes no background work, so `recovery` stays off: this probe is about
- * facet IDENTITY across incarnations, and a keepalive alarm would add a second
- * thing that revives the facet.
- */
-const probeFacetSource = (revision: string) => `
-import { StreamProcessorFacet } from "iterate/sdk";
-import { defineProcessorContract, StreamProcessor } from "iterate/processors";
-import { z } from "zod";
-
-export const VersionProbeContract = defineProcessorContract({
-  slug: "facet-version",
-  version: "1.0.0",
-  description: "Reports which facet instance and which loaded build handled each ping.",
-  stateSchema: z.object({ seen: z.array(z.string()).default([]) }),
-  events: {
-    "${PING}": {
-      description: "Ask the facet to identify itself.",
-      payloadSchema: z.object({ id: z.string() }),
-    },
-    "${SEEN}": {
-      description: "The answering facet instance, its build key, and its source revision.",
-      payloadSchema: z.object({
-        id: z.string(),
-        bootId: z.string(),
-        buildKey: z.string(),
-        revision: z.string(),
-      }),
-    },
-  },
-  consumes: ["${PING}"],
-  emits: ["${SEEN}"],
-});
-
-class VersionProbeProcessor extends StreamProcessor {
-  contract = VersionProbeContract;
-  // Set by the facet below, once per created processor.
-  bootId = "unset";
-  buildKey = "unset";
-
-  reduce({ state, event }) {
-    return { ...state, seen: [...state.seen, event.payload.id] };
-  }
-
-  processEvent({ event, append, blockProcessorWhile }) {
-    if (event === null || event.type !== "${PING}") return;
-    const id = event.payload.id;
-    const bootId = this.bootId;
-    const buildKey = this.buildKey;
-    // Per-event work the cursor must not outrun: the answer IS the measurement.
-    blockProcessorWhile(async () => {
-      await append({
-        type: "${SEEN}",
-        idempotencyKey: "seen@" + id,
-        // Baked into the SOURCE, so the answer says which build actually ran.
-        payload: { id, bootId, buildKey, revision: "${revision}" },
-      });
-    });
-  }
-}
-
-export class VersionProbeFacet extends StreamProcessorFacet {
-  // One per FACET INSTANCE: a new value proves the facet was torn down and
-  // started again (the base rebuilds its host per incarnation, but this field
-  // lives on the Durable Object instance itself).
-  #bootId = crypto.randomUUID();
-
-  createProcessor(deps) {
-    const processor = new VersionProbeProcessor(deps);
-    processor.bootId = this.#bootId;
-    // The build key the Stream DO resolved for this load — verbatim the
-    // cacheKey half of the facetSourceVersion marker that drives the abort.
-    processor.buildKey = String(this.env.ITERATE_WORKER_VERSION ?? "missing");
-    return processor;
-  }
-}
-`;
 
 /**
  * A STATELESS worker off the same repo. It holds no facet and caches nothing,


### PR DESCRIPTION
The facet source-version pin has gone red at least five times without anything
being wrong — six now, because **it false-alarmed again on this PR's own
preview run**, which is why CI here is red. This adds a `test.fails` that
reproduces the mechanism on demand instead of waiting for the coincidence.
**It does not fix it.**

## The pin, and why it false-alarms

`apps/os/e2e/vitest/userspace-facet-source-version.e2e.test.ts` is a
`test.fails`: it asserts the *fix* ("a source commit reaches the **running**
facet"), so it stays green only while the bug survives and goes red the moment
someone fixes it. Its whole verdict is four comparisons between the probe
answer from before the commit and the one from after it:

```ts
revision === "v2" && buildKey !== before.buildKey
  && /^[0-9a-f]{64}$/.test(buildKey) && bootId !== before.bootId
```

None of them says *why* the facet changed. A facet that recycles for its own
reasons — eviction, a redeploy rolling the isolate, a crash — comes back cold
and builds the newest source, because a facet that starts cold always does. A
recycle landing inside the pin's 45s poll window therefore produces all four,
the pinned expectation passes, and vitest turns that into
`Error: Expect test to fail`.

## Occurrences

| When | Where | Evidence |
| --- | --- | --- |
| Several runs | #2512 | the pin the only failure |
| 2026-08-20 | preview run | the `.fails` was briefly deleted before the next run put it back — already written up in the pin's header; that run's probe showed the after-commit answer on a new bootId |
| #2516 @ `1906b2aee` | preview CI | the pin the only failure |
| #2516 @ `9bc655d82` | preview CI | Depot run `97mhddbj6d`, job `7dm8bqj38b` — `1 failed / 202 passed / 1 expected fail`, the failure being only this pin |
| **this PR @ `235aeb2b1`** | preview CI | Depot job `wz1s7587kt` — `1 failed / 202 passed / 2 expected fail`, the failure being only this pin, **with the probe dump attached** |

```bash
depot ci logs 7dm8bqj38b --org 0p91s0lz49   # the #2516 occurrence
depot ci logs wz1s7587kt --org 0p91s0lz49   # this PR's, with the probe dump
```

### The newest one, in full

The pin printed exactly what the header above describes:

```
third:            bootId 7c3831dc…  buildKey 1121ca01…  revision v1
after-commit-0:   bootId 20bc97b2…  buildKey 20a39c96…  revision v2
afterCommitPolls: 1
```

The boot id moved between the pre-commit probe and the **first** post-commit
poll. The facet recycled in the gap, came back cold, and built v2 on the way
up — so the pin never observed a running facet at all, and its four
comparisons all held anyway. `Error: Expect test to fail`.

**CI on this PR is red for that reason, not for anything this diff does.**

## The repro

`apps/os/e2e/vitest/userspace-facet-recycle-false-alarm.e2e.test.ts` stops
waiting for the coincidence and causes it:

```ts
const beforeCommit = await identify("before-commit", 90_000); // v1, running
await project.repo.commitFiles({ changes: [{ content: probeFacetSource("v2"), ... }] });

// THE COINCIDENCE, forced — the same event as an eviction, as far as the
// facet is concerned. Nothing about the commit caused it.
await stream.kill().catch(() => undefined);

const recycled = /* poll until the replacement facet answers v2 */;

// Ground truth: a NEW facet. It never ran the v1 build; no running facet
// picked the commit up.
expect(recycled).not.toMatchObject({ bootId: beforeCommit.bootId });

// The pin's four comparisons, verbatim, on that answer. One of them has to be
// the one that notices. None is.
expect(pinVerdict).not.toMatchObject({
  revisionIsNewSource: true, buildKeyMoved: true,
  buildKeyWellFormed: true, bootIdMoved: true,
});
```

Red today, so the `test.fails` is green. Delete the `.fails` when the pin
learns to tell the two apart.

## This test cannot become the next false alarm

Every way of *not* reaching the four comparisons — the project not coming up,
the facet never building v2, a ping going unanswered — ends in a throw, which
`test.fails` absorbs. The only path to red is reaching the bottom and finding
the bug gone. That is deliberate: the fragility being reproduced here is
exactly a pinned test going red for reasons other than the thing it pins.

## Verification

Runs against local dev in ~6s. The phase log reaches `verdict` and the run
fails at the intended assertion — the pin's four comparisons, all four true on
a facet that was killed and restarted:

```
[facet-recycle] verdict {
  beforeCommit: { bootId: 'eec2837c…', buildKey: 'a029f750…', revision: 'v1' },
  recycled:     { bootId: '5e6c6527…', buildKey: 'c78aa7e1…', revision: 'v2' }
}

AssertionError: expected { revisionIsNewSource: true, …(3) }
             to not match object { revisionIsNewSource: true, …(3) }
  ❯ userspace-facet-recycle-false-alarm.e2e.test.ts:208
```

Confirmed on a deployment too — this PR's preview run at `40c6d7484` (Depot
job `qj026bcd6k`) is green, `202 passed | 3 expected fail`, and the repro's log
reaches `verdict` there with the same shape: `before-commit` v1 on boot
`26e27ee2…`, `after-recycle-0` v2 on boot `731a479f…`, 44s.

Getting there took three runs that "passed" without reaching the assertion at
all, which is worth stating plainly: **`test.fails` reports every throw as the
expected one**, so a green pin is no evidence that the pinned thing happened —
the same blind spot this PR is about, in the test written to expose it. Hence
the `[facet-recycle]` phase log: a run counts only if its log reaches
`verdict`.

One harness quirk worth knowing, visible in that run: **every `test.fails`
burns two attempts in CI.** Both this test and the pin are annotated
`(retry x1)`, with both attempts reaching the same verdict — the `retry: 1`
policy sees the raw failure before the `fails` inversion. It doubles the wall
cost of every pinned test; not this PR's business to change, but it explains
the durations.

## A silent product flaw this turned up

The three empty runs had one cause, found by bisecting my setup against the
pin's: **a `facet-processor` subscription whose name differs from its
processor contract's slug is delivered nothing.** No error, no
`subscription-delivery-halted` event, no log — the facet builds and then sits
there. Named `facet-version` (the probe contract's slug) it answers in 3s;
named `facet-recycle` it never answers, whatever the stream path is.

The pin only ever worked because its subscription name happened to equal the
slug. Both suites now take the name from `PROBE_CONTRACT_SLUG` and say why.
Not fixed here — flagged for its own change, since silently dropping delivery
is a product decision, not a test detail.

## What the fix is not

A cleverer comparison over these same two answers. A real in-place rebuild
lands on a new boot id too — the abort *replaces* the facet — so the recycle
and the fix are the same tuple. On seeing a new boot id the pin has to go back
and re-probe for evidence that the commit is what replaced the facet. Separate
PR.

## Also in here

The probe facet source moves to `apps/os/e2e/vitest/facet-version-probe.ts` so
both suites commit the same instrument and a reader comparing them only has to
compare what they *do* to it. The pin's assertions are untouched; its header
gains a pointer to the repro.

## Risk map

Test-only diff: no product code, no runtime behavior change, nothing to
screenshot.

- **Riskiest**: `userspace-facet-recycle-false-alarm.e2e.test.ts` — verified
  to fail for the right reason (see above), but like any `test.fails` it will
  report a *wrong*-reason throw as a pass. The phase log is the mitigation,
  not a guarantee.
- **Second**: the `PROBE_CONTRACT_SLUG` rename touches the pin's subscription
  name. Same value it always had (`"facet-version"`), now taken from a
  constant — the pin's behavior is unchanged, and it still fails-as-expected
  locally in 55s.
- **On merge**: the OS e2e suite gains one ~10-60s file. The pin keeps
  false-alarming until it is hardened; this PR makes the mechanism
  reproducible on demand, it does not stop it.
- **Review order**:
  1. `userspace-facet-recycle-false-alarm.e2e.test.ts` — the argument is the
     header comment, the assertion is the last 20 lines.
  2. `userspace-facet-source-version.e2e.test.ts` — check the extraction is
     inert: imports swapped, `Answer` renamed to `FacetProbeAnswer`,
     subscription name from the constant, header breadcrumb added, assertions
     byte-identical.
  3. `facet-version-probe.ts` — moved text plus the slug constant.

---
Claude Code session `4de46ffe-964f-42d8-841a-fb8cbb7106a3`
