### PR TITLE
Pause prd deploy-os push trigger (Cloudflare Artifacts binding bug)

### DIFF
--- a/.depot/workflows/deploy-os.yml
+++ b/.depot/workflows/deploy-os.yml
@@ -10,36 +10,38 @@ concurrency:
   group: deploy-auth-os-production
   cancel-in-progress: false
 on:
-  # PAUSED 2026-09-01: deploying os-prd right now would break it. Cloudflare
-  # Artifacts has a bug where redeploying a worker whose `artifacts` binding
-  # predates ~2026-09-01 makes that binding mint tokens the git endpoints
-  # reject with 403 (this is what broke every preview slot's e2e today —
-  # each CI preview deploy poisoned its slot). os-prd's binding is from May,
-  # so its next deploy would poison production the same way. Restore the
-  # push trigger below once Cloudflare confirms the fix (verify by
-  # redeploying one preview slot and creating a project on it first).
-  #
-  # push:
-  #   branches:
-  #     - main
-  #   paths:
-  #     - .depot/workflows/deploy-os.yml
-  #     - .depot/workflows/deploy-auth.yml
-  #     - envs.ts
-  #     - scripts/lib/**
-  #     - apps/os/**
-  #     # New-project template seeding pins github references to the DEPLOYED
-  #     # revision's SHA, so a template content change is unreachable until the
-  #     # OS app redeploys and moves its pin (same reasoning as the preview
-  #     # workflow's configs/** entry).
-  #     - configs/**
-  #     - packages/iterate/**
-  #     - apps/auth/**
-  #     - apps/auth-contract/**
-  #     - apps/os/src/domains/streams/**
-  #     - packages/shared/**
-  #     - packages/ui/**
-  #     - patches/**
+  push:
+    branches:
+      # PAUSED 2026-09-01 (normally: main). Deploying os-prd right now would
+      # break it: Cloudflare Artifacts has a bug where redeploying a worker
+      # whose `artifacts` binding predates ~2026-09-01 makes that binding mint
+      # tokens the git endpoints reject with 403 (this is what broke every
+      # preview slot's e2e today — each CI preview deploy poisoned its slot).
+      # os-prd's binding is from May, so its next deploy would poison
+      # production the same way. This placeholder branch never receives
+      # pushes, which disables the trigger while keeping the paths list
+      # intact for depot-workflows.test.ts. Restore `- main` once Cloudflare
+      # confirms the fix (verify by redeploying one preview slot and creating
+      # a project on it first).
+      - _deploys-paused-cloudflare-artifacts-403
+    paths:
+      - .depot/workflows/deploy-os.yml
+      - .depot/workflows/deploy-auth.yml
+      - envs.ts
+      - scripts/lib/**
+      - apps/os/**
+      # New-project template seeding pins github references to the DEPLOYED
+      # revision's SHA, so a template content change is unreachable until the
+      # OS app redeploys and moves its pin (same reasoning as the preview
+      # workflow's configs/** entry).
+      - configs/**
+      - packages/iterate/**
+      - apps/auth/**
+      - apps/auth-contract/**
+      - apps/os/src/domains/streams/**
+      - packages/shared/**
+      - packages/ui/**
+      - patches/**
   workflow_dispatch:
     inputs:
       ref:

--- a/.depot/workflows/deploy-os.yml
+++ b/.depot/workflows/deploy-os.yml
@@ -10,27 +10,36 @@ concurrency:
   group: deploy-auth-os-production
   cancel-in-progress: false
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - .depot/workflows/deploy-os.yml
-      - .depot/workflows/deploy-auth.yml
-      - envs.ts
-      - scripts/lib/**
-      - apps/os/**
-      # New-project template seeding pins github references to the DEPLOYED
-      # revision's SHA, so a template content change is unreachable until the
-      # OS app redeploys and moves its pin (same reasoning as the preview
-      # workflow's configs/** entry).
-      - configs/**
-      - packages/iterate/**
-      - apps/auth/**
-      - apps/auth-contract/**
-      - apps/os/src/domains/streams/**
-      - packages/shared/**
-      - packages/ui/**
-      - patches/**
+  # PAUSED 2026-09-01: deploying os-prd right now would break it. Cloudflare
+  # Artifacts has a bug where redeploying a worker whose `artifacts` binding
+  # predates ~2026-09-01 makes that binding mint tokens the git endpoints
+  # reject with 403 (this is what broke every preview slot's e2e today —
+  # each CI preview deploy poisoned its slot). os-prd's binding is from May,
+  # so its next deploy would poison production the same way. Restore the
+  # push trigger below once Cloudflare confirms the fix (verify by
+  # redeploying one preview slot and creating a project on it first).
+  #
+  # push:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - .depot/workflows/deploy-os.yml
+  #     - .depot/workflows/deploy-auth.yml
+  #     - envs.ts
+  #     - scripts/lib/**
+  #     - apps/os/**
+  #     # New-project template seeding pins github references to the DEPLOYED
+  #     # revision's SHA, so a template content change is unreachable until the
+  #     # OS app redeploys and moves its pin (same reasoning as the preview
+  #     # workflow's configs/** entry).
+  #     - configs/**
+  #     - packages/iterate/**
+  #     - apps/auth/**
+  #     - apps/auth-contract/**
+  #     - apps/os/src/domains/streams/**
+  #     - packages/shared/**
+  #     - packages/ui/**
+  #     - patches/**
   workflow_dispatch:
     inputs:
       ref:


### PR DESCRIPTION
## What

Comments out `deploy-os.yml`'s `push` trigger so merges to main stop auto-deploying os-prd. `workflow_dispatch` stays, so a deliberate manual deploy is still possible. Revert this PR to re-enable.

## Why

Cloudflare Artifacts currently has a bug (started between Aug 31 ~23:00 and Sep 1 06:44 UTC): **redeploying a worker whose `artifacts` binding was provisioned before the cutoff makes that binding start minting tokens the Artifacts git endpoints reject with 403.** The mint call succeeds and the token record is visible in REST token lists, but the plaintext fails auth (`GET info/refs` → 401 unauthenticated / 403 with the token), so every git-wire operation — config-repo seeding, file reads, worker builds — dies. This is what turned every preview slot's e2e red today: each CI preview run redeploys its slot's os worker, poisoning it (preview-2 broke at 06:49, five minutes after its 06:44 deploy; then 16 → 10 → 6 → 12 in deploy order). The poison is sticky: further redeploys, removing+re-adding the binding, and binding a brand-new namespace all stay broken. Fresh worker names provision healthy bindings — which is why nothing repros on a new worker.

os-prd (binding from May, last deployed Aug 31 19:04) is still healthy — but its next deploy would poison production the same way. Hence this pause.

## Risk map

- The change is comment-only YAML on one workflow's `on:` block; the risk is operational, not code: while merged, **no push-triggered prd deploys happen at all**, so a genuinely needed hotfix deploy must go through `workflow_dispatch` deliberately (and would poison os-prd until Cloudflare's fix — don't, unless the outage math says otherwise).
- **Merging this PR may itself fire one final deploy run** from the pre-merge trigger registration (Depot registers triggers from the default branch, and this file is in its own `paths` list). An auto-cancel guard is running that kills any `deploy-os.yml`/`deploy-auth.yml` workflow the moment it appears; keep it running until this lands, or cancel manually: `depot ci cancel <run-id> --workflow <wf-id> --org 0p91s0lz49`.

## Re-enabling

Once Cloudflare confirms the fix: redeploy one preview slot, create a project on it (`doppler run --project os --config preview_N -- pnpm cli itx run --eval '...projects.get(...).create()'`), and if that succeeds, revert this PR.

---
Coding agent session: `a9a82a1e-deec-4f92-957d-d719fb5281a6` (Artifacts 403 investigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML-only operational guard with no application code changes; the main risk is that push-to-main no longer rolls out os-prd until reverted or manually dispatched.
> 
> **Overview**
> **Pauses automatic production OS deploys on merge to `main`** by changing the `deploy-os.yml` `push` trigger from `main` to a non-existent placeholder branch (`_deploys-paused-cloudflare-artifacts-403`), so pushes no longer start the Auth + OS production workflow.
> 
> The inline comment documents why: redeploying workers with pre–Sep 2026 `artifacts` bindings can poison the binding (403 on git wire), which already broke preview slots; **os-prd’s next push-triggered deploy would risk the same.** `workflow_dispatch` is unchanged for deliberate manual deploys. The `paths` filter is left as-is so `depot-workflows.test.ts` expectations stay valid; restore `- main` after Cloudflare’s fix is verified on a preview slot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 843b571e8b58382887559247a3d775ef09b1411e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| CI & scripts | +12 -1 | +12 -1 🟩🟩🟩🟩🟩 |
| **Total** | **+12 -1** | **+12 -1** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 7231cfb and 843b571, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->