### PR TITLE
Fix refresh-install-qr: eas build:view rejects --non-interactive

### DIFF
--- a/scripts/ci/mobile-preview.ts
+++ b/scripts/ci/mobile-preview.ts
@@ -147,11 +147,13 @@ export const run = (command: string, args: string[], cwd: string) =>
 // pnpm dlx prefixes install noise and eas-cli appends upgrade notices, so
 // slice out the JSON payload rather than parsing the whole stream.
 export const easJson = (args: string[]) => {
-  const output = run(
-    "pnpm",
-    ["dlx", "eas-cli@21.0.1", ...args, "--non-interactive", "--json"],
-    mobileDir,
-  );
+  // build:view rejects --non-interactive outright (eas-cli 21.0.1:
+  // "Nonexistent flag") — it prompts for nothing anyway. Every other
+  // command we run wants it so CI can never hang on a prompt. Seen live:
+  // refresh-install-qr died on its first real run (2026-08-31), leaving
+  // "build still running" captions unflipped.
+  const flags = args[0] === "build:view" ? ["--json"] : ["--non-interactive", "--json"];
+  const output = run("pnpm", ["dlx", "eas-cli@21.0.1", ...args, ...flags], mobileDir);
   const start = output.search(/[[{]/);
   const end = Math.max(output.lastIndexOf("]"), output.lastIndexOf("}"));
   if (start === -1 || end < start) {


### PR DESCRIPTION
The Mobile EAS Update `refresh-install-qr` job died on its first-ever real run (the #2558 merge — the first fingerprint-moving merge since #2550 shipped the job): `easJson` appends `--non-interactive` to every eas-cli call, and `build:view` hard-errors on it ("Nonexistent flag"). One-line fix: `build:view` drops the flag (it prompts for nothing); everything else keeps it.

Verified live: `eas build:view 11d92e4a --json` works without the flag and returned the build's status. Note the job's failure was caption-only — publishes were unaffected.

---

<sub>Claude Code session `615c997a-13a6-422b-8a6f-11b4f3bab871` — "mobile native build economy"</sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional in shared CI helper; behavior change is limited to `build:view` while other EAS calls stay non-interactive.
> 
> **Overview**
> Fixes the **mobile EAS `refresh-install-qr`** job failing when it polls build status via **`easJson`**.
> 
> **`easJson`** used to append **`--non-interactive`** to every `eas-cli@21.0.1` invocation. **`build:view`** treats that flag as invalid and exits, so install QR captions stayed on “build still running” even after the build finished. The change passes only **`--json`** for **`build:view`** and keeps **`--non-interactive --json`** for all other commands so CI still cannot hang on prompts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ce5435f22c8289d122ad958f9a4f527bc841051. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| CI & scripts | +7 -5 | +2 -5 🟩🟥🟥🟥🟥 |
| **Total** | **+7 -5** | **+2 -5** 🟩🟥🟥🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 2d815b8 and 3ce5435, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- mobile-pr-preview -->
## 📱 Mobile preview — main

Channel `preview` · runtime `85f7d91fa` · **JS-only** — the installed app can run it

<details open><summary>OTA — default-channel phones pull this automatically (`7231cfb`)</summary>

**[Switch this phone back to the default channel now](https://mobile.iterate.com/preview-channel/preview)**

<a href="https://mobile.iterate.com/preview-channel/preview"><img src="https://github.com/iterate/iterate/releases/download/gh-attach-assets/mobile-main-ota-scheme.png" width="90" alt="QR code" /></a>

</details>
<details><summary>Full install — if the app is uninstalled or the runtime differs (`3ce5435`)</summary>

**[Open the install page](https://mobile.iterate.com/install/preview)**

<a href="https://mobile.iterate.com/install/preview"><img src="https://github.com/iterate/iterate/releases/download/gh-attach-assets/mobile-main-install-site.png" width="90" alt="QR code" /></a>

</details>

<sub>Posted by mobile-eas-update on merges touching apps/mobile.</sub>
<!-- /mobile-pr-preview -->