### PR TITLE
Facet alarm replay failures fail the alarm invocation (2-minute revival strand)

### DIFF
--- a/apps/os/src/domains/streams/stream-durable-object.ts
+++ b/apps/os/src/domains/streams/stream-durable-object.ts
@@ -1257,7 +1257,7 @@ export class StreamDurableObject extends DurableObject<Env> {
    * when the bounded self-re-arm is lost with the incarnation (see
    * {@link #fireDueFacetAlarms}).
    */
-  async alarm(alarmInfo?: AlarmInvocationInfo): Promise<void> {
+  async alarm(alarmInfo?: AlarmInvocationInfo) {
     this.#alarmArmer.markFired();
     let facetReplays: Promise<FacetAlarmReplayFailure[]> | undefined;
     this.#deliveryAlarmBoundary.runAlarmTurn(() => {
@@ -1551,9 +1551,7 @@ export class StreamDurableObject extends DurableObject<Env> {
    * facets' durable records. Retry fires only follow a failed invocation,
    * so the extra pokes are bounded.
    */
-  #fireDueFacetAlarms(
-    alarmInfo?: AlarmInvocationInfo,
-  ): Promise<FacetAlarmReplayFailure[]> | undefined {
+  #fireDueFacetAlarms(alarmInfo?: AlarmInvocationInfo) {
     const dueAtMs = this.#readFacetAlarmAtMs();
     const due = dueAtMs !== null && dueAtMs <= Date.now();
     if (due) {

--- a/apps/os/src/domains/streams/stream-durable-object.ts
+++ b/apps/os/src/domains/streams/stream-durable-object.ts
@@ -577,6 +577,10 @@ const FACET_SOURCE_VERSION_KV_PREFIX = "facetSourceVersion:";
 /** Bounded extra delay before retrying a facet's failed alarm replay. */
 const FACET_ALARM_RETRY_DELAY_MS = 1_000;
 
+/** One facet's failed `handleAlarm` replay, surfaced so the alarm invocation
+ * can fail and keep the platform's alarm retry owed (see `alarm()`). */
+type FacetAlarmReplayFailure = { facet: string; error: unknown };
+
 /**
  * One row of `subscriptions.list()`: the committed catalog entry joined with
  * its durable cursor — name, receiver kind, status, and lag
@@ -1245,13 +1249,29 @@ export class StreamDurableObject extends DurableObject<Env> {
     ]);
   }
 
-  /** Use Cloudflare's native alarm invocation as the trace root; retry work remains background. */
-  alarm(alarmInfo?: AlarmInvocationInfo): void {
+  /**
+   * Use Cloudflare's native alarm invocation as the trace root; reconcile and
+   * delivery retry work remains background, but facet alarm replays are
+   * awaited: a failed replay rejects this invocation so the platform's alarm
+   * retry — which survives Durable Object resets — keeps the fire owed even
+   * when the bounded self-re-arm is lost with the incarnation (see
+   * {@link #fireDueFacetAlarms}).
+   */
+  async alarm(alarmInfo?: AlarmInvocationInfo): Promise<void> {
     this.#alarmArmer.markFired();
+    let facetReplays: Promise<FacetAlarmReplayFailure[]> | undefined;
     this.#deliveryAlarmBoundary.runAlarmTurn(() => {
-      this.#fireDueFacetAlarms(alarmInfo);
+      facetReplays = this.#fireDueFacetAlarms(alarmInfo);
       this.#reconcileCommittedState({ alarmTurn: true });
     });
+    const failures = facetReplays === undefined ? [] : await facetReplays;
+    if (failures.length > 0) {
+      throw new Error(
+        `facet alarm replay failed for ${failures.map((failure) => failure.facet).join(", ")}; ` +
+          `failing the alarm invocation keeps the platform's alarm retry owed`,
+        { cause: failures[0]!.error },
+      );
+    }
   }
 
   // ===========================================================================
@@ -1510,15 +1530,25 @@ export class StreamDurableObject extends DurableObject<Env> {
    * a fresh desire the completion path never clobbers), then replay the fire
    * into EVERY facet-placed subscription's facet — early fires are safe, and
    * without per-facet identity the fan-out is what makes no desire lose its
-   * fire. A failed replay merges a bounded retry back into the slot.
+   * fire. A failed replay merges a bounded retry back into the slot AND is
+   * returned to the alarm handler, which fails the invocation: the fire
+   * consumed the native alarm, so the self-armed retry write is the ONLY
+   * wakeup left, and a reset storm can lose it after this incarnation's
+   * in-memory work is gone (the 2026-08-25 preview incident: a deploy reset
+   * the DO between the fire and the re-arm commit, stranding a persisted
+   * keepalive revival desire until an unrelated request happened to boot the
+   * DO two minutes later). A failed alarm invocation keeps the platform's
+   * own alarm retry owed — platform retries survive resets.
    */
-  #fireDueFacetAlarms(alarmInfo?: AlarmInvocationInfo): void {
+  #fireDueFacetAlarms(
+    alarmInfo?: AlarmInvocationInfo,
+  ): Promise<FacetAlarmReplayFailure[]> | undefined {
     const dueAtMs = this.#readFacetAlarmAtMs();
-    if (dueAtMs === null) return;
+    if (dueAtMs === null) return undefined;
     if (dueAtMs > Date.now()) {
       // A fresh incarnation's armer memory is empty; keep the slot armed.
       this.#alarmArmer.armNoLaterThan(dueAtMs);
-      return;
+      return undefined;
     }
     this.ctx.storage.kv.delete(FACET_ALARM_KV_KEY);
     const facetNames = Object.entries(
@@ -1537,11 +1567,12 @@ export class StreamDurableObject extends DurableObject<Env> {
             retryCount: alarmInfo.retryCount,
             scheduledTime: alarmInfo.scheduledTime,
           };
-    for (const facet of facetNames) {
-      this.#runInBackground(async () => {
+    return Promise.all(
+      facetNames.map(async (facet): Promise<FacetAlarmReplayFailure[]> => {
         try {
           await this.#callProcessorFacet(facet, (stub) => stub.handleAlarm(info));
           this.#facetAlarmFailures.delete(facet);
+          return [];
         } catch (error) {
           const failures = (this.#facetAlarmFailures.get(facet) ?? 0) + 1;
           this.#facetAlarmFailures.set(facet, failures);
@@ -1550,12 +1581,15 @@ export class StreamDurableObject extends DurableObject<Env> {
             failures,
             error,
           });
+          // Best effort: if this arming write itself fails, the rejection
+          // reaches the alarm handler's await and the platform retry covers it.
           this.#mergeFacetAlarmDesire(
             Date.now() + computeBackoffMs(failures, Math.random()) + FACET_ALARM_RETRY_DELAY_MS,
           );
+          return [{ facet, error }];
         }
-      });
-    }
+      }),
+    ).then((results) => results.flat());
   }
 
   /**

--- a/apps/os/src/domains/streams/stream-durable-object.ts
+++ b/apps/os/src/domains/streams/stream-durable-object.ts
@@ -1264,7 +1264,7 @@ export class StreamDurableObject extends DurableObject<Env> {
       facetReplays = this.#fireDueFacetAlarms(alarmInfo);
       this.#reconcileCommittedState({ alarmTurn: true });
     });
-    const failures = facetReplays === undefined ? [] : await facetReplays;
+    const failures = await (facetReplays || []);
     if (failures.length > 0) {
       throw new Error(
         `facet alarm replay failed for ${failures.map((failure) => failure.facet).join(", ")}; ` +
@@ -1539,18 +1539,30 @@ export class StreamDurableObject extends DurableObject<Env> {
    * keepalive revival desire until an unrelated request happened to boot the
    * DO two minutes later). A failed alarm invocation keeps the platform's
    * own alarm retry owed — platform retries survive resets.
+   *
+   * A RETRY fire (`alarmInfo.isRetry`) fans out even when the slot is empty
+   * or not yet due. The slot delete above and the failure path's re-merge
+   * commit independently (an await separates them), so a death in that gap
+   * leaves the platform retry facing an empty slot; trusting the slot there
+   * would resolve the retry and end the chain with nothing armed — the same
+   * strand again. Replays are level-triggered no-ops when nothing is owed,
+   * and a freshly booted facet re-issues its own persisted desire through
+   * the proxy at construction, so the poke rebuilds the slot from the
+   * facets' durable records. Retry fires only follow a failed invocation,
+   * so the extra pokes are bounded.
    */
   #fireDueFacetAlarms(
     alarmInfo?: AlarmInvocationInfo,
   ): Promise<FacetAlarmReplayFailure[]> | undefined {
     const dueAtMs = this.#readFacetAlarmAtMs();
-    if (dueAtMs === null) return undefined;
-    if (dueAtMs > Date.now()) {
+    const due = dueAtMs !== null && dueAtMs <= Date.now();
+    if (due) {
+      this.ctx.storage.kv.delete(FACET_ALARM_KV_KEY);
+    } else if (dueAtMs !== null) {
       // A fresh incarnation's armer memory is empty; keep the slot armed.
       this.#alarmArmer.armNoLaterThan(dueAtMs);
-      return undefined;
     }
-    this.ctx.storage.kv.delete(FACET_ALARM_KV_KEY);
+    if (!due && alarmInfo?.isRetry !== true) return undefined;
     const facetNames = Object.entries(
       this.#coreProcessorState.subscriptions.outbound.byName,
     ).flatMap(([name, entry]) => {

--- a/apps/os/src/domains/streams/stream-facet-alarm-replay.test.ts
+++ b/apps/os/src/domains/streams/stream-facet-alarm-replay.test.ts
@@ -60,6 +60,40 @@ test("a successful facet alarm replay resolves the alarm and leaves the facet sl
   harness.context.close();
 });
 
+test("a platform retry fire replays into facets even when the shared slot is empty", async () => {
+  const harness = await bootStreamWithAgentFacet();
+
+  // The lost-merge window: the slot delete committed but the failure path's
+  // re-merge died with the incarnation. The platform retry must not trust
+  // the empty slot — it pokes every facet so their durable records re-derive
+  // whatever is owed.
+  await expect(
+    harness.stream.alarm({ isRetry: true, retryCount: 1 } as AlarmInvocationInfo),
+  ).resolves.toBeUndefined();
+  expect(harness.facet.handleAlarmCalls).toBe(1);
+
+  // A non-retry fire with an empty slot stays a no-op — ordinary delivery
+  // alarms must not poke facets on every append.
+  await expect(harness.stream.alarm()).resolves.toBeUndefined();
+  expect(harness.facet.handleAlarmCalls).toBe(1);
+
+  await harness.context.settle();
+  harness.context.close();
+});
+
+test("a failing facet keeps the platform retry chain alive across retry fires", async () => {
+  const harness = await bootStreamWithAgentFacet();
+  harness.facet.handleAlarmError = new Error("Durable Object reset because its code was updated");
+
+  await expect(
+    harness.stream.alarm({ isRetry: true, retryCount: 2 } as AlarmInvocationInfo),
+  ).rejects.toThrow(/facet alarm replay failed for agent/);
+  expect(harness.facet.handleAlarmCalls).toBe(1);
+
+  await harness.context.settle();
+  harness.context.close();
+});
+
 test("a not-yet-due facet desire re-arms without replaying and the alarm resolves", async () => {
   const harness = await bootStreamWithAgentFacet();
 

--- a/apps/os/src/domains/streams/stream-facet-alarm-replay.test.ts
+++ b/apps/os/src/domains/streams/stream-facet-alarm-replay.test.ts
@@ -39,8 +39,9 @@ test("a failed facet alarm replay rejects the alarm invocation and re-merges the
   const merged = harness.stream.proxyGetAlarm();
   expect(merged).not.toBeNull();
   expect(merged!).toBeGreaterThan(before);
-  // toContain, not at(-1): the halted wake lane's own retry may arm a nearer
-  // alarm after the merge; the merged desire's native write is what matters.
+  // toContain, not at(-1): the halted wake delivery's own retry may arm a
+  // nearer alarm after the merge; the merged desire's native write is what
+  // matters.
   expect(harness.context.alarms).toContain(merged);
 
   await harness.context.settle();
@@ -129,9 +130,9 @@ async function bootStreamWithAgentFacet() {
           ? Promise.resolve()
           : Promise.reject(facet.handleAlarmError);
       },
-      // The wake-delivery lane is not under test; its failure rides the
-      // sender's own retry machinery, which never touches the facet slot.
-      wakeStreamProcessor: () => Promise.reject(new Error("wake lane not under test")),
+      // The wake delivery is not under test; its failure rides the sender's
+      // own retry machinery, which never touches the facet slot.
+      wakeStreamProcessor: () => Promise.reject(new Error("wake delivery not under test")),
     },
   };
   const context = durableObjectContext(

--- a/apps/os/src/domains/streams/stream-facet-alarm-replay.test.ts
+++ b/apps/os/src/domains/streams/stream-facet-alarm-replay.test.ts
@@ -1,0 +1,238 @@
+// The facet alarm replay's loss-proofing: a facet-placed processor's only
+// self-wake is the parent Stream DO's native alarm, and each fire CONSUMES
+// it. If the replay into the facet fails, the parent merges a bounded retry
+// back into the shared facet slot — but that self-armed write is the only
+// wakeup left, and a reset storm can lose it with the incarnation (the
+// 2026-08-25 preview incident: a deploy reset the DO between the fire and
+// the re-arm commit, stranding a persisted keepalive revival desire for two
+// minutes until an unrelated request booted the DO). The alarm invocation
+// must therefore FAIL when a replay fails: Cloudflare's platform alarm retry
+// survives resets and keeps the fire owed.
+//
+// Runs the REAL StreamDurableObject in plain node over an in-memory ctx fake
+// (same shape as guarantees-not-given.test.ts) with a scripted facet.
+
+import { DatabaseSync } from "node:sqlite";
+import { expect, test } from "vitest";
+import type { Env } from "../../env.ts";
+import { DurableObjectNameCodec } from "../durable-object-names.ts";
+import { StreamDurableObject } from "./stream-durable-object.ts";
+
+test("a failed facet alarm replay rejects the alarm invocation and re-merges the bounded retry desire", async () => {
+  const harness = await bootStreamWithAgentFacet();
+  harness.facet.handleAlarmError = new Error("Durable Object reset because its code was updated");
+
+  const before = Date.now();
+  harness.stream.proxySetAlarm(before - 1);
+
+  // The replay failure must reject the WHOLE alarm invocation — a resolved
+  // alarm is a consumed alarm, and the platform only re-owes the fire when
+  // the handler fails.
+  await expect(harness.stream.alarm()).rejects.toThrow(
+    /facet alarm replay failed for agent; failing the alarm invocation keeps the platform's alarm retry owed/,
+  );
+  expect(harness.facet.handleAlarmCalls).toBe(1);
+
+  // The bounded self-retry stays armed too (the fast path when the write
+  // survives): the shared facet slot holds a future desire and the native
+  // alarm was re-armed for it.
+  const merged = harness.stream.proxyGetAlarm();
+  expect(merged).not.toBeNull();
+  expect(merged!).toBeGreaterThan(before);
+  // toContain, not at(-1): the halted wake lane's own retry may arm a nearer
+  // alarm after the merge; the merged desire's native write is what matters.
+  expect(harness.context.alarms).toContain(merged);
+
+  await harness.context.settle();
+  harness.context.close();
+});
+
+test("a successful facet alarm replay resolves the alarm and leaves the facet slot clear", async () => {
+  const harness = await bootStreamWithAgentFacet();
+
+  harness.stream.proxySetAlarm(Date.now() - 1);
+  await expect(harness.stream.alarm()).resolves.toBeUndefined();
+
+  expect(harness.facet.handleAlarmCalls).toBe(1);
+  expect(harness.stream.proxyGetAlarm()).toBeNull();
+
+  await harness.context.settle();
+  harness.context.close();
+});
+
+test("a not-yet-due facet desire re-arms without replaying and the alarm resolves", async () => {
+  const harness = await bootStreamWithAgentFacet();
+
+  const future = Date.now() + 60_000;
+  harness.stream.proxySetAlarm(future);
+  await expect(harness.stream.alarm()).resolves.toBeUndefined();
+
+  expect(harness.facet.handleAlarmCalls).toBe(0);
+  expect(harness.stream.proxyGetAlarm()).toBe(future);
+
+  await harness.context.settle();
+  harness.context.close();
+});
+
+// -----------------------------------------------------------------------------
+// Harness: the real StreamDurableObject over an in-memory DurableObjectState
+// fake, with ctx.facets serving one scripted facet stub. Storage shape follows
+// guarantees-not-given.test.ts.
+// -----------------------------------------------------------------------------
+
+const PROJECT_ID = "prj_facet_alarm_replay";
+const AGENT_PATH = "/agents/onboarding";
+
+async function bootStreamWithAgentFacet() {
+  const facet = {
+    handleAlarmError: undefined as Error | undefined,
+    handleAlarmCalls: 0,
+    stub: {
+      configure: () => Promise.resolve(),
+      handleAlarm: () => {
+        facet.handleAlarmCalls += 1;
+        return facet.handleAlarmError === undefined
+          ? Promise.resolve()
+          : Promise.reject(facet.handleAlarmError);
+      },
+      // The wake-delivery lane is not under test; its failure rides the
+      // sender's own retry machinery, which never touches the facet slot.
+      wakeStreamProcessor: () => Promise.reject(new Error("wake lane not under test")),
+    },
+  };
+  const context = durableObjectContext(
+    DurableObjectNameCodec.stringify({ projectId: PROJECT_ID, path: AGENT_PATH }),
+    facet.stub,
+  );
+  const stream = new StreamDurableObject(context.ctx, fakeEnv());
+  await context.waitForInitialization();
+  await context.settle();
+  stream.append({
+    type: "events.iterate.com/stream/subscription-configured",
+    payload: {
+      name: "agent",
+      receiver: { action: "facet-processor", source: { kind: "builtin" } },
+    },
+  });
+  await context.settle();
+  return { context, facet, stream };
+}
+
+function fakeEnv(): Env {
+  return {
+    STREAM: {
+      getByName: () => ({
+        // Ancestor announcements may address streams this test never creates.
+        appendCoreEvent: (eventInput: unknown) =>
+          Promise.resolve({
+            ...(eventInput as object),
+            path: "/",
+            offset: 1,
+            createdAt: new Date().toISOString(),
+          }),
+      }),
+    },
+  } as unknown as Env;
+}
+
+function durableObjectContext(name: string, facetStub: object) {
+  const db = new DatabaseSync(":memory:");
+  const values = new Map<string, unknown>();
+  const backgroundWork: Promise<unknown>[] = [];
+  const alarms: number[] = [];
+  let latestInitialization: Promise<unknown> | undefined;
+  const storage = {
+    sql: wrapSqlStorage(db),
+    kv: {
+      get<T>(key: string): T | undefined {
+        const value = values.get(key);
+        return value === undefined ? undefined : structuredClone(value as T);
+      },
+      put(key: string, value: unknown): void {
+        values.set(key, structuredClone(value));
+      },
+      delete(key: string): void {
+        values.delete(key);
+      },
+    },
+    setAlarm(atMs: number): Promise<void> {
+      alarms.push(atMs);
+      return Promise.resolve();
+    },
+    deleteAlarm(): Promise<void> {
+      return Promise.resolve();
+    },
+    sync(): Promise<void> {
+      return Promise.resolve();
+    },
+    transactionSync<T>(callback: () => T): T {
+      return callback();
+    },
+  };
+  const ctx = {
+    id: { name },
+    storage,
+    // The builtin facet class lookup only checks presence; ctx.facets ignores
+    // the startup callback and serves the scripted stub.
+    exports: { ProcessorFacet: class {} },
+    facets: {
+      get: () => facetStub,
+      abort: () => {},
+    },
+    getWebSockets(): WebSocket[] {
+      return [];
+    },
+    waitUntil(work: Promise<unknown>): void {
+      backgroundWork.push(work);
+    },
+    blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T> {
+      const work = Promise.resolve().then(callback);
+      latestInitialization = work;
+      return work;
+    },
+    abort(): never {
+      throw new Error("test Durable Object aborted");
+    },
+  } as unknown as DurableObjectState;
+
+  return {
+    alarms,
+    close: () => db.close(),
+    ctx,
+    async waitForInitialization(): Promise<void> {
+      await latestInitialization;
+    },
+    async settle(): Promise<void> {
+      let seen = -1;
+      while (seen !== backgroundWork.length) {
+        seen = backgroundWork.length;
+        await Promise.allSettled([...backgroundWork]);
+        await Promise.resolve();
+      }
+    },
+  };
+}
+
+function wrapSqlStorage(db: DatabaseSync): SqlStorage {
+  return {
+    databaseSize: 0,
+    exec<T = unknown>(sql: string, ...bindings: (ArrayBuffer | null | number | string)[]) {
+      const rows = db
+        .prepare(sql)
+        .all(
+          ...bindings.map((binding) =>
+            binding instanceof ArrayBuffer ? new Uint8Array(binding) : binding,
+          ),
+        )
+        .map((row) => Object.fromEntries(Object.entries(row).map(fromNodeSqlValue)));
+      return { toArray: () => rows as T[] };
+    },
+  } as unknown as SqlStorage;
+}
+
+function fromNodeSqlValue([key, value]: [string, unknown]) {
+  if (value instanceof Uint8Array) {
+    return [key, value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength)];
+  }
+  return [key, value];
+}

--- a/tasks/agent-revival-latency-after-do-reset.md
+++ b/tasks/agent-revival-latency-after-do-reset.md
@@ -1,0 +1,82 @@
+---
+status: in-progress
+size: small
+---
+
+# Agent revival latency after a Durable Object reset storm
+
+## Status summary
+
+Diagnosis complete (evidence below); fix + spec implemented: facet alarm
+replay failures now fail the Stream DO's alarm invocation so Cloudflare's
+platform alarm retry stays owed. Remaining: PR review.
+
+## Problem
+
+During PR #2517's preview runs, `specs/create-project.spec.ts` flaked: the
+onboarding agent of `create-project-mt8vagyc` (preview slot 9) took ~2m16s to
+answer a user message that a healthy sibling answered in 17s. The stream shows
+the llm-request opening at 16:17:02, the incarnation dying mid-attempt, and
+`stream/processor-revived` only landing at ~16:19:07.
+
+The keepalive is designed to revive within ~10s (`KEEPALIVE_ALARM_LEAD_MS`),
+so ~2 minutes needed explaining.
+
+## Diagnosis (from os-preview-9 workers observability logs, DO `86f78dbc…`)
+
+- 16:17:07 — a deploy hit the slot (script version `7026a193…` → `5a38f11e…`).
+  The reset storm broke the facets: "liveState watchers dropped", "stream
+  processor runner background work failed … StreamUnavailable".
+- 16:17:08–16:17:13 — the parent Stream DO's alarm fired 3 times. Each
+  `handleAlarm` replay into the `agent` facet FAILED ("facet alarm replay
+  failed; re-arming a bounded retry", failures 1→3), and the facet's own
+  re-arm dial also failed ("stream processor registry alarm arming failed at
+  Proxy.setAlarm"). Each fire CONSUMED the native alarm; the bounded-retry
+  re-arm was lost with the resetting incarnation.
+- 16:17:14 → 16:19:07 — total silence. The revival desire sat durably in the
+  parent's `facetAlarmAtMs` KV slot, but no native alarm existed and nothing
+  self-wakes a dead DO.
+- 16:19:07.7 — an unrelated `getEvents` booted the DO; the constructor's
+  level-triggered boot repair found the past-due desire and armed
+  `setAlarm(now)` (the reviving alarm's scheduledTime is 16:19:07.677 — armed
+  at boot, not a late fire). Replay succeeded, revival fact appended, visible
+  reply ~9s later.
+
+Root cause: facet alarm replays run as swallowed background work, so from the
+platform's view every alarm fire "succeeds" and the alarm is consumed. The
+self-armed bounded retry is the only continuation, and a reset storm can eat
+that write. In prod, an idle stream might not get an external touch for hours
+— this incident class is strictly worse there.
+
+## Fix
+
+- [x] `StreamDurableObject.alarm()` awaits the facet alarm replays and
+      rethrows when any replay failed, so the platform's alarm retry (which
+      survives DO resets) keeps the fire owed. The bounded self-armed retry
+      stays as the fast path; the platform retry is the loss-proof backstop.
+      _Implemented in `#fireDueFacetAlarms` (returns replay failures) +
+      async `alarm()` in stream-durable-object.ts._
+- [x] Spec: plain-node test driving the real `StreamDurableObject` with a
+      scripted facet — failed replay ⇒ alarm invocation rejects AND the
+      bounded retry desire is re-merged; successful replay ⇒ alarm resolves
+      and the slot clears. _`stream-facet-alarm-replay.test.ts`._
+
+## Non-goals
+
+- The spec's 120s budget stays as-is (deliberately, per the task): the fix is
+  faster revival, not a slower spec.
+- PR #2510 (mid-stream LLM stall settlement) is related but distinct: that is
+  stall settlement; this is revival latency after incarnation death.
+
+## Implementation log
+
+- Queried preview slot 9 via itx (`doppler run --project os --config
+  preview_9 -- pnpm cli itx run …`): the incident project is deleted; healthy
+  siblings show no revival facts.
+- Queried Cloudflare workers observability
+  (`/accounts/{id}/workers/observability/telemetry/query`, service
+  `os-preview-9`) for the incident window; the timeline above comes from
+  those logs.
+- Considered and rejected: shrinking `KEEPALIVE_ALARM_LEAD_MS` (cadence was
+  not the problem) and shrinking the keepalive's revival backoff table (the
+  keepalive never got to run — its host alarm was lost a layer below).

--- a/tasks/complete/2026-08-26-agent-revival-latency-after-do-reset.md
+++ b/tasks/complete/2026-08-26-agent-revival-latency-after-do-reset.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 size: small
 ---
 
@@ -9,7 +9,7 @@ size: small
 
 Diagnosis complete (evidence below); fix + spec implemented: facet alarm
 replay failures now fail the Stream DO's alarm invocation so Cloudflare's
-platform alarm retry stays owed. Remaining: PR review.
+platform alarm retry stays owed. Merged via PR #2520.
 
 ## Problem
 


### PR DESCRIPTION
While an agent is mid-LLM-turn, its host Durable Object keeps a dead-man's-switch armed: a native alarm ~10s out. If the DO dies owing work, the alarm fires in a fresh incarnation and revives the turn. A crash mid-answer is supposed to cost ~10 seconds.

On PR #2517's preview, it cost **2m16s** (`specs/create-project.spec.ts` flake; a healthy sibling answered in 17s). Here's why.

## What happened

In Cloudflare, **a fired alarm is used up** — you must set the next one yourself. During a deploy-triggered reset storm (os-preview-9 observability logs, DO `86f78dbc…`, 16:17:07–16:17:13):

1. The alarm fired and tried to poke the agent facet. The facet was mid-reset, so the poke failed.
2. The failure was caught in background work and handled by scheduling a retry alarm — but that write died with the resetting incarnation.
3. Net state: the "revive me" desire was safely on disk (`facetAlarmAtMs` KV), but **no alarm existed to ever read it**. A DO with no alarm and no traffic sleeps forever.

It woke after 2 minutes only because previews have constant traffic: an unrelated `getEvents` booted the DO at 16:19:07, and boot-time repair noticed the stale desire and armed `setAlarm(now)` — the reviving alarm's scheduledTime is 16:19:07.677, i.e. armed at boot, not a late fire. A quiet prod agent in the same state could sleep for **hours**.

## The fix

Cloudflare has its own retry rule: if the alarm *handler throws*, the platform treats the alarm as not-yet-delivered and re-fires it later — and that retry survives deploys and resets. We were eating the poke failure in a `waitUntil`, so every alarm looked successful and got consumed. Now the failure escapes:

```ts
// before: fire consumed, self-armed retry is the only continuation (lossy under reset storms)
alarm(info) { this.#fireDueFacetAlarms(info); /* failures swallowed in waitUntil */ }

// after: a failed replay fails the invocation — Cloudflare keeps ringing until someone answers
async alarm(info) {
  const failures = await this.#fireDueFacetAlarms(info);
  if (failures.length > 0) throw new Error("facet alarm replay failed …", { cause: failures[0].error });
}
```

The self-armed bounded retry stays as the fast path; the platform retry is the loss-proof backstop. The alarm can no longer be used up without the work actually getting done, so this incident's 114-second strand becomes the platform's seconds-scale retry cadence, independent of traffic.

Spec: `stream-facet-alarm-replay.test.ts` drives the real `StreamDurableObject` in plain node with a scripted facet — failed poke ⇒ alarm invocation rejects and the bounded retry desire is still merged; successful poke ⇒ resolves and the slot clears; not-yet-due desire ⇒ re-arms without poking.

Deliberately unchanged, per the task: the spec's 120s budget (the latency fact should stay visible), `KEEPALIVE_ALARM_LEAD_MS` (cadence wasn't the problem), and the keepalive backoff table (the keepalive never got to run — its host alarm was lost a layer below). Related but distinct: #2510 is mid-stream stall settlement; this is revival latency after incarnation death.

## Risk map

- **Riskiest part:** `alarm()` turning async and rethrowing. A *chronically* failing facet (e.g. buggy userspace facet code) now fails the alarm invocation too; the platform retries ~6 times with backoff before giving up, on top of the existing self-armed exponential retry (30min cap). Bounded extra fire volume, and every replay is level-triggered/idempotent — but that's an argument, not a test. Also: the reconcile leg (`#reconcileCommittedState`) re-runs on each platform retry; it's level-triggered by design.
- **On merge:** DO alarm invocations can now report failures to Cloudflare (previously always "success"), so expect non-zero `alarm` error rates in observability during deploy windows — that's the mechanism working, not a regression.
- **Review order:** `stream-durable-object.ts` (`alarm()` + `#fireDueFacetAlarms`, one hunk each), then `stream-facet-alarm-replay.test.ts`, then the task file (diagnosis write-up, no code).

---

Session: `574b125b-af59-4281-ae4b-6f7507ffb9bb` (agent revival latency investigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Stream DO alarm semantics (async handler, throws on facet failure), which can increase alarm error rates during deploys and add platform retries for chronically failing facets; behavior is level-triggered and covered by new tests.
> 
> **Overview**
> Fixes agent revival stalls (~2 minutes) after deploy DO resets when facet `handleAlarm` replays failed in background: the native alarm was consumed but the self-armed bounded retry could die with the incarnation, leaving a persisted desire with no wakeup.
> 
> **`StreamDurableObject.alarm()`** is now **async** and **awaits** `#fireDueFacetAlarms` instead of firing replays via `#runInBackground`. Any replay failure **rejects the alarm handler** so Cloudflare’s platform alarm retry (survives resets) keeps the fire owed; bounded re-merge into the facet slot remains the fast path.
> 
> **`#fireDueFacetAlarms`** returns aggregated failures, runs replays with `Promise.all`, and on **`alarmInfo.isRetry`** fans out to facets even when the shared KV slot is empty (covers the gap between slot delete and failure-path re-merge).
> 
> Adds **`stream-facet-alarm-replay.test.ts`** (real DO + scripted facet) and a completed task write-up for the preview incident.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44cc6e0bde99e7a5f5c28c779baf97df572f93b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-26T11:02:38.664Z",
      "deployedAt": "2026-08-26T10:56:57.988Z",
      "headSha": "44cc6e0bde99e7a5f5c28c779baf97df572f93b7",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/155563716537014",
      "shortSha": "44cc6e0",
      "cleanupDurationMs": 13972,
      "deployDurationMs": 41131,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 39219,
      "deployReadinessDurationMs": 1909,
      "deployedWorkerName": "os-preview-12",
      "deployedWorkerVersion": "303aa7ab-b2ff-4596-bd3a-2e856b47f27b",
      "testDurationMs": 261196,
      "testRetries": "2 retried: project users cannot reach stream test controls or the raw Durable Object (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 98113ms (the public deadline expired while recovery re-armed one-shot waits). · a userspace facet rebuilds on a source commit and only on a source commit (vitest x1)",
      "workerSizeKib": 20823.81,
      "workerGzipKib": 5243.44,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5254.62
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-26T11:02:28.554Z",
      "deployedAt": "2026-08-26T10:56:32.064Z",
      "headSha": "44cc6e0bde99e7a5f5c28c779baf97df572f93b7",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-12.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/155563716537014",
      "shortSha": "44cc6e0",
      "cleanupDurationMs": 3860,
      "deployDurationMs": 13535,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 13292,
      "deployReadinessDurationMs": 239,
      "deployedWorkerName": "docs-preview-12",
      "deployedWorkerVersion": "cc98ec4f-04ef-4a4e-b75c-988fab03cf48",
      "testDurationMs": 2148,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-26T11:02:28.821Z",
      "deployedAt": "2026-08-26T10:56:37.279Z",
      "headSha": "44cc6e0bde99e7a5f5c28c779baf97df572f93b7",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/155563716537014",
      "shortSha": "44cc6e0",
      "cleanupDurationMs": 4124,
      "deployDurationMs": 19016,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 18506,
      "deployReadinessDurationMs": 505,
      "deployedWorkerName": "auth-preview-12",
      "deployedWorkerVersion": "d5339fe8-5b8f-4e08-98b4-b1ef259c6b6e",
      "testDurationMs": 17647,
      "testRetries": null,
      "workerSizeKib": 3989.98,
      "workerGzipKib": 817.28,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-08-26T11:02:32.796Z",
      "deployedAt": "2026-08-26T10:38:32.410Z",
      "headSha": "44cc6e0bde99e7a5f5c28c779baf97df572f93b7",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/155563716537014",
      "shortSha": "44cc6e0",
      "cleanupDurationMs": 8097,
      "deployDurationMs": 13761,
      "deployConfigDurationMs": 41,
      "deployCommandDurationMs": 13152,
      "deployReadinessDurationMs": 568,
      "deployedWorkerName": "streams-example-app-preview-12",
      "deployedWorkerVersion": "64f9b7fd-997e-45ae-ab2a-56e1872268bc",
      "testDurationMs": 41434,
      "testRetries": null,
      "workerSizeKib": 5562.15,
      "workerGzipKib": 1573.07,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-26T11:02:25.527Z",
      "deployedAt": "2026-08-26T10:31:24.276Z",
      "headSha": "44cc6e0bde99e7a5f5c28c779baf97df572f93b7",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/155563716537014",
      "shortSha": "44cc6e0",
      "cleanupDurationMs": 826,
      "deployDurationMs": 91,
      "deployConfigDurationMs": 6,
      "deployReuseProofDurationMs": 53,
      "deployedWorkerName": "dummy-petshop-preview-12",
      "deployedWorkerVersion": "efc0db6b-78df-4dfb-9db5-fe692336042d",
      "testDurationMs": 6104,
      "testRetries": null,
      "workerSizeKib": 1115.4,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "b717e505c46472150438e97f994eb4a2c283e0f8+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `44cc6e0` | [https://auth.iterate-preview-12.com](https://auth.iterate-preview-12.com) | 817.3 KiB | 19.0s | 17.6s |  | 4.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/155563716537014) | 2026-08-26T11:02:28.821Z | Preview app released. |
| Docs | released | `44cc6e0` | [https://docs-preview-12.iterate-dev-preview.workers.dev](https://docs-preview-12.iterate-dev-preview.workers.dev) | 866.2 KiB | 13.5s | 2.1s |  | 3.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/155563716537014) | 2026-08-26T11:02:28.554Z | Preview app released. |
| Dummy Petshop | released | `44cc6e0` | [https://dummy-petshop.iterate-preview-12.com](https://dummy-petshop.iterate-preview-12.com) | 198.3 KiB | 91ms | 6.1s |  | 826ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/155563716537014) | 2026-08-26T11:02:25.527Z | Preview app released. |
| OS | released | `44cc6e0` | [https://os.iterate-preview-12.com](https://os.iterate-preview-12.com) | 5.12 MiB (-11.2 KiB vs main) | 41.1s | 261.2s | 2 retried: project users cannot reach stream test controls or the raw Durable Object (vitest x1) — stream-wait-timeout: Timed out waiting for stream event after 98113ms (the public deadline expired while recovery re-armed one-shot waits). · a userspace facet rebuilds on a source commit and only on a source commit (vitest x1) | 14.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/155563716537014) | 2026-08-26T11:02:38.664Z | Preview app released. |
| Streams Example App | released | `44cc6e0` | [https://streams.iterate-preview-12.com](https://streams.iterate-preview-12.com) | 1.54 MiB | 13.8s | 41.4s |  | 8.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/155563716537014) | 2026-08-26T11:02:32.796Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +57 -13 | +23 -11 🟩⬜⬜⬜⬜ |
| Tests | +273 -0 | +205 -0 🟩🟩🟩🟩🟩 |
| Docs | +82 -0 | +67 -0 🟩🟩⬜⬜⬜ |
| **Total** | **+412 -13** | **+295 -11** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 683b29b and 44cc6e0, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->