### PR TITLE
Mobile: fix stale status when messages weave between rounds

### DIFF
--- a/apps/os/src/components/agent-ui-reducer.test.ts
+++ b/apps/os/src/components/agent-ui-reducer.test.ts
@@ -2163,3 +2163,105 @@ describe("live status derivation", () => {
     expect(resumed.paused).toBe(false);
   });
 });
+
+describe("summary updates racing settlement", () => {
+  const request = (offset: number) => ({
+    type: "events.iterate.com/agent/llm-request-requested",
+    offset,
+    payload: {},
+  });
+  const requestSettled2 = (requestOffset: number) => ({
+    type: "events.iterate.com/agent/llm-request-settled",
+    payload: { requestOffset, result: { status: "succeeded", text: "await work()" } },
+  });
+  const scriptRequested2 = (executionId: string) => ({
+    type: "events.iterate.com/capability-host/script-run-requested",
+    payload: { executionId, code: "await work()", expiresAt: SCRIPT_EXPIRES_AT },
+  });
+
+  test("a status append that lands just after the deferred-flush settle still reaches the card", () => {
+    // The on-device weave: the script batches its status append with a
+    // sendMessage and a value-less return via Promise.all, so the
+    // summary-updated event can journal AFTER script-run-settled — which
+    // already settled the activity to flush the deferred reply. The late
+    // status must still land on the just-settled card (re-emitted as a
+    // same-id correction), not evaporate.
+    const state = reduceAll([
+      request(5),
+      requestSettled2(5),
+      scriptRequested2("x1"),
+      {
+        type: "events.iterate.com/agents/web-message-sent",
+        payload: { message: "All done." },
+      },
+      {
+        type: "events.iterate.com/capability-host/script-run-settled",
+        payload: { executionId: "x1", settlement: { status: "succeeded" } },
+      },
+      {
+        type: "events.iterate.com/agent/summary-updated",
+        payload: { activity: "Extracting the voice brief" },
+      },
+    ]);
+    expect(state.live).toBeNull();
+    const activities = state.items.filter((item) => item.kind === "activity");
+    expect(activities.at(-1)).toMatchObject({
+      status: "done",
+      steps: [{ kind: "llm" }, { kind: "code", activitySummary: "Extracting the voice brief" }],
+    });
+  });
+
+  test("a status append during the processing gap reaches the settled step", () => {
+    // Between a value-returning script settling and the next request
+    // journaling, the activity is live but nothing runs — a status append
+    // here previously stamped nothing.
+    const state = reduceAll([
+      request(5),
+      requestSettled2(5),
+      scriptRequested2("x1"),
+      {
+        type: "events.iterate.com/capability-host/script-run-settled",
+        payload: { executionId: "x1", settlement: { status: "succeeded", result: 42 } },
+      },
+      {
+        type: "events.iterate.com/agent/summary-updated",
+        payload: { activity: "Extracting the voice brief" },
+      },
+    ]);
+    expect(state.live?.steps.at(-1)).toMatchObject({
+      kind: "code",
+      status: "done",
+      activitySummary: "Extracting the voice brief",
+    });
+  });
+
+  test("the correction window closes at the next turn: a later status leaves old cards alone", () => {
+    const state = reduceAll([
+      request(5),
+      requestSettled2(5),
+      scriptRequested2("x1"),
+      {
+        type: "events.iterate.com/agents/web-message-sent",
+        payload: { message: "All done." },
+      },
+      {
+        type: "events.iterate.com/capability-host/script-run-settled",
+        payload: { executionId: "x1", settlement: { status: "succeeded" } },
+      },
+      // The next turn begins…
+      {
+        type: "events.iterate.com/agents/context-added",
+        payload: { role: "user", actor: { type: "user", origin: "web" }, content: "next" },
+      },
+      // …so this status belongs to the NEW turn, not the settled card.
+      {
+        type: "events.iterate.com/agent/summary-updated",
+        payload: { activity: "A totally different job" },
+      },
+    ]);
+    const activities = state.items.filter((item) => item.kind === "activity");
+    expect(activities.at(-1)!.steps.at(-1)).not.toMatchObject({
+      activitySummary: "A totally different job",
+    });
+  });
+});

