### PR TITLE
itx example: generate video with Seedance 2.0

### DIFF
--- a/apps/os/src/itx/examples-source.ts
+++ b/apps/os/src/itx/examples-source.ts
@@ -1942,7 +1942,7 @@ export default class ProjectWorker extends WorkerEntrypoint {
     e2eProven: false,
     title: "Generate video with a Workers AI model",
     description:
-      "Runs xAI Grok Imagine Video through itx.ai.run(). The model returns a hosted MP4 URL in result.video. First-party docs: https://developers.cloudflare.com/ai/models/xai/grok-imagine-video/ . Uses paid/remote AI infrastructure — interactive-only.",
+      "Runs xAI Grok Imagine Video through itx.ai.run(). The model returns a hosted MP4 URL in result.video. Note: partner models like xai/* and bytedance/* do not appear in itx.ai.models() (it lists only the classic @cf/* catalog) but work directly via itx.ai.run(). First-party docs: https://developers.cloudflare.com/ai/models/xai/grok-imagine-video/ . Uses paid/remote AI infrastructure — interactive-only.",
     runtimes: INTERACTIVE_RUNTIMES,
     fn: async (itx) => {
       const response = await itx.ai.run("xai/grok-imagine-video", {
@@ -1954,6 +1954,33 @@ export default class ProjectWorker extends WorkerEntrypoint {
 
       return {
         docs: "https://developers.cloudflare.com/ai/models/xai/grok-imagine-video/",
+        videoUrl: response?.result?.video,
+        response,
+      };
+    },
+  }),
+  projectExample<{
+    // Same run<T> rationale as ai-generate-text; Seedance answers with a
+    // hosted MP4 URL in `result.video`.
+    ai: { run(model: string, body: unknown): Promise<{ result?: { video?: string } }> };
+  }>({
+    id: "ai-generate-video-seedance",
+    e2eProven: false,
+    title: "Generate video with ByteDance Seedance 2.0",
+    description:
+      "Runs bytedance/seedance-2.0 (ByteDance Seedance, a partner Workers AI model) through itx.ai.run(). Partner models like bytedance/seedance-2.0 and xai/* do NOT appear in itx.ai.models() — that lists only the classic @cf/* catalog — but they work directly via itx.ai.run(), so do not conclude a model is unavailable just because models() omits it. Seedance takes prompt (max 2000 chars), duration 4-12 seconds, resolution 480p/720p/1080p/4K, aspect_ratio (16:9, 4:3, 1:1, 3:4, 9:16, 21:9, 9:21), plus optional reference images/videos, audio, and seed. result.video is a ByteDance-hosted SIGNED URL that expires after ~24h — download and store the file to keep it. First-party docs: https://developers.cloudflare.com/ai/models/bytedance/seedance-2.0/ . Uses paid/remote AI infrastructure — interactive-only.",
+    runtimes: INTERACTIVE_RUNTIMES,
+    fn: async (itx) => {
+      const response = await itx.ai.run("bytedance/seedance-2.0", {
+        prompt: "A red ball rolling across a clean white table, soft studio lighting",
+        duration: 4,
+        resolution: "480p",
+        aspect_ratio: "16:9",
+      });
+
+      return {
+        docs: "https://developers.cloudflare.com/ai/models/bytedance/seedance-2.0/",
+        // Signed, short-lived (~24h) URL — download the MP4 to keep it.
         videoUrl: response?.result?.video,
         response,
       };

--- a/apps/os/src/itx/examples-source.ts
+++ b/apps/os/src/itx/examples-source.ts
@@ -1942,7 +1942,7 @@ export default class ProjectWorker extends WorkerEntrypoint {
     e2eProven: false,
     title: "Generate video with a Workers AI model",
     description:
-      "Runs xAI Grok Imagine Video through itx.ai.run(). The model returns a hosted MP4 URL in result.video. Note: partner models like xai/* and bytedance/* do not appear in itx.ai.models() (it lists only the classic @cf/* catalog) but work directly via itx.ai.run(). First-party docs: https://developers.cloudflare.com/ai/models/xai/grok-imagine-video/ . Uses paid/remote AI infrastructure — interactive-only.",
+      "Runs xAI Grok Imagine Video through itx.ai.run(). The model returns a hosted MP4 URL in result.video. Note: partner models like xai/* and bytedance/* do not appear in itx.ai.models() (it lists only the classic @cf/* catalog) but work directly via itx.ai.run() — discover them by fetching the full catalog page https://developers.cloudflare.com/ai/models/ . First-party docs: https://developers.cloudflare.com/ai/models/xai/grok-imagine-video/ . Uses paid/remote AI infrastructure — interactive-only.",
     runtimes: INTERACTIVE_RUNTIMES,
     fn: async (itx) => {
       const response = await itx.ai.run("xai/grok-imagine-video", {
@@ -1968,7 +1968,7 @@ export default class ProjectWorker extends WorkerEntrypoint {
     e2eProven: false,
     title: "Generate video with ByteDance Seedance 2.0",
     description:
-      "Runs bytedance/seedance-2.0 (ByteDance Seedance, a partner Workers AI model) through itx.ai.run(). Partner models like bytedance/seedance-2.0 and xai/* do NOT appear in itx.ai.models() — that lists only the classic @cf/* catalog — but they work directly via itx.ai.run(), so do not conclude a model is unavailable just because models() omits it. Seedance takes prompt (max 2000 chars), duration 4-12 seconds, resolution 480p/720p/1080p/4K, aspect_ratio (16:9, 4:3, 1:1, 3:4, 9:16, 21:9, 9:21), plus optional reference images/videos, audio, and seed. result.video is a ByteDance-hosted SIGNED URL that expires after ~24h — download and store the file to keep it. First-party docs: https://developers.cloudflare.com/ai/models/bytedance/seedance-2.0/ . Uses paid/remote AI infrastructure — interactive-only.",
+      "Runs bytedance/seedance-2.0 (ByteDance Seedance, a partner Workers AI model) through itx.ai.run(). Partner models like bytedance/seedance-2.0 and xai/* do NOT appear in itx.ai.models() — that lists only the classic @cf/* catalog — but they work directly via itx.ai.run(), so do not conclude a model is unavailable just because models() omits it; discover the full catalog (partner models included, e.g. bytedance/seedance-2.0-fast, bytedance/seedance-2.5, bytedance/seedream-4.0) by fetching https://developers.cloudflare.com/ai/models/ . Seedance takes prompt (max 2000 chars), duration 4-12 seconds, resolution 480p/720p/1080p/4K, aspect_ratio (16:9, 4:3, 1:1, 3:4, 9:16, 21:9, 9:21), plus optional reference images/videos, audio, and seed. result.video is a ByteDance-hosted SIGNED URL that expires after ~24h — download and store the file to keep it. First-party docs: https://developers.cloudflare.com/ai/models/bytedance/seedance-2.0/ . Uses paid/remote AI infrastructure — interactive-only.",
     runtimes: INTERACTIVE_RUNTIMES,
     fn: async (itx) => {
       const response = await itx.ai.run("bytedance/seedance-2.0", {

--- a/apps/os/src/itx/examples-typecheck.test.ts
+++ b/apps/os/src/itx/examples-typecheck.test.ts
@@ -167,6 +167,8 @@ const SURFACE_GAPS: Record<string, string> = {
   "ai-transcribe-audio":
     "same run<T> constraint as ai-generate-image; the body reads result.text and friends",
   "ai-generate-video": "same run<T> constraint as ai-generate-image; the body reads result.video",
+  "ai-generate-video-seedance":
+    "same run<T> constraint as ai-generate-image; the body reads result.video",
   "cf-browser-markdown":
     "browser.quickAction() returns the action-shaped unknown; markdown is a string per entry",
   "parallel-search-and-research":

--- a/apps/os/src/itx/examples.generated.ts
+++ b/apps/os/src/itx/examples.generated.ts
@@ -1793,7 +1793,7 @@ return {
     e2eProven: false,
     title: "Generate video with a Workers AI model",
     description:
-      "Runs xAI Grok Imagine Video through itx.ai.run(). The model returns a hosted MP4 URL in result.video. First-party docs: https://developers.cloudflare.com/ai/models/xai/grok-imagine-video/ . Uses paid/remote AI infrastructure — interactive-only.",
+      "Runs xAI Grok Imagine Video through itx.ai.run(). The model returns a hosted MP4 URL in result.video. Note: partner models like xai/* and bytedance/* do not appear in itx.ai.models() (it lists only the classic @cf/* catalog) but work directly via itx.ai.run(). First-party docs: https://developers.cloudflare.com/ai/models/xai/grok-imagine-video/ . Uses paid/remote AI infrastructure — interactive-only.",
     context: "project",
     runtimes: ["browser", "node", "cli"],
     code: `
@@ -1806,6 +1806,30 @@ const response = await itx.ai.run("xai/grok-imagine-video", {
 
 return {
   docs: "https://developers.cloudflare.com/ai/models/xai/grok-imagine-video/",
+  videoUrl: response?.result?.video,
+  response,
+};
+`.trim(),
+  },
+  {
+    id: "ai-generate-video-seedance",
+    e2eProven: false,
+    title: "Generate video with ByteDance Seedance 2.0",
+    description:
+      "Runs bytedance/seedance-2.0 (ByteDance Seedance, a partner Workers AI model) through itx.ai.run(). Partner models like bytedance/seedance-2.0 and xai/* do NOT appear in itx.ai.models() — that lists only the classic @cf/* catalog — but they work directly via itx.ai.run(), so do not conclude a model is unavailable just because models() omits it. Seedance takes prompt (max 2000 chars), duration 4-12 seconds, resolution 480p/720p/1080p/4K, aspect_ratio (16:9, 4:3, 1:1, 3:4, 9:16, 21:9, 9:21), plus optional reference images/videos, audio, and seed. result.video is a ByteDance-hosted SIGNED URL that expires after ~24h — download and store the file to keep it. First-party docs: https://developers.cloudflare.com/ai/models/bytedance/seedance-2.0/ . Uses paid/remote AI infrastructure — interactive-only.",
+    context: "project",
+    runtimes: ["browser", "node", "cli"],
+    code: `
+const response = await itx.ai.run("bytedance/seedance-2.0", {
+  prompt: "A red ball rolling across a clean white table, soft studio lighting",
+  duration: 4,
+  resolution: "480p",
+  aspect_ratio: "16:9",
+});
+
+return {
+  docs: "https://developers.cloudflare.com/ai/models/bytedance/seedance-2.0/",
+  // Signed, short-lived (~24h) URL — download the MP4 to keep it.
   videoUrl: response?.result?.video,
   response,
 };

--- a/apps/os/src/itx/examples.generated.ts
+++ b/apps/os/src/itx/examples.generated.ts
@@ -1793,7 +1793,7 @@ return {
     e2eProven: false,
     title: "Generate video with a Workers AI model",
     description:
-      "Runs xAI Grok Imagine Video through itx.ai.run(). The model returns a hosted MP4 URL in result.video. Note: partner models like xai/* and bytedance/* do not appear in itx.ai.models() (it lists only the classic @cf/* catalog) but work directly via itx.ai.run(). First-party docs: https://developers.cloudflare.com/ai/models/xai/grok-imagine-video/ . Uses paid/remote AI infrastructure — interactive-only.",
+      "Runs xAI Grok Imagine Video through itx.ai.run(). The model returns a hosted MP4 URL in result.video. Note: partner models like xai/* and bytedance/* do not appear in itx.ai.models() (it lists only the classic @cf/* catalog) but work directly via itx.ai.run() — discover them by fetching the full catalog page https://developers.cloudflare.com/ai/models/ . First-party docs: https://developers.cloudflare.com/ai/models/xai/grok-imagine-video/ . Uses paid/remote AI infrastructure — interactive-only.",
     context: "project",
     runtimes: ["browser", "node", "cli"],
     code: `
@@ -1816,7 +1816,7 @@ return {
     e2eProven: false,
     title: "Generate video with ByteDance Seedance 2.0",
     description:
-      "Runs bytedance/seedance-2.0 (ByteDance Seedance, a partner Workers AI model) through itx.ai.run(). Partner models like bytedance/seedance-2.0 and xai/* do NOT appear in itx.ai.models() — that lists only the classic @cf/* catalog — but they work directly via itx.ai.run(), so do not conclude a model is unavailable just because models() omits it. Seedance takes prompt (max 2000 chars), duration 4-12 seconds, resolution 480p/720p/1080p/4K, aspect_ratio (16:9, 4:3, 1:1, 3:4, 9:16, 21:9, 9:21), plus optional reference images/videos, audio, and seed. result.video is a ByteDance-hosted SIGNED URL that expires after ~24h — download and store the file to keep it. First-party docs: https://developers.cloudflare.com/ai/models/bytedance/seedance-2.0/ . Uses paid/remote AI infrastructure — interactive-only.",
+      "Runs bytedance/seedance-2.0 (ByteDance Seedance, a partner Workers AI model) through itx.ai.run(). Partner models like bytedance/seedance-2.0 and xai/* do NOT appear in itx.ai.models() — that lists only the classic @cf/* catalog — but they work directly via itx.ai.run(), so do not conclude a model is unavailable just because models() omits it; discover the full catalog (partner models included, e.g. bytedance/seedance-2.0-fast, bytedance/seedance-2.5, bytedance/seedream-4.0) by fetching https://developers.cloudflare.com/ai/models/ . Seedance takes prompt (max 2000 chars), duration 4-12 seconds, resolution 480p/720p/1080p/4K, aspect_ratio (16:9, 4:3, 1:1, 3:4, 9:16, 21:9, 9:21), plus optional reference images/videos, audio, and seed. result.video is a ByteDance-hosted SIGNED URL that expires after ~24h — download and store the file to keep it. First-party docs: https://developers.cloudflare.com/ai/models/bytedance/seedance-2.0/ . Uses paid/remote AI infrastructure — interactive-only.",
     context: "project",
     runtimes: ["browser", "node", "cli"],
     code: `

--- a/tasks/complete/2026-08-26-itx-example-seedance-video.md
+++ b/tasks/complete/2026-08-26-itx-example-seedance-video.md
@@ -1,5 +1,5 @@
 ---
-status: in-review
+status: done
 size: small
 branch: itx-example-seedance-video
 pr: https://github.com/iterate/iterate/pull/2522

--- a/tasks/itx-example-seedance-video.md
+++ b/tasks/itx-example-seedance-video.md
@@ -86,3 +86,8 @@ this via `itx.docs.search`.
   the surface ever gains a typed `run<T>`, the excuse must be deleted.
 - No other generated artifacts involved — `examples.generated.ts` is the only
   derived file, freshness enforced by `examples.generated.test.ts`.
+- Review feedback (mmkal): "how would you recommend discovering them then?" —
+  fair; the text only warned about models() with no positive path. Both video
+  descriptions now recommend fetching
+  https://developers.cloudflare.com/ai/models/ (verified it lists the partner
+  models: seedance-2.0/-fast/-mini/2.5, seedream, xai/*). Commit 4f0dc6aab.

--- a/tasks/itx-example-seedance-video.md
+++ b/tasks/itx-example-seedance-video.md
@@ -1,0 +1,70 @@
+---
+status: in-progress
+size: small
+branch: itx-example-seedance-video
+---
+
+# itx example: Seedance 2.0 video generation
+
+## Status summary
+
+Spec committed; implementation not started yet. Next: add the example to
+examples-source.ts, regenerate, run checks.
+
+## Why
+
+Cloudflare acquired Replicate and `bytedance/seedance-2.0` is now a
+first-class Workers AI model. It works TODAY through the existing zero-config
+`itx.ai.run()` surface — verified 2026-08-26 on prod project `misha`:
+
+```ts
+await itx.ai.run("bytedance/seedance-2.0", {
+  prompt: "a red ball rolling on a white table",
+  duration: 4,
+  resolution: "480p",
+  aspect_ratio: "16:9",
+})
+// → { state: "Completed", result: { video: "https://ark-acg-....volces.com/....mp4?...24h-signed..." },
+//     gatewayMetadata: { keySource: "Unified" } }
+```
+
+But yesterday a prod web agent, asked to make a Seedance video, wrongly
+replied "not available" because:
+
+- `itx.ai.models()` only returns the classic `@cf/*` catalog — partner models
+  (`bytedance/*`, `xai/*`) never appear there
+- `itx.docs.search` has no seedance/video hit that mentions this
+
+So the example's summary text IS the fix: it's what makes agents discover
+this via `itx.docs.search`.
+
+## Spec
+
+- [ ] Add `ai-generate-video-seedance` example to
+      `apps/os/src/itx/examples-source.ts`, modeled on the existing
+      `ai-generate-video` (grok) entry: `e2eProven: false`,
+      `INTERACTIVE_RUNTIMES` (paid/remote AI infrastructure), link
+      https://developers.cloudflare.com/ai/models/bytedance/seedance-2.0/
+- [ ] Description must explicitly say partner models like
+      `bytedance/seedance-2.0` do NOT appear in `itx.ai.models()` (classic
+      `@cf/*` catalog only) but work directly via `itx.ai.run()` — that
+      sentence is the docs-search discoverability fix
+- [ ] Note in the example that `result.video` is a ByteDance-hosted signed
+      URL that expires (~24h) — download/store to keep it
+- [ ] Give the sibling `ai-generate-video` (grok) description the same
+      one-line models()-under-reporting clarification (small tasteful edit)
+- [ ] Regenerate `examples.generated.ts` (`pnpm generate:itx-examples`),
+      AFTER `pnpm format`
+- [ ] `pnpm typecheck && pnpm lint && pnpm knip && pnpm format` + relevant
+      tests before pushing
+
+### Model params (from Cloudflare docs)
+
+`prompt` (≤2000 chars, required), `duration` 4–12s, `resolution`
+480p/720p/1080p/4K, `aspect_ratio` 16:9 | 4:3 | 1:1 | 3:4 | 9:16 | 21:9 |
+9:21; optional reference images (≤9), reference videos (≤3), audio files
+(≤3), `seed`, watermark toggle, audio-generation flag.
+
+## Implementation log
+
+(nothing yet)

--- a/tasks/itx-example-seedance-video.md
+++ b/tasks/itx-example-seedance-video.md
@@ -1,15 +1,17 @@
 ---
-status: in-progress
+status: in-review
 size: small
 branch: itx-example-seedance-video
+pr: https://github.com/iterate/iterate/pull/2522
 ---
 
 # itx example: Seedance 2.0 video generation
 
 ## Status summary
 
-Spec committed; implementation not started yet. Next: add the example to
-examples-source.ts, regenerate, run checks.
+Implementation done, PR open (draft). Example added, generated file
+regenerated, typecheck/lint/knip/format + all 83 src/itx tests green.
+Remaining: review-bot wave + human review.
 
 ## Why
 
@@ -40,23 +42,32 @@ this via `itx.docs.search`.
 
 ## Spec
 
-- [ ] Add `ai-generate-video-seedance` example to
+- [x] Add `ai-generate-video-seedance` example to
       `apps/os/src/itx/examples-source.ts`, modeled on the existing
       `ai-generate-video` (grok) entry: `e2eProven: false`,
       `INTERACTIVE_RUNTIMES` (paid/remote AI infrastructure), link
       https://developers.cloudflare.com/ai/models/bytedance/seedance-2.0/
-- [ ] Description must explicitly say partner models like
+      _added right after the grok entry, same `run<T>` local-shape pattern_
+- [x] Description must explicitly say partner models like
       `bytedance/seedance-2.0` do NOT appear in `itx.ai.models()` (classic
       `@cf/*` catalog only) but work directly via `itx.ai.run()` — that
       sentence is the docs-search discoverability fix
-- [ ] Note in the example that `result.video` is a ByteDance-hosted signed
+      _description says exactly this, plus "do not conclude a model is
+      unavailable just because models() omits it"_
+- [x] Note in the example that `result.video` is a ByteDance-hosted signed
       URL that expires (~24h) — download/store to keep it
-- [ ] Give the sibling `ai-generate-video` (grok) description the same
+      _in the description and as an inline comment on `videoUrl`_
+- [x] Give the sibling `ai-generate-video` (grok) description the same
       one-line models()-under-reporting clarification (small tasteful edit)
-- [ ] Regenerate `examples.generated.ts` (`pnpm generate:itx-examples`),
+      _one added sentence: "Note: partner models like xai/* and bytedance/*
+      do not appear in itx.ai.models() ... but work directly via
+      itx.ai.run()."_
+- [x] Regenerate `examples.generated.ts` (`pnpm generate:itx-examples`),
       AFTER `pnpm format`
-- [ ] `pnpm typecheck && pnpm lint && pnpm knip && pnpm format` + relevant
+      _done in that order; format idempotent afterwards_
+- [x] `pnpm typecheck && pnpm lint && pnpm knip && pnpm format` + relevant
       tests before pushing
+      _all clean; all 83 tests in apps/os/src/itx pass_
 
 ### Model params (from Cloudflare docs)
 
@@ -67,4 +78,11 @@ this via `itx.docs.search`.
 
 ## Implementation log
 
-(nothing yet)
+- The examples-typecheck contract test typechecks each generated body against
+  the REAL itx surface, where `ai.run` returns `unknown`. Like the other
+  `ai-*` media entries, the new one reads `result.video`, so it needed a
+  `SURFACE_GAPS` excuse in `examples-typecheck.test.ts` ("same run<T>
+  constraint as ai-generate-image"). The test enforces the excuse is real: if
+  the surface ever gains a typed `run<T>`, the excuse must be deleted.
+- No other generated artifacts involved — `examples.generated.ts` is the only
+  derived file, freshness enforced by `examples.generated.test.ts`.


### PR DESCRIPTION
## What

Adds an `ai-generate-video-seedance` entry to the itx example catalogue, so project agents can discover and use `bytedance/seedance-2.0` — now a first-class Workers AI model since Cloudflare acquired Replicate — through the existing zero-config `itx.ai.run()` surface:

```ts
const response = await itx.ai.run("bytedance/seedance-2.0", {
  prompt: "A red ball rolling across a clean white table, soft studio lighting",
  duration: 4,          // 4–12 seconds
  resolution: "480p",  // 480p | 720p | 1080p | 4K
  aspect_ratio: "16:9",
})
// response.result.video → hosted MP4 URL (signed, expires ~24h — download to keep)
```

The sibling `ai-generate-video` (grok) entry gets the same one-line clarification about `itx.ai.models()` under-reporting.

## Why

A prod web agent was asked yesterday to make a Seedance video and wrongly replied "not available": partner models (`bytedance/*`, `xai/*`) never appear in `itx.ai.models()` (classic `@cf/*` catalog only), and docs search had no seedance hit. The new example's description states this explicitly — that sentence is what future agents will find via `itx.docs.search`. Verified working 2026-08-26 on prod project `misha` (evidence in the task file).

## Risk map

- Lowest-risk kind of change: catalogue text + one new `e2eProven: false`, interactive-only example; no runtime code paths change.
- The new entry needed a `SURFACE_GAPS` excuse in `examples-typecheck.test.ts` (same `run<T>` gap as the other `ai-*` media examples); the test enforces the excuse stays real.
- Review order: `apps/os/src/itx/examples-source.ts` (hand-written), `examples-typecheck.test.ts` (one excuse line), then the regenerated `examples.generated.ts` and the task file.

---

Spawned from a parent Claude Code session investigating Seedance availability on prod. Session id: `736d214e-8983-4022-888b-048774be6761`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-26T14:59:47.629Z",
      "deployedAt": "2026-08-26T12:06:27.133Z",
      "headSha": "cb59d05bb0bd0ac89aadcfb1b0fc1af13ec47f06",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/516290444218037",
      "shortSha": "cb59d05",
      "cleanupDurationMs": 16523,
      "deployDurationMs": 50927,
      "deployConfigDurationMs": 1,
      "deployCommandDurationMs": 49242,
      "deployReadinessDurationMs": 1683,
      "deployedWorkerName": "os-preview-5",
      "deployedWorkerVersion": "d89bf050-b952-4e51-8804-102c1167efe8",
      "testDurationMs": 195403,
      "testRetries": "1 retried: a userspace facet rebuilds on a source commit and only on a source commit (vitest x1)",
      "workerSizeKib": 20825.68,
      "workerGzipKib": 5243.82,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5255.31
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-26T14:59:33.831Z",
      "deployedAt": "2026-08-26T12:06:01.513Z",
      "headSha": "cb59d05bb0bd0ac89aadcfb1b0fc1af13ec47f06",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-5.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/516290444218037",
      "shortSha": "cb59d05",
      "cleanupDurationMs": 2723,
      "deployDurationMs": 25057,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 23619,
      "deployReadinessDurationMs": 1434,
      "deployedWorkerName": "docs-preview-5",
      "deployedWorkerVersion": "83d688ac-d1e0-4bf2-96bf-2367d760b878",
      "testDurationMs": 4016,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-26T14:59:34.622Z",
      "deployedAt": "2026-08-26T12:06:09.749Z",
      "headSha": "cb59d05bb0bd0ac89aadcfb1b0fc1af13ec47f06",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/516290444218037",
      "shortSha": "cb59d05",
      "cleanupDurationMs": 3511,
      "deployDurationMs": 32168,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 31853,
      "deployReadinessDurationMs": 310,
      "deployedWorkerName": "auth-preview-5",
      "deployedWorkerVersion": "ce884e61-a97f-4955-9109-0be4edd710fb",
      "testDurationMs": 18699,
      "testRetries": null,
      "workerSizeKib": 3989.97,
      "workerGzipKib": 817.39,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-26T14:59:32.733Z",
      "deployedAt": "2026-08-26T11:53:18.845Z",
      "headSha": "cb59d05bb0bd0ac89aadcfb1b0fc1af13ec47f06",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-5.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/516290444218037",
      "shortSha": "cb59d05",
      "cleanupDurationMs": 1619,
      "deployDurationMs": 52,
      "deployConfigDurationMs": 40,
      "deployReuseProofDurationMs": 10,
      "deployedWorkerName": "dummy-petshop-preview-5",
      "deployedWorkerVersion": "ec472169-7780-4c98-a07c-b2a126992fba",
      "testDurationMs": 7225,
      "testRetries": null,
      "workerSizeKib": 1115.4,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "b717e505c46472150438e97f994eb4a2c283e0f8+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `cb59d05` | [https://auth.iterate-preview-5.com](https://auth.iterate-preview-5.com) | 817.4 KiB | 32.2s | 18.7s |  | 3.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/516290444218037) | 2026-08-26T14:59:34.622Z | Preview app released. |
| Docs | released | `cb59d05` | [https://docs-preview-5.iterate-dev-preview.workers.dev](https://docs-preview-5.iterate-dev-preview.workers.dev) | 866.2 KiB | 25.1s | 4.0s |  | 2.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/516290444218037) | 2026-08-26T14:59:33.831Z | Preview app released. |
| Dummy Petshop | released | `cb59d05` | [https://dummy-petshop.iterate-preview-5.com](https://dummy-petshop.iterate-preview-5.com) | 198.3 KiB | 52ms | 7.2s |  | 1.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/516290444218037) | 2026-08-26T14:59:32.733Z | Preview app released. |
| OS | released | `cb59d05` | [https://os.iterate-preview-5.com](https://os.iterate-preview-5.com) | 5.12 MiB (-11.5 KiB vs main) | 50.9s | 195.4s | 1 retried: a userspace facet rebuilds on a source commit and only on a source commit (vitest x1) | 16.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/516290444218037) | 2026-08-26T14:59:47.629Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +28 -1 | +23 -1 🟩🟩⬜⬜⬜ |
| Tests | +2 -0 | +2 -0 🟩⬜⬜⬜⬜ |
| Docs | +93 -0 | +78 -0 🟩🟩🟩🟩🟩 |
| Generated | +25 -1 | +12 -1 🟩⬜⬜⬜⬜ |
| **Total** | **+148 -2** | **+115 -2** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between cff7976 and 0518849, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example-catalog changes only; no production runtime or auth paths change.
> 
> **Overview**
> Adds an **`ai-generate-video-seedance`** itx catalogue entry so agents can find **`bytedance/seedance-2.0`** via `itx.docs.search` and run it with `itx.ai.run()` (interactive-only, `e2eProven: false`). The description stresses that partner models (`bytedance/*`, `xai/*`) are missing from `itx.ai.models()` but still work via `run()`, points to the full Cloudflare models page for discovery, and notes that **`result.video`** is a short-lived signed URL (~24h).
> 
> The existing **`ai-generate-video`** (Grok) entry gets the same partner-model / catalog clarification. **`examples.generated.ts`** is regenerated from source; **`examples-typecheck.test.ts`** adds a `SURFACE_GAPS` line for the new entry (same `run<T>` pattern as other AI media examples). A completed task note documents motivation and verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05188491d3aa19c114e04a04380e7afa6c3d0c8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->