### PR TITLE
Stream crash-loop quarantine: park a DO that OOMs on every boot

### DIFF
--- a/apps/os/src/domains/streams/boot-crash-probe.test.ts
+++ b/apps/os/src/domains/streams/boot-crash-probe.test.ts
@@ -1,0 +1,121 @@
+// Scenario replays for the boot-crash probe. The incident that motivates the
+// numbers: a poison 7MB settlement event OOMed the stream DO on every fold
+// attempt, and Cloudflare's alarm retry re-booted it every ~5s for hours
+// (tasks/bound-script-settlements.md). The probe must trip on that signature
+// while never tripping healthy streams that merely wake often.
+import { describe, expect, it } from "vitest";
+
+import {
+  BOOT_CRASH_QUARANTINE_THRESHOLD,
+  clearProbe,
+  isQuarantined,
+  RAPID_REBOOT_MS,
+  recordBootAttempt,
+  type BootCrashProbeRecord,
+} from "./boot-crash-probe.ts";
+
+const V1 = "worker-v1";
+const V2 = "worker-v2";
+const T0 = Date.parse("2026-09-02T11:37:00Z");
+
+/** Drive N boots at a fixed cadence, persisting each returned record like the
+ * DO would, and hand back the final decision. */
+function bootLoop(input: {
+  boots: number;
+  cadenceMs: number;
+  record?: BootCrashProbeRecord;
+  version?: string;
+}) {
+  let record = input.record;
+  let decision = undefined as ReturnType<typeof recordBootAttempt> | undefined;
+  for (let boot = 0; boot < input.boots; boot++) {
+    decision = recordBootAttempt({
+      record,
+      nowMs: T0 + boot * input.cadenceMs,
+      version: input.version || V1,
+    });
+    record = decision.record;
+  }
+  return decision!;
+}
+
+describe("recordBootAttempt", () => {
+  it("trips quarantine on the incident signature — boots every ~5s", () => {
+    const decision = bootLoop({ boots: BOOT_CRASH_QUARANTINE_THRESHOLD, cadenceMs: 5_500 });
+    expect(decision).toMatchObject({
+      action: "quarantine",
+      record: { rapidBoots: 5, quarantinedAtMs: expect.any(Number) },
+    });
+    // Under half a minute of looping — hours of prod wake-loop, never again.
+    expect(decision.record.quarantinedAtMs! - T0).toBeLessThan(30_000);
+  });
+
+  it("never trips on spaced wakes — a stream woken per event resets each boot", () => {
+    const decision = bootLoop({ boots: 50, cadenceMs: RAPID_REBOOT_MS });
+    expect(decision).toMatchObject({ action: "proceed", record: { rapidBoots: 1 } });
+  });
+
+  it("a clean signal mid-run resets the count — busy streams that finish their folds stay up", () => {
+    // Three rapid boots, then the incarnation completes a fold pass...
+    let record = bootLoop({ boots: 3, cadenceMs: 5_000 }).record;
+    expect(record.rapidBoots).toBe(3);
+    record = clearProbe({ nowMs: T0 + 16_000, version: V1 });
+    // ...so the next rapid burst starts counting from scratch.
+    const decision = recordBootAttempt({ record, nowMs: T0 + 20_000, version: V1 });
+    expect(decision).toMatchObject({ action: "proceed", record: { rapidBoots: 1 } });
+  });
+
+  it("stays quarantined across spaced boots — dropped alarms slow the wakes, and that slowdown is not recovery", () => {
+    const tripped = bootLoop({ boots: 5, cadenceMs: 5_000 }).record;
+    const laterBoot = recordBootAttempt({
+      record: tripped,
+      nowMs: T0 + 6 * 60 * 60_000,
+      version: V1,
+    });
+    expect(laterBoot.action).toBe("quarantine");
+    expect(laterBoot.record.quarantinedAtMs).toBe(tripped.quarantinedAtMs);
+  });
+
+  it("a deploy unparks — new code may have devalued the poison", () => {
+    const tripped = bootLoop({ boots: 5, cadenceMs: 5_000 }).record;
+    const decision = recordBootAttempt({ record: tripped, nowMs: T0 + 60_000, version: V2 });
+    expect(decision).toMatchObject({
+      action: "proceed",
+      record: { rapidBoots: 1, version: V2 },
+    });
+    expect(decision.record.quarantinedAtMs).toBeUndefined();
+  });
+
+  it("re-trips after an unpark if the loop resumes — bounded retries, not a loop", () => {
+    const tripped = bootLoop({ boots: 5, cadenceMs: 5_000 }).record;
+    expect(isQuarantined({ record: tripped, version: V1 })).toBe(true);
+    // Admin unpark: clearProbe REPLACES the record — clearing is the reset.
+    const cleared = clearProbe({ nowMs: T0 + 60_000, version: V1 });
+    expect(isQuarantined({ record: cleared, version: V1 })).toBe(false);
+    // ...but the poison is still there and the loop resumes: parks again.
+    const decision = bootLoop({
+      boots: BOOT_CRASH_QUARANTINE_THRESHOLD,
+      cadenceMs: 5_000,
+      record: cleared,
+    });
+    expect(decision.action).toBe("quarantine");
+  });
+
+  it("first boot ever proceeds", () => {
+    expect(recordBootAttempt({ record: undefined, nowMs: T0, version: V1 })).toMatchObject({
+      action: "proceed",
+      record: { rapidBoots: 1, lastBootAtMs: T0, version: V1 },
+    });
+  });
+});
+
+describe("isQuarantined", () => {
+  it("reads parked state without writing, and ignores stale-version records", () => {
+    const tripped = bootLoop({ boots: 5, cadenceMs: 5_000 }).record;
+    expect(isQuarantined({ record: tripped, version: V1 })).toBe(true);
+    // A deploy happened but the stream has not booted yet: not quarantined —
+    // the next boot's version reset will unpark it.
+    expect(isQuarantined({ record: tripped, version: V2 })).toBe(false);
+    expect(isQuarantined({ record: undefined, version: V1 })).toBe(false);
+  });
+});

