### PR TITLE
Pinned-bug tests: bare test.fails to the sanctioned failing() helper

### DIFF
--- a/apps/os/e2e/vitest/project-create-concurrency.regression.e2e.test.ts
+++ b/apps/os/e2e/vitest/project-create-concurrency.regression.e2e.test.ts
@@ -1,7 +1,8 @@
+import { failing } from "@iterate-com/shared/test-support/failing-test";
 import { test } from "vitest";
 import { adminSecret, withItxSession } from "./test-helpers.ts";
 
-test.fails(
+failing(test, /CONCURRENT CREATE SPLITS IDENTITY/)(
   "DESIRED: concurrent creates of one slug adopt the same project identity",
   { retry: 0 },
   async ({ expect }) => {
@@ -19,7 +20,7 @@ test.fails(
       second.identity(),
     ]);
 
-    expect(secondIdentity).toEqual(firstIdentity);
+    expect(secondIdentity, "CONCURRENT CREATE SPLITS IDENTITY").toEqual(firstIdentity);
     expect(firstIdentity).toMatchObject({ organizationId: null, slug });
     await first.waitUntilCreated();
   },

--- a/apps/os/e2e/vitest/userspace-facet-recycle-false-alarm.e2e.test.ts
+++ b/apps/os/e2e/vitest/userspace-facet-recycle-false-alarm.e2e.test.ts
@@ -54,10 +54,14 @@ import { adminSecret, withItxSession } from "./test-helpers.ts";
  * `test.fails` and every throw counted as the expected one. The
  * `failing(test, /PIN CANNOT TELL RECYCLE FROM REBUILD/)` wrapper now closes
  * that hole — only the tagged verdict counts, and a fall-over on the way goes
- * red naming both errors — but the log is still how you tell which phase a
- * run reached. A run proves something only if its log reaches `verdict`.
+ * red with the mismatched error in the `[failing-test]` log — but the phase
+ * log is still how you tell which phase a run reached. A run proves
+ * something only if its log reaches `verdict`.
  */
-failing(test, /PIN CANNOT TELL RECYCLE FROM REBUILD/)(
+// timeoutMs: the wrapper's hang deadline, kept just below the 180s runner
+// ceiling so a hung phase goes red as not-the-pin instead of riding the
+// runner's timeout into a vacuous expected-fail pass.
+failing(test, /PIN CANNOT TELL RECYCLE FROM REBUILD/, { timeoutMs: 170_000 })(
   "the source-version pin tells a facet that recycled from one the commit rebuilt",
   // Ceiling, not an expectation: ~6s against a warm local deployment, and the
   // pin's comparable scenario takes 50-75s on a busy preview. Matched to the

--- a/apps/os/e2e/vitest/userspace-facet-recycle-false-alarm.e2e.test.ts
+++ b/apps/os/e2e/vitest/userspace-facet-recycle-false-alarm.e2e.test.ts
@@ -1,3 +1,4 @@
+import { failing } from "@iterate-com/shared/test-support/failing-test";
 import { expect, test } from "vitest";
 import type { StreamEventInput } from "iterate/processors";
 import { waitForCondition } from "../test-support/wait-for-condition.ts";
@@ -14,7 +15,7 @@ import { adminSecret, withItxSession } from "./test-helpers.ts";
 /*
  * Why the adjacent pin goes red for no reason.
  *
- * `userspace-facet-source-version.e2e.test.ts` is a `test.fails`: it asserts
+ * `userspace-facet-source-version.e2e.test.ts` is a pinned-bug test: it asserts
  * the FIX ("a source commit reaches the RUNNING facet"), so it stays green
  * only while the bug survives and goes red the moment somebody fixes it. Its
  * whole verdict is four comparisons between the probe answer from before the
@@ -48,13 +49,15 @@ import { adminSecret, withItxSession } from "./test-helpers.ts";
  * the commit is what replaced the facet. That is a separate change; this test
  * only holds the bug still.
  *
- * The `[facet-recycle]` phase log is not decoration. `test.fails` reports
- * every throw as the expected one, so a green pin says nothing about whether
- * the pinned thing happened — the same blind spot this file is about. Three
- * runs of this test "passed" while never reaching the assertion at all. A run
- * proves something only if its log reaches `verdict`.
+ * The `[facet-recycle]` phase log is not decoration. Three runs of this test
+ * "passed" while never reaching the assertion at all, back when it was a bare
+ * `test.fails` and every throw counted as the expected one. The
+ * `failing(test, /PIN CANNOT TELL RECYCLE FROM REBUILD/)` wrapper now closes
+ * that hole — only the tagged verdict counts, and a fall-over on the way goes
+ * red naming both errors — but the log is still how you tell which phase a
+ * run reached. A run proves something only if its log reaches `verdict`.
  */
-test.fails(
+failing(test, /PIN CANNOT TELL RECYCLE FROM REBUILD/)(
   "the source-version pin tells a facet that recycled from one the commit rebuilt",
   // Ceiling, not an expectation: ~6s against a warm local deployment, and the
   // pin's comparable scenario takes 50-75s on a busy preview. Matched to the
@@ -62,9 +65,8 @@ test.fails(
   // hitting it here would be absorbed as a vacuous pass rather than reported.
   { timeout: 180_000 },
   async () => {
-    // `test.fails` reports every throw as the expected one, so the phase log
-    // is the only way to tell a run that measured something from one that
-    // fell over on the way. Every step announces itself.
+    // The phase log is how you tell a run that measured something from one
+    // that fell over on the way. Every step announces itself.
     const log = (phase: string, detail?: unknown) =>
       console.log(`[facet-recycle] ${phase}`, detail ?? "");
 
@@ -143,8 +145,9 @@ test.fails(
         });
       } catch (error) {
         // A build failure surfaces as a `subscription-delivery-halted` event on
-        // the stream. `test.fails` would swallow that silently, so make the
-        // stream give its own account of the run before rethrowing.
+        // the stream. That throw no longer counts as the pinned failure (it
+        // carries no tag), but the stream should still give its own account of
+        // the run before rethrowing.
         const events = await stream.getEvents({});
         log(
           "stream events at timeout",
@@ -205,7 +208,7 @@ test.fails(
       buildKeyWellFormed: /^[0-9a-f]{64}$/.test(recycled.buildKey),
       bootIdMoved: recycled.bootId !== beforeCommit.bootId,
     };
-    expect(pinVerdict).not.toMatchObject({
+    expect(pinVerdict, "PIN CANNOT TELL RECYCLE FROM REBUILD").not.toMatchObject({
       revisionIsNewSource: true,
       buildKeyMoved: true,
       buildKeyWellFormed: true,

--- a/apps/os/e2e/vitest/userspace-facet-source-version.e2e.test.ts
+++ b/apps/os/e2e/vitest/userspace-facet-source-version.e2e.test.ts
@@ -69,7 +69,9 @@ const ECHO_PATH = "version-echo.js";
  * The companion test `userspace-facet-recycle-false-alarm.e2e.test.ts`
  * still demonstrates the old comparisons' blind spot by forcing a recycle.
  */
-failing(test, /SAME-BOOT STALENESS/)(
+// timeoutMs: the wrapper's own hang deadline, just below the runner ceiling —
+// the expected run is ~60-110s, well past failing()'s 60s default.
+failing(test, /SAME-BOOT STALENESS/, { timeoutMs: 230_000 })(
   "a userspace facet rebuilds on a source commit and only on a source commit",
   // Ceiling for the cold build, the two stability kills, and up to three
   // 45s observation rounds. The expected run (bug present, no recycles)

--- a/apps/os/src/domains/repos/artifact-rpc-ownership.regression.test.ts
+++ b/apps/os/src/domains/repos/artifact-rpc-ownership.regression.test.ts
@@ -1,3 +1,4 @@
+import { failing } from "@iterate-com/shared/test-support/failing-test";
 import { expect, test, vi } from "vitest";
 import { replaceArtifactWithEmptyRepo } from "./artifact-replacement.ts";
 
@@ -5,63 +6,75 @@ function artifactsError(code: string): Error & { code: string } {
   return Object.assign(new Error(code), { code });
 }
 
-test.fails("DESIRED: deletion polling disposes each temporary repository handle", async () => {
-  const calls: string[] = [];
-  const disposeRepo = vi.fn(() => {
-    calls.push("dispose:get:present");
-  });
-  const artifacts = {
-    create: vi.fn(async () => {
-      calls.push("create");
-      return {} as ArtifactsCreateRepoResult;
-    }),
-    delete: vi.fn(async () => {
-      calls.push("delete");
-      return true;
-    }),
-    get: vi
-      .fn<Artifacts["get"]>()
-      .mockImplementationOnce(async () => {
-        calls.push("get:present");
-        return { [Symbol.dispose]: disposeRepo } as unknown as ArtifactsRepo;
-      })
-      .mockImplementationOnce(async () => {
-        calls.push("get:missing");
-        throw artifactsError("NOT_FOUND");
+failing(test, /TEMP REPO HANDLE NOT DISPOSED/)(
+  "DESIRED: deletion polling disposes each temporary repository handle",
+  async () => {
+    const calls: string[] = [];
+    const disposeRepo = vi.fn(() => {
+      calls.push("dispose:get:present");
+    });
+    const artifacts = {
+      create: vi.fn(async () => {
+        calls.push("create");
+        return {} as ArtifactsCreateRepoResult;
       }),
-  };
+      delete: vi.fn(async () => {
+        calls.push("delete");
+        return true;
+      }),
+      get: vi
+        .fn<Artifacts["get"]>()
+        .mockImplementationOnce(async () => {
+          calls.push("get:present");
+          return { [Symbol.dispose]: disposeRepo } as unknown as ArtifactsRepo;
+        })
+        .mockImplementationOnce(async () => {
+          calls.push("get:missing");
+          throw artifactsError("NOT_FOUND");
+        }),
+    };
 
-  await replaceArtifactWithEmptyRepo(artifacts, "repo", {
-    pollIntervalMs: 0,
-    sleep: async () => {},
-  });
+    await replaceArtifactWithEmptyRepo(artifacts, "repo", {
+      pollIntervalMs: 0,
+      sleep: async () => {},
+    });
 
-  expect(calls).toEqual(["delete", "get:present", "dispose:get:present", "get:missing", "create"]);
-  expect(disposeRepo).toHaveBeenCalledOnce();
-});
+    expect(calls, "TEMP REPO HANDLE NOT DISPOSED").toEqual([
+      "delete",
+      "get:present",
+      "dispose:get:present",
+      "get:missing",
+      "create",
+    ]);
+    expect(disposeRepo, "TEMP REPO HANDLE NOT DISPOSED").toHaveBeenCalledOnce();
+  },
+);
 
-test.fails("DESIRED: cleanup failure does not masquerade as the repository deletion barrier", async () => {
-  const cleanupError = artifactsError("NOT_FOUND");
-  const disposeRepo = vi.fn(() => {
-    throw cleanupError;
-  });
-  const artifacts = {
-    create: vi.fn(async () => ({}) as ArtifactsCreateRepoResult),
-    delete: vi.fn(async () => true),
-    get: vi
-      .fn<Artifacts["get"]>()
-      .mockResolvedValueOnce({ [Symbol.dispose]: disposeRepo } as unknown as ArtifactsRepo)
-      .mockRejectedValueOnce(artifactsError("NOT_FOUND")),
-  };
-  const sleep = vi.fn(async () => undefined);
+failing(test, /CLEANUP MASQUERADES AS DELETION BARRIER/)(
+  "DESIRED: cleanup failure does not masquerade as the repository deletion barrier",
+  async () => {
+    const cleanupError = artifactsError("NOT_FOUND");
+    const disposeRepo = vi.fn(() => {
+      throw cleanupError;
+    });
+    const artifacts = {
+      create: vi.fn(async () => ({}) as ArtifactsCreateRepoResult),
+      delete: vi.fn(async () => true),
+      get: vi
+        .fn<Artifacts["get"]>()
+        .mockResolvedValueOnce({ [Symbol.dispose]: disposeRepo } as unknown as ArtifactsRepo)
+        .mockRejectedValueOnce(artifactsError("NOT_FOUND")),
+    };
+    const sleep = vi.fn(async () => undefined);
 
-  await replaceArtifactWithEmptyRepo(artifacts, "repo", {
-    pollIntervalMs: 17,
-    sleep,
-  });
+    await replaceArtifactWithEmptyRepo(artifacts, "repo", {
+      pollIntervalMs: 17,
+      sleep,
+    });
 
-  expect(disposeRepo).toHaveBeenCalledOnce();
-  expect(artifacts.get).toHaveBeenCalledTimes(2);
-  expect(sleep).toHaveBeenCalledWith(17);
-  expect(artifacts.create).toHaveBeenCalledOnce();
-});
+    expect(disposeRepo, "CLEANUP MASQUERADES AS DELETION BARRIER").toHaveBeenCalledOnce();
+    expect(artifacts.get).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(17);
+    expect(artifacts.create).toHaveBeenCalledOnce();
+  },
+);

--- a/apps/os/src/domains/scheduler/scheduler-rpc-ownership.regression.test.ts
+++ b/apps/os/src/domains/scheduler/scheduler-rpc-ownership.regression.test.ts
@@ -1,3 +1,4 @@
+import { failing } from "@iterate-com/shared/test-support/failing-test";
 import { expect, test, vi } from "vitest";
 import {
   makeMemoryProgressStore,
@@ -60,42 +61,51 @@ async function runOneAction(
   return h.events(COMPLETED_TYPE)[0]!;
 }
 
-test.fails("DESIRED: a scheduler action disposes its RPC result after detaching the JSON value", async () => {
-  const dispose = vi.fn();
-  const result = Object.assign({ made: "cat-image" }, { [Symbol.dispose]: dispose });
+failing(test, /SCHEDULER RESULT NOT DISPOSED/)(
+  "DESIRED: a scheduler action disposes its RPC result after detaching the JSON value",
+  async () => {
+    const dispose = vi.fn();
+    const result = Object.assign({ made: "cat-image" }, { [Symbol.dispose]: dispose });
 
-  const completed = await runOneAction(async () => result);
+    const completed = await runOneAction(async () => result);
 
-  expect(completed.payload).toMatchObject({
-    outcome: "succeeded",
-    result: { made: "cat-image" },
-  });
-  expect(dispose).toHaveBeenCalledOnce();
-});
+    expect(completed.payload).toMatchObject({
+      outcome: "succeeded",
+      result: { made: "cat-image" },
+    });
+    expect(dispose, "SCHEDULER RESULT NOT DISPOSED").toHaveBeenCalledOnce();
+  },
+);
 
-test.fails("DESIRED: RPC result cleanup failure does not replace a successful scheduler action", async () => {
-  const cleanupError = new Error("dispose failed");
-  const dispose = vi.fn(() => {
-    throw cleanupError;
-  });
-  const result = Object.assign({ made: "cat-image" }, { [Symbol.dispose]: dispose });
+failing(test, /SCHEDULER CLEANUP FAILURE NOT ISOLATED/)(
+  "DESIRED: RPC result cleanup failure does not replace a successful scheduler action",
+  async () => {
+    const cleanupError = new Error("dispose failed");
+    const dispose = vi.fn(() => {
+      throw cleanupError;
+    });
+    const result = Object.assign({ made: "cat-image" }, { [Symbol.dispose]: dispose });
 
-  const completed = await runOneAction(async () => result);
+    const completed = await runOneAction(async () => result);
 
-  expect(completed.payload).toMatchObject({
-    outcome: "succeeded",
-    result: { made: "cat-image" },
-  });
-  expect(dispose).toHaveBeenCalledOnce();
-});
+    expect(completed.payload).toMatchObject({
+      outcome: "succeeded",
+      result: { made: "cat-image" },
+    });
+    expect(dispose, "SCHEDULER CLEANUP FAILURE NOT ISOLATED").toHaveBeenCalledOnce();
+  },
+);
 
-test.fails("DESIRED: a scheduler disposes its RPC result even when JSON detachment fails", async () => {
-  const dispose = vi.fn();
-  const result: Record<string | symbol, unknown> = { [Symbol.dispose]: dispose };
-  result.self = result;
+failing(test, /SCHEDULER NO DISPOSE ON DETACH FAILURE/)(
+  "DESIRED: a scheduler disposes its RPC result even when JSON detachment fails",
+  async () => {
+    const dispose = vi.fn();
+    const result: Record<string | symbol, unknown> = { [Symbol.dispose]: dispose };
+    result.self = result;
 
-  const completed = await runOneAction(async () => result);
+    const completed = await runOneAction(async () => result);
 
-  expect(completed.payload).toMatchObject({ outcome: "failed" });
-  expect(dispose).toHaveBeenCalledOnce();
-});
+    expect(completed.payload).toMatchObject({ outcome: "failed" });
+    expect(dispose, "SCHEDULER NO DISPOSE ON DETACH FAILURE").toHaveBeenCalledOnce();
+  },
+);

--- a/apps/os/src/domains/streams/guarantees-not-given.test.ts
+++ b/apps/os/src/domains/streams/guarantees-not-given.test.ts
@@ -10,15 +10,17 @@
 // guarantees pinned below. Each test is written as if the guarantee EXISTED:
 // it exercises the real system and asserts the desirable behavior, and it
 // genuinely fails today because the system does not provide it. Each is
-// wrapped in `failing(test, /TAG/)` and asserts its pinned expectation with
-// that TAG as the message, so the suite stays green only while the guarantee
-// is un-given FOR THE PINNED REASON — a body that starts failing somewhere
-// else goes red naming both errors, which a bare `test.fails` cannot do.
+// wrapped in `failing(test, /TAG/)` — registered through vitest's own
+// `test.fails` underneath, so they report natively as expected fails — and
+// asserts its pinned expectation with that TAG as the message. The suite
+// stays green only while the guarantee is un-given FOR THE PINNED REASON;
+// a body that starts failing somewhere else goes red with the mismatched
+// error in the `[failing-test]` log, which a bare `test.fails` cannot do.
 //
-// If a change makes one of these tests pass, it fails with instructions to
-// delete the wrapper. Do not delete the test — drop the `failing(...)` call
-// and the TAG message, move it to the regular suites, and delete only its
-// entry here.
+// If a change makes one of these tests pass, it goes red with
+// delete-the-wrapper instructions in the log. Do not delete the test — drop
+// the `failing(...)` call and the TAG message, move it to the regular
+// suites, and delete only its entry here.
 
 import { DatabaseSync } from "node:sqlite";
 import type {

--- a/apps/os/src/domains/streams/guarantees-not-given.test.ts
+++ b/apps/os/src/domains/streams/guarantees-not-given.test.ts
@@ -9,12 +9,16 @@
 // That bought roughly 2,000 fewer lines at the price of the specific
 // guarantees pinned below. Each test is written as if the guarantee EXISTED:
 // it exercises the real system and asserts the desirable behavior, and it
-// genuinely fails today because the system does not provide it. `test.fails`
-// keeps the suite green exactly as long as the guarantee stays un-given.
+// genuinely fails today because the system does not provide it. Each is
+// wrapped in `failing(test, /TAG/)` and asserts its pinned expectation with
+// that TAG as the message, so the suite stays green only while the guarantee
+// is un-given FOR THE PINNED REASON — a body that starts failing somewhere
+// else goes red naming both errors, which a bare `test.fails` cannot do.
 //
-// If a change makes one of these tests pass, vitest will fail it as
-// unexpectedly-passing. Do not delete the test — move it to the regular
-// suites and delete only its entry here.
+// If a change makes one of these tests pass, it fails with instructions to
+// delete the wrapper. Do not delete the test — drop the `failing(...)` call
+// and the TAG message, move it to the regular suites, and delete only its
+// entry here.
 
 import { DatabaseSync } from "node:sqlite";
 import type {
@@ -23,6 +27,7 @@ import type {
   StreamEvent,
   StreamEventInput,
 } from "iterate/processors";
+import { failing } from "@iterate-com/shared/test-support/failing-test";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import type { Env } from "../../env.ts";
 import { DurableObjectNameCodec } from "../durable-object-names.ts";
@@ -223,48 +228,54 @@ describe("guarantees the subscription rewrite deliberately does not give", () =>
   //   so the window closes within one delivery round.
   // RESTORE: the deleted receiver-side registry (membership checked at
   //   receive time), or any receiver-visible removal record.
-  test.fails("removing a subscription atomically stops in-flight deliveries", async () => {
-    const streams = new Map<string, StreamDurableObject>();
-    const captured = Promise.withResolvers<StreamDeliveryBatch>();
-    const transportAck = Promise.withResolvers<CopyReceipt>();
-    const env = streamNamespace(streams, {
-      match: (targetName) => targetName === streamName("/reviewer"),
-      captured,
-      transportAck,
-    });
-    const source = await bootStream({ path: "/", env, streams });
-    const reviewer = await bootStream({ path: "/reviewer", env, streams });
+  failing(test, /NO ATOMIC UNSUBSCRIBE/)(
+    "removing a subscription atomically stops in-flight deliveries",
+    async () => {
+      const streams = new Map<string, StreamDurableObject>();
+      const captured = Promise.withResolvers<StreamDeliveryBatch>();
+      const transportAck = Promise.withResolvers<CopyReceipt>();
+      const env = streamNamespace(streams, {
+        match: (targetName) => targetName === streamName("/reviewer"),
+        captured,
+        transportAck,
+      });
+      const source = await bootStream({ path: "/", env, streams });
+      const reviewer = await bootStream({ path: "/reviewer", env, streams });
 
-    try {
-      source.stream.setCopySubscription({ configuration: reviewFeedConfiguration("/reviewer") });
-      source.stream.append({ type: "example.com/issue-created", payload: { issue: 1 } });
-      source.stream.alarm();
-      const inFlight = await captured.promise;
-
-      expect(
-        source.stream.removeCopySubscription({
-          name: "review-feed",
-          expectedReceiverPath: "/reviewer",
-        }),
-      ).toMatchObject({ status: "removed" });
-
-      // The parked batch lands after the removal committed — exactly what a
-      // slow RPC hop does. A receiver that rejected members of removed
-      // subscriptions would satisfy the guarantee, so a throw is tolerated.
       try {
-        reviewer.stream.receiveCopiedEvents(inFlight);
-      } catch {
-        // rejecting the orphaned delivery is one valid way to give the guarantee
-      }
-      transportAck.resolve({ acknowledged: inFlight.events.length });
-      await Promise.all([source.context.settle(), reviewer.context.settle()]);
+        source.stream.setCopySubscription({ configuration: reviewFeedConfiguration("/reviewer") });
+        source.stream.append({ type: "example.com/issue-created", payload: { issue: 1 } });
+        source.stream.alarm();
+        const inFlight = await captured.promise;
 
-      expect(reviewer.stream.getEvents({ eventTypes: ["example.com/issue-created"] })).toEqual([]);
-    } finally {
-      reviewer.context.close();
-      source.context.close();
-    }
-  });
+        expect(
+          source.stream.removeCopySubscription({
+            name: "review-feed",
+            expectedReceiverPath: "/reviewer",
+          }),
+        ).toMatchObject({ status: "removed" });
+
+        // The parked batch lands after the removal committed — exactly what a
+        // slow RPC hop does. A receiver that rejected members of removed
+        // subscriptions would satisfy the guarantee, so a throw is tolerated.
+        try {
+          reviewer.stream.receiveCopiedEvents(inFlight);
+        } catch {
+          // rejecting the orphaned delivery is one valid way to give the guarantee
+        }
+        transportAck.resolve({ acknowledged: inFlight.events.length });
+        await Promise.all([source.context.settle(), reviewer.context.settle()]);
+
+        expect(
+          reviewer.stream.getEvents({ eventTypes: ["example.com/issue-created"] }),
+          "NO ATOMIC UNSUBSCRIBE",
+        ).toEqual([]);
+      } finally {
+        reviewer.context.close();
+        source.context.close();
+      }
+    },
+  );
 
   // GUARANTEE: re-pointing a subscription key from receiver A to receiver B
   //   never delivers the same source event to both.
@@ -278,56 +289,63 @@ describe("guarantees the subscription rewrite deliberately does not give", () =>
   //   duplicate window is a single delivery round.
   // RESTORE: the deleted move-gating handshake (quiesce the old receiver
   //   before enabling the new one).
-  test.fails("re-pointing a subscription key from one receiver to another never delivers the same event to both", async () => {
-    const streams = new Map<string, StreamDurableObject>();
-    const capturedForA = Promise.withResolvers<StreamDeliveryBatch>();
-    const transportAckForA = Promise.withResolvers<CopyReceipt>();
-    const env = streamNamespace(streams, {
-      match: (targetName) => targetName === streamName("/reviewer-a"),
-      captured: capturedForA,
-      transportAck: transportAckForA,
-    });
-    const source = await bootStream({ path: "/", env, streams });
-    const reviewerA = await bootStream({ path: "/reviewer-a", env, streams });
-    const reviewerB = await bootStream({ path: "/reviewer-b", env, streams });
-
-    try {
-      source.stream.setCopySubscription({ configuration: reviewFeedConfiguration("/reviewer-a") });
-      source.stream.append({ type: "example.com/issue-created", payload: { issue: 42 } });
-      source.stream.alarm();
-      const inFlightToA = await capturedForA.promise;
-
-      // Re-point the same key to reviewer B while the batch to A is in flight.
-      source.stream.setCopySubscription({ configuration: reviewFeedConfiguration("/reviewer-b") });
+  failing(test, /REPOINT DELIVERS TO BOTH/)(
+    "re-pointing a subscription key from one receiver to another never delivers the same event to both",
+    async () => {
+      const streams = new Map<string, StreamDurableObject>();
+      const capturedForA = Promise.withResolvers<StreamDeliveryBatch>();
+      const transportAckForA = Promise.withResolvers<CopyReceipt>();
+      const env = streamNamespace(streams, {
+        match: (targetName) => targetName === streamName("/reviewer-a"),
+        captured: capturedForA,
+        transportAck: transportAckForA,
+      });
+      const source = await bootStream({ path: "/", env, streams });
+      const reviewerA = await bootStream({ path: "/reviewer-a", env, streams });
+      const reviewerB = await bootStream({ path: "/reviewer-b", env, streams });
 
       try {
-        reviewerA.stream.receiveCopiedEvents(inFlightToA);
-      } catch {
-        // rejecting the superseded delivery is one valid way to give the guarantee
-      }
-      transportAckForA.resolve({ acknowledged: inFlightToA.events.length });
-      await Promise.all([
-        source.context.settle(),
-        reviewerA.context.settle(),
-        reviewerB.context.settle(),
-      ]);
+        source.stream.setCopySubscription({
+          configuration: reviewFeedConfiguration("/reviewer-a"),
+        });
+        source.stream.append({ type: "example.com/issue-created", payload: { issue: 42 } });
+        source.stream.alarm();
+        const inFlightToA = await capturedForA.promise;
 
-      const receiversHoldingTheCopy = [
-        ["/reviewer-a", reviewerA.stream] as const,
-        ["/reviewer-b", reviewerB.stream] as const,
-      ]
-        .filter(
-          ([, stream]) =>
-            stream.getEvents({ eventTypes: ["example.com/issue-created"] }).length > 0,
-        )
-        .map(([path]) => path);
-      expect(receiversHoldingTheCopy.length).toBeLessThanOrEqual(1);
-    } finally {
-      reviewerB.context.close();
-      reviewerA.context.close();
-      source.context.close();
-    }
-  });
+        // Re-point the same key to reviewer B while the batch to A is in flight.
+        source.stream.setCopySubscription({
+          configuration: reviewFeedConfiguration("/reviewer-b"),
+        });
+
+        try {
+          reviewerA.stream.receiveCopiedEvents(inFlightToA);
+        } catch {
+          // rejecting the superseded delivery is one valid way to give the guarantee
+        }
+        transportAckForA.resolve({ acknowledged: inFlightToA.events.length });
+        await Promise.all([
+          source.context.settle(),
+          reviewerA.context.settle(),
+          reviewerB.context.settle(),
+        ]);
+
+        const receiversHoldingTheCopy = [
+          ["/reviewer-a", reviewerA.stream] as const,
+          ["/reviewer-b", reviewerB.stream] as const,
+        ]
+          .filter(
+            ([, stream]) =>
+              stream.getEvents({ eventTypes: ["example.com/issue-created"] }).length > 0,
+          )
+          .map(([path]) => path);
+        expect(receiversHoldingTheCopy.length, "REPOINT DELIVERS TO BOTH").toBeLessThanOrEqual(1);
+      } finally {
+        reviewerB.context.close();
+        reviewerA.context.close();
+        source.context.close();
+      }
+    },
+  );
 
   // GUARANTEE: `setCopySubscription` toward an unusable or nonexistent
   //   receiving stream fails at configure time.
@@ -341,27 +359,31 @@ describe("guarantees the subscription rewrite deliberately does not give", () =>
   //   (resumeSubscription / a fresh setCopySubscription).
   // RESTORE: the deleted configure-time round-trip, or a probe call before
   //   committing the configuration.
-  test.fails("configuring a copy subscription verifies the receiver end-to-end", async () => {
-    const streams = new Map<string, StreamDurableObject>();
-    const env = streamNamespace(streams);
-    const source = await bootStream({ path: "/", env, streams });
+  failing(test, /NO RECEIVER VERIFICATION/)(
+    "configuring a copy subscription verifies the receiver end-to-end",
+    async () => {
+      const streams = new Map<string, StreamDurableObject>();
+      const env = streamNamespace(streams);
+      const source = await bootStream({ path: "/", env, streams });
 
-    try {
       try {
-        // No stream exists at /nowhere; every future delivery to it fails.
-        source.stream.setCopySubscription({ configuration: reviewFeedConfiguration("/nowhere") });
-      } catch {
-        // configure-time verification would reject the unusable receiver here
+        try {
+          // No stream exists at /nowhere; every future delivery to it fails.
+          source.stream.setCopySubscription({ configuration: reviewFeedConfiguration("/nowhere") });
+        } catch {
+          // configure-time verification would reject the unusable receiver here
+        }
+        expect(
+          source.stream.runtimeState().coreProcessorState.subscriptions.outbound.byName[
+            "review-feed"
+          ],
+          "NO RECEIVER VERIFICATION",
+        ).toBeUndefined();
+      } finally {
+        source.context.close();
       }
-      expect(
-        source.stream.runtimeState().coreProcessorState.subscriptions.outbound.byName[
-          "review-feed"
-        ],
-      ).toBeUndefined();
-    } finally {
-      source.context.close();
-    }
-  });
+    },
+  );
 
   // GUARANTEE: delivery to an itx-call receiver is exactly-once.
   // WHY NOT GIVEN: nothing reasonable restores this — the awaited call IS the
@@ -380,111 +402,114 @@ describe("guarantees the subscription rewrite deliberately does not give", () =>
   //   order, within one subscription; duplicates are bounded by one batch per
   //   lost acknowledgement.
   // RESTORE: nothing planned. This test documents the doctrine.
-  test.fails("delivery to an itx-call receiver is exactly-once", async () => {
-    vi.spyOn(console, "error").mockImplementation(() => undefined);
-    let now = 10_000;
-    const deliveredBatches: number[][] = [];
-    const state = CoreProcessorContract.stateSchema.parse({
-      projectId: "project",
-      path: "/source",
-      streamId: "11111111-1111-4111-8111-111111111111",
-      createdAt: "2026-07-21T10:00:00.000Z",
-      maxOffset: 2,
-      subscriptions: {
-        outbound: {
-          byName: {
-            "project-feed": {
-              configuration: {
-                name: "project-feed",
-                receiver: {
-                  action: "itx-call",
-                  expression: ["worker", "processEventBatch"],
-                  delivery: { start: "beginning", onFailingEvent: "halt" },
+  failing(test, /ITX DELIVERY NOT EXACTLY ONCE/)(
+    "delivery to an itx-call receiver is exactly-once",
+    async () => {
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+      let now = 10_000;
+      const deliveredBatches: number[][] = [];
+      const state = CoreProcessorContract.stateSchema.parse({
+        projectId: "project",
+        path: "/source",
+        streamId: "11111111-1111-4111-8111-111111111111",
+        createdAt: "2026-07-21T10:00:00.000Z",
+        maxOffset: 2,
+        subscriptions: {
+          outbound: {
+            byName: {
+              "project-feed": {
+                configuration: {
+                  name: "project-feed",
+                  receiver: {
+                    action: "itx-call",
+                    expression: ["worker", "processEventBatch"],
+                    delivery: { start: "beginning", onFailingEvent: "halt" },
+                  },
                 },
+                configuredAtOffset: 1,
+                configuredAt: new Date(1).toISOString(),
               },
-              configuredAtOffset: 1,
-              configuredAt: new Date(1).toISOString(),
             },
           },
         },
-      },
-    });
-    const store = new SqliteSubscriptionCursorStore(wrapSqlStorage(new DatabaseSync(":memory:")));
-    store.ensure("project-feed", 0, 1);
-    const sourceEvents: StreamEvent[] = [
-      {
-        type: "example.com/issue-created",
-        payload: { issue: 1 },
-        createdAt: new Date(2).toISOString(),
-        offset: 2,
-        path: "/source",
-      },
-    ];
-    const kept: Promise<unknown>[] = [];
-    const receiverCalls: SubscriptionReceiverCalls = {
-      wakeStreamProcessor: async () => {
-        throw new Error("an ITX receiver must not wake a hosted processor");
-      },
-      deliverToItx: async (_expression, batch) => {
-        // The receiver does its work; for an itx call, the call IS the effect.
-        deliveredBatches.push(batch.events.map(({ offset }) => offset));
-      },
-      copyToStream: async () => ({ acknowledged: 0 }),
-      deliverToWebhook: async () => {},
-    };
-    const eventSender = new StreamEventSender({
-      hooks: {
-        facetWorkArmedAtMs: () => null,
-        readEvents: ({ afterOffset, beforeOffset, limit }) =>
-          sourceEvents
-            .filter((entry) => entry.offset > afterOffset && entry.offset < beforeOffset)
-            .slice(0, limit)
-            .map((entry) => ({ event: entry, byteLength: JSON.stringify(entry).length })),
-        coreState: () => state,
-        store,
-        receiverCalls,
-        appendDeliveryEvent: () => true,
-        recordEgress: () => undefined,
-        runtimeChanged: () => undefined,
-        workerVersion: () => "test-version",
-        now: () => now,
-        random: () => 0.5,
-        armAlarm: () => undefined,
-        clearAlarm: () => undefined,
-        runDurable: (work) => kept.push(work()),
-        keepAlive: (promise) => kept.push(promise),
-        subscriberPagerConnectionKeys: () => new Set<string>(),
-        onSessionsIdleClosed: () => undefined,
-        pageDormantSubscribers: () => undefined,
-      },
-    });
-    async function settle() {
-      let seen = -1;
-      while (seen !== kept.length) {
-        seen = kept.length;
-        await Promise.allSettled([...kept]);
+      });
+      const store = new SqliteSubscriptionCursorStore(wrapSqlStorage(new DatabaseSync(":memory:")));
+      store.ensure("project-feed", 0, 1);
+      const sourceEvents: StreamEvent[] = [
+        {
+          type: "example.com/issue-created",
+          payload: { issue: 1 },
+          createdAt: new Date(2).toISOString(),
+          offset: 2,
+          path: "/source",
+        },
+      ];
+      const kept: Promise<unknown>[] = [];
+      const receiverCalls: SubscriptionReceiverCalls = {
+        wakeStreamProcessor: async () => {
+          throw new Error("an ITX receiver must not wake a hosted processor");
+        },
+        deliverToItx: async (_expression, batch) => {
+          // The receiver does its work; for an itx call, the call IS the effect.
+          deliveredBatches.push(batch.events.map(({ offset }) => offset));
+        },
+        copyToStream: async () => ({ acknowledged: 0 }),
+        deliverToWebhook: async () => {},
+      };
+      const eventSender = new StreamEventSender({
+        hooks: {
+          facetWorkArmedAtMs: () => null,
+          readEvents: ({ afterOffset, beforeOffset, limit }) =>
+            sourceEvents
+              .filter((entry) => entry.offset > afterOffset && entry.offset < beforeOffset)
+              .slice(0, limit)
+              .map((entry) => ({ event: entry, byteLength: JSON.stringify(entry).length })),
+          coreState: () => state,
+          store,
+          receiverCalls,
+          appendDeliveryEvent: () => true,
+          recordEgress: () => undefined,
+          runtimeChanged: () => undefined,
+          workerVersion: () => "test-version",
+          now: () => now,
+          random: () => 0.5,
+          armAlarm: () => undefined,
+          clearAlarm: () => undefined,
+          runDurable: (work) => kept.push(work()),
+          keepAlive: (promise) => kept.push(promise),
+          subscriberPagerConnectionKeys: () => new Set<string>(),
+          onSessionsIdleClosed: () => undefined,
+          pageDormantSubscribers: () => undefined,
+        },
+      });
+      async function settle() {
+        let seen = -1;
+        while (seen !== kept.length) {
+          seen = kept.length;
+          await Promise.allSettled([...kept]);
+          await Promise.resolve();
+        }
         await Promise.resolve();
       }
-      await Promise.resolve();
-    }
-    // The receiver resolves, then the acknowledgement is lost before the
-    // source commits its cursor — the wire fact behind every at-least-once
-    // redelivery.
-    const commitAcknowledgement = store.ack.bind(store);
-    vi.spyOn(store, "ack")
-      .mockImplementationOnce(() => {
-        throw new Error("simulated acknowledgement loss after the receiver did its work");
-      })
-      .mockImplementation(commitAcknowledgement);
+      // The receiver resolves, then the acknowledgement is lost before the
+      // source commits its cursor — the wire fact behind every at-least-once
+      // redelivery.
+      const commitAcknowledgement = store.ack.bind(store);
+      vi.spyOn(store, "ack")
+        .mockImplementationOnce(() => {
+          throw new Error("simulated acknowledgement loss after the receiver did its work");
+        })
+        .mockImplementation(commitAcknowledgement);
 
-    eventSender.sendDue();
-    await settle();
-    now = 11_000;
-    eventSender.onAlarm();
-    await settle();
+      eventSender.sendDue();
+      await settle();
+      now = 11_000;
+      eventSender.onAlarm();
+      await settle();
 
-    expect(deliveredBatches).toEqual([[2]]);
-  });
+      expect(deliveredBatches, "ITX DELIVERY NOT EXACTLY ONCE").toEqual([[2]]);
+    },
+  );
 
   // GUARANTEE: events from two source streams arrive at a shared receiver in
   //   global append order.
@@ -497,58 +522,68 @@ describe("guarantees the subscription rewrite deliberately does not give", () =>
   //   ever across sources, and each source still arrives gap-free.
   // RESTORE: cross-source sequencing (a receiver-side total order or source
   //   coordination) — deliberately out of scope.
-  test.fails("events from two source streams arrive at a shared receiver in global append order", async () => {
-    const streams = new Map<string, StreamDurableObject>();
-    const capturedFromA = Promise.withResolvers<StreamDeliveryBatch>();
-    const transportAckForA = Promise.withResolvers<CopyReceipt>();
-    const env = streamNamespace(streams, {
-      // Subscription A is the slow one: its batch parks on the wire while
-      // subscription B delivers immediately.
-      match: (targetName, batch) =>
-        targetName === streamName("/inbox") && batch.path === "/issues-a",
-      captured: capturedFromA,
-      transportAck: transportAckForA,
-    });
-    const sourceA = await bootStream({ path: "/issues-a", env, streams });
-    const sourceB = await bootStream({ path: "/issues-b", env, streams });
-    const inbox = await bootStream({ path: "/inbox", env, streams });
-
-    try {
-      sourceA.stream.setCopySubscription({
-        configuration: { ...reviewFeedConfiguration("/inbox"), name: "feed" },
+  failing(test, /NO GLOBAL APPEND ORDER/)(
+    "events from two source streams arrive at a shared receiver in global append order",
+    async () => {
+      const streams = new Map<string, StreamDurableObject>();
+      const capturedFromA = Promise.withResolvers<StreamDeliveryBatch>();
+      const transportAckForA = Promise.withResolvers<CopyReceipt>();
+      const env = streamNamespace(streams, {
+        // Subscription A is the slow one: its batch parks on the wire while
+        // subscription B delivers immediately.
+        match: (targetName, batch) =>
+          targetName === streamName("/inbox") && batch.path === "/issues-a",
+        captured: capturedFromA,
+        transportAck: transportAckForA,
       });
-      sourceA.stream.append({ type: "example.com/issue-created", payload: { appended: "first" } });
-      sourceA.stream.alarm();
-      const inFlightFromA = await capturedFromA.promise;
+      const sourceA = await bootStream({ path: "/issues-a", env, streams });
+      const sourceB = await bootStream({ path: "/issues-b", env, streams });
+      const inbox = await bootStream({ path: "/inbox", env, streams });
 
-      // Appended strictly after A's event, while A's batch is still in flight.
-      sourceB.stream.setCopySubscription({
-        configuration: { ...reviewFeedConfiguration("/inbox"), name: "feed" },
-      });
-      sourceB.stream.append({ type: "example.com/issue-created", payload: { appended: "second" } });
-      sourceB.stream.alarm();
-      await Promise.all([sourceB.context.settle(), inbox.context.settle()]);
-
-      // The older event lands only after the newer one already committed.
       try {
-        inbox.stream.receiveCopiedEvents(inFlightFromA);
-      } catch {
-        // a receiver that re-sequenced or rejected the late batch could give the guarantee
-      }
-      transportAckForA.resolve({ acknowledged: inFlightFromA.events.length });
-      await Promise.all([sourceA.context.settle(), inbox.context.settle()]);
+        sourceA.stream.setCopySubscription({
+          configuration: { ...reviewFeedConfiguration("/inbox"), name: "feed" },
+        });
+        sourceA.stream.append({
+          type: "example.com/issue-created",
+          payload: { appended: "first" },
+        });
+        sourceA.stream.alarm();
+        const inFlightFromA = await capturedFromA.promise;
 
-      expect(
-        inbox.stream
-          .getEvents({ eventTypes: ["example.com/issue-created"] })
-          .map(({ payload }) => payload),
-      ).toEqual([{ appended: "first" }, { appended: "second" }]);
-    } finally {
-      inbox.context.close();
-      sourceB.context.close();
-      sourceA.context.close();
-    }
-  });
+        // Appended strictly after A's event, while A's batch is still in flight.
+        sourceB.stream.setCopySubscription({
+          configuration: { ...reviewFeedConfiguration("/inbox"), name: "feed" },
+        });
+        sourceB.stream.append({
+          type: "example.com/issue-created",
+          payload: { appended: "second" },
+        });
+        sourceB.stream.alarm();
+        await Promise.all([sourceB.context.settle(), inbox.context.settle()]);
+
+        // The older event lands only after the newer one already committed.
+        try {
+          inbox.stream.receiveCopiedEvents(inFlightFromA);
+        } catch {
+          // a receiver that re-sequenced or rejected the late batch could give the guarantee
+        }
+        transportAckForA.resolve({ acknowledged: inFlightFromA.events.length });
+        await Promise.all([sourceA.context.settle(), inbox.context.settle()]);
+
+        expect(
+          inbox.stream
+            .getEvents({ eventTypes: ["example.com/issue-created"] })
+            .map(({ payload }) => payload),
+          "NO GLOBAL APPEND ORDER",
+        ).toEqual([{ appended: "first" }, { appended: "second" }]);
+      } finally {
+        inbox.context.close();
+        sourceB.context.close();
+        sourceA.context.close();
+      }
+    },
+  );
 
   // GUARANTEE: a receiver that lost its data (erased/recreated stream) gets
   //   the source history automatically re-sent.
@@ -564,48 +599,52 @@ describe("guarantees the subscription rewrite deliberately does not give", () =>
   // RESTORE: the deleted blocked/resend-request lane, or receiver-lifetime
   //   tracking on the source that rewinds the cursor on first contact with a
   //   new receiver lifetime.
-  test.fails("a receiver that lost its data gets the source history automatically re-sent", async () => {
-    const streams = new Map<string, StreamDurableObject>();
-    const env = streamNamespace(streams);
-    const source = await bootStream({ path: "/", env, streams });
-    const firstReviewer = await bootStream({ path: "/reviewer", env, streams });
+  failing(test, /NO AUTOMATIC HISTORY RESEND/)(
+    "a receiver that lost its data gets the source history automatically re-sent",
+    async () => {
+      const streams = new Map<string, StreamDurableObject>();
+      const env = streamNamespace(streams);
+      const source = await bootStream({ path: "/", env, streams });
+      const firstReviewer = await bootStream({ path: "/reviewer", env, streams });
 
-    try {
-      source.stream.setCopySubscription({ configuration: reviewFeedConfiguration("/reviewer") });
-      source.stream.append({
-        type: "example.com/issue-created",
-        payload: { issue: "before-the-loss" },
-      });
-      source.stream.alarm();
-      await Promise.all([source.context.settle(), firstReviewer.context.settle()]);
-      expect(
-        firstReviewer.stream.getEvents({ eventTypes: ["example.com/issue-created"] }),
-      ).toHaveLength(1);
-
-      // Destroy and recreate the receiving stream: fresh storage, new stream
-      // lifetime, empty history.
-      const recreatedReviewer = await bootStream({ path: "/reviewer", env, streams });
       try {
+        source.stream.setCopySubscription({ configuration: reviewFeedConfiguration("/reviewer") });
         source.stream.append({
           type: "example.com/issue-created",
-          payload: { issue: "after-the-loss" },
+          payload: { issue: "before-the-loss" },
         });
         source.stream.alarm();
-        await Promise.all([source.context.settle(), recreatedReviewer.context.settle()]);
-
+        await Promise.all([source.context.settle(), firstReviewer.context.settle()]);
         expect(
-          recreatedReviewer.stream
-            .getEvents({ eventTypes: ["example.com/issue-created"] })
-            .map(({ payload }) => payload),
-        ).toEqual([{ issue: "before-the-loss" }, { issue: "after-the-loss" }]);
+          firstReviewer.stream.getEvents({ eventTypes: ["example.com/issue-created"] }),
+        ).toHaveLength(1);
+
+        // Destroy and recreate the receiving stream: fresh storage, new stream
+        // lifetime, empty history.
+        const recreatedReviewer = await bootStream({ path: "/reviewer", env, streams });
+        try {
+          source.stream.append({
+            type: "example.com/issue-created",
+            payload: { issue: "after-the-loss" },
+          });
+          source.stream.alarm();
+          await Promise.all([source.context.settle(), recreatedReviewer.context.settle()]);
+
+          expect(
+            recreatedReviewer.stream
+              .getEvents({ eventTypes: ["example.com/issue-created"] })
+              .map(({ payload }) => payload),
+            "NO AUTOMATIC HISTORY RESEND",
+          ).toEqual([{ issue: "before-the-loss" }, { issue: "after-the-loss" }]);
+        } finally {
+          recreatedReviewer.context.close();
+        }
       } finally {
-        recreatedReviewer.context.close();
+        firstReviewer.context.close();
+        source.context.close();
       }
-    } finally {
-      firstReviewer.context.close();
-      source.context.close();
-    }
-  });
+    },
+  );
 
   // GUARANTEE: the receiver can enumerate its inbound subscriptions before the
   //   first event arrives.
@@ -617,27 +656,31 @@ describe("guarantees the subscription rewrite deliberately does not give", () =>
   // BOUND: debug/introspection only — delivery itself never needed the record,
   //   and the source side lists the subscription immediately.
   // RESTORE: the deleted configure-time registration event on the receiver.
-  test.fails("the receiver can enumerate its inbound subscriptions before the first event arrives", async () => {
-    const streams = new Map<string, StreamDurableObject>();
-    const env = streamNamespace(streams);
-    const source = await bootStream({ path: "/", env, streams });
-    const reviewer = await bootStream({ path: "/reviewer", env, streams });
+  failing(test, /NO INBOUND ENUMERATION/)(
+    "the receiver can enumerate its inbound subscriptions before the first event arrives",
+    async () => {
+      const streams = new Map<string, StreamDurableObject>();
+      const env = streamNamespace(streams);
+      const source = await bootStream({ path: "/", env, streams });
+      const reviewer = await bootStream({ path: "/reviewer", env, streams });
 
-    try {
-      source.stream.setCopySubscription({ configuration: reviewFeedConfiguration("/reviewer") });
-      // Give the source every chance to tell the receiver: run a full delivery
-      // round. No event matches the filter, so no batch is sent.
-      source.stream.alarm();
-      await Promise.all([source.context.settle(), reviewer.context.settle()]);
+      try {
+        source.stream.setCopySubscription({ configuration: reviewFeedConfiguration("/reviewer") });
+        // Give the source every chance to tell the receiver: run a full delivery
+        // round. No event matches the filter, so no batch is sent.
+        source.stream.alarm();
+        await Promise.all([source.context.settle(), reviewer.context.settle()]);
 
-      expect(
-        reviewer.stream.runtimeState().coreProcessorState.subscriptions.inbound.bySourcePath["/"]?.[
-          "review-feed"
-        ],
-      ).toBeDefined();
-    } finally {
-      reviewer.context.close();
-      source.context.close();
-    }
-  });
+        expect(
+          reviewer.stream.runtimeState().coreProcessorState.subscriptions.inbound.bySourcePath[
+            "/"
+          ]?.["review-feed"],
+          "NO INBOUND ENUMERATION",
+        ).toBeDefined();
+      } finally {
+        reviewer.context.close();
+        source.context.close();
+      }
+    },
+  );
 });

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -552,7 +552,7 @@ fail("a userspace facet rebuilds on a source commit", { timeout: 240_000 }, asyn
 the "expected fail" summary count and telemetry's expected state need no
 extra plumbing. The wrapper filters WHICH failure satisfies that machinery:
 the body must fail matching the pattern. A different failure, a success, or
-a body still running after the wrapper's 60s deadline all come back as
+a body still running after the wrapper's 30s deadline all come back as
 "success", which the expected-fail machinery rejects — red, with the actual
 reason in the adjacent `[failing-test]` log line. (A bare `test.fails`
 stays silently green in all three cases.) A pin that legitimately runs

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -547,13 +547,19 @@ fail("a userspace facet rebuilds on a source commit", { timeout: 240_000 }, asyn
 });
 ```
 
-The body asserts the desired behavior and must fail with an error matching
-the pattern. A different failure goes red naming both errors (a bare
-`test.fails` stays silently green when the body starts failing for an
-unrelated reason), and a succeeding body goes red with delete-the-wrapper
-instructions. Write the body so the bug throws a distinctive message, and so
-conditions that prove nothing (a coincidental restart masking the bug for
-one observation) retry instead of succeeding —
+`failing` registers through the runner's own expected-fail variant
+(vitest `test.fails`, playwright `test.fail`), so pins report natively —
+the "expected fail" summary count and telemetry's expected state need no
+extra plumbing. The wrapper filters WHICH failure satisfies that machinery:
+the body must fail matching the pattern. A different failure, a success, or
+a body still running after the wrapper's 60s deadline all come back as
+"success", which the expected-fail machinery rejects — red, with the actual
+reason in the adjacent `[failing-test]` log line. (A bare `test.fails`
+stays silently green in all three cases.) A pin that legitimately runs
+longer raises the deadline via `options.timeoutMs`, kept below the runner's
+test timeout. Write the body so the bug throws a distinctive message, and
+so conditions that prove nothing (a coincidental restart masking the bug
+for one observation) retry instead of succeeding —
 `apps/os/e2e/vitest/userspace-facet-source-version.e2e.test.ts` is the
 worked example; its `test.fails` predecessor false-alarmed 7+ times.
 

--- a/packages/shared/src/test-support/e2e-policy/retry-telemetry-reporter.ts
+++ b/packages/shared/src/test-support/e2e-policy/retry-telemetry-reporter.ts
@@ -160,19 +160,6 @@ export class RetryTelemetryReporter {
     unhandledErrors: readonly unknown[] = [],
     reason?: "passed" | "interrupted" | "failed",
   ): Promise<void> {
-    // Policy gate, deliberately OUTSIDE the try below: the catch exists so a
-    // telemetry failure never breaks a test run, but this one must — a bare
-    // `test.fails` counts every throw as the expected one and stops pinning
-    // anything once its body fails for an unrelated reason.
-    for (const testModule of testModules) {
-      for (const test of testModule.children.allTests()) {
-        if (test.options?.fails) {
-          throw new Error(
-            `${test.fullName}: use the \`failing(test, /failure reason/)\` helper instead of bare \`test.fails\` — see docs/testing.md "Pinned bugs"`,
-          );
-        }
-      }
-    }
     try {
       const tests: TestTelemetryRecord[] = [];
       const modules: ModuleTelemetryRecord[] = [];
@@ -241,7 +228,9 @@ export class RetryTelemetryReporter {
               expectedState:
                 test.options.mode === "skip" || test.options.mode === "todo"
                   ? test.options.mode
-                  : "passed",
+                  : test.options.fails
+                    ? "failed"
+                    : "passed",
             }),
             ...(test.options?.timeout === undefined
               ? {}

--- a/packages/shared/src/test-support/e2e-policy/retry-telemetry-reporter.ts
+++ b/packages/shared/src/test-support/e2e-policy/retry-telemetry-reporter.ts
@@ -160,6 +160,19 @@ export class RetryTelemetryReporter {
     unhandledErrors: readonly unknown[] = [],
     reason?: "passed" | "interrupted" | "failed",
   ): Promise<void> {
+    // Policy gate, deliberately OUTSIDE the try below: the catch exists so a
+    // telemetry failure never breaks a test run, but this one must — a bare
+    // `test.fails` counts every throw as the expected one and stops pinning
+    // anything once its body fails for an unrelated reason.
+    for (const testModule of testModules) {
+      for (const test of testModule.children.allTests()) {
+        if (test.options?.fails) {
+          throw new Error(
+            `${test.fullName}: use the \`failing(test, /failure reason/)\` helper instead of bare \`test.fails\` — see docs/testing.md "Pinned bugs"`,
+          );
+        }
+      }
+    }
     try {
       const tests: TestTelemetryRecord[] = [];
       const modules: ModuleTelemetryRecord[] = [];
@@ -228,9 +241,7 @@ export class RetryTelemetryReporter {
               expectedState:
                 test.options.mode === "skip" || test.options.mode === "todo"
                   ? test.options.mode
-                  : test.options.fails
-                    ? "failed"
-                    : "passed",
+                  : "passed",
             }),
             ...(test.options?.timeout === undefined
               ? {}

--- a/packages/shared/src/test-support/failing-test.test.ts
+++ b/packages/shared/src/test-support/failing-test.test.ts
@@ -1,26 +1,34 @@
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { expectFailure, failing } from "./failing-test.ts";
 
-// The wrapper in real use, registered through vitest itself: this test is
-// green because its body throws the pinned error.
+// The wrapper in real use, registered through vitest itself: this lands on
+// vitest's native `test.fails`, so it reports in the "expected fail" summary
+// count, and it is green because its body throws the pinned error.
 const fail = failing(test, /foo bar exploded/);
 fail("a body failing for the pinned reason passes", async () => {
   throw new Error("boom: foo bar exploded (as pinned)");
 });
 
-test("options objects and body arguments pass through the wrapped test function", async () => {
+test("registration lands on the runner's own expected-fail variant", async () => {
   const registered: { args: unknown[]; body: (...bodyArgs: unknown[]) => Promise<unknown> }[] = [];
-  failing(
-    (...args: unknown[]) => registered.push({ args: args.slice(0, -1), body: args.at(-1) as any }),
-    /pinned/,
-  )("name", { timeout: 123 }, async (fixtures: any) => {
+  const plain = vi.fn();
+  const fakeVitest = Object.assign(plain, {
+    fails: (...args: unknown[]) =>
+      registered.push({ args: args.slice(0, -1), body: args.at(-1) as any }),
+  });
+
+  failing(fakeVitest, /pinned/)("name", { timeout: 123 }, async (fixtures: any) => {
     throw new Error(`pinned, saw fixture ${fixtures.page}`);
   });
 
+  // Registered through .fails, never through the plain test function — that is
+  // what makes the pin native to the runner's reporting (summary counts,
+  // telemetry expectedState).
+  expect(plain).not.toHaveBeenCalled();
   expect(registered).toMatchObject([{ args: ["name", { timeout: 123 }] }]);
-  // The wrapped body forwards playwright-style fixtures and passes when the
-  // pinned error is thrown.
-  await registered[0]!.body({ page: "fake-page" });
+  // The wrapped body forwards playwright-style fixtures, and a pinned throw
+  // passes through to satisfy the expected-fail machinery.
+  await expect(registered[0]!.body({ page: "fake-page" })).rejects.toThrow(/pinned/);
   // Runners discover fixtures by PARSING the test function's source for its
   // destructured first parameter — the wrapper must present the body's own
   // source or playwright/test.extend would instantiate no fixtures at all.
@@ -28,7 +36,83 @@ test("options objects and body arguments pass through the wrapped test function"
   expect(String(registered[0]!.body)).not.toContain("bodyArgs");
 });
 
-test("a body failing for a different reason fails, naming both errors", async () => {
+test("a playwright-shaped test object registers through .fail", async () => {
+  const registered: unknown[][] = [];
+  const fakePlaywright = Object.assign(vi.fn(), {
+    fail: (...args: unknown[]) => registered.push(args),
+  });
+  failing(fakePlaywright, /pinned/)("name", async () => {});
+  expect(registered).toHaveLength(1);
+});
+
+test("a body failing for a different reason returns success, so the native machinery goes red", async () => {
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  try {
+    const registered: ((...args: unknown[]) => Promise<unknown>)[] = [];
+    const fake = Object.assign(vi.fn(), {
+      fails: (...args: unknown[]) => registered.push(args.at(-1) as any),
+    });
+    failing(fake, /foo bar exploded/)("name", async () => {
+      throw new Error("ECONNREFUSED: the test infra broke");
+    });
+
+    // Resolving WITHOUT throwing is the inverted failure signal: test.fails /
+    // test.fail reject a successful body ("Expect test to fail" / "passed
+    // unexpectedly"), so the pin goes red — where a bare test.fails would have
+    // stayed silently green. The reason lives in the adjacent log line.
+    await expect(registered[0]!()).resolves.toBeUndefined();
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringMatching(/Expected failure to match \/foo bar exploded\//),
+      expect.objectContaining({ message: expect.stringContaining("ECONNREFUSED") }),
+    );
+  } finally {
+    consoleError.mockRestore();
+  }
+});
+
+test("a body that succeeds returns success with delete-the-wrapper instructions in the log", async () => {
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  try {
+    const registered: ((...args: unknown[]) => Promise<unknown>)[] = [];
+    const fake = Object.assign(vi.fn(), {
+      fails: (...args: unknown[]) => registered.push(args.at(-1) as any),
+    });
+    failing(fake, /foo bar exploded/)("name", async () => {
+      expect(1 + 1).toBe(2);
+    });
+
+    await expect(registered[0]!()).resolves.toBeUndefined();
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringMatching(/should have failed .* delete the failing\(\) wrapper/s),
+    );
+  } finally {
+    consoleError.mockRestore();
+  }
+});
+
+test("a hung body reports as not-the-pinned-failure at the wrapper's own deadline", async () => {
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  try {
+    const registered: ((...args: unknown[]) => Promise<unknown>)[] = [];
+    const fake = Object.assign(vi.fn(), {
+      fails: (...args: unknown[]) => registered.push(args.at(-1) as any),
+    });
+    failing(fake, /pinned/, { timeoutMs: 50 })("name", async () => new Promise(() => {}));
+
+    // Without the wrapper's own deadline this would ride to the RUNNER's test
+    // timeout, which the expected-fail machinery counts as the pin holding —
+    // the hang would pass vacuously.
+    await expect(registered[0]!()).resolves.toBeUndefined();
+    expect(consoleError).toHaveBeenCalledWith(expect.stringMatching(/still running after 50ms/));
+  } finally {
+    consoleError.mockRestore();
+  }
+});
+
+// expectFailure is the standalone assertion for use INSIDE a plain test,
+// where throwing (not inverted success) is the right failure signal.
+
+test("expectFailure: a different reason throws, naming both errors", async () => {
   await expect(
     expectFailure({ failure: /foo bar exploded/ }, async () => {
       throw new Error("ECONNREFUSED: the test infra broke");
@@ -36,7 +120,7 @@ test("a body failing for a different reason fails, naming both errors", async ()
   ).rejects.toThrow(/Expected failure to match \/foo bar exploded\/, got: .*ECONNREFUSED/);
 });
 
-test("a body that succeeds fails with delete-the-wrapper instructions", async () => {
+test("expectFailure: success throws with delete-the-wrapper instructions", async () => {
   await expect(
     expectFailure({ failure: /foo bar exploded/ }, async () => {
       expect(1 + 1).toBe(2);

--- a/packages/shared/src/test-support/failing-test.ts
+++ b/packages/shared/src/test-support/failing-test.ts
@@ -33,7 +33,7 @@
  * counts as the expected one. The wrapper therefore races the body against
  * its own 30s deadline and reports a timeout as NOT-the-pinned-failure (red),
  * so a hang cannot vanish into a vacuous pass. The default sits below every
- * lane's runner timeout (apps/os unit: 45s; e2e: 120s) — it must, or the
+ * test lane's runner timeout (apps/os unit: 45s; e2e: 120s) — it must, or the
  * runner fires first and the blind spot returns. A pin whose body
  * legitimately needs longer raises it via `options.timeoutMs`, still kept
  * BELOW the runner's own test timeout for the same reason.

--- a/packages/shared/src/test-support/failing-test.ts
+++ b/packages/shared/src/test-support/failing-test.ts
@@ -2,10 +2,12 @@
  * Pinned-bug tests: the body asserts the DESIRED behavior, and while the bug
  * exists it must fail with an error matching the given pattern.
  *
- * `failing` wraps any test-registering function — vitest's `test`,
- * playwright's `test`, their `.only`/`.skip` variants — and returns one with
- * the same shape, so fixtures, options objects, and timeouts pass straight
- * through:
+ * `failing` registers the test through the runner's own expected-fail variant
+ * — vitest spells it `test.fails`, playwright `test.fail` — so the pin is
+ * native as far as reporting goes: it shows up in the "expected fail" summary
+ * count, telemetry classifies it as expected-to-fail, and nothing downstream
+ * needs to know the wrapper exists. The wrapper's only job is filtering WHICH
+ * failure is allowed to satisfy that machinery:
  *
  * ```ts
  * const fail = failing(test, /SAME-BOOT STALENESS/);
@@ -15,13 +17,24 @@
  * ```
  *
  * Three outcomes:
- * - body fails matching the pattern → the test passes (the bug is still pinned)
- * - body fails with anything else → the test fails, naming both errors — this
- *   is what a bare `test.fails` cannot do: there, a body that starts failing
- *   for an unrelated reason (infra, typo) stays silently green and the pin
- *   stops pinning anything
- * - body succeeds → the test fails with instructions to delete the wrapper —
- *   the bug appears fixed, so the body should become a plain test
+ * - body fails matching the pattern → the error is rethrown, the runner's
+ *   expected-fail machinery is satisfied → green (the bug is still pinned)
+ * - body fails with anything else → the wrapper logs the mismatch and returns
+ *   SUCCESS, which the expected-fail machinery rejects → red. The runner's own
+ *   message is generic ("Expect test to fail" / "passed unexpectedly"); the
+ *   actual reason sits in the adjacent `[failing-test]` log line. A bare
+ *   `test.fails` would have stayed silently green here — that is the whole
+ *   point of the wrapper.
+ * - body succeeds → same mechanism: logged, returned, red — with instructions
+ *   to delete the wrapper, since the bug appears fixed.
+ *
+ * The native machinery has one blind spot: a failure that never passes
+ * through the body — chiefly a runner-level test timeout on a hung body —
+ * counts as the expected one. The wrapper therefore races the body against
+ * its own 60s deadline and reports a timeout as NOT-the-pinned-failure (red),
+ * so a hang cannot vanish into a vacuous pass. A pin whose body legitimately
+ * needs longer raises it via `options.timeoutMs` — kept BELOW the runner's
+ * own test timeout, or the runner fires first and the blind spot returns.
  *
  * Write the body so the pinned bug produces a DISTINCTIVE error (throw a
  * purpose-built message rather than relying on a generic assertion diff), and
@@ -29,12 +42,20 @@
  * masks the bug for one observation — retry or fail with a NON-matching
  * error instead of succeeding. See
  * apps/os/e2e/vitest/userspace-facet-source-version.e2e.test.ts for the
- * worked example (its predecessor `test.fails` false-alarmed 7+ times).
+ * worked example (its predecessor bare `test.fails` false-alarmed 7+ times).
  */
 export function failing<TestFn extends (...args: any[]) => any>(
   test: TestFn,
   failure: RegExp,
+  options?: { timeoutMs: number },
 ): TestFn {
+  const timeoutMs = options?.timeoutMs || 60_000;
+  const failer: unknown = "fails" in test ? test.fails : "fail" in test ? test.fail : undefined;
+  if (typeof failer !== "function") {
+    throw new Error(
+      "failing(test, pattern): test has neither .fails (vitest) nor .fail (playwright)",
+    );
+  }
   const register = (...args: any[]) => {
     const body = args.at(-1);
     if (typeof body !== "function") {
@@ -43,15 +64,54 @@ export function failing<TestFn extends (...args: any[]) => any>(
     // The body's own arguments pass through untouched — playwright fixtures
     // ({ page, ... }, testInfo), vitest context — whatever the wrapped test
     // function provides.
-    const wrapped = async (...bodyArgs: any[]) =>
-      expectFailure({ failure }, async () => await body(...bodyArgs));
+    const wrapped = async (...bodyArgs: any[]) => {
+      // Race the body against the wrapper's own deadline: a hung body must
+      // fail as NOT-the-pinned-failure rather than letting the runner's test
+      // timeout fire, which the expected-fail machinery would count as the
+      // pin holding.
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const outcome = await Promise.race([
+        (async () => body(...bodyArgs))().then(
+          () => ({ kind: "succeeded" as const }),
+          (error: unknown) => ({ kind: "failed" as const, error }),
+        ),
+        new Promise<{ kind: "timed-out" }>((resolve) => {
+          timer = setTimeout(() => resolve({ kind: "timed-out" }), timeoutMs);
+        }),
+      ]).finally(() => clearTimeout(timer));
+
+      if (outcome.kind === "failed") {
+        // The ONLY throw allowed out: the pinned failure, which satisfies the
+        // runner's expected-fail machinery.
+        if (failure.test(String(outcome.error))) throw outcome.error;
+        console.error(
+          `[failing-test] Expected failure to match /${failure.source}/, got a different failure — ` +
+            `this run proves nothing about the pinned bug:`,
+          outcome.error,
+        );
+        return; // "success" here is what makes test.fails / test.fail go red
+      }
+      if (outcome.kind === "timed-out") {
+        console.error(
+          `[failing-test] The body is still running after ${timeoutMs}ms — a hang is not the ` +
+            `pinned failure. Raise failing()'s options.timeoutMs (keeping it below the runner's ` +
+            `test timeout) if the pin legitimately needs longer.`,
+        );
+        return; // same inversion: success → the expected-fail machinery goes red
+      }
+      console.error(
+        `[failing-test] The test should have failed with /${failure.source}/ but it succeeded. ` +
+          `If the pinned bug is fixed, delete the failing() wrapper and keep the body as a plain test.`,
+      );
+      // Fall through to success for the same reason as above.
+    };
     // Playwright and vitest's test.extend decide WHICH fixtures to set up by
     // parsing the test function's source for its destructured first
     // parameter. A rest-args wrapper would hide the body's fixture names and
     // the runner would instantiate none of them — so present the body's own
     // source when the runner looks.
     Object.defineProperty(wrapped, "toString", { value: () => body.toString() });
-    return test(...args.slice(0, -1), wrapped);
+    return failer(...args.slice(0, -1), wrapped);
   };
   // The cast restates the contract the wrapper keeps by construction: it
   // forwards every argument unchanged except the trailing body, which it
@@ -62,7 +122,11 @@ export function failing<TestFn extends (...args: any[]) => any>(
   return register as TestFn;
 }
 
-/** The assertion core of {@link failing}, callable directly in unit tests. */
+/**
+ * Assert that a body fails for exactly the given reason — the standalone
+ * sibling of {@link failing} for use INSIDE a plain test, where throwing (not
+ * inverted success) is the right failure signal.
+ */
 export async function expectFailure(options: { failure: RegExp }, body: () => Promise<unknown>) {
   try {
     await body();

--- a/packages/shared/src/test-support/failing-test.ts
+++ b/packages/shared/src/test-support/failing-test.ts
@@ -31,10 +31,12 @@
  * The native machinery has one blind spot: a failure that never passes
  * through the body — chiefly a runner-level test timeout on a hung body —
  * counts as the expected one. The wrapper therefore races the body against
- * its own 60s deadline and reports a timeout as NOT-the-pinned-failure (red),
- * so a hang cannot vanish into a vacuous pass. A pin whose body legitimately
- * needs longer raises it via `options.timeoutMs` — kept BELOW the runner's
- * own test timeout, or the runner fires first and the blind spot returns.
+ * its own 30s deadline and reports a timeout as NOT-the-pinned-failure (red),
+ * so a hang cannot vanish into a vacuous pass. The default sits below every
+ * lane's runner timeout (apps/os unit: 45s; e2e: 120s) — it must, or the
+ * runner fires first and the blind spot returns. A pin whose body
+ * legitimately needs longer raises it via `options.timeoutMs`, still kept
+ * BELOW the runner's own test timeout for the same reason.
  *
  * Write the body so the pinned bug produces a DISTINCTIVE error (throw a
  * purpose-built message rather than relying on a generic assertion diff), and
@@ -49,7 +51,7 @@ export function failing<TestFn extends (...args: any[]) => any>(
   failure: RegExp,
   options?: { timeoutMs: number },
 ): TestFn {
-  const timeoutMs = options?.timeoutMs || 60_000;
+  const timeoutMs = options?.timeoutMs || 30_000;
   const failer: unknown = "fails" in test ? test.fails : "fail" in test ? test.fail : undefined;
   if (typeof failer !== "function") {
     throw new Error(
@@ -70,6 +72,9 @@ export function failing<TestFn extends (...args: any[]) => any>(
       // timeout fire, which the expected-fail machinery would count as the
       // pin holding.
       let timer: ReturnType<typeof setTimeout> | undefined;
+      // `as const` on the kinds: without it each arm's `kind` widens to
+      // `string`, the union stops discriminating, and `outcome.kind ===
+      // "failed"` below would not narrow to expose `.error`.
       const outcome = await Promise.race([
         (async () => body(...bodyArgs))().then(
           () => ({ kind: "succeeded" as const }),


### PR DESCRIPTION
`docs/testing.md` has mandated `failing(test, /pattern/)` over bare `test.fails` since the source-version pin false-alarmed 7+ times — but only that one pin had actually adopted it. The other **14 pins across 5 files** were still bare. This converts them.

## Why it matters

A bare `test.fails` counts **every** throw as the expected one. Once a pin's body starts failing for an unrelated reason it stays silently green and pins nothing. `failing()` requires the failure to match a pattern — anything else goes red.

This isn't theoretical. While converting, running one pin without doppler produced:

```
Error: Expected failure to match /CONCURRENT CREATE SPLITS IDENTITY/,
  got: Error: itx e2e needs APP_CONFIG_ADMIN_API_SECRET (run under doppler).
```

Under the bare form that missing-env error would have counted as the expected failure and the pin would have gone green having tested nothing.

## The part that wasn't mechanical

All 14 failed with **generic assertion diffs** — four of them the identical `expected "vi.fn()" to be called once, but got 0 times` across two different files. No useful regex distinguishes those, so a mechanical wrap would have produced pins that match almost any accidental failure.

Each pin's assertion now carries a distinctive tag as its message, and the wrapper matches that tag:

```ts
failing(test, /NO GLOBAL APPEND ORDER/)(
  "events from two source streams arrive at a shared receiver in global append order",
  async () => {
    // …
    expect(delivered, "NO GLOBAL APPEND ORDER").toEqual([{ appended: "first" }, …]);
  },
);
```

Converted: `guarantees-not-given` (7), `scheduler-rpc-ownership` (3), `artifact-rpc-ownership` (2), `project-create-concurrency` (1), `userspace-facet-recycle-false-alarm` (1).

`userspace-facet-recycle-false-alarm` is the pointed one. It is an essay about how a bare `test.fails` hides whether the pinned thing actually happened — *"three runs of this test 'passed' while never reaching the assertion at all"* — and was itself still bare. Its comments are corrected to describe what the wrapper now guarantees, keeping the phase-log reasoning that is still true.

## Risk map

**Riskiest: choosing the right tag per pin.** The tag is attached to the assertion that fails *today*. If a pin later fails at a **different** assertion in the same body, it goes red — that is the intended behaviour, not a regression, but it will look like a new failure to whoever hits it. The error message names both errors, so the reason is legible.

Where several assertions express the same pinned guarantee (the two `artifact-rpc` handle-disposal ones) they share a tag, so either failing keeps the pin green. Where the guarantees are genuinely distinct (the three scheduler pins, which happen to fail on the same line today) the tags differ, so a failure that moves between them is reported rather than absorbed.

**On merge:** no product code changes. The reported counts change — `apps/os` goes from `3026 passed | 12 expected fail` to `3043 passed`, the same tests now reporting as real passes. Anything keyed on the expected-fail count will see it drop to zero.

**Review order:** `guarantees-not-given.test.ts` (7 pins + header rewrite) → `userspace-facet-recycle-false-alarm.e2e.test.ts` (comment corrections) → the three small files (mechanical).

## Verification

- [x] Every pin still holds for its own reason — full unit suite green, both e2e pins run against local dev under doppler
- [x] The recycle pin's run reached `verdict` — per that file's own rule, the proof a run measured something rather than falling over early
- [x] **Negative check**: deliberately mismatching one tag goes red as intended — `Expected failure to match /THIS TAG WILL NOT MATCH/, got: AssertionError: NO GLOBAL APPEND ORDER: expected …`
- [x] `typecheck` / `lint` / `knip` / `format` / `test`

## Redesigned mid-review: ride the native expected-fail machinery

The first version of the wrapper registered pins as plain tests and asserted the failure itself — perfect diagnostics, but **invisible to reporting**: the `N expected fail` summary line disappeared and telemetry's `expectedState` classified every pin as an ordinary pass.

The wrapper now registers through the runner's own expected-fail variant (vitest `test.fails`, playwright `test.fail`) and only filters **which** failure satisfies it:

- body fails **matching the pattern** → rethrown → native expected-fail satisfied → green
- body fails with **anything else**, **succeeds**, or is **still running after the wrapper's own 60s deadline** → the wrapper returns "success", which the native machinery rejects → red, with the actual reason in an adjacent `[failing-test]` log line

That restores `3031 passed | 12 expected fail` in apps/os and telemetry's `expected_state` for free — no reporter changes, no annotation plumbing.

The 60s inner deadline (overridable via `options.timeoutMs`, kept below the runner's test timeout) closes the native machinery's one blind spot: a runner-level timeout never passes through the body, so a hung pin would count as expectedly-failed and pass vacuously. The two long e2e pins set explicit overrides (230s/240s and 170s/180s).

Accepted trade-off: mismatch diagnostics move from the failure message to a console line next to the runner's generic `Expect test to fail` — under `test.fails`, throwing anything would read as the pin holding, so logs are the only side channel.

One observed consequence, working as designed: in a local batch run the concurrency pin went red 3ms after the recycle pin's deliberate `stream.kill()` churn — an infra error a bare `test.fails` would have absorbed as green. It passes alone; the e2e lane's retry layer absorbs one-off blips in CI.

## One thing left alone

`packages/shared/src/test-support/e2e-policy/retry-telemetry-reporter.ts` reads `test.options.fails` to classify a test's expected state. With no bare `test.fails` left in the repo that branch no longer fires, but it reads vitest's own runner API defensively rather than being dead code introduced here, so it stays. (A commit briefly turned it into a throw-on-sight enforcement gate; reverted — a telemetry reporter is the wrong layer for policy, and it only covers runs wired with the reporter. If enforcement is ever wanted, a custom oxlint rule is the right home.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to pinned-bug harnesses and documentation; product code is untouched aside from test expectations and reporting semantics.
> 
> **Overview**
> **Migrates remaining bare `test.fails` pins** to the shared `failing(test, /TAG/)` helper and **extends that helper** so pins stay visible in Vitest/Playwright “expected fail” reporting while only regex-matched failures count as the pinned bug.
> 
> The `failing()` wrapper now registers via `test.fails` / `test.fail`, rethrows matching errors, and otherwise returns success so the runner goes red (with `[failing-test]` console detail). It also races the body against an optional `timeoutMs` (default 30s; long e2e pins use 170s/230s) so hangs do not vacuously pass on runner timeout. Assertions in migrated tests gain **distinctive message tags** (e.g. `NO ATOMIC UNSUBSCRIBE`, `SCHEDULER RESULT NOT DISPOSED`) so generic assertion diffs are not mistaken for the intended failure.
> 
> Touches **14 pins** across stream guarantees, scheduler/artifact RPC ownership, project-create concurrency, and userspace facet e2e tests, plus **`docs/testing.md`** and expanded **`failing-test` unit tests**. No production runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0e647d919e61fc42c94b56f2d059bc5e4ae8248. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-28T18:38:40.649Z",
      "deployedAt": "2026-08-28T17:19:17.566Z",
      "headSha": "e0e647d919e61fc42c94b56f2d059bc5e4ae8248",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/272795067589038",
      "shortSha": "e0e647d",
      "cleanupDurationMs": 18470,
      "deployDurationMs": 61138,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 59478,
      "deployReadinessDurationMs": 1658,
      "deployedWorkerName": "os-preview-1",
      "deployedWorkerVersion": "ea30513f-fbcb-455e-b710-4eba3c9edc7f",
      "testDurationMs": 302096,
      "testRetries": "4 retried: the source-version pin tells a facet that recycled from one the commit rebuilt (vitest x1) · a userspace facet rebuilds on a source commit and only on a source commit (vitest x1) · agent-script-reuse.spec.ts › run() return values are typed from the reused row's data, through the real gate › web (playwright x1) — TimeoutError: locator.waitFor: Timeout 1ms exceeded. Call log: \u001b[2m - waiting for getByText('factors of 8633: 89 × 97') to be visible\u001b[22m \u001b[33m If this is a slow operation, update the product code to add a spinner while it's running. This will improve the user experience and buy you more time fo... · create-project.spec.ts › the config template opens a proactive onboarding conversation for a new project › web (playwright x1) — TimeoutError: locator.waitFor: Timeout 90000ms exceeded. Call log: \u001b[2m - waiting for getByPlaceholder('Message this agent') to be visible\u001b[22m",
      "workerSizeKib": 20885.49,
      "workerGzipKib": 5263.06,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5274.4
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-28T18:38:26.106Z",
      "deployedAt": "2026-08-28T17:18:45.153Z",
      "headSha": "e0e647d919e61fc42c94b56f2d059bc5e4ae8248",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-1.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/272795067589038",
      "shortSha": "e0e647d",
      "cleanupDurationMs": 3924,
      "deployDurationMs": 28479,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 27061,
      "deployReadinessDurationMs": 1411,
      "deployedWorkerName": "docs-preview-1",
      "deployedWorkerVersion": "92b975d4-8d96-4c79-a4f0-86128bacf7bb",
      "testDurationMs": 3042,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-08-28T18:38:22.854Z",
      "deployedAt": "2026-08-28T17:18:52.765Z",
      "headSha": "e0e647d919e61fc42c94b56f2d059bc5e4ae8248",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/272795067589038",
      "shortSha": "e0e647d",
      "cleanupDurationMs": 671,
      "deployDurationMs": 34870,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 34672,
      "deployReadinessDurationMs": 192,
      "deployedWorkerName": "semaphore-preview-1",
      "deployedWorkerVersion": "a153b605-5ac3-4af7-99a7-cdd635029028",
      "testDurationMs": 75869,
      "testRetries": null,
      "workerSizeKib": 1915.87,
      "workerGzipKib": 441.25,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-28T18:38:27.154Z",
      "deployedAt": "2026-08-28T17:18:49.178Z",
      "headSha": "e0e647d919e61fc42c94b56f2d059bc5e4ae8248",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/272795067589038",
      "shortSha": "e0e647d",
      "cleanupDurationMs": 4969,
      "deployDurationMs": 31506,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 31084,
      "deployReadinessDurationMs": 415,
      "deployedWorkerName": "auth-preview-1",
      "deployedWorkerVersion": "9a1744b9-a34f-4cb6-b347-6430153c6070",
      "testDurationMs": 8908,
      "testRetries": null,
      "workerSizeKib": 3989.97,
      "workerGzipKib": 817.07,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-08-28T18:38:30.794Z",
      "deployedAt": "2026-08-28T17:18:42.491Z",
      "headSha": "e0e647d919e61fc42c94b56f2d059bc5e4ae8248",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/272795067589038",
      "shortSha": "e0e647d",
      "cleanupDurationMs": 8607,
      "deployDurationMs": 28736,
      "deployConfigDurationMs": 8,
      "deployCommandDurationMs": 24395,
      "deployReadinessDurationMs": 4333,
      "deployedWorkerName": "streams-example-app-preview-1",
      "deployedWorkerVersion": "1bf45ecf-8e7e-4251-bb6a-c462851ea921",
      "testDurationMs": 93969,
      "testRetries": null,
      "workerSizeKib": 5600.88,
      "workerGzipKib": 1585.1,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-28T18:38:23.935Z",
      "deployedAt": "2026-08-28T16:21:37.821Z",
      "headSha": "e0e647d919e61fc42c94b56f2d059bc5e4ae8248",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/272795067589038",
      "shortSha": "e0e647d",
      "cleanupDurationMs": 1081,
      "deployDurationMs": 61,
      "deployConfigDurationMs": 1,
      "deployReuseProofDurationMs": 56,
      "deployedWorkerName": "dummy-petshop-preview-1",
      "deployedWorkerVersion": "0c208159-a12c-4720-8da1-35823eb1b527",
      "testDurationMs": 7151,
      "testRetries": null,
      "workerSizeKib": 1115.4,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "b717e505c46472150438e97f994eb4a2c283e0f8+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `e0e647d` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 817.1 KiB | 31.5s | 8.9s |  | 5.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/272795067589038) | 2026-08-28T18:38:27.154Z | Preview app released. |
| Docs | released | `e0e647d` | [https://docs-preview-1.iterate-dev-preview.workers.dev](https://docs-preview-1.iterate-dev-preview.workers.dev) | 866.2 KiB | 28.5s | 3.0s |  | 3.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/272795067589038) | 2026-08-28T18:38:26.106Z | Preview app released. |
| Dummy Petshop | released | `e0e647d` | [https://dummy-petshop.iterate-preview-1.com](https://dummy-petshop.iterate-preview-1.com) | 198.3 KiB | 61ms | 7.2s |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/272795067589038) | 2026-08-28T18:38:23.935Z | Preview app released. |
| OS | released | `e0e647d` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 5.14 MiB (-11.3 KiB vs main) | 61.1s | 302.1s | 4 retried: the source-version pin tells a facet that recycled from one the commit rebuilt (vitest x1) · a userspace facet rebuilds on a source commit and only on a source commit (vitest x1) · agent-script-reuse.spec.ts › run() return values are typed from the reused row's data, through the real gate › web (playwright x1) — TimeoutError: locator.waitFor: Timeout 1ms exceeded. Call log: [2m - waiting for getByText('factors of 8633: 89 × 97') to be visible[22m [33m If this is a slow operation, update the product code to add a spinner while it's running. This will improve the user experience and buy you more time fo... · create-project.spec.ts › the config template opens a proactive onboarding conversation for a new project › web (playwright x1) — TimeoutError: locator.waitFor: Timeout 90000ms exceeded. Call log: [2m - waiting for getByPlaceholder('Message this agent') to be visible[22m | 18.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/272795067589038) | 2026-08-28T18:38:40.649Z | Preview app released. |
| Semaphore | released | `e0e647d` | [https://semaphore.iterate-preview-1.com](https://semaphore.iterate-preview-1.com) | 441.3 KiB | 34.9s | 75.9s |  | 671ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/272795067589038) | 2026-08-28T18:38:22.854Z | Preview app released. |
| Streams Example App | released | `e0e647d` | [https://streams.iterate-preview-1.com](https://streams.iterate-preview-1.com) | 1.55 MiB | 28.7s | 94.0s |  | 8.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/272795067589038) | 2026-08-28T18:38:30.794Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +85 -16 | +42 -3 🟩⬜⬜⬜⬜ |
| Tests | +589 -427 | +495 -369 🟩🟩🟩🟥🟥 |
| Docs | +13 -7 | +13 -7 🟩⬜⬜⬜⬜ |
| **Total** | **+687 -450** | **+550 -379** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 6f29833 and e0e647d, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->