### PR TITLE
Mobile: simplify phase icons — ellipsis for indeterminate, check on settled

### DIFF
--- a/apps/mobile/src/components/activity-card.tsx
+++ b/apps/mobile/src/components/activity-card.tsx
@@ -105,7 +105,20 @@ export function ActivityCard({
         ) : (
           <Text style={styles.chevron}>{expanded ? "▾" : "▸"}</Text>
         )}
-        {isLive ? <PhaseGlyph phase={liveStatus?.phase} /> : <View style={styles.phaseGlyphSlot} />}
+        {/* Settled cards wear a faint check in the same 14px slot — the turn
+            finished — in the chevron's muted color so it can't be confused
+            with the accent-colored approval check on the right. */}
+        {isLive ? (
+          <PhaseGlyph phase={liveStatus?.phase} />
+        ) : (
+          <Feather
+            accessibilityLabel="done"
+            color={colors.textFaint}
+            name="check"
+            size={12}
+            style={styles.rowIcon}
+          />
+        )}
         <Text style={styles.summary} numberOfLines={1}>
           {isLive ? liveSummary(activity, liveStatus) : summarizeActivity(activity)}
         </Text>
@@ -305,11 +318,12 @@ function PhaseGlyph({ phase }: { phase: AgentUiLiveStatus["phase"] | undefined }
   let icon: { name: ComponentProps<typeof Feather>["name"]; label: string };
   if (phase === "writing") icon = { name: "edit-2", label: "writing code" };
   else if (phase === "running") icon = { name: "play", label: "running code" };
-  else if (phase === "processing") icon = { name: "rotate-cw", label: "processing result" };
-  // Ellipsis for all three nothing-concrete-yet phases: the loader icon read
-  // as a second spinner next to the real one (a circle of dashes IS a
-  // spinner glyph), and thinking/working/waiting are the same visual promise
-  // — something's underway, nothing to show yet.
+  // Ellipsis for every phase without concrete progress to depict
+  // (processing/thinking/working/waiting): distinct icons here either read
+  // as a second spinner (loader is a circle of dashes) or a reload arrow
+  // (rotate-cw), and all four make the same visual promise — something's
+  // underway, nothing to show yet. Only the labels differ.
+  else if (phase === "processing") icon = { name: "more-horizontal", label: "processing result" };
   else if (phase === "thinking") icon = { name: "more-horizontal", label: "thinking" };
   else if (phase === "working") icon = { name: "more-horizontal", label: "working" };
   else icon = { name: "more-horizontal", label: "waiting for a response" };
@@ -759,7 +773,6 @@ const styles = StyleSheet.create({
   rowIcon: { width: 14, textAlign: "center", lineHeight: 18 },
   // The settled row's stand-in for the glyph: same 14px, keeps the summary
   // text in the exact place it held while live.
-  phaseGlyphSlot: { width: 14 },
   // The stock small spinner is 20px — taller than the chevron's line, which
   // made the LIVE card the bigger of the two. Scale it into the settled
   // card's 14px lead slot instead (layout box first, visual scale second).

--- a/apps/mobile/src/components/activity-card.tsx
+++ b/apps/mobile/src/components/activity-card.tsx
@@ -306,9 +306,13 @@ function PhaseGlyph({ phase }: { phase: AgentUiLiveStatus["phase"] | undefined }
   if (phase === "writing") icon = { name: "edit-2", label: "writing code" };
   else if (phase === "running") icon = { name: "play", label: "running code" };
   else if (phase === "processing") icon = { name: "rotate-cw", label: "processing result" };
+  // Ellipsis for all three nothing-concrete-yet phases: the loader icon read
+  // as a second spinner next to the real one (a circle of dashes IS a
+  // spinner glyph), and thinking/working/waiting are the same visual promise
+  // — something's underway, nothing to show yet.
   else if (phase === "thinking") icon = { name: "more-horizontal", label: "thinking" };
-  else if (phase === "working") icon = { name: "loader", label: "working" };
-  else icon = { name: "loader", label: "waiting for a response" };
+  else if (phase === "working") icon = { name: "more-horizontal", label: "working" };
+  else icon = { name: "more-horizontal", label: "waiting for a response" };
   return (
     <Feather
       accessibilityLabel={icon.label}


### PR DESCRIPTION
Icon-set simplification for the live activity card, from real-device review:

- Only concrete progress keeps a distinct icon: `edit-2` (writing code) and `play` (running code).
- Every indeterminate phase — processing / thinking / working / waiting — wears `more-horizontal` (ellipsis). The old distinct icons read wrong next to the spinner: `loader` is itself a spinner glyph, and `rotate-cw` reads as a reload arrow; all four phases make the same visual promise (something's underway, nothing to show yet), so only the accessible labels differ.
- Settled cards now fill the glyph slot with a faint `check` in the chevron's muted color — the turn finished — instead of an empty spacer. The accent-colored approval check on the row's right stays unmistakable.

Accessible labels are all unchanged, so no test coupling; `live-status.spec.ts` passes unchanged.

## Risk map

- Presentation-only changes inside `PhaseGlyph` and the settled branch of the summary row. The judgment calls: four phases sharing one icon (deliberate — same promise), and a muted vs accent check distinguishing "turn done" from "approval approved".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Session: 14b5556a-4238-462b-817c-f4b02b1c9911 — "Mobile live status icons"

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Mobile | +22 -5 | +16 -5 🟩🟩🟩🟩🟥 |
| **Total** | **+22 -5** | **+16 -5** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 46be4ce and 053b722, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-29T21:59:02.940Z",
      "deployedAt": "2026-08-29T21:25:48.529Z",
      "headSha": "053b722a75d783c7efab3fa7ab73b0280da02004",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/110638221737388",
      "shortSha": "053b722",
      "cleanupDurationMs": 12320,
      "deployDurationMs": 72065,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 70574,
      "deployReadinessDurationMs": 1488,
      "deployedWorkerName": "os-preview-6",
      "deployedWorkerVersion": "f3474787-ee6a-46f4-be86-ed0cabc125eb",
      "testDurationMs": 271839,
      "testRetries": "2 retried: the source-version pin tells a facet that recycled from one the commit rebuilt (vitest x1) · a userspace facet rebuilds on a source commit and only on a source commit (vitest x1)",
      "workerSizeKib": 20885.62,
      "workerGzipKib": 5263.09,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5274.38
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-29T21:58:53.819Z",
      "deployedAt": "2026-08-29T21:24:59.113Z",
      "headSha": "053b722a75d783c7efab3fa7ab73b0280da02004",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-6.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/110638221737388",
      "shortSha": "053b722",
      "cleanupDurationMs": 3196,
      "deployDurationMs": 21387,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 21157,
      "deployReadinessDurationMs": 227,
      "deployedWorkerName": "docs-preview-6",
      "deployedWorkerVersion": "99282411-4a3a-407d-bfc7-827d6bf2da1c",
      "testDurationMs": 2416,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-29T21:58:54.642Z",
      "deployedAt": "2026-08-29T21:25:20.510Z",
      "headSha": "053b722a75d783c7efab3fa7ab73b0280da02004",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/110638221737388",
      "shortSha": "053b722",
      "cleanupDurationMs": 4017,
      "deployDurationMs": 43098,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 42553,
      "deployReadinessDurationMs": 542,
      "deployedWorkerName": "auth-preview-6",
      "deployedWorkerVersion": "c843d614-7f53-484a-bcb1-ed0568dc8ee9",
      "testDurationMs": 17257,
      "testRetries": null,
      "workerSizeKib": 3989.97,
      "workerGzipKib": 817.29,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-29T21:58:51.946Z",
      "deployedAt": "2026-08-29T21:24:44.279Z",
      "headSha": "053b722a75d783c7efab3fa7ab73b0280da02004",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/110638221737388",
      "shortSha": "053b722",
      "cleanupDurationMs": 1317,
      "deployDurationMs": 6561,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 6288,
      "deployReadinessDurationMs": 234,
      "deployedWorkerName": "dummy-petshop-preview-6",
      "deployedWorkerVersion": "0f649336-f1c7-4837-b12e-639823a3735d",
      "testDurationMs": 26449,
      "testRetries": null,
      "workerSizeKib": 1115.4,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "b717e505c46472150438e97f994eb4a2c283e0f8+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `053b722` | [https://auth.iterate-preview-6.com](https://auth.iterate-preview-6.com) | 817.3 KiB | 43.1s | 17.3s |  | 4.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/110638221737388) | 2026-08-29T21:58:54.642Z | Preview app released. |
| Docs | released | `053b722` | [https://docs-preview-6.iterate-dev-preview.workers.dev](https://docs-preview-6.iterate-dev-preview.workers.dev) | 866.2 KiB | 21.4s | 2.4s |  | 3.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/110638221737388) | 2026-08-29T21:58:53.819Z | Preview app released. |
| Dummy Petshop | released | `053b722` | [https://dummy-petshop.iterate-preview-6.com](https://dummy-petshop.iterate-preview-6.com) | 198.3 KiB | 6.6s | 26.4s |  | 1.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/110638221737388) | 2026-08-29T21:58:51.946Z | Preview app released. |
| OS | released | `053b722` | [https://os.iterate-preview-6.com](https://os.iterate-preview-6.com) | 5.14 MiB (-11.3 KiB vs main) | 72.1s | 271.8s | 2 retried: the source-version pin tells a facet that recycled from one the commit rebuilt (vitest x1) · a userspace facet rebuilds on a source commit and only on a source commit (vitest x1) | 12.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/110638221737388) | 2026-08-29T21:59:02.940Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only updates in the mobile activity card summary row; accessible labels are unchanged.
> 
> **Overview**
> **Live activity cards** now use a single **`more-horizontal`** (ellipsis) icon for every indeterminate phase—processing, thinking, working, and waiting—instead of mixed glyphs that looked like a second spinner or reload. **Writing** and **running** still use **`edit-2`** and **`play`**.
> 
> **Settled** summary rows replace the empty glyph spacer with a faint **`check`** in `textFaint`, signaling the turn finished without clashing with the accent approval check on the right. The unused **`phaseGlyphSlot`** style is removed; layout still uses the shared **`rowIcon`** slot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 053b722a75d783c7efab3fa7ab73b0280da02004. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->