--- a/apps/os/src/domains/streams/boot-crash-probe.ts
+++ b/apps/os/src/domains/streams/boot-crash-probe.ts
@@ -1,0 +1,125 @@
+// The Stream DO's crash-loop breaker: pure decisions over a small durable
+// record, written BEFORE risky boot work — the crash that needs the record
+// (an isolate OOM) is uncatchable and kills every in-memory counter, so the
+// only bookkeeping that survives is what was synced ahead of the attempt.
+//
+// A crashed boot cannot be observed directly (no eviction hook, and an OOM
+// leaves nothing behind), but a crash LOOP has an unmistakable signature in
+// durable state: rapid successive boots with no clean signal in between. The
+// bound-script-settlements incident (tasks/bound-script-settlements.md) wake-
+// looped at ~5s cadence for hours — Cloudflare's alarm retry plus subscriber
+// read retries re-boot the DO, the poisoned fold OOMs, repeat. Healthy
+// streams never look like that: boots driven by real traffic are spaced out
+// (spacing resets the count), and busy streams complete fold work (the clean
+// signal resets the count). Only the conjunction — boots landing faster than
+// RAPID_REBOOT_MS apart, threshold times in a row, with no clean signal —
+// trips quarantine.
+
+/** Boots closer together than this are treated as one crash-loop run. The
+ * observed pathology re-boots every ~5s (platform alarm retry cadence);
+ * legitimate wake-per-event streams that evict between events re-boot at
+ * event spacing, comfortably above this. */
+export const RAPID_REBOOT_MS = 30_000;
+
+/** Rapid boots in a row, with no clean signal, before the stream parks.
+ * 5 × ~5s ≈ trips within half a minute of a real loop; a deploy-restart or
+ * one-off platform reset never strings 5 rapid boots together. */
+export const BOOT_CRASH_QUARANTINE_THRESHOLD = 5;
+
+/**
+ * The durable record, stored in DO KV below the journal/fold (the same
+ * placement as the keepalive's revival mark). `version` is the worker deploy
+ * version: new code may fix the poison, so a deploy resets the count and
+ * un-parks a quarantined stream on its next boot.
+ */
+export type BootCrashProbeRecord = {
+  /** Rapid successive boots since the last clean signal (or spaced boot). */
+  rapidBoots: number;
+  /** Epoch ms of the most recent boot attempt (drives the spacing check). */
+  lastBootAtMs: number;
+  /** Worker deploy version at the last write. */
+  version: string;
+  /** Set when the threshold tripped; survives spaced-out boots (quarantine
+   * means "stop retrying", and dropping the alarms slows the wakes — that
+   * slowdown must not read as recovery). Cleared only by a version change or
+   * clearProbe (the admin unpark). */
+  quarantinedAtMs?: number;
+};
+
+type BootProbeDecision = {
+  /** Persist with storage.sync() BEFORE arming alarms/folds/deliveries. */
+  record: BootCrashProbeRecord;
+  /**
+   * "proceed": arm everything as normal.
+   * "quarantine": do not arm alarms, facet replays, fold catch-up, or
+   * delivery lanes; serve reads; reject appends loudly. Includes boots that
+   * arrive already-quarantined (the record says so and nothing reset it).
+   */
+  action: "proceed" | "quarantine";
+};
+
+/**
+ * The boot-time decision. Callers persist the returned record (sync) before
+ * doing anything that could OOM. The count resets when any of these hold —
+ * each means "this is not a crash loop continuing":
+ *  - no prior record (first boot ever);
+ *  - a different worker version (the deploy antidote, mirroring the
+ *    keepalive's version-reset budget — also the unpark path, including for
+ *    an already-quarantined record);
+ *  - the previous boot was RAPID_REBOOT_MS or more ago (spaced wakes are
+ *    real traffic, not a retry loop) — though an existing quarantine is NOT
+ *    reset by spacing, see BootCrashProbeRecord.quarantinedAtMs.
+ */
+export function recordBootAttempt(input: {
+  record: BootCrashProbeRecord | undefined;
+  nowMs: number;
+  version: string;
+}): BootProbeDecision {
+  const { record, nowMs, version } = input;
+  if (record === undefined || record.version !== version) {
+    return { action: "proceed", record: { rapidBoots: 1, lastBootAtMs: nowMs, version } };
+  }
+  if (record.quarantinedAtMs !== undefined) {
+    // Parked this version: stay parked whatever the spacing, keep the
+    // original trip time so operators can see when it happened.
+    return { action: "quarantine", record: { ...record, lastBootAtMs: nowMs } };
+  }
+  if (nowMs - record.lastBootAtMs >= RAPID_REBOOT_MS) {
+    return { action: "proceed", record: { rapidBoots: 1, lastBootAtMs: nowMs, version } };
+  }
+  const rapidBoots = record.rapidBoots + 1;
+  if (rapidBoots >= BOOT_CRASH_QUARANTINE_THRESHOLD) {
+    return {
+      action: "quarantine",
+      record: { rapidBoots, lastBootAtMs: nowMs, version, quarantinedAtMs: nowMs },
+    };
+  }
+  return { action: "proceed", record: { rapidBoots, lastBootAtMs: nowMs, version } };
+}
+
+/**
+ * Read-only quarantine check for surfaces that gate on parked state without
+ * booting (append rejection, the UI banner, __describe). A record from an
+ * older worker version never counts — the next boot's version reset will
+ * unpark it.
+ */
+export function isQuarantined(input: {
+  record: BootCrashProbeRecord | undefined;
+  version: string;
+}): boolean {
+  return (
+    input.record !== undefined &&
+    input.record.version === input.version &&
+    input.record.quarantinedAtMs !== undefined
+  );
+}
+
+/**
+ * The clean signal: a fold/alarm pass completed with nothing left owing, or
+ * the incarnation survived its confirmation window. Persisting the cleared
+ * record ends the current run — the next boot starts counting from 1 again.
+ * Also the admin unpark ("unquarantine"): clearing IS the reset.
+ */
+export function clearProbe(input: { nowMs: number; version: string }): BootCrashProbeRecord {
+  return { rapidBoots: 0, lastBootAtMs: input.nowMs, version: input.version };
+}

