### PR TITLE
Move merged mobile task files to complete/

### DIFF
--- a/tasks/complete/2026-08-31-mobile-itms-install.md
+++ b/tasks/complete/2026-08-31-mobile-itms-install.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 size: small
 branch: mobile-itms-install
 base: mobile-native-build-economy (#2555)

--- a/tasks/complete/2026-09-01-mobile-website-worker.md
+++ b/tasks/complete/2026-09-01-mobile-website-worker.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 size: large
 branch: mobile-website
 ---
@@ -14,8 +14,7 @@ mobile.iterate.com is also a **universal-link prefix** now — the worker
 serves apple-app-site-association (team 5N6A5Q26NT, dug out of the build's
 embedded.mobileprovision) for `/preview-channel/*`, bare paths are
 canonical, and app.json gains the applinks entitlement (fingerprint moves →
-this PR triggers the one build carrying it). Remaining: merge → first
-deploy → cutover runbook below → phone-verify the universal link.
+this PR triggers the one build carrying it). Merged (#2558); cutover runbook executed and verified live 2026-09-01 (site, snapshot, AASA, 301s, in-place install with build b43a12e5). Only the on-phone universal-link tap remains a human check.
 
 ## Why (Misha, condensed)
 


### PR DESCRIPTION
Bookkeeping: [tasks/mobile-itms-install.md](tasks/complete/2026-08-31-mobile-itms-install.md) (#2557) and [tasks/mobile-website-worker.md](tasks/complete/2026-09-01-mobile-website-worker.md) (#2558) are merged and verified live — moving them to complete/ per the tasks convention, with the website's status note updated to reflect the executed cutover.

---

<sub>Claude Code session `615c997a-13a6-422b-8a6f-11b4f3bab871` — "mobile native build economy"</sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and task-tracking only; no runtime, deploy, or application code changes.
> 
> **Overview**
> **Bookkeeping** for two finished mobile workstreams (#2557 itms-services install, #2558 mobile.iterate.com worker): their task markdown lives under `tasks/complete/` with frontmatter **`status: done`** instead of `in-progress`.
> 
> The **mobile website** task’s status blurb is refreshed to record merge **#2558**, the **2026-09-01 cutover** (site, snapshot, AASA, 301s, in-place install **b43a12e5**), and that only an on-device universal-link tap is left as a manual check. The itms-install task is marked done without further narrative changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0e3ab7b4157cde493103a6911d126e93e52c7c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Docs | +3 -4 | +3 -4 🟩🟩🟥🟥🟥 |
| **Total** | **+3 -4** | **+3 -4** 🟩🟩🟥🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 7231cfb and c0e3ab7, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->