### PR TITLE
evals: add project token audit command

### DIFF
--- a/apps/os/scripts/itx.ts
+++ b/apps/os/scripts/itx.ts
@@ -203,57 +203,6 @@ export async function agentSmoke(options: AgentSmokeOptions) {
   process.exit(0);
 }
 
-type EvalAuditOptions = {
-  /** OS base URL. Defaults to APP_CONFIG_BASE_URL. */
-  baseUrl?: string;
-  /** Eval project slug or project id. */
-  project: string;
-};
-
-/** Report every agent stream and aggregate model usage for one eval project. */
-export async function evalAudit(options: EvalAuditOptions) {
-  const projectReference = options.project.trim();
-  if (!projectReference) throw new Error("--project is required.");
-
-  using root = await connectItxReady(adminConnection(options), initialConnectionRetryOptions());
-  using project = root.projects.get(projectReference);
-  const [identity, agents] = await Promise.all([project.identity(), project.agents.list()]);
-  const agentStreams = await Promise.all(
-    agents.map(async (agent) => {
-      const snapshot = await project.agents.get(agent.path).processor.snapshot();
-      const usage = snapshot.state.tokenUsage;
-      return {
-        createdAt: agent.createdAt,
-        inputTokens: usage.totalInputTokens,
-        outputTokens: usage.totalOutputTokens,
-        cachedInputTokens: usage.totalCachedInputTokens,
-        reasoningOutputTokens: usage.totalReasoningOutputTokens,
-        path: agent.path,
-        title: agent.title || null,
-        totalTokens: usage.totalInputTokens + usage.totalOutputTokens,
-      };
-    }),
-  );
-  const totals = agentStreams.reduce(
-    (sum, stream) => ({
-      cachedInputTokens: sum.cachedInputTokens + stream.cachedInputTokens,
-      inputTokens: sum.inputTokens + stream.inputTokens,
-      outputTokens: sum.outputTokens + stream.outputTokens,
-      reasoningOutputTokens: sum.reasoningOutputTokens + stream.reasoningOutputTokens,
-      totalTokens: sum.totalTokens + stream.totalTokens,
-    }),
-    {
-      cachedInputTokens: 0,
-      inputTokens: 0,
-      outputTokens: 0,
-      reasoningOutputTokens: 0,
-      totalTokens: 0,
-    },
-  );
-
-  process.stdout.write(`${JSON.stringify({ project: identity, agentStreams, totals }, null, 2)}\n`);
-}
-
 function adminConnection(options: { baseUrl?: string }) {
   const baseUrl =
     options.baseUrl ??

--- a/apps/os/scripts/itx.ts
+++ b/apps/os/scripts/itx.ts
@@ -203,6 +203,57 @@ export async function agentSmoke(options: AgentSmokeOptions) {
   process.exit(0);
 }
 
+type EvalAuditOptions = {
+  /** OS base URL. Defaults to APP_CONFIG_BASE_URL. */
+  baseUrl?: string;
+  /** Eval project slug or project id. */
+  project: string;
+};
+
+/** Report every agent stream and aggregate model usage for one eval project. */
+export async function evalAudit(options: EvalAuditOptions) {
+  const projectReference = options.project.trim();
+  if (!projectReference) throw new Error("--project is required.");
+
+  using root = await connectItxReady(adminConnection(options), initialConnectionRetryOptions());
+  using project = root.projects.get(projectReference);
+  const [identity, agents] = await Promise.all([project.identity(), project.agents.list()]);
+  const agentStreams = await Promise.all(
+    agents.map(async (agent) => {
+      const snapshot = await project.agents.get(agent.path).processor.snapshot();
+      const usage = snapshot.state.tokenUsage;
+      return {
+        createdAt: agent.createdAt,
+        inputTokens: usage.totalInputTokens,
+        outputTokens: usage.totalOutputTokens,
+        cachedInputTokens: usage.totalCachedInputTokens,
+        reasoningOutputTokens: usage.totalReasoningOutputTokens,
+        path: agent.path,
+        title: agent.title || null,
+        totalTokens: usage.totalInputTokens + usage.totalOutputTokens,
+      };
+    }),
+  );
+  const totals = agentStreams.reduce(
+    (sum, stream) => ({
+      cachedInputTokens: sum.cachedInputTokens + stream.cachedInputTokens,
+      inputTokens: sum.inputTokens + stream.inputTokens,
+      outputTokens: sum.outputTokens + stream.outputTokens,
+      reasoningOutputTokens: sum.reasoningOutputTokens + stream.reasoningOutputTokens,
+      totalTokens: sum.totalTokens + stream.totalTokens,
+    }),
+    {
+      cachedInputTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      reasoningOutputTokens: 0,
+      totalTokens: 0,
+    },
+  );
+
+  process.stdout.write(`${JSON.stringify({ project: identity, agentStreams, totals }, null, 2)}\n`);
+}
+
 function adminConnection(options: { baseUrl?: string }) {
   const baseUrl =
     options.baseUrl ??

--- a/evals/run.ts
+++ b/evals/run.ts
@@ -1,14 +1,85 @@
 import { spawn } from "node:child_process";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import process from "node:process";
 
 import { existsSync } from "node:fs";
 import dedent from "dedent";
 import { createCli } from "trpc-cli";
+import { cloudflareWorkerVersionOverrideHeaders } from "@iterate-com/shared/test-support/cloudflare-worker-version-overrides";
+import { connectItxReady } from "iterate/node";
+import { readDevServerInfo } from "../apps/os/scripts/lib/dev-server-info.ts";
 
 export async function list() {
   const list = await fs.readdir(import.meta.dirname);
   return list.filter((item) => existsSync(path.join(import.meta.dirname, item, "eval.md")));
+}
+
+type AuditOptions = {
+  /** OS base URL. Defaults to APP_CONFIG_BASE_URL or this worktree's live dev server. */
+  baseUrl?: string;
+};
+
+/** Report every agent stream and aggregate model usage for one eval project. */
+export async function audit(project: string, options?: AuditOptions) {
+  const projectReference = project.trim();
+  if (!projectReference) throw new Error("Project slug or id is required.");
+
+  const baseUrl =
+    options?.baseUrl ||
+    process.env.APP_CONFIG_BASE_URL?.trim() ||
+    readDevServerInfo(path.join(import.meta.dirname, "..", "apps", "os"), {
+      requireLive: true,
+    })?.baseUrl.replace(/\/+$/, "");
+  if (!baseUrl) {
+    throw new Error(
+      "No base URL: pass --base-url, set APP_CONFIG_BASE_URL, or start the local dev server.",
+    );
+  }
+  const secret = process.env.APP_CONFIG_ADMIN_API_SECRET?.trim() || "";
+  if (!secret) throw new Error("APP_CONFIG_ADMIN_API_SECRET is required.");
+
+  using root = await connectItxReady({
+    auth: { type: "admin-secret", secret },
+    baseUrl,
+    headers: cloudflareWorkerVersionOverrideHeaders(process.env),
+  });
+  using projectItx = root.projects.get(projectReference);
+  const [identity, agents] = await Promise.all([projectItx.identity(), projectItx.agents.list()]);
+  const agentStreams = await Promise.all(
+    agents.map(async (agent) => {
+      const snapshot = await projectItx.agents.get(agent.path).processor.snapshot();
+      const usage = snapshot.state.tokenUsage;
+      return {
+        createdAt: agent.createdAt,
+        inputTokens: usage.totalInputTokens,
+        outputTokens: usage.totalOutputTokens,
+        cachedInputTokens: usage.totalCachedInputTokens,
+        reasoningOutputTokens: usage.totalReasoningOutputTokens,
+        path: agent.path,
+        title: agent.title || null,
+        totalTokens: usage.totalInputTokens + usage.totalOutputTokens,
+      };
+    }),
+  );
+  const totals = agentStreams.reduce(
+    (sum, stream) => ({
+      cachedInputTokens: sum.cachedInputTokens + stream.cachedInputTokens,
+      inputTokens: sum.inputTokens + stream.inputTokens,
+      outputTokens: sum.outputTokens + stream.outputTokens,
+      reasoningOutputTokens: sum.reasoningOutputTokens + stream.reasoningOutputTokens,
+      totalTokens: sum.totalTokens + stream.totalTokens,
+    }),
+    {
+      cachedInputTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      reasoningOutputTokens: 0,
+      totalTokens: 0,
+    },
+  );
+
+  return { project: identity, agentStreams, totals };
 }
 
 export default async function run(
@@ -50,7 +121,7 @@ export default async function run(
 
     Include in ${resultFile} every agent stream created in the eval project and the total token usage. You can write helper tools in the \`evals/\` directory. Track a helper in git only if it will help future evals; otherwise give it a gitignored filename.
 
-    Once you know the eval project's slug or id, collect this accounting with \`cd apps/os && doppler run --config <config> -- pnpm cli itx eval-audit --project <slug-or-id>\`. It reports every agent stream plus per-stream and project-wide token usage.
+    Once you know the eval project's slug or id, collect this accounting with \`doppler run --project os --config <config> -- pnpm eval audit <slug-or-id>\`. It reports every agent stream plus per-stream and project-wide token usage.
 
     Also include the coding agent session id in the result so it can be resumed later.
 

--- a/evals/run.ts
+++ b/evals/run.ts
@@ -50,6 +50,8 @@ export default async function run(
 
     Include in ${resultFile} every agent stream created in the eval project and the total token usage. You can write helper tools in the \`evals/\` directory. Track a helper in git only if it will help future evals; otherwise give it a gitignored filename.
 
+    Once you know the eval project's slug or id, collect this accounting with \`cd apps/os && doppler run --config <config> -- pnpm cli itx eval-audit --project <slug-or-id>\`. It reports every agent stream plus per-stream and project-wide token usage.
+
     Also include the coding agent session id in the result so it can be resumed later.
 
     If there are links to agent chats that are relevant, include a command like \`cd apps/os && doppler run --config prd -- pnpm cli session create --project prj_... --return-to /projects/eval-.../agents/streams/agents/... --open\` to make them easy to inspect after the run.


### PR DESCRIPTION
Eval runs can now collect every agent stream and project-wide model usage with one supported command:

```sh
doppler run --project os --config dev -- pnpm eval audit eval-example
```

The command returns canonical project identity, one row per agent stream, per-stream token counts, and aggregate totals. It reads the Agent processors' durable token-usage state, so long streams do not need custom event pagination.

The headless eval prompt now points future coding agents at this command instead of asking each run to build an ad hoc audit script.

## Risk map

- Highest attention: `evals/run.ts`; the command assumes `agents.list()` is the complete created-agent catalog and reads each matching processor snapshot.
- On merge: one read-only CLI command is added. No deployed behavior or stored data changes.
- Review order: the `audit` command in `evals/run.ts`, then its prompt integration in the same file.

## Verification

- Live local-dev audit against a completed eval project reproduced 45,527 journaled tokens across both agent streams.
- `pnpm eval audit --help`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knip`
- `pnpm format:check`
- `pnpm test`

Coding agent session: `01a03f41-7cbf-7932-a33d-0fc2b7d6d8dd`

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Other | +73 -0 | +61 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+73 -0** | **+61 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between a7f9252 and 03ec757, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->