--- a/packages/ui/src/components/events/agent-ui-reducer.ts
+++ b/packages/ui/src/components/events/agent-ui-reducer.ts
@@ -443,6 +443,11 @@ export type AgentUiState = {
    * to tell a this-turn status from stale previous-turn text (code steps
    * inherit `summaryActivity` at birth regardless of age). */
   summaryActivityUpdatedAtMs: number | null;
+  /** The most recently settled activity, correctable until the next turn
+   * begins: a status append can journal moments AFTER the script settle
+   * that flushed the turn (the script batches its append with sendMessage
+   * and its return), and it still describes the just-finished card. */
+  correctableActivity: AgentUiActivity | null;
   /** The stream/agent is paused (agent/paused or stream/paused, uncleared by
    * a resume). A paused loop owes no follow-up round, so the "processing"
    * inference must not claim one. */
@@ -572,6 +577,7 @@ export const AgentUiStateSchema = z
     provisionalActivities: z.record(z.string(), AgentUiActivitySchema),
     summaryActivity: z.string().nullable(),
     summaryActivityUpdatedAtMs: z.number().finite().nullable(),
+    correctableActivity: AgentUiActivitySchema.nullable(),
     paused: z.boolean(),
   })
   .superRefine((state, context) => {
@@ -613,6 +619,7 @@ export function initialAgentUiState(): AgentUiState {
     provisionalActivities: {},
     summaryActivity: null,
     summaryActivityUpdatedAtMs: null,
+    correctableActivity: null,
     paused: false,
   };
 }
@@ -859,7 +866,11 @@ function reduceAgentUiEvent(
         responseWindows: [],
         startedAtMs: timestampMs,
       };
-      return { ...ready, live: { ...live, steps: [...live.steps, step] } };
+      return {
+        ...ready,
+        correctableActivity: null,
+        live: { ...live, steps: [...live.steps, step] },
+      };
     }
 
     case AGENT_LLM_RESPONSE_CHUNKS: {
@@ -976,7 +987,11 @@ function reduceAgentUiEvent(
         // inferred (deadline/idle) closes carry it — not only durable settles.
         ...(state.summaryActivity == null ? {} : { activitySummary: state.summaryActivity }),
       };
-      return { ...interpretedState, live: { ...live, steps: [...live.steps, step] } };
+      return {
+        ...interpretedState,
+        correctableActivity: null,
+        live: { ...live, steps: [...live.steps, step] },
+      };
     }
 
     case SCRIPT_EXECUTION_COMPLETED: {
@@ -1030,10 +1045,19 @@ function reduceAgentUiEvent(
       if (activity == null || activity === "") return state;
       // Summaries are usually appended by the running script itself, so the
       // running code step picks the new text up immediately (live rounds show
-      // it before the settle stamp lands).
+      // it before the settle stamp lands). With nothing running (the
+      // processing gap between a value-returning settle and the next
+      // request), the append still belongs to the last step — scripts batch
+      // their status append with other calls, so it can journal just after
+      // the settle.
       if (state.live != null) {
-        const steps = state.live.steps.map((step) =>
-          step.kind === "code" && step.status === "running"
+        const running = state.live.steps.some(
+          (step) => step.kind === "code" && step.status === "running",
+        );
+        const lastCodeIndex = state.live.steps.findLastIndex((step) => step.kind === "code");
+        const steps = state.live.steps.map((step, index) =>
+          step.kind === "code" &&
+          (step.status === "running" || (!running && index === lastCodeIndex))
             ? { ...step, activitySummary: activity }
             : step,
         );
@@ -1043,6 +1067,31 @@ function reduceAgentUiEvent(
           summaryActivityUpdatedAtMs: timestampMs,
           live: { ...state.live, steps },
         };
+      }
+      // No live activity: if the previous turn JUST settled (window closes
+      // when the next turn starts), this append raced that settle — the
+      // script fired it alongside the sendMessage/return that flushed the
+      // card. Re-emit the settled activity with the stamp; same id, so
+      // consumers replace the item rather than duplicate it.
+      const correctable = state.correctableActivity;
+      if (correctable !== null && correctable.steps.some((step) => step.kind === "code")) {
+        const lastCodeIndex = correctable.steps.findLastIndex((step) => step.kind === "code");
+        const corrected: AgentUiActivity = {
+          ...correctable,
+          steps: correctable.steps.map((step, index) =>
+            index === lastCodeIndex ? { ...step, activitySummary: activity } : step,
+          ),
+        };
+        return emitItem(
+          {
+            ...state,
+            summaryActivity: activity,
+            summaryActivityUpdatedAtMs: timestampMs,
+            correctableActivity: corrected,
+          },
+          items,
+          corrected,
+        );
       }
       return { ...state, summaryActivity: activity, summaryActivityUpdatedAtMs: timestampMs };
     }
@@ -1260,6 +1309,9 @@ function reduceAgentUiEvent(
 function ensureLive(state: AgentUiState, offset: number, startedAtMs: number): AgentUiActivity {
   // Multiple simultaneous steps render as one live activity.
   if (state.live != null) return { ...state.live, status: "running" };
+  // A new activity is a new turn-half: late status appends now belong here,
+  // so the previous card's correction window is over. (Callers spread the
+  // returned activity into state; the flag is cleared at the same moment.)
   return {
     kind: "activity",
     id: `activity-${offset}`,
@@ -1369,7 +1421,11 @@ function settleLive(state: AgentUiState, endedAtMs: number, items: AgentUiItem[]
       delete provisionalActivities[oldestId];
     }
   }
-  return emitItem({ ...state, live: null, provisionalActivities }, items, settled);
+  return emitItem(
+    { ...state, live: null, provisionalActivities, correctableActivity: settled },
+    items,
+    settled,
+  );
 }
 
 function flushQueuedUserMessages(state: AgentUiState, items: AgentUiItem[]): AgentUiState {
@@ -1407,7 +1463,9 @@ function emitUserMessageItem(
     return { ...settled, queuedUserMessages: [...settled.queuedUserMessages, item] };
   }
   const flushed = settled.live === null ? flushDeferredMessages(settled, items) : settled;
-  return emitItem(flushed, items, item);
+  // An emitted user message is the NEXT turn's input: any later status
+  // append describes that turn, not the settled card — window over.
+  return emitItem({ ...flushed, correctableActivity: null }, items, item);
 }
 
 /**

--- a/specs/mobile/interwoven-status.spec.ts
+++ b/specs/mobile/interwoven-status.spec.ts
@@ -1,0 +1,116 @@
+// Repro for the on-device stale-status bug (task
+// mobile-interwoven-status.md): a turn whose script sends a chat message
+// mid-turn AND returns a value splits into two activity cards with the
+// reply bubble between them (known behavior — the reducer settles the live
+// activity to flush the deferred bubble, and the next round's request
+// births a new card). The bug: the SECOND card keeps wearing round 1's
+// status even after its own script's first line set a new one.
+//
+//   user: "Inspect the refund API"
+//   round 1 <codemode: Inspecting the refund API>
+//     sendMessage("Checking that now.") + held GET /step-one + return value
+//   → reply bubble flushes, card 1 settles, card 2 is born
+//   round 2 <codemode: Extracting the voice brief>
+//     held GET /step-two, sendMessage("All done."), return
+//
+// The key assertion: while round 2's script runs, the LIVE card shows
+// round 2's status — not round 1's.
+
+import { expect } from "@playwright/test";
+import { withTunnel } from "../../apps/os/e2e/test-support/tunnel.ts";
+import { test } from "../test-support/test.ts";
+
+test("a mid-turn reply doesn't strand the next round on the previous status", async ({
+  page,
+  helpers,
+}) => {
+  await using fixture = await helpers.createMobileFixture("mobile-interwoven");
+
+  const stepOneHold = Promise.withResolvers<void>();
+  const stepTwoHold = Promise.withResolvers<void>();
+  await using api = await withTunnel({
+    async fetch(request) {
+      const url = new URL(request.url);
+      if (url.pathname.endsWith("/step-one")) {
+        await stepOneHold.promise;
+        return Response.json({ found: true });
+      }
+      if (url.pathname.endsWith("/step-two")) {
+        await stepTwoHold.promise;
+        return Response.json({ brief: "the voice brief" });
+      }
+      return Response.json({ error: "unknown endpoint" }, { status: 404 });
+    },
+  });
+
+  const agent = await fixture.createAgent({
+    // big debounce so the between-rounds windows are observable
+    llmRequestDebounceMs: 4_000,
+  });
+  await page.goto(agent.mobileUrl);
+
+  // Round 1: status, the mid-turn reply (the weave), a held fetch, and a
+  // returned value — the promise of another round.
+  agent.responses.setOnce(`
+    async (itx) => {
+      await itx.agent.append({
+        type: "events.iterate.com/agent/summary-updated",
+        payload: { title: "Refund API check", activity: "Inspecting the refund API" },
+      });
+      await itx.chat.sendMessage("Checking that now.");
+      const response = await fetch(${JSON.stringify(api.url + "/step-one")});
+      return await response.json();
+    }
+  `);
+  // Round 2: a NEW status on its first line, then a held fetch, a final
+  // reply, and no return — turn over.
+  agent.responses.set(`
+    async (itx) => {
+      await itx.agent.append({
+        type: "events.iterate.com/agent/summary-updated",
+        payload: { activity: "Extracting the voice brief" },
+      });
+      const response = await fetch(${JSON.stringify(api.url + "/step-two")});
+      await itx.chat.sendMessage("All done.");
+      return;
+    }
+  `);
+
+  // insertText, not fill: RN-web's controlled multiline TextInput
+  // intermittently fails fill's post-check (see approvals.spec.ts).
+  await page.getByPlaceholder("Message").click();
+  await page.keyboard.insertText("Inspect the refund API");
+  await page.getByRole("button", { name: "Send" }).click();
+
+  // ── Round 1 held mid-fetch: one live card wearing round 1's status.
+  const liveCard = page.getByTestId(/^activity-card-/).filter({ has: page.getByLabel("Loading") });
+  await liveCard.getByText("Inspecting the refund API").waitFor();
+  await liveCard.getByLabel("running code").waitFor();
+
+  // ── Release step one: the script settles WITH a value, which flushes the
+  // deferred reply and splits the turn — bubble between two cards.
+  stepOneHold.resolve();
+  await page.getByText("Checking that now.").waitFor();
+
+  // ── Round 2's script runs (held on step two). THE BUG: the live card kept
+  // showing "Inspecting the refund API" here. It must wear round 2's status
+  // once the script's first-line summary append folds (plus the 250ms
+  // display debounce, which the held fetch outlasts by design).
+  await liveCard.getByLabel("running code").waitFor();
+  await liveCard.getByText("Extracting the voice brief").waitFor();
+  // Pin the second card's identity now, for the post-settle header check.
+  // timeout: attribute read of rendered state, outside the spinner-waiter
+  const secondCardId = await liveCard.getAttribute("data-testid", { timeout: 10_000 });
+
+  // ── Release step two: the turn ends; the SECOND card settles into round
+  // 2's status, not round 1's.
+  stepTwoHold.resolve();
+  await page.getByText("All done.").waitFor();
+  const secondCard = page.getByTestId(secondCardId!);
+  await secondCard.getByLabel("Loading").waitFor({ state: "hidden" });
+  await secondCard.getByText("Extracting the voice brief", { exact: false }).waitFor();
+
+  // ── The weave itself: reply bubble between two settled cards (current,
+  // deliberate split behavior — this assertion documents it).
+  expect(await page.getByTestId(/^activity-card-/).count()).toBe(2);
+});

--- a/tasks/mobile-interwoven-status.md
+++ b/tasks/mobile-interwoven-status.md
@@ -1,0 +1,79 @@
+---
+status: in-progress
+size: medium
+branch: mobile-interwoven-status
+---
+
+# Mobile: stale status on cards when messages weave between rounds
+
+## Status summary
+
+Fleshed-out spec; repro first (worktreeify), then diagnose, then fix.
+
+## What (observed, Misha's phone 2026-08-30)
+
+A turn where a script sends a chat message mid-turn AND returns a value
+splits into two activity cards with the reply bubble between them (that part
+is known behavior: the reducer settles the live activity to flush the
+deferred bubble, and the next round's request births a new activity). The
+bug: **the second card wears the FIRST round's status** ("Inspecting PR
+2548 and its public prompt configuration") even though its own script's
+first line set a new one ("Found PR 2548; extracting its public voice
+brief") — the previous status hangs around too long.
+
+## Repro plan (deterministic, via the intercepted-model harness)
+
+New spec `specs/mobile/interwoven-status.spec.ts`, same skeleton as
+live-status.spec.ts (`createMobileFixture` + `createAgentHelper` +
+`withTunnel` holds):
+
+- Round 1 script: set status "Inspecting the refund API", `sendMessage`
+  a mid-turn reply, fetch a held endpoint, RETURN a value (the weave:
+  message + continued turn).
+- Round 2 script: first line sets status "Extracting the voice brief",
+  fetch a second held endpoint, then release and settle the turn.
+- Assertions:
+  - the reply bubble renders between two cards (current split behavior —
+    assert it as-is unless the fix changes it);
+  - while round 2 runs, the SECOND card's summary shows "Extracting the
+    voice brief" (this is the expected failure — it's expected to show
+    round 1's status);
+  - after settle, the second card's header shows round 2's status.
+
+## Hypotheses to check once the repro fails
+
+- Round-2's code step inherits `state.summaryActivity` at birth (deliberate,
+  for round headers) — is the round-2 `summary-updated` stamp being lost or
+  ordered after something that overwrites it?
+- `deriveAgentUiLiveStatus` gates statusText on
+  `summaryActivityUpdatedAtMs >= live.startedAtMs` — after the split, the
+  NEW activity's startedAtMs may be later than the round-2 status append
+  in some orderings (statusText rejected as "previous turn"), leaving the
+  fallback/settled label to surface the stale birth-inherited text.
+- The 250ms display debounce (`useDebouncedValue`) caches per item id —
+  the split means a NEW item id; check the cache isn't serving a stale
+  entry, and that `keepPreviousData` isn't holding the old text across the
+  card boundary.
+- Whether the split itself is the right behavior is EXPLICITLY out of
+  scope unless the status fix forces the question — one card per turn is a
+  bigger product decision for Misha.
+
+## Checklist
+
+- [ ] Failing-then-fixed spec `specs/mobile/interwoven-status.spec.ts`
+- [ ] Diagnose which fold/derivation serves the stale status
+- [ ] Fix (reducer/mobile-lib/presentation as the diagnosis dictates —
+      no new journal events)
+- [ ] Reducer/feed unit coverage for the weave ordering
+- [ ] Existing live-status + approvals specs stay green
+
+## Assumptions (Misha on phone)
+
+- "Status hangs around too long" = the second card showing round-1 text;
+  fix means round-2's status shows as soon as its summary-updated folds
+  (plus the standard 250ms display debounce).
+- Keep the two-card split as-is.
+
+## Implementation log
+
+(append as you go)

--- a/tasks/mobile-interwoven-status.md
+++ b/tasks/mobile-interwoven-status.md
@@ -8,7 +8,22 @@ branch: mobile-interwoven-status
 
 ## Status summary
 
-Fleshed-out spec; repro first (worktreeify), then diagnose, then fix.
+Done pending review. Root cause found and fixed in the reducer; pinned by
+three unit tests (the e2e weave spec documents the surrounding behavior
+but cannot force the racing ordering — it passed even pre-fix).
+
+**Root cause**: scripts batch their `summary-updated` append with
+`sendMessage` and their return (Promise.all), so the status event can
+journal just AFTER the script settle — and the settle had already flushed
+and settled the card (deferred-reply path). The fold only stamped RUNNING
+code steps, so the late status landed on nothing and the card kept its
+birth-inherited previous-round text forever.
+
+**Fix (agent-ui-reducer)**: a summary-updated with nothing running stamps
+the LAST code step of the live activity (the processing gap); with no live
+activity it corrects the just-settled card — `settleLive` records a
+`correctableActivity`, the correction re-emits the same-id item, and the
+window closes when the next turn begins (new request/script/user message).
 
 ## What (observed, Misha's phone 2026-08-30)
 
@@ -60,12 +75,14 @@ live-status.spec.ts (`createMobileFixture` + `createAgentHelper` +
 
 ## Checklist
 
-- [ ] Failing-then-fixed spec `specs/mobile/interwoven-status.spec.ts`
-- [ ] Diagnose which fold/derivation serves the stale status
-- [ ] Fix (reducer/mobile-lib/presentation as the diagnosis dictates —
-      no new journal events)
-- [ ] Reducer/feed unit coverage for the weave ordering
-- [ ] Existing live-status + approvals specs stay green
+- [x] Repro: reducer unit tests pin the racing orderings (post-settle
+      append, processing-gap append, window-close); e2e weave spec added
+      as the user-visible guard _(it cannot force the race — passed pre-fix)_
+- [x] Diagnosed: late summary-updated vs settle ordering (see summary)
+- [x] Fix in agent-ui-reducer: last-done-step stamp + correctableActivity
+      window _(no new journal events; one client-fold state field)_
+- [x] Reducer/feed unit coverage for the weave ordering
+- [x] Existing live-status spec green alongside the new weave spec
 
 ## Assumptions (Misha on phone)
 


### PR DESCRIPTION
Observed on a real device: a turn whose script sends a chat message mid-turn AND returns a value splits into two activity cards (known behavior — the reply bubble flushes between them), but the **second card wore the first round's status** even after its own script's first line set a new one.

## Root cause

Scripts batch their status append with other calls (`Promise.all([itx.agent.append({...summary-updated}), itx.chat.sendMessage(...)])` … `return`), so the `summary-updated` event can journal just **after** `script-run-settled` — and that settle had already settled the card to flush the deferred reply. The fold only stamped **running** code steps, so the late status landed on nothing and the card kept its birth-inherited previous-round text forever. Pinned by reducer unit tests reproducing the exact orderings (a deterministic e2e can't force the race — the honest-sequencing weave passed even pre-fix).

## Fix (packages/ui agent-ui-reducer — no new journal events)

- A `summary-updated` with nothing running stamps the live activity's **last** code step (covers the processing gap between a value-returning settle and the next request).
- With no live activity, the **just-settled card is corrected**: `settleLive` records a `correctableActivity`, the late status re-emits it as a same-id item (every consumer already replaces same-id items — the provisional-outcome correction uses the same channel), and the window closes the moment the next turn begins (new request, new script, or an emitted user message) so a genuinely-later status can never rewrite an old card.

## Testing

- Three reducer tests: post-settle append reaches the card; processing-gap append reaches the settled step; the window closes at the next turn.
- `specs/mobile/interwoven-status.spec.ts`: the full weave through the real UI — mid-turn reply bubble between two cards, each card wearing its own round's status live and settled (intercepted model + two held tunnel endpoints, all-UI waits).
- 277 os component/projector tests, mobile feed tests, live-status spec all green.

## Risk map

- The judgment call is the correction window: a post-settle `summary-updated` **rewrites the just-settled card's label**. Bounded to end at the next request/script/user-message, which is also semantically when a status stops describing the finished turn. Review `AGENT_SUMMARY_UPDATED` + `settleLive` + the three window-close sites.
- `AgentUiState` gained `correctableActivity`; the strict schema invalidates persisted web snapshots → one cold feed rebuild per client after deploy (established pattern).
- Suggested order: agent-ui-reducer.ts → reducer tests → interwoven-status.spec.ts.

Task file: `tasks/mobile-interwoven-status.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Session: 14b5556a-4238-462b-817c-f4b02b1c9911 — "Mobile live status icons"

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-30T13:45:49.274Z",
      "deployedAt": "2026-08-30T07:17:30.251Z",
      "headSha": "422d347b2fcdfe3d384849fcfc5bfac6e19289b1",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/510508149525313",
      "shortSha": "422d347",
      "cleanupDurationMs": 14337,
      "deployDurationMs": 76034,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 74938,
      "deployReadinessDurationMs": 1092,
      "deployedWorkerName": "os-preview-8",
      "deployedWorkerVersion": "9536df04-c65a-467b-9f7c-d5d2aff549f9",
      "testDurationMs": 260136,
      "testRetries": "2 retried: the source-version pin tells a facet that recycled from one the commit rebuilt (vitest x1) · a userspace facet rebuilds on a source commit and only on a source commit (vitest x1)",
      "workerSizeKib": 20885.7,
      "workerGzipKib": 5263.28,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5274.38
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-30T13:45:39.240Z",
      "deployedAt": "2026-08-30T07:16:36.739Z",
      "headSha": "422d347b2fcdfe3d384849fcfc5bfac6e19289b1",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-8.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/510508149525313",
      "shortSha": "422d347",
      "cleanupDurationMs": 4300,
      "deployDurationMs": 21626,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 21424,
      "deployReadinessDurationMs": 197,
      "deployedWorkerName": "docs-preview-8",
      "deployedWorkerVersion": "4f803b1f-4c10-489e-bab9-6ef976363cc6",
      "testDurationMs": 6270,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-08-30T13:45:38.084Z",
      "deployedAt": "2026-08-30T07:16:35.829Z",
      "headSha": "422d347b2fcdfe3d384849fcfc5bfac6e19289b1",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/510508149525313",
      "shortSha": "422d347",
      "cleanupDurationMs": 3143,
      "deployDurationMs": 20675,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 20513,
      "deployReadinessDurationMs": 157,
      "deployedWorkerName": "semaphore-preview-8",
      "deployedWorkerVersion": "7b61ee50-8778-46c4-b35d-c578a49e9290",
      "testDurationMs": 53023,
      "testRetries": null,
      "workerSizeKib": 1915.87,
      "workerGzipKib": 441.25,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-30T13:45:39.001Z",
      "deployedAt": "2026-08-30T07:16:45.023Z",
      "headSha": "422d347b2fcdfe3d384849fcfc5bfac6e19289b1",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/510508149525313",
      "shortSha": "422d347",
      "cleanupDurationMs": 4058,
      "deployDurationMs": 29982,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 29705,
      "deployReadinessDurationMs": 271,
      "deployedWorkerName": "auth-preview-8",
      "deployedWorkerVersion": "19a54387-ca3a-47a4-8305-c51c602c3cc4",
      "testDurationMs": 18673,
      "testRetries": null,
      "workerSizeKib": 3989.97,
      "workerGzipKib": 817.5,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-08-30T13:45:45.812Z",
      "deployedAt": "2026-08-30T07:16:42.612Z",
      "headSha": "422d347b2fcdfe3d384849fcfc5bfac6e19289b1",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/510508149525313",
      "shortSha": "422d347",
      "cleanupDurationMs": 10868,
      "deployDurationMs": 28280,
      "deployConfigDurationMs": 7,
      "deployCommandDurationMs": 27293,
      "deployReadinessDurationMs": 980,
      "deployedWorkerName": "streams-example-app-preview-8",
      "deployedWorkerVersion": "6ae05357-5ff7-4d7d-941f-df4966d37752",
      "testDurationMs": 71883,
      "testRetries": null,
      "workerSizeKib": 5600.88,
      "workerGzipKib": 1585.11,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-30T13:45:40.891Z",
      "deployedAt": "2026-08-30T07:16:44.415Z",
      "headSha": "422d347b2fcdfe3d384849fcfc5bfac6e19289b1",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/510508149525313",
      "shortSha": "422d347",
      "cleanupDurationMs": 2806,
      "deployDurationMs": 8713,
      "deployConfigDurationMs": 1,
      "deployCommandDurationMs": 8424,
      "deployReadinessDurationMs": 285,
      "deployedWorkerName": "dummy-petshop-preview-8",
      "deployedWorkerVersion": "74e04833-cb88-47f0-b9ac-929f92055b0d",
      "testDurationMs": 45849,
      "testRetries": null,
      "workerSizeKib": 1115.4,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "b717e505c46472150438e97f994eb4a2c283e0f8+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `422d347` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 817.5 KiB | 30.0s | 18.7s |  | 4.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/510508149525313) | 2026-08-30T13:45:39.001Z | Preview app released. |
| Docs | released | `422d347` | [https://docs-preview-8.iterate-dev-preview.workers.dev](https://docs-preview-8.iterate-dev-preview.workers.dev) | 866.2 KiB | 21.6s | 6.3s |  | 4.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/510508149525313) | 2026-08-30T13:45:39.240Z | Preview app released. |
| Dummy Petshop | released | `422d347` | [https://dummy-petshop.iterate-preview-8.com](https://dummy-petshop.iterate-preview-8.com) | 198.3 KiB | 8.7s | 45.8s |  | 2.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/510508149525313) | 2026-08-30T13:45:40.891Z | Preview app released. |
| OS | released | `422d347` | [https://os.iterate-preview-8.com](https://os.iterate-preview-8.com) | 5.14 MiB (-11.1 KiB vs main) | 76.0s | 260.1s | 2 retried: the source-version pin tells a facet that recycled from one the commit rebuilt (vitest x1) · a userspace facet rebuilds on a source commit and only on a source commit (vitest x1) | 14.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/510508149525313) | 2026-08-30T13:45:49.274Z | Preview app released. |
| Semaphore | released | `422d347` | [https://semaphore.iterate-preview-8.com](https://semaphore.iterate-preview-8.com) | 441.3 KiB | 20.7s | 53.0s |  | 3.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/510508149525313) | 2026-08-30T13:45:38.084Z | Preview app released. |
| Streams Example App | released | `422d347` | [https://streams.iterate-preview-8.com](https://streams.iterate-preview-8.com) | 1.55 MiB | 28.3s | 71.9s |  | 10.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/510508149525313) | 2026-08-30T13:45:45.812Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| UI components | +65 -7 | +60 -7 🟩🟩⬜⬜⬜ |
| Tests | +218 -0 | +139 -0 🟩🟩🟩🟩🟩 |
| Docs | +96 -0 | +78 -0 🟩🟩🟩⬜⬜ |
| **Total** | **+379 -7** | **+277 -7** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between d9ab24e and 422d347, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->