### PR TITLE
Mobile: install from our own page (itms-services)

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -110,8 +110,10 @@ on the PR — pick by what your phone already has:
 - **Full install** — the channel-stable interstitial
   `os.iterate.com/m/install/<channel>`, which resolves the channel's expected
   native build _at scan time_ from the CI-pushed snapshot (so a QR printed
-  three pushes ago still lands on the right build), links its EAS install
-  page, and keeps an **Open in app** tap for the post-install channel switch.
+  three pushes ago still lands on the right build), installs it in place via
+  an OS-served itms-services manifest (the EAS build page stays linked for
+  details, and as the fallback while a build compiles), and keeps an
+  **Open in app** tap for the post-install channel switch.
 
 Builds are shared across channels — one per runtime fingerprint, all plain
 `preview` profile. A JS-only PR triggers **no build** (its install QR

--- a/apps/os/src/domains/mobile/channel-status.test.ts
+++ b/apps/os/src/domains/mobile/channel-status.test.ts
@@ -256,6 +256,21 @@ test("the manifest plist names the app and its ipa, XML-escaped", async () => {
   expect(xml).toContain("<string>software-package</string>");
 });
 
+test("a null ipaUrl is rejected — writers must normalize EAS's null to an absent key", async () => {
+  // EAS reports applicationArchiveUrl: null (not absent) on in-progress
+  // builds; scripts/ci/mobile-preview.ts converts it to undefined so the key
+  // never reaches the wire. This pins the contract from the store's side.
+  const bucket = fakeBucket();
+  const response = await handleChannelStatusRequest({
+    bucket,
+    channel: "my-feature",
+    config: config(),
+    request: request("PUT", "my-feature", { body: { ...status, ipaUrl: null }, admin: true }),
+  });
+  expect(response.status).toBe(400);
+  expect(bucket.objects.size).toBe(0);
+});
+
 test("the manifest 404s without the itms fields or without a snapshot", async () => {
   const bucket = fakeBucket();
   bucket.objects.set(channelStatusKey("my-feature"), JSON.stringify(status));

--- a/apps/os/src/domains/mobile/channel-status.test.ts
+++ b/apps/os/src/domains/mobile/channel-status.test.ts
@@ -3,12 +3,14 @@ import { parseAppConfigFromEnv } from "@iterate-com/shared/config";
 import {
   channelStatusKey,
   handleChannelStatusRequest,
+  handleInstallManifestRequest,
   handleInstallPageRequest,
   type StatusBucket,
 } from "./channel-status.ts";
 import { AppConfig } from "~/config.ts";
 
 const ADMIN_SECRET = "channel-status-test-admin-secret";
+const ORIGIN = "https://os.example.test";
 
 const status = {
   channel: "my-feature",
@@ -119,7 +121,11 @@ test("an invalid channel name 404s before touching storage", async () => {
 test("the install page offers the snapshot's build and the open-in-app link, install first", async () => {
   const bucket = fakeBucket();
   bucket.objects.set(channelStatusKey("my-feature"), JSON.stringify(status));
-  const response = await handleInstallPageRequest({ bucket, channel: "my-feature" });
+  const response = await handleInstallPageRequest({
+    bucket,
+    origin: ORIGIN,
+    channel: "my-feature",
+  });
   const html = await response.text();
   expect(response.status).toBe(200);
   expect(html).toContain(status.installUrl);
@@ -136,14 +142,22 @@ test("the install page for a still-compiling build says so instead of promising 
     channelStatusKey("my-feature"),
     JSON.stringify({ ...status, buildFinished: false }),
   );
-  const response = await handleInstallPageRequest({ bucket, channel: "my-feature" });
+  const response = await handleInstallPageRequest({
+    bucket,
+    origin: ORIGIN,
+    channel: "my-feature",
+  });
   const html = await response.text();
   expect(html).toContain("still compiling");
   expect(html).not.toContain("Install this build");
 });
 
 test("the install page without a snapshot falls back to the EAS builds list", async () => {
-  const response = await handleInstallPageRequest({ bucket: fakeBucket(), channel: "mystery" });
+  const response = await handleInstallPageRequest({
+    bucket: fakeBucket(),
+    origin: ORIGIN,
+    channel: "mystery",
+  });
   const html = await response.text();
   expect(response.status).toBe(200);
   expect(html).toContain("https://expo.dev/accounts/mishanustom/projects/iterate/builds");
@@ -156,10 +170,99 @@ test("snapshot text is HTML-escaped on the install page", async () => {
     channelStatusKey("my-feature"),
     JSON.stringify({ ...status, message: `<script>alert("x")</script>` }),
   );
-  const response = await handleInstallPageRequest({ bucket, channel: "my-feature" });
+  const response = await handleInstallPageRequest({
+    bucket,
+    origin: ORIGIN,
+    channel: "my-feature",
+  });
   const html = await response.text();
   expect(html).not.toContain("<script>alert");
   expect(html).toContain("&lt;script&gt;");
+});
+
+test("a fully-stocked snapshot makes the install page install in place (itms-services)", async () => {
+  const bucket = fakeBucket();
+  bucket.objects.set(
+    channelStatusKey("my-feature"),
+    JSON.stringify({
+      ...status,
+      ipaUrl: "https://expo.dev/artifacts/eas/abc.ipa",
+      appVersion: "0.1.0",
+      bundleId: "com.iterate.mobile",
+    }),
+  );
+  const response = await handleInstallPageRequest({
+    bucket,
+    origin: ORIGIN,
+    channel: "my-feature",
+  });
+  const html = await response.text();
+  expect(html).toContain(
+    `itms-services://?action=download-manifest&amp;url=${encodeURIComponent(
+      `${ORIGIN}/m/install-manifest/my-feature`,
+    )}`,
+  );
+  // The expo.dev build page demotes to a details link, but stays reachable.
+  expect(html).toContain("Build details");
+  expect(html).toContain(status.installUrl);
+});
+
+test("an itms-less snapshot (pre-field, or build unfinished) keeps the build-page CTA", async () => {
+  const bucket = fakeBucket();
+  bucket.objects.set(channelStatusKey("my-feature"), JSON.stringify(status));
+  const withoutFields = await handleInstallPageRequest({
+    bucket,
+    origin: ORIGIN,
+    channel: "my-feature",
+  });
+  expect(await withoutFields.text()).not.toContain("itms-services");
+
+  bucket.objects.set(
+    channelStatusKey("my-feature"),
+    JSON.stringify({
+      ...status,
+      buildFinished: false,
+      ipaUrl: "https://expo.dev/artifacts/eas/abc.ipa",
+      appVersion: "0.1.0",
+      bundleId: "com.iterate.mobile",
+    }),
+  );
+  const unfinished = await handleInstallPageRequest({
+    bucket,
+    origin: ORIGIN,
+    channel: "my-feature",
+  });
+  expect(await unfinished.text()).not.toContain("itms-services");
+});
+
+test("the manifest plist names the app and its ipa, XML-escaped", async () => {
+  const bucket = fakeBucket();
+  bucket.objects.set(
+    channelStatusKey("my-feature"),
+    JSON.stringify({
+      ...status,
+      ipaUrl: "https://expo.dev/artifacts/eas/abc.ipa?a=1&b=2",
+      appVersion: "0.1.0",
+      bundleId: "com.iterate.mobile",
+    }),
+  );
+  const response = await handleInstallManifestRequest({ bucket, channel: "my-feature" });
+  const xml = await response.text();
+  expect(response.status).toBe(200);
+  expect(response.headers.get("content-type")).toContain("application/xml");
+  expect(xml).toContain("<string>https://expo.dev/artifacts/eas/abc.ipa?a=1&amp;b=2</string>");
+  expect(xml).toContain("<string>com.iterate.mobile</string>");
+  expect(xml).toContain("<string>0.1.0</string>");
+  expect(xml).toContain("<string>software-package</string>");
+});
+
+test("the manifest 404s without the itms fields or without a snapshot", async () => {
+  const bucket = fakeBucket();
+  bucket.objects.set(channelStatusKey("my-feature"), JSON.stringify(status));
+  const preItms = await handleInstallManifestRequest({ bucket, channel: "my-feature" });
+  expect(preItms.status).toBe(404);
+  const missing = await handleInstallManifestRequest({ bucket: fakeBucket(), channel: "ghost" });
+  expect(missing.status).toBe(404);
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/os/src/domains/mobile/channel-status.ts
+++ b/apps/os/src/domains/mobile/channel-status.ts
@@ -144,19 +144,44 @@ const EAS_BUILDS_LIST_URL = "https://expo.dev/accounts/mishanustom/projects/iter
 export async function handleInstallPageRequest(input: {
   bucket: StatusBucket;
   channel: string;
+  /** The deployment's own origin (from the request URL) — the itms manifest
+   * URL must point back at the same host that served this page. */
+  origin: string;
 }): Promise<Response> {
-  const { bucket, channel } = input;
+  const { bucket, channel, origin } = input;
   if (!CHANNEL_RE.test(channel)) return new Response("not found", { status: 404 });
   const status = await readChannelStatus(bucket, channel);
   const deepLink = `iterate://preview-channel/${channel}`;
+  // Install in place when the snapshot carries everything the manifest
+  // needs: iOS fetches /m/install-manifest/<channel> over https and installs
+  // to the home screen without ever leaving this page. Otherwise (build
+  // still compiling, or a pre-itms snapshot) the expo.dev build page — whose
+  // own Install tap is the same itms mechanism, minus the staying-here part
+  // — remains the way in.
+  const installable =
+    status !== null &&
+    status.buildFinished &&
+    status.ipaUrl &&
+    status.bundleId &&
+    status.appVersion;
+  const itmsHref = `itms-services://?action=download-manifest&amp;url=${encodeURIComponent(
+    `${origin}/m/install-manifest/${channel}`,
+  )}`;
 
   const buildBlock = status
     ? [
-        `<a class="cta" href="${escapeHtml(status.installUrl)}">${
-          status.buildFinished
-            ? "Install this build"
-            : "Open the build page (still compiling when last published — Install appears there when it finishes)"
-        }</a>`,
+        installable
+          ? `<a class="cta" href="${itmsHref}">Install this build</a>`
+          : `<a class="cta" href="${escapeHtml(status.installUrl)}">${
+              status.buildFinished
+                ? "Install this build"
+                : "Open the build page (still compiling when last published — Install appears there when it finishes)"
+            }</a>`,
+        ...(installable
+          ? [
+              `<p>Installs in place — watch your home screen. <a href="${escapeHtml(status.installUrl)}">Build details</a>.</p>`,
+            ]
+          : []),
         `<p>Runtime <code>${escapeHtml(status.runtimeVersion.slice(0, 9))}</code> · <code>${escapeHtml(
           status.commit.slice(0, 7),
         )}</code> ${escapeHtml(status.message)}</p>`,
@@ -194,5 +219,62 @@ export async function handleInstallPageRequest(input: {
 </html>`;
   return new Response(html, {
     headers: { "content-type": "text/html; charset=utf-8", "cache-control": "no-store" },
+  });
+}
+
+/**
+ * The itms-services manifest iOS fetches when the install page's button is
+ * tapped: a plist naming the app (bundle id + version) and where its .ipa
+ * lives (the stable expo.dev artifact URL from the snapshot). Must be https
+ * with an XML content type or iOS refuses ("cannot connect to <host>").
+ * 404 when the snapshot is missing or predates the itms fields — the page
+ * only renders the itms button when they're all present, so a 404 here
+ * means a snapshot changed between page load and tap.
+ */
+export async function handleInstallManifestRequest(input: {
+  bucket: StatusBucket;
+  channel: string;
+}): Promise<Response> {
+  const { bucket, channel } = input;
+  if (!CHANNEL_RE.test(channel)) return new Response("not found", { status: 404 });
+  const status = await readChannelStatus(bucket, channel);
+  if (status === null || !status.ipaUrl || !status.bundleId || !status.appVersion) {
+    return new Response("no installable manifest for this channel", { status: 404 });
+  }
+  // escapeHtml doubles as an XML escaper (&, <, >, ").
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>items</key>
+  <array>
+    <dict>
+      <key>assets</key>
+      <array>
+        <dict>
+          <key>kind</key>
+          <string>software-package</string>
+          <key>url</key>
+          <string>${escapeHtml(status.ipaUrl)}</string>
+        </dict>
+      </array>
+      <key>metadata</key>
+      <dict>
+        <key>bundle-identifier</key>
+        <string>${escapeHtml(status.bundleId)}</string>
+        <key>bundle-version</key>
+        <string>${escapeHtml(status.appVersion)}</string>
+        <key>kind</key>
+        <string>software</string>
+        <key>title</key>
+        <string>Iterate</string>
+      </dict>
+    </dict>
+  </array>
+</dict>
+</plist>
+`;
+  return new Response(xml, {
+    headers: { "content-type": "application/xml; charset=utf-8", "cache-control": "no-store" },
   });
 }

--- a/apps/os/src/routeTree.gen.ts
+++ b/apps/os/src/routeTree.gen.ts
@@ -32,6 +32,7 @@ import { Route as AdminStreamsIndexRouteImport } from './routes/admin/streams/in
 import { Route as AppProjectsIndexRouteImport } from './routes/_app/projects/index'
 import { Route as MPreviewChannelChannelRouteImport } from './routes/m.preview-channel.$channel'
 import { Route as MInstallChannelRouteImport } from './routes/m.install.$channel'
+import { Route as MInstallManifestChannelRouteImport } from './routes/m.install-manifest.$channel'
 import { Route as MChannelStatusChannelRouteImport } from './routes/m.channel-status.$channel'
 import { Route as AdminStreamsProjectIdRouteRouteImport } from './routes/admin/streams/$projectId/route'
 import { Route as AppProjectsProjectSlugRouteRouteImport } from './routes/_app/projects/$projectSlug/route'
@@ -174,6 +175,11 @@ const MPreviewChannelChannelRoute = MPreviewChannelChannelRouteImport.update({
 const MInstallChannelRoute = MInstallChannelRouteImport.update({
   id: '/m/install/$channel',
   path: '/m/install/$channel',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const MInstallManifestChannelRoute = MInstallManifestChannelRouteImport.update({
+  id: '/m/install-manifest/$channel',
+  path: '/m/install-manifest/$channel',
   getParentRoute: () => rootRouteImport,
 } as any)
 const MChannelStatusChannelRoute = MChannelStatusChannelRouteImport.update({
@@ -360,6 +366,7 @@ export interface FileRoutesByFullPath {
   '/projects/$projectSlug': typeof AppProjectsProjectSlugRouteRouteWithChildren
   '/admin/streams/$projectId': typeof AdminStreamsProjectIdRouteRouteWithChildren
   '/m/channel-status/$channel': typeof MChannelStatusChannelRoute
+  '/m/install-manifest/$channel': typeof MInstallManifestChannelRoute
   '/m/install/$channel': typeof MInstallChannelRoute
   '/m/preview-channel/$channel': typeof MPreviewChannelChannelRoute
   '/projects/': typeof AppProjectsIndexRoute
@@ -405,6 +412,7 @@ export interface FileRoutesByTo {
   '/admin': typeof AdminIndexRoute
   '/docs': typeof DocsIndexRoute
   '/m/channel-status/$channel': typeof MChannelStatusChannelRoute
+  '/m/install-manifest/$channel': typeof MInstallManifestChannelRoute
   '/m/install/$channel': typeof MInstallChannelRoute
   '/m/preview-channel/$channel': typeof MPreviewChannelChannelRoute
   '/projects': typeof AppProjectsIndexRoute
@@ -457,6 +465,7 @@ export interface FileRoutesById {
   '/_app/projects/$projectSlug': typeof AppProjectsProjectSlugRouteRouteWithChildren
   '/admin/streams/$projectId': typeof AdminStreamsProjectIdRouteRouteWithChildren
   '/m/channel-status/$channel': typeof MChannelStatusChannelRoute
+  '/m/install-manifest/$channel': typeof MInstallManifestChannelRoute
   '/m/install/$channel': typeof MInstallChannelRoute
   '/m/preview-channel/$channel': typeof MPreviewChannelChannelRoute
   '/_app/projects/': typeof AppProjectsIndexRoute
@@ -510,6 +519,7 @@ export interface FileRouteTypes {
     | '/projects/$projectSlug'
     | '/admin/streams/$projectId'
     | '/m/channel-status/$channel'
+    | '/m/install-manifest/$channel'
     | '/m/install/$channel'
     | '/m/preview-channel/$channel'
     | '/projects/'
@@ -555,6 +565,7 @@ export interface FileRouteTypes {
     | '/admin'
     | '/docs'
     | '/m/channel-status/$channel'
+    | '/m/install-manifest/$channel'
     | '/m/install/$channel'
     | '/m/preview-channel/$channel'
     | '/projects'
@@ -606,6 +617,7 @@ export interface FileRouteTypes {
     | '/_app/projects/$projectSlug'
     | '/admin/streams/$projectId'
     | '/m/channel-status/$channel'
+    | '/m/install-manifest/$channel'
     | '/m/install/$channel'
     | '/m/preview-channel/$channel'
     | '/_app/projects/'
@@ -650,6 +662,7 @@ export interface RootRouteChildren {
   SignInSplatRoute: typeof SignInSplatRoute
   SignUpSplatRoute: typeof SignUpSplatRoute
   MChannelStatusChannelRoute: typeof MChannelStatusChannelRoute
+  MInstallManifestChannelRoute: typeof MInstallManifestChannelRoute
   MInstallChannelRoute: typeof MInstallChannelRoute
   MPreviewChannelChannelRoute: typeof MPreviewChannelChannelRoute
 }
@@ -815,6 +828,13 @@ declare module '@tanstack/react-router' {
       path: '/m/install/$channel'
       fullPath: '/m/install/$channel'
       preLoaderRoute: typeof MInstallChannelRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/m/install-manifest/$channel': {
+      id: '/m/install-manifest/$channel'
+      path: '/m/install-manifest/$channel'
+      fullPath: '/m/install-manifest/$channel'
+      preLoaderRoute: typeof MInstallManifestChannelRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/m/channel-status/$channel': {
@@ -1199,6 +1219,7 @@ const rootRouteChildren: RootRouteChildren = {
   SignInSplatRoute: SignInSplatRoute,
   SignUpSplatRoute: SignUpSplatRoute,
   MChannelStatusChannelRoute: MChannelStatusChannelRoute,
+  MInstallManifestChannelRoute: MInstallManifestChannelRoute,
   MInstallChannelRoute: MInstallChannelRoute,
   MPreviewChannelChannelRoute: MPreviewChannelChannelRoute,
 }

--- a/apps/os/src/routes/m.install-manifest.$channel.ts
+++ b/apps/os/src/routes/m.install-manifest.$channel.ts
@@ -1,0 +1,18 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { handleInstallManifestRequest } from "../domains/mobile/channel-status.ts";
+import { itxEnv } from "../env.ts";
+
+/**
+ * The itms-services manifest behind /m/install/<channel>'s Install button:
+ * iOS fetches this plist and installs the channel's expected build to the
+ * home screen without leaving the page. Logic + tests:
+ * domains/mobile/channel-status.ts.
+ */
+export const Route = createFileRoute("/m/install-manifest/$channel")({
+  server: {
+    handlers: {
+      GET: ({ params }) =>
+        handleInstallManifestRequest({ bucket: itxEnv.FILES_BUCKET, channel: params.channel }),
+    },
+  },
+});

--- a/apps/os/src/routes/m.install.$channel.ts
+++ b/apps/os/src/routes/m.install.$channel.ts
@@ -11,8 +11,12 @@ import { itxEnv } from "../env.ts";
 export const Route = createFileRoute("/m/install/$channel")({
   server: {
     handlers: {
-      GET: ({ params }) =>
-        handleInstallPageRequest({ bucket: itxEnv.FILES_BUCKET, channel: params.channel }),
+      GET: ({ params, request }) =>
+        handleInstallPageRequest({
+          bucket: itxEnv.FILES_BUCKET,
+          channel: params.channel,
+          origin: new URL(request.url).origin,
+        }),
     },
   },
 });

--- a/explainers/mobile-install-state-matrix.html
+++ b/explainers/mobile-install-state-matrix.html
@@ -277,7 +277,9 @@
           <dt>install page</dt>
           <dd>
             <code>os.iterate.com/m/install/&lt;channel&gt;</code> — what install QRs encode.
-            Resolves the channel's expected build <i>at scan time</i> (never stale), and keeps an
+            Resolves the channel's expected build <i>at scan time</i> (never stale), installs it in
+            place (an OS-served itms-services manifest — no expo.dev hop; the build page stays
+            linked for details, and as the fallback while a build compiles), and keeps an
             <b>Open in app</b> link for the post-install switch.
           </dd>
         </dl>
@@ -379,10 +381,10 @@
               <details>
                 <summary>steps</summary>
                 <div>
-                  Install (the expo.dev tap fires a native install dialog — the app lands on the
-                  home screen in the background, Safari stays put; no callback, our page is one Back
-                  away) → <b>Open in app</b> → Switch to <code>pr-1234</code>. The confirm screen
-                  also offers the PR's preview backend + test sign-in (stamped into the bundle).
+                  Install (the tap fires the native install dialog right on our page — the app lands
+                  on your home screen while the page stays open) → <b>Open in app</b> → Switch to
+                  <code>pr-1234</code>. The confirm screen also offers the PR's preview backend +
+                  test sign-in (stamped into the bundle).
                 </div>
               </details>
             </td>

--- a/packages/shared/src/mobile-channel-status.ts
+++ b/packages/shared/src/mobile-channel-status.ts
@@ -29,6 +29,20 @@ export const MobileChannelStatus = z.object({
   message: z.string(),
   /** ISO timestamp of the publish that wrote this snapshot. */
   publishedAt: z.string(),
+  // The three fields below power the in-place itms-services install on the
+  // /m/install page. Optional — a deliberate exception to the
+  // no-optional-properties preference, because absence is a real state with
+  // one meaning ("fall back to linking the build page"): snapshots written
+  // before these fields existed, a freshly triggered build with no artifact
+  // yet, and PUTs through an older deployed worker whose zod strips unknown
+  // keys all land there.
+  /** The build's .ipa artifact (artifacts.applicationArchiveUrl) — a stable
+   * unsigned expo.dev URL, valid until the build's ~90-day expiry. */
+  ipaUrl: z.url().optional(),
+  /** app.json expo.version — the manifest's bundle-version. */
+  appVersion: z.string().optional(),
+  /** app.json expo.ios.bundleIdentifier — the manifest's bundle-identifier. */
+  bundleId: z.string().optional(),
 });
 
 export type MobileChannelStatus = z.infer<typeof MobileChannelStatus>;

--- a/scripts/ci/mobile-preview.ts
+++ b/scripts/ci/mobile-preview.ts
@@ -199,6 +199,9 @@ export type InstallBuild = {
    * exists but has nothing to install yet, and the section says so rather
    * than offering a link that dead-ends. */
   finished: boolean;
+  /** The .ipa artifact URL (stable, unsigned) — undefined until the build
+   * finishes; the install page falls back to the build-page link without it. */
+  ipaUrl: string | undefined;
 };
 
 /**
@@ -237,6 +240,7 @@ export const ensureBuildForRuntime = (input: { runtime: string }): InstallBuild 
     id: build.id,
     gitCommitHash: build.gitCommitHash,
     finished: build.status === "FINISHED",
+    ipaUrl: build.artifacts?.applicationArchiveUrl,
   };
 };
 

--- a/scripts/ci/mobile-preview.ts
+++ b/scripts/ci/mobile-preview.ts
@@ -240,7 +240,10 @@ export const ensureBuildForRuntime = (input: { runtime: string }): InstallBuild 
     id: build.id,
     gitCommitHash: build.gitCommitHash,
     finished: build.status === "FINISHED",
-    ipaUrl: build.artifacts?.applicationArchiveUrl,
+    // || undefined: EAS reports null (not absent) on in-progress builds, and
+    // the snapshot schema rejects null — undefined serializes to an absent
+    // key, which means "fall back to the build page".
+    ipaUrl: build.artifacts?.applicationArchiveUrl || undefined,
   };
 };
 

--- a/scripts/ci/publish-mobile-pr-preview.ts
+++ b/scripts/ci/publish-mobile-pr-preview.ts
@@ -138,6 +138,11 @@ async function publishMobilePrPreview() {
     commit: headSha,
     message,
     publishedAt: new Date().toISOString(),
+    // Powers the in-place itms-services install; absent until the build
+    // finishes (the next push then carries it).
+    ipaUrl: installBuild.ipaUrl,
+    appVersion: appConfig.expo.version,
+    bundleId: appConfig.expo.ios.bundleIdentifier,
   });
 
   const plan = planPreview({

--- a/scripts/ci/publish-mobile-update.ts
+++ b/scripts/ci/publish-mobile-update.ts
@@ -93,6 +93,11 @@ async function publishMobileUpdate() {
     commit: sha,
     message,
     publishedAt: new Date().toISOString(),
+    // Powers the in-place itms-services install; absent until the build
+    // finishes (the refresher fills it in then).
+    ipaUrl: installBuild.ipaUrl,
+    appVersion: appConfig.expo.version,
+    bundleId: appConfig.expo.ios.bundleIdentifier,
   });
 
   const plan = planPreview({

--- a/scripts/ci/refresh-mobile-main-qr.ts
+++ b/scripts/ci/refresh-mobile-main-qr.ts
@@ -57,7 +57,12 @@ async function refreshMobileMainQr() {
   // superseded this build's snapshot, which must not be regressed.
   const status = await fetchChannelStatus("preview");
   if (status !== null && status.buildId === build.id) {
-    await pushChannelStatus({ ...status, buildFinished: true });
+    await pushChannelStatus({
+      ...status,
+      buildFinished: true,
+      // The publish wrote no ipaUrl (the build hadn't finished); it has one now.
+      ipaUrl: build.artifacts?.applicationArchiveUrl || status.ipaUrl,
+    });
   } else {
     console.log(
       `snapshot now points at ${status?.buildId || "nothing"} (not ${build.id}) — leaving it`,

--- a/tasks/mobile-itms-install.md
+++ b/tasks/mobile-itms-install.md
@@ -9,9 +9,10 @@ base: mobile-native-build-economy (#2555)
 
 ## Status summary
 
-Spec committed first; implementation follows in this branch. One coherent
-change: the install page installs the app in place instead of bouncing
-through expo.dev.
+Implemented and green (typecheck/lint/knip/format, scripts 291, os 13 incl.
+6 new manifest/interstitial tests). Remaining: reapply onto main once #2555
+merges; a phone-scan sanity check of the itms dialog is the only thing CI
+can't prove.
 
 ## The problem
 
@@ -66,13 +67,13 @@ happens ON our page, with "Open in app" sitting right below it.
 
 ## Checklist
 
-- [ ] Schema: optional `ipaUrl`/`appVersion`/`bundleId` + comment on why
+- [x] Schema: optional `ipaUrl`/`appVersion`/`bundleId` + comment on why
       optional
-- [ ] `mobile-preview.ts`: `InstallBuild.ipaUrl`; writers pass
+- [x] `mobile-preview.ts`: `InstallBuild.ipaUrl`; writers pass
       ipaUrl/appVersion/bundleId; refresher upgrades ipaUrl when the build
       finishes
-- [ ] OS: `handleInstallManifestRequest` + thin route, plist rendering,
+- [x] OS: `handleInstallManifestRequest` + thin route, plist rendering,
       404s, tests (incl. XML escaping)
-- [ ] OS: interstitial itms CTA variant + demoted build-details link, tests
-- [ ] Explainer + README copy
-- [ ] Gauntlet: typecheck, lint, knip, format, scripts + os tests
+- [x] OS: interstitial itms CTA variant + demoted build-details link, tests
+- [x] Explainer + README copy
+- [x] Gauntlet: typecheck, lint, knip, format, scripts + os tests

--- a/tasks/mobile-itms-install.md
+++ b/tasks/mobile-itms-install.md
@@ -1,0 +1,78 @@
+---
+status: in-progress
+size: small
+branch: mobile-itms-install
+base: mobile-native-build-economy (#2555)
+---
+
+# Install the app from our own interstitial (itms-services)
+
+## Status summary
+
+Spec committed first; implementation follows in this branch. One coherent
+change: the install page installs the app in place instead of bouncing
+through expo.dev.
+
+## The problem
+
+`/m/install/<channel>` links the expo.dev build page, whose Install tap
+fires `itms-services://` (native iOS dialog, background install, Safari
+stays put). expo.dev takes no callback URL, so getting back to our page for
+the "Open in app" step is a manual Back tap.
+
+## The unlock
+
+`eas build:list` exposes `artifacts.applicationArchiveUrl` — a **stable,
+unsigned** expo.dev `.ipa` URL, valid until the build's `expirationDate`
+(~90 days; verified live on build 6932e8e3). iOS installs ad-hoc apps from
+any https manifest plist, so OS can serve the manifest itself and the
+interstitial's Install button becomes
+`itms-services://?action=download-manifest&url=<https manifest>` — install
+happens ON our page, with "Open in app" sitting right below it.
+
+## Design
+
+1. **Snapshot grows three optional fields**
+   (`packages/shared/src/mobile-channel-status.ts`): `ipaUrl`, `appVersion`,
+   `bundleId`. Optional is justified here: old snapshots predate the fields,
+   an old deployed worker's zod strips unknown keys from a new CI's PUT
+   (deploy-order tolerance), and a freshly triggered build has no artifact
+   yet. Absence of any of them = the interstitial keeps today's
+   build-page-link behavior.
+2. **CI writers fill them.** `ensureBuildForRuntime` (and the refresher's
+   `build:view`) pass through `artifacts.applicationArchiveUrl`;
+   `appVersion`/`bundleId` come from `app.json` (`expo.version`,
+   `expo.ios.bundleIdentifier`). A PR build that finishes later gets its
+   `ipaUrl` on the next push, same staleness contract as `buildFinished`.
+3. **OS serves the manifest**: `/m/install-manifest/<channel>` renders the
+   plist (kind software, bundle-identifier, bundle-version, title,
+   software-package = ipaUrl) from the snapshot; 404 when the snapshot is
+   missing or lacks the fields. `application/xml`, XML-escaped, no-store.
+4. **Interstitial CTA**: when `buildFinished && ipaUrl && bundleId &&
+   appVersion`, the primary button is the itms-services link ("installs in
+   place — watch your home screen, then tap Open in app below"); the
+   expo.dev build page demotes to a "build details" link. Otherwise
+   unchanged. Manifest URL derives from the request's own origin, so
+   previews serve their own.
+5. **Explainer + README copy** updated (install now happens on the page).
+
+## Not doing
+
+- Signed/expiring manifest URLs: the ipa URL is already unguessable
+  (content-hash path) and expires with the build; the manifest exposes
+  nothing the build page didn't.
+- display-image in the manifest: generic icon during install is fine.
+- Android: iOS-only flow, like everything else here.
+
+## Checklist
+
+- [ ] Schema: optional `ipaUrl`/`appVersion`/`bundleId` + comment on why
+      optional
+- [ ] `mobile-preview.ts`: `InstallBuild.ipaUrl`; writers pass
+      ipaUrl/appVersion/bundleId; refresher upgrades ipaUrl when the build
+      finishes
+- [ ] OS: `handleInstallManifestRequest` + thin route, plist rendering,
+      404s, tests (incl. XML escaping)
+- [ ] OS: interstitial itms CTA variant + demoted build-details link, tests
+- [ ] Explainer + README copy
+- [ ] Gauntlet: typecheck, lint, knip, format, scripts + os tests


### PR DESCRIPTION
The `/m/install/<channel>` interstitial currently bounces to the expo.dev build page, whose Install tap fires `itms-services://` — but expo.dev takes no callback URL, so the "Open in app" step means a manual Back tap. EAS exposes `artifacts.applicationArchiveUrl`, a stable unsigned `.ipa` URL, so OS can serve the itms manifest itself: **Install happens on our page**, native dialog, no navigation, "Open in app" right below.

Stacked on #2555.

## What changes (spec-first draft)

1. The channel snapshot gains optional `ipaUrl` / `appVersion` / `bundleId` (absent → today's behavior, which also covers still-compiling builds and deploy-order skew).
2. CI writers fill them from the build's artifacts + app.json; the main refresher upgrades `ipaUrl` when a fresh build finishes.
3. New `/m/install-manifest/<channel>` serves the plist; the interstitial's primary CTA becomes the itms-services link, with the expo.dev page demoted to "build details".

Spec: [`tasks/mobile-itms-install.md`](https://github.com/iterate/iterate/blob/mobile-itms-install/tasks/mobile-itms-install.md)

---

<sub>Claude Code session `615c997a-13a6-422b-8a6f-11b4f3bab871` — "mobile native build economy"</sub>

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +126 -8 | +59 -8 🟩🟩🟩⬜⬜ |
| Mobile | +4 -2 | +4 -2 🟩⬜⬜⬜⬜ |
| Tests | +122 -4 | +112 -4 🟩🟩🟩🟩🟩 |
| CI & scripts | +23 -1 | +12 -1 🟩⬜⬜⬜⬜ |
| Docs | +79 -0 | +66 -0 🟩🟩🟩⬜⬜ |
| Other | +7 -5 | +7 -5 🟩⬜⬜⬜⬜ |
| Generated | +21 -0 | +7 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+382 -20** | **+267 -20** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between ad12f10 and 080e1e3, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-08-31T17:23:18.052Z",
      "deployedAt": "2026-08-31T17:17:02.506Z",
      "headSha": "080e1e30d86c364c9e507914e2edcde80d49c0bf",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/544273836753232",
      "shortSha": "080e1e3",
      "cleanupDurationMs": 16655,
      "deployDurationMs": 89891,
      "deployConfigDurationMs": 1,
      "deployCommandDurationMs": 87519,
      "deployReadinessDurationMs": 2369,
      "deployedWorkerName": "os-preview-13",
      "deployedWorkerVersion": "6ace4d2a-ad5f-4220-b8af-0f96582252d3",
      "testDurationMs": 277792,
      "testRetries": "3 retried: the source-version pin tells a facet that recycled from one the commit rebuilt (vitest x1) · a userspace facet rebuilds on a source commit and only on a source commit (vitest x1) · repo-ide-svg-index-preview.spec.ts › preview a staged snapshot from the readonly Index view › web (playwright x1) — TimeoutError: locator.waitFor: Timeout 1ms exceeded. Call log: \u001b[2m - waiting for getByRole('tree') to be visible\u001b[22m \u001b[33m If this is a slow operation, update the product code to add a spinner while it's running. This will improve the user experience and buy you more time for this assertion. To...",
      "workerSizeKib": 20899.28,
      "workerGzipKib": 5267.09,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5277.96
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-08-31T17:23:05.547Z",
      "deployedAt": "2026-08-31T17:16:00.425Z",
      "headSha": "080e1e30d86c364c9e507914e2edcde80d49c0bf",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-13.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/544273836753232",
      "shortSha": "080e1e3",
      "cleanupDurationMs": 4148,
      "deployDurationMs": 25891,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 25435,
      "deployReadinessDurationMs": 452,
      "deployedWorkerName": "docs-preview-13",
      "deployedWorkerVersion": "45d39555-8757-46be-9980-f75a62b1a5be",
      "testDurationMs": 4884,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-08-31T17:23:03.432Z",
      "deployedAt": "2026-08-31T17:02:31.963Z",
      "headSha": "080e1e30d86c364c9e507914e2edcde80d49c0bf",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/544273836753232",
      "shortSha": "080e1e3",
      "cleanupDurationMs": 2030,
      "deployDurationMs": 25133,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 24893,
      "deployReadinessDurationMs": 234,
      "deployedWorkerName": "semaphore-preview-13",
      "deployedWorkerVersion": "55b79686-069c-49e5-befd-7edf39dffc52",
      "testDurationMs": 33394,
      "testRetries": null,
      "workerSizeKib": 1915.87,
      "workerGzipKib": 441.25,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-08-31T17:23:06.042Z",
      "deployedAt": "2026-08-31T17:16:07.347Z",
      "headSha": "080e1e30d86c364c9e507914e2edcde80d49c0bf",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/544273836753232",
      "shortSha": "080e1e3",
      "cleanupDurationMs": 4639,
      "deployDurationMs": 32733,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 32355,
      "deployReadinessDurationMs": 373,
      "deployedWorkerName": "auth-preview-13",
      "deployedWorkerVersion": "c441ce2f-941a-4cea-871b-dc7dcd3792a6",
      "testDurationMs": 21192,
      "testRetries": null,
      "workerSizeKib": 3989.98,
      "workerGzipKib": 817.38,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-08-31T17:23:11.194Z",
      "deployedAt": "2026-08-31T17:02:30.894Z",
      "headSha": "080e1e30d86c364c9e507914e2edcde80d49c0bf",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/544273836753232",
      "shortSha": "080e1e3",
      "cleanupDurationMs": 9789,
      "deployDurationMs": 25165,
      "deployConfigDurationMs": 7,
      "deployCommandDurationMs": 23822,
      "deployReadinessDurationMs": 1336,
      "deployedWorkerName": "streams-example-app-preview-13",
      "deployedWorkerVersion": "6298147c-881c-4c06-98de-007167023ddc",
      "testDurationMs": 67333,
      "testRetries": null,
      "workerSizeKib": 5600.88,
      "workerGzipKib": 1585.11,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-08-31T17:23:04.805Z",
      "deployedAt": "2026-08-31T17:15:45.124Z",
      "headSha": "080e1e30d86c364c9e507914e2edcde80d49c0bf",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/544273836753232",
      "shortSha": "080e1e3",
      "cleanupDurationMs": 1373,
      "deployDurationMs": 10354,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 10101,
      "deployReadinessDurationMs": 216,
      "deployedWorkerName": "dummy-petshop-preview-13",
      "deployedWorkerVersion": "e77eda8c-fa67-4b48-8870-02c6ba4c35eb",
      "testDurationMs": 22744,
      "testRetries": null,
      "workerSizeKib": 1115.4,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "b717e505c46472150438e97f994eb4a2c283e0f8+bfab28a2c1794a35118c88bad09eba3f5105f3d7",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `080e1e3` | [https://auth.iterate-preview-13.com](https://auth.iterate-preview-13.com) | 817.4 KiB | 32.7s | 21.2s |  | 4.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/544273836753232) | 2026-08-31T17:23:06.042Z | Preview app released. |
| Docs | released | `080e1e3` | [https://docs-preview-13.iterate-dev-preview.workers.dev](https://docs-preview-13.iterate-dev-preview.workers.dev) | 866.2 KiB | 25.9s | 4.9s |  | 4.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/544273836753232) | 2026-08-31T17:23:05.547Z | Preview app released. |
| Dummy Petshop | released | `080e1e3` | [https://dummy-petshop.iterate-preview-13.com](https://dummy-petshop.iterate-preview-13.com) | 198.3 KiB | 10.4s | 22.7s |  | 1.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/544273836753232) | 2026-08-31T17:23:04.805Z | Preview app released. |
| OS | released | `080e1e3` | [https://os.iterate-preview-13.com](https://os.iterate-preview-13.com) | 5.14 MiB (-10.9 KiB vs main) | 89.9s | 277.8s | 3 retried: the source-version pin tells a facet that recycled from one the commit rebuilt (vitest x1) · a userspace facet rebuilds on a source commit and only on a source commit (vitest x1) · repo-ide-svg-index-preview.spec.ts › preview a staged snapshot from the readonly Index view › web (playwright x1) — TimeoutError: locator.waitFor: Timeout 1ms exceeded. Call log: [2m - waiting for getByRole('tree') to be visible[22m [33m If this is a slow operation, update the product code to add a spinner while it's running. This will improve the user experience and buy you more time for this assertion. To... | 16.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/544273836753232) | 2026-08-31T17:23:18.052Z | Preview app released. |
| Semaphore | released | `080e1e3` | [https://semaphore.iterate-preview-13.com](https://semaphore.iterate-preview-13.com) | 441.3 KiB | 25.1s | 33.4s |  | 2.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/544273836753232) | 2026-08-31T17:23:03.432Z | Preview app released. |
| Streams Example App | released | `080e1e3` | [https://streams.iterate-preview-13.com](https://streams.iterate-preview-13.com) | 1.55 MiB | 25.2s | 67.3s |  | 9.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/544273836753232) | 2026-08-31T17:23:11.194Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- mobile-pr-preview -->
## 📱 Mobile preview — main

Channel `preview` · runtime `867f6b81b` · **JS-only** — the installed app can run it

<details open><summary>OTA — default-channel phones pull this automatically (`12c68eb`)</summary>

**[Switch this phone back to the default channel now](https://os.iterate.com/m/preview-channel/preview)**

<a href="https://os.iterate.com/m/preview-channel/preview"><img src="https://github.com/iterate/iterate/releases/download/gh-attach-assets/mobile-main-ota-scheme.png" width="90" alt="QR code" /></a>

</details>
<details><summary>Full install — if the app is uninstalled or the runtime differs (`ef997f1`)</summary>

**[Open the install page](https://os.iterate.com/m/install/preview)**

<a href="https://os.iterate.com/m/install/preview"><img src="https://github.com/iterate/iterate/releases/download/gh-attach-assets/mobile-main-install-page.png" width="90" alt="QR code" /></a>

</details>

<sub>Posted by mobile-eas-update on merges touching apps/mobile.</sub>
<!-- /mobile-pr-preview -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public mobile install path and serves plist manifests that reference external IPA URLs; behavior is gated on snapshot completeness with fallbacks, but a bad or stale snapshot could affect what users install.
> 
> **Overview**
> **Enables on-page iOS installs** from the channel-stable `/m/install/<channel>` interstitial: when the CI snapshot has a finished build plus `ipaUrl`, `appVersion`, and `bundleId`, the primary **Install** button uses `itms-services://` against a new **`/m/install-manifest/<channel>`** plist served by OS (manifest URL uses the request origin so previews work). The expo.dev build page stays as **Build details** or as the full CTA when artifacts are missing, the build is still compiling, or the snapshot predates the new fields.
> 
> **Channel status** (`MobileChannelStatus`) gains those three optional fields; publish/refresh CI scripts populate them from EAS `applicationArchiveUrl` and `app.json`, with `null` artifact URLs normalized away before PUT. **Open in app** ordering and compile-time messaging are unchanged; docs and tests cover manifest XML escaping, 404s, and itms vs fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 080e1e30d86c364c9e507914e2edcde80d49c0bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->