--- a/tasks/stream-crash-quarantine.md
+++ b/tasks/stream-crash-quarantine.md
@@ -5,10 +5,10 @@ size: large
 
 # Stream crash-loop quarantine (park a DO that OOMs on every boot)
 
-**Status summary:** specced, implementation not started. Adds a mark-before-work
-boot-crash probe to the Stream DO; N crashed boots without a clean confirmation
-parks the stream (no alarms, no folds, reads still served) until an admin unpark
-or a deploy.
+**Status summary:** pure probe core implemented and tested (boot-spacing
+signature, quarantine survives slowed wakes, deploy/admin unpark); DO wiring,
+core event, RPC, and UI not started — held for Misha's look at the flagged
+assumptions.
 
 ## Why
 
@@ -37,17 +37,29 @@ boot itself.
 catch-up / alarms, read+write a KV record `bootCrashProbe`:
 
 ```ts
-{ crashedBoots: number, windowStartMs: number, version: string }
+{ rapidBoots: number, lastBootAtMs: number, version: string, quarantinedAtMs?: number }
 ```
+
+_Refined during implementation:_ a crashed boot can't be observed directly (an
+OOM leaves no record, and there's no eviction hook), but a crash **loop** has an
+unmistakable durable signature — rapid successive boots. So the probe keys on
+**boot spacing** rather than a time window:
 
 - increment + `storage.sync()` BEFORE the risky work (the crash that needs the
   record is the one that prevents writing it afterwards);
