### PR TITLE
Voicelab: keep transcript JSON machine-readable

### DIFF
--- a/apps/os/scripts/voicelab/transcript.ts
+++ b/apps/os/scripts/voicelab/transcript.ts
@@ -40,7 +40,8 @@ interface TranscriptEventLike {
   payload?: { conversationId?: string; text?: string; cancelled?: boolean; reason?: string };
 }
 
-export async function transcript(options: TranscriptOptions): Promise<TranscriptRow[]> {
+/** Print exactly once; a returned value would make trpc-cli render the rows a second time. */
+export async function transcript(options: TranscriptOptions): Promise<void> {
   if (!options.path.startsWith("/")) {
     throw new Error(`--path must be absolute; received ${JSON.stringify(options.path)}`);
   }
@@ -105,7 +106,7 @@ export async function transcript(options: TranscriptOptions): Promise<Transcript
 
   if (options.json === true) {
     console.log(JSON.stringify(rows, null, 2));
-    return rows;
+    return;
   }
   const column = [...rows, ...boundaries.map((b) => ({ ...b, boundary: true as const }))].sort(
     (a, b) => a.offset - b.offset,
@@ -113,7 +114,7 @@ export async function transcript(options: TranscriptOptions): Promise<Transcript
   if (column.length === 0) {
     console.log(`no durable transcript on ${options.path} — either nothing was said, or the`);
     console.log(`stream predates the transcript events (voice-agent contract 13.0.0).`);
-    return rows;
+    return;
   }
   for (const entry of column) {
     if ("boundary" in entry) {
@@ -124,5 +125,4 @@ export async function transcript(options: TranscriptOptions): Promise<Transcript
     const marker = entry.cancelled === true ? " [barged]" : "";
     console.log(`${entry.at.slice(11, 19)} ${speaker}${marker}  ${entry.text}`);
   }
-  return rows;
 }


### PR DESCRIPTION
The voicelab transcript command now emits each transcript exactly once. In `--json` mode, redirected output is one valid JSON document that can be consumed by eval assertions and tools such as `jq`.

Previously the command printed JSON itself and then returned the rows, causing trpc-cli to append a formatted table:

```text
[{ ... }]
┌────────┬─────
```

After this change:

```text
[{ ... }]
```

The command remains responsible for its human and JSON rendering, but returns no value to the generic CLI logger.

This PR is stacked on `voice-colleague-per-stream`, where the transcript command was introduced.

Verification:
- production smoke: `voicelab transcript ... --json | jq -e "length == 14"`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm format`
- `pnpm test`

Coding agent session: `01a03ed2-4a5f-7db0-a851-2075d48b3100`

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| CI & scripts | +4 -4 | +3 -4 🟩🟩🟥🟥🟥 |
| **Total** | **+4 -4** | **+3 -4** 🟩🟩🟥🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between ad01c33 and b727783, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

> [!CAUTION]
> Teardown skipped: Slot preview-2 no longer belongs to pr-2524: it is now leased by pr-2537 (https://github.com/iterate/iterate/pull/2537). Their deployment has replaced this PR's apps on preview_2.

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-28T15:41:25.547Z",
      "headSha": "b727783e170ba21ee60c5dba0be7e7064beb293a",
      "message": "Teardown skipped: Slot preview-2 no longer belongs to pr-2524: it is now leased by pr-2537 (https://github.com/iterate/iterate/pull/2537). Their deployment has replaced this PR's apps on preview_2.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/9610365395196",
      "shortSha": "b727783",
      "deployDurationMs": 126391,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 126388,
      "workerSizeKib": 14447.9,
      "workerGzipKib": 3824.99,
      "mainWorkerGzipKib": 5255.64
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-28T15:41:25.547Z",
      "deployedAt": "2026-08-26T16:27:19.963Z",
      "headSha": "b727783e170ba21ee60c5dba0be7e7064beb293a",
      "message": "Teardown skipped: Slot preview-2 no longer belongs to pr-2524: it is now leased by pr-2537 (https://github.com/iterate/iterate/pull/2537). Their deployment has replaced this PR's apps on preview_2.",
      "publicUrl": "https://docs-preview-2.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/9610365395196",
      "shortSha": "b727783",
      "deployDurationMs": 16138,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 15799,
      "deployReadinessDurationMs": 334,
      "deployedWorkerName": "docs-preview-2",
      "deployedWorkerVersion": "dfe66831-04a0-441a-bf80-690b0ddd299b",
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-28T15:41:25.547Z",
      "deployedAt": "2026-08-26T16:27:23.810Z",
      "headSha": "b727783e170ba21ee60c5dba0be7e7064beb293a",
      "message": "Teardown skipped: Slot preview-2 no longer belongs to pr-2524: it is now leased by pr-2537 (https://github.com/iterate/iterate/pull/2537). Their deployment has replaced this PR's apps on preview_2.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/9610365395196",
      "shortSha": "b727783",
      "deployDurationMs": 20023,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 19645,
      "deployReadinessDurationMs": 372,
      "deployedWorkerName": "auth-preview-2",
      "deployedWorkerVersion": "f152b95d-47e9-4ac9-9a85-6457daf284c9",
      "workerSizeKib": 3989.97,
      "workerGzipKib": 817.28,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-28T15:41:25.547Z",
      "deployedAt": "2026-08-26T16:27:10.774Z",
      "headSha": "b727783e170ba21ee60c5dba0be7e7064beb293a",
      "message": "Teardown skipped: Slot preview-2 no longer belongs to pr-2524: it is now leased by pr-2537 (https://github.com/iterate/iterate/pull/2537). Their deployment has replaced this PR's apps on preview_2.",
      "publicUrl": "https://dummy-petshop.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/9610365395196",
      "shortSha": "b727783",
      "deployDurationMs": 6860,
      "deployConfigDurationMs": 7,
      "deployCommandDurationMs": 6572,
      "deployReadinessDurationMs": 246,
      "deployedWorkerName": "dummy-petshop-preview-2",
      "deployedWorkerVersion": "d1688bc2-0a5c-437a-bf46-bf87f027cf92",
      "workerSizeKib": 1115.4,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "b717e505c46472150438e97f994eb4a2c283e0f8+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": "Teardown skipped: Slot preview-2 no longer belongs to pr-2524: it is now leased by pr-2537 (https://github.com/iterate/iterate/pull/2537). Their deployment has replaced this PR's apps on preview_2."
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `b727783` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 817.3 KiB | 20.0s |  |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/9610365395196) | 2026-08-28T15:41:25.547Z | Teardown skipped: Slot preview-2 no longer belongs to pr-2524: it is now leased by pr-2537 (https://github.com/iterate/iterate/pull/2537). Their deployment has replaced this PR's ... |
| Docs | released | `b727783` | [https://docs-preview-2.iterate-dev-preview.workers.dev](https://docs-preview-2.iterate-dev-preview.workers.dev) | 866.2 KiB | 16.1s |  |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/9610365395196) | 2026-08-28T15:41:25.547Z | Teardown skipped: Slot preview-2 no longer belongs to pr-2524: it is now leased by pr-2537 (https://github.com/iterate/iterate/pull/2537). Their deployment has replaced this PR's ... |
| Dummy Petshop | released | `b727783` | [https://dummy-petshop.iterate-preview-2.com](https://dummy-petshop.iterate-preview-2.com) | 198.3 KiB | 6.9s |  |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/9610365395196) | 2026-08-28T15:41:25.547Z | Teardown skipped: Slot preview-2 no longer belongs to pr-2524: it is now leased by pr-2537 (https://github.com/iterate/iterate/pull/2537). Their deployment has replaced this PR's ... |
| OS | released | `b727783` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 3.74 MiB (-1.40 MiB vs main) | 126.4s |  |  |  | [Workflow run](https://github.com/iterate/iterate/actions/runs/9610365395196) | 2026-08-28T15:41:25.547Z | Teardown skipped: Slot preview-2 no longer belongs to pr-2524: it is now leased by pr-2537 (https://github.com/iterate/iterate/pull/2537). Their deployment has replaced this PR's ... |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only change in a dev script; no runtime product paths or data handling affected.
> 
> **Overview**
> The **`voicelab transcript`** handler now returns **`Promise<void>`** instead of the row array after it prints. **trpc-cli** was serializing the returned rows as a second table after **`--json`** or human **`console.log`** output, which broke piping to **`jq`** and eval assertions.
> 
> Behavior is unchanged: the command still owns all rendering (JSON or readable column) and simply **`return`s** without a value so the generic CLI layer does not emit duplicate output. A short comment documents why returning rows would regress machine-readable output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b727783e170ba21ee60c5dba0be7e7064beb293a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->