-- a clean confirmation — the incarnation surviving a short quiet period (e.g.
-  60s alarm) or the first successful fold ack — resets it to zero;
+- a boot ≥30s (`RAPID_REBOOT_MS`) after the previous one resets the count —
+  spaced wakes are real traffic, not a retry loop (the observed pathology
+  reboots every ~5s on the platform's alarm retry cadence);
+- a clean signal — a fold/alarm pass completing with nothing owed, or the
+  incarnation surviving its confirmation window — resets it to zero;
 - a different worker version resets it (a deploy is the antidote, matching the
-  keepalive's version-reset budget).
+  keepalive's version-reset budget);
+- an existing quarantine is NOT reset by spacing (dropping the alarms slows
+  the wakes; that slowdown must not read as recovery) — only a deploy or the
+  admin unpark clears it.
 
-**Trip:** `crashedBoots >= 5` within the window → quarantined:
+**Trip:** 5 rapid boots in a row (`BOOT_CRASH_QUARANTINE_THRESHOLD`) →
+quarantined:
 
 - append an idempotent `stream/quarantined` evidence event (per version), so
   the journal records why the stream went quiet;
@@ -73,8 +85,10 @@ memory limit" error the user currently sees.
 
 ## Checklist
 
-- [ ] boot-crash probe record + trip/reset logic (likely a small pure module
-      next to `stream-processor-keepalive.ts`, unit-tested in isolation)
+- [x] boot-crash probe record + trip/reset logic _pure module at
+      `apps/os/src/domains/streams/boot-crash-probe.ts` (next to its consumers
+      rather than in packages/iterate — nothing outside the stream DO needs
+      it), 8 scenario tests incl. an incident replay at 5s cadence_
 - [ ] wire into `StreamDurableObject` init: mark before facet/fold arming,
       confirm-clean alarm, skip arming when tripped
 - [ ] `stream/quarantined` core event + reducer handling

--- a/tasks/stream-crash-quarantine.md
+++ b/tasks/stream-crash-quarantine.md
@@ -1,0 +1,96 @@
+---
+status: in-progress
+size: large
+---
+
+# Stream crash-loop quarantine (park a DO that OOMs on every boot)
+
+**Status summary:** specced, implementation not started. Adds a mark-before-work
+boot-crash probe to the Stream DO; N crashed boots without a clean confirmation
+parks the stream (no alarms, no folds, reads still served) until an admin unpark
+or a deploy.
+
+## Why
+
+The bound-script-settlements incident (see `tasks/bound-script-settlements.md`,
+PR #2572): a poison event OOMed the stream DO's isolate on every fold attempt.
+Nothing stopped the loop — it ran at ~5s cadence for hours:
+
+- The keepalive's revival backoff (10s→6h) and crash-loop evidence exist, but
+  the wake source here is **Cloudflare's platform alarm retry plus subscriber
+  retries** (`rpc-targets.ts` retries reads after "Durable Object reset"), not
+  the keepalive.
+- An OOM is uncatchable in-process: the incarnation dies before any code can
+  record "that attempt failed", so every in-memory counter
+  (`#busyRefires`, etc.) resets to zero on each boot.
+- `stream/woken` is appended on every cold boot
+  ([stream-durable-object.ts:1247](../apps/os/src/domains/streams/stream-durable-object.ts)),
+  which is how we can see the loop in the journal — ~170+ events and climbing.
+
+The fix pattern already exists in this codebase: the keepalive's durable mark
+"stored in DO KV BELOW the journal/fold" written before work. Extend it to DO
+boot itself.
+
+## Design
+
+**Probe (mark-before-work):** at DO init, before arming facet replays / fold
+catch-up / alarms, read+write a KV record `bootCrashProbe`:
+
+```ts
+{ crashedBoots: number, windowStartMs: number, version: string }
+```
+
+- increment + `storage.sync()` BEFORE the risky work (the crash that needs the
+  record is the one that prevents writing it afterwards);
+- a clean confirmation — the incarnation surviving a short quiet period (e.g.
+  60s alarm) or the first successful fold ack — resets it to zero;
+- a different worker version resets it (a deploy is the antidote, matching the
+  keepalive's version-reset budget).
+
+**Trip:** `crashedBoots >= 5` within the window → quarantined:
+
+- append an idempotent `stream/quarantined` evidence event (per version), so
+  the journal records why the stream went quiet;
+- do NOT arm alarms, facet replays, fold catch-up, or delivery lanes;
+- keep serving reads (`getEvents`, `getEventPage`) — the journal itself is
+  healthy and the UI should show history plus a quarantine banner instead of
+  the raw platform OOM error;
+- reject appends with a clear error naming the unpark path (appends feed folds;
+  accepting them while folds are parked grows the poison backlog silently).
+
+**Unpark:**
+
+- automatic on worker version change (deploy may carry the fix — exactly this
+  incident: #2572 devalues the poison event);
+- explicit admin RPC (`unquarantine`) exposed through itx for operators,
+  mirroring the keepalive's "operator's no-deploy antidote";
+- unpark resets the probe and re-arms normally; if the stream re-trips, it
+  re-parks after N more crashes — bounded, not a loop.
+
+**UI:** the stream view should render the quarantined state (banner + retry
+control wired to unquarantine) instead of the generic "isolate exceeded its
+memory limit" error the user currently sees.
+
+## Checklist
+
+- [ ] boot-crash probe record + trip/reset logic (likely a small pure module
+      next to `stream-processor-keepalive.ts`, unit-tested in isolation)
+- [ ] wire into `StreamDurableObject` init: mark before facet/fold arming,
+      confirm-clean alarm, skip arming when tripped
+- [ ] `stream/quarantined` core event + reducer handling
+- [ ] read paths stay open; appends rejected with a clear message
+- [ ] auto-unpark on version change; admin `unquarantine` RPC via itx
+- [ ] UI: quarantine banner + unpark control in the stream view
+- [ ] tests: probe unit tests; DO-level test that a constructor/fold crash loop
+      trips quarantine and a version bump unparks
+
+## Assumptions (to confirm with Misha)
+
+- Threshold 5 crashed boots / 10 min window — generous enough that transient
+  platform resets (deploys, evictions) never trip it; a real OOM loop trips in
+  under a minute.
+- Appends rejected while quarantined (fail loud) rather than accepted-but-unfolded.
+- Quarantine is DO-level, not per-processor: an OOM takes out the whole isolate,
+  so finer-grained parking can't be attributed reliably.
+
+## Implementation log


### PR DESCRIPTION
## Problem

When a stream DO's isolate OOMs on every boot (e.g. the 7MB poison settlement behind #2572), nothing stops the loop. The keepalive has a durable revival backoff (10s→6h) and crash-loop evidence, but the wake source in this mode is **Cloudflare's platform alarm retry plus subscriber read retries** — and an OOM is uncatchable in-process, so every in-memory counter resets with each dead incarnation. The prod stream wake-looped at ~5s cadence for hours, and the user saw the raw platform error with a useless Retry button.

## Fix (spec — implementation following in this branch)

Mark-before-work at DO boot, the same durable-mark-below-the-journal pattern the keepalive already uses:

- On init, **before** arming facet replays/folds/alarms, increment a `bootCrashProbe` KV record and `storage.sync()` it. A clean confirmation (surviving a quiet period / first fold ack) resets it; a worker version change resets it.
- 5 crashed boots inside the window → **quarantined**: append an idempotent `stream/quarantined` evidence event, stop arming alarms/folds/deliveries, keep serving reads, reject appends loudly.
- Unpark automatically on deploy (new code may devalue the poison — exactly the #2572 case), or explicitly via an admin `unquarantine` RPC. Re-tripping re-parks after N more crashes — bounded, never a loop.
- UI renders a quarantine banner with an unpark control instead of the raw "isolate exceeded its memory limit" error.

Task file: `tasks/stream-crash-quarantine.md` (design, thresholds, assumptions).

Related: #2572 (bounds the settlements that created this poison event class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session: de3434f2-c52a-4b11-8fe0-39cb5581ef94 ("Diagnose/fix stream DO OOM + worktreeify")

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +125 -0 | +34 -0 🟩🟩⬜⬜⬜ |
| Tests | +121 -0 | +91 -0 🟩🟩🟩🟩🟩 |
| Docs | +110 -0 | +89 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+356 -0** | **+214 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 39b0ddd and feb991f, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-09-02T20:29:32.022Z",
      "deployedAt": "2026-09-02T13:04:39.977Z",
      "headSha": "feb991fdcbce187cb270fca47c57f3c0272481b2",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/104361917194558",
      "shortSha": "feb991f",
      "cleanupDurationMs": 98500,
      "deployDurationMs": 83462,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 81909,
      "deployReadinessDurationMs": 1550,
      "deployedWorkerName": "os-preview-6",
      "deployedWorkerVersion": "c0934ce1-90ce-4084-a583-e343f25358fc",
      "testDurationMs": 284416,
      "testRetries": "2 retried: the source-version pin tells a facet that recycled from one the commit rebuilt (vitest x1) · a userspace facet rebuilds on a source commit and only on a source commit (vitest x1)",
      "workerSizeKib": 20890.58,
      "workerGzipKib": 5264.5,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5276.02
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-09-02T20:27:57.302Z",
      "deployedAt": "2026-09-02T13:03:42.281Z",
      "headSha": "feb991fdcbce187cb270fca47c57f3c0272481b2",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-6.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/104361917194558",
      "shortSha": "feb991f",
      "cleanupDurationMs": 3777,
      "deployDurationMs": 24463,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 24211,
      "deployReadinessDurationMs": 248,
      "deployedWorkerName": "docs-preview-6",
      "deployedWorkerVersion": "77c7384d-80e9-4750-838f-f9921d8f2cf1",
      "testDurationMs": 4988,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-09-02T20:27:59.333Z",
      "deployedAt": "2026-09-02T13:03:51.320Z",
      "headSha": "feb991fdcbce187cb270fca47c57f3c0272481b2",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/104361917194558",
      "shortSha": "feb991f",
      "cleanupDurationMs": 5807,
      "deployDurationMs": 34058,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 33249,
      "deployReadinessDurationMs": 805,
      "deployedWorkerName": "auth-preview-6",
      "deployedWorkerVersion": "0d988a12-b1d5-46ce-b694-670a141faf73",
      "testDurationMs": 20763,
      "testRetries": null,
      "workerSizeKib": 3989.97,
      "workerGzipKib": 817.19,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-09-02T20:28:02.576Z",
      "deployedAt": "2026-09-02T13:03:42.891Z",
      "headSha": "feb991fdcbce187cb270fca47c57f3c0272481b2",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/104361917194558",
      "shortSha": "feb991f",
      "cleanupDurationMs": 9047,
      "deployDurationMs": 25562,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 24819,
      "deployReadinessDurationMs": 738,
      "deployedWorkerName": "streams-example-app-preview-6",
      "deployedWorkerVersion": "05fc213f-3598-41b1-92a2-ae6aee766eda",
      "testDurationMs": 75144,
      "testRetries": null,
      "workerSizeKib": 5601.88,
      "workerGzipKib": 1585.48,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-09-02T20:27:54.890Z",
      "deployedAt": "2026-09-02T13:03:26.105Z",
      "headSha": "feb991fdcbce187cb270fca47c57f3c0272481b2",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/104361917194558",
      "shortSha": "feb991f",
      "cleanupDurationMs": 1359,
      "deployDurationMs": 8431,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 8006,
      "deployReadinessDurationMs": 394,
      "deployedWorkerName": "dummy-petshop-preview-6",
      "deployedWorkerVersion": "41b9bbcd-fb9e-46a7-9e81-feb48fddb761",
      "testDurationMs": 16639,
      "testRetries": null,
      "workerSizeKib": 1115.4,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "b717e505c46472150438e97f994eb4a2c283e0f8+c5abf1055de73f3b4ffbc5e5b742dff1f0b5ee52",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `feb991f` | [https://auth.iterate-preview-6.com](https://auth.iterate-preview-6.com) | 817.2 KiB | 34.1s | 20.8s |  | 5.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/104361917194558) | 2026-09-02T20:27:59.333Z | Preview app released. |
| Docs | released | `feb991f` | [https://docs-preview-6.iterate-dev-preview.workers.dev](https://docs-preview-6.iterate-dev-preview.workers.dev) | 866.2 KiB | 24.5s | 5.0s |  | 3.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/104361917194558) | 2026-09-02T20:27:57.302Z | Preview app released. |
| Dummy Petshop | released | `feb991f` | [https://dummy-petshop.iterate-preview-6.com](https://dummy-petshop.iterate-preview-6.com) | 198.3 KiB | 8.4s | 16.6s |  | 1.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/104361917194558) | 2026-09-02T20:27:54.890Z | Preview app released. |
| OS | released | `feb991f` | [https://os.iterate-preview-6.com](https://os.iterate-preview-6.com) | 5.14 MiB (-11.5 KiB vs main) | 83.5s | 284.4s | 2 retried: the source-version pin tells a facet that recycled from one the commit rebuilt (vitest x1) · a userspace facet rebuilds on a source commit and only on a source commit (vitest x1) | 98.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/104361917194558) | 2026-09-02T20:29:32.022Z | Preview app released. |
| Streams Example App | released | `feb991f` | [https://streams.iterate-preview-6.com](https://streams.iterate-preview-6.com) | 1.55 MiB | 25.6s | 75.1s |  | 9.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/104361917194558) | 2026-09-02T20:28:02.576Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->