### PR TITLE
DO ice switch: freeze an env's alarm loops without destroying data

### DIFF
--- a/apps/os/scripts/cli.ts
+++ b/apps/os/scripts/cli.ts
@@ -8,6 +8,7 @@ import { isMainModule } from "@iterate-com/shared/dev/is-main-module";
 
 export * as configRepo from "./reset-config-repo.ts";
 export * as dev from "./dev.ts";
+export * as ice from "./ice.ts";
 export * as itx from "./itx.ts";
 export * as projectSeed from "./project-seed.ts";
 export * as session from "./session.ts";

--- a/apps/os/scripts/ice.ts
+++ b/apps/os/scripts/ice.ts
@@ -1,0 +1,74 @@
+/**
+ * Operator surface for the DO ice switch (src/domains/streams/do-ice.ts):
+ * freeze or resume an environment's stream-DO alarm loops without touching
+ * data. The reversible containment for a Durable Objects duration runaway —
+ * see tasks/do-ice-circuit-breaker.md and tasks/stream-do-wake-loop-runaway.md.
+ *
+ *   pnpm cli ice status --env preview_3
+ *   pnpm cli ice on     --env preview_3 --reason "duration runaway 2026-09-02"
+ *   pnpm cli ice off    --env preview_3
+ *
+ * Writes the flag through the Cloudflare KV REST API (control plane), so it
+ * works even while the environment's workers are the thing melting down.
+ * Propagation: hot (rebooting) DOs read the flag on their next boot; a
+ * long-resident incarnation converges within one alarm cycle after its
+ * ~30s cached read expires.
+ */
+import { envs } from "../../../envs.ts";
+import { resolveEnvContext } from "../../../scripts/lib/env-context.ts";
+import { DO_ICE_KV_KEY } from "../src/domains/streams/do-ice.ts";
+
+type IceTargetOptions = {
+  /** Target environment name from envs.ts. Required — a containment switch must never infer its target. */
+  env: string;
+};
+
+export async function status(options: IceTargetOptions) {
+  const { cf, env, name } = await context(options);
+  const keys = await cf<{ name: string }[]>(
+    `/storage/kv/namespaces/${env.resources.projectDirectoryKvId}/keys?prefix=${encodeURIComponent(DO_ICE_KV_KEY)}`,
+  );
+  const iced = keys.some((key) => key.name === DO_ICE_KV_KEY);
+  console.log(
+    iced ? `🧊 ${name} is ICED (stream alarms drain, no re-arm)` : `🔥 ${name} is not iced`,
+  );
+  return { env: name, iced };
+}
+
+export async function on(options: IceTargetOptions & { reason?: string }) {
+  const { cf, env, name } = await context(options);
+  await cf(
+    `/storage/kv/namespaces/${env.resources.projectDirectoryKvId}/values/${encodeURIComponent(DO_ICE_KV_KEY)}`,
+    {
+      method: "PUT",
+      body: JSON.stringify({
+        icedAt: new Date().toISOString(),
+        reason: options.reason || "unspecified",
+      }),
+    },
+  );
+  console.log(
+    `🧊 ${name} iced. Stream DOs stop re-arming alarms and minting woken events as their ` +
+      `cached flag reads expire (next boot for hot DOs, ~1 alarm cycle for residents). ` +
+      `Un-ice with: pnpm cli ice off --env ${name}`,
+  );
+  return { env: name, iced: true };
+}
+
+export async function off(options: IceTargetOptions) {
+  const { cf, env, name } = await context(options);
+  await cf(
+    `/storage/kv/namespaces/${env.resources.projectDirectoryKvId}/values/${encodeURIComponent(DO_ICE_KV_KEY)}`,
+    { method: "DELETE" },
+  );
+  console.log(
+    `🔥 ${name} un-iced. Streams resume lazily: the next real interaction boots them and ` +
+      `deliveries catch up from durable cursors.`,
+  );
+  return { env: name, iced: false };
+}
+
+async function context(options: IceTargetOptions) {
+  const ctx = await resolveEnvContext({ envs, dopplerProject: "os", env: options.env });
+  return { cf: ctx.cf, env: ctx.env, name: ctx.name };
+}

--- a/apps/os/src/domains/streams/do-ice.ts
+++ b/apps/os/src/domains/streams/do-ice.ts
@@ -1,0 +1,65 @@
+// The environment-wide Durable Object circuit breaker ("ice switch").
+//
+// During a duration runaway (tasks/stream-do-wake-loop-runaway.md) the fleet's
+// alarm loops — alarm → wake → woken-append → deliver → re-arm — keep tens of
+// thousands of stream DOs billable around the clock, and the only historical
+// containment was erase-data (destroys every DO; unusable on prd). This switch
+// is the reversible alternative: while the flag is set, stream DOs consume
+// alarms without re-arming, stop appending boot `woken` events, and refuse new
+// alarm writes. Every hot loop dies at its next fire; data and cursors stay
+// intact. Clearing the flag resumes normal behavior lazily — the next real
+// interaction boots a stream, appends `woken`, and deliveries catch up from
+// durable cursors exactly like post-eviction recovery.
+//
+// The flag lives in the environment's project-directory KV under a reserved
+// key (never a valid project slug). That namespace is bound to every os
+// worker and wiped by erase-data — the right reset semantics for a switch
+// whose whole point is incident containment. Flip it with `pnpm cli ice`.
+//
+// Failure posture: the switch must never become its own outage. A missing
+// binding, a KV read error, or a slow read all resolve to "not iced", and a
+// read is raced against a short timeout so a KV incident cannot block DO
+// boots behind blockConcurrencyWhile.
+
+export const DO_ICE_KV_KEY = "reserved:do-ice";
+
+/** Floor between KV re-reads in one incarnation. Long-lived residents pick up
+ * a flip on their next alarm turn after this; hot (rebooting) DOs — the ones
+ * that matter during a runaway — read fresh on every boot. */
+const REFRESH_MS = 30_000;
+
+/** A KV read must never hold up a DO boot (it sits inside the boot's
+ * blockConcurrencyWhile); slower than this reads as un-iced and the next
+ * refresh retries. */
+const READ_TIMEOUT_MS = 500;
+
+export class DoIceSwitch {
+  readonly #kv: { get(key: string): Promise<string | null> } | undefined;
+  #iced = false;
+  #lastReadAtMs = 0;
+
+  constructor(kv: { get(key: string): Promise<string | null> } | undefined) {
+    this.#kv = kv;
+  }
+
+  get iced(): boolean {
+    return this.#iced;
+  }
+
+  /** Refresh from KV, rate-limited; never throws and never hangs. */
+  async refresh(): Promise<void> {
+    if (this.#kv === undefined) return;
+    const now = Date.now();
+    if (now - this.#lastReadAtMs < REFRESH_MS) return;
+    this.#lastReadAtMs = now;
+    try {
+      const value = await Promise.race([
+        this.#kv.get(DO_ICE_KV_KEY),
+        new Promise<null>((resolve) => setTimeout(() => resolve(null), READ_TIMEOUT_MS)),
+      ]);
+      this.#iced = value !== null;
+    } catch {
+      this.#iced = false;
+    }
+  }
+}

--- a/apps/os/src/domains/streams/stream-do-ice.test.ts
+++ b/apps/os/src/domains/streams/stream-do-ice.test.ts
@@ -1,0 +1,243 @@
+// The ice switch's contract (do-ice.ts): an iced environment's stream DOs
+// consume alarms without re-arming, plant no new alarms, and stop minting
+// boot `woken` events — the reversible containment for a duration runaway
+// (tasks/stream-do-wake-loop-runaway.md). Un-icing resumes normal boots.
+//
+// Runs the REAL StreamDurableObject in plain node over an in-memory ctx fake
+// (same shape as stream-facet-alarm-replay.test.ts / guarantees-not-given.test.ts).
+
+import { DatabaseSync } from "node:sqlite";
+import { expect, test } from "vitest";
+import type { Env } from "../../env.ts";
+import { DurableObjectNameCodec } from "../durable-object-names.ts";
+import { DO_ICE_KV_KEY } from "./do-ice.ts";
+import { StreamDurableObject } from "./stream-durable-object.ts";
+
+const PROJECT_ID = "prj_ice_test";
+const STREAM_PATH = "/agents/ice-test";
+
+test("an iced boot appends no woken event and plants no alarm", async () => {
+  const harness = await bootStream({ iced: true });
+
+  const events = harness.stream.getEventPage().events.map((event) => event.type);
+  // The birth certificate and its platform feeds still append — creation is
+  // user-facing — but the wake oscillator's fuel does not.
+  expect(events).toContain("events.iterate.com/stream/created");
+  expect(events).not.toContain("events.iterate.com/stream/woken");
+  expect(harness.context.alarms).toEqual([]);
+
+  await harness.context.settle();
+  harness.context.close();
+});
+
+test("an iced alarm fire is consumed without re-arming or facet replays", async () => {
+  const harness = await bootStream({ iced: true });
+
+  // A facet desire arrives (e.g. a keepalive re-assert from before icing).
+  harness.stream.proxySetAlarm(Date.now() - 1);
+  expect(harness.context.alarms).toEqual([]);
+
+  await expect(harness.stream.alarm()).resolves.toBeUndefined();
+  expect(harness.facet.handleAlarmCalls).toBe(0);
+  expect(harness.context.alarms).toEqual([]);
+
+  await harness.context.settle();
+  harness.context.close();
+});
+
+test("an un-iced boot appends woken and arms its delivery alarm as before", async () => {
+  const harness = await bootStream({ iced: false });
+
+  const events = harness.stream.getEventPage().events.map((event) => event.type);
+  expect(events).toContain("events.iterate.com/stream/woken");
+  expect(harness.context.alarms.length).toBeGreaterThan(0);
+
+  await harness.context.settle();
+  harness.context.close();
+});
+
+test("clearing the flag un-ices the next incarnation over the same storage", async () => {
+  const flag = { iced: true };
+  const first = await bootStream(flag);
+  expect(first.stream.getEventPage().events.map((e) => e.type)).not.toContain(
+    "events.iterate.com/stream/woken",
+  );
+  await first.context.settle();
+
+  // Same durable storage, new incarnation, flag cleared — the post-incident
+  // resume path. The boot appends `woken` and re-arms normally.
+  flag.iced = false;
+  const second = await rebootStream(first, flag);
+  expect(second.stream.getEventPage().events.map((e) => e.type)).toContain(
+    "events.iterate.com/stream/woken",
+  );
+  expect(second.context.alarms.length).toBeGreaterThan(0);
+
+  await second.context.settle();
+  second.context.close();
+});
+
+// ---------------------------------------------------------------------------
+// Harness (mirrors stream-facet-alarm-replay.test.ts; kept local per the
+// repo's test-structure convention — the scenario reads first, plumbing last)
+// ---------------------------------------------------------------------------
+
+async function bootStream(flag: { iced: boolean }) {
+  const context = durableObjectContext(
+    DurableObjectNameCodec.stringify({ projectId: PROJECT_ID, path: STREAM_PATH }),
+  );
+  return bootOverContext(context, flag);
+}
+
+/** Boot a fresh incarnation over an existing context's storage. */
+async function rebootStream(
+  previous: Awaited<ReturnType<typeof bootStream>>,
+  flag: { iced: boolean },
+) {
+  previous.context.alarms.length = 0;
+  return bootOverContext(previous.context, flag);
+}
+
+async function bootOverContext(
+  context: ReturnType<typeof durableObjectContext>,
+  flag: { iced: boolean },
+) {
+  const facet = {
+    handleAlarmCalls: 0,
+    stub: {
+      configure: () => Promise.resolve(),
+      handleAlarm: () => {
+        facet.handleAlarmCalls += 1;
+        return Promise.resolve();
+      },
+      wakeStreamProcessor: () => Promise.resolve(),
+    },
+  };
+  context.facetStub.current = facet.stub;
+  const stream = new StreamDurableObject(context.ctx, fakeEnv(flag));
+  await context.waitForInitialization();
+  await context.settle();
+  return { context, facet, stream };
+}
+
+function fakeEnv(flag: { iced: boolean }): Env {
+  return {
+    STREAM: {
+      getByName: () => ({
+        appendCoreEvent: (eventInput: unknown) =>
+          Promise.resolve({
+            ...(eventInput as object),
+            path: "/",
+            offset: 1,
+            createdAt: new Date().toISOString(),
+          }),
+      }),
+    },
+    PROJECT: {},
+    PROJECT_DIRECTORY: {
+      get: (key: string) => Promise.resolve(key === DO_ICE_KV_KEY && flag.iced ? "iced" : null),
+    },
+  } as unknown as Env;
+}
+
+function durableObjectContext(name: string) {
+  const db = new DatabaseSync(":memory:");
+  const values = new Map<string, unknown>();
+  const backgroundWork: Promise<unknown>[] = [];
+  const alarms: number[] = [];
+  const facetStub: { current: object } = { current: {} };
+  let latestInitialization: Promise<unknown> | undefined;
+  const storage = {
+    sql: wrapSqlStorage(db),
+    kv: {
+      get<T>(key: string): T | undefined {
+        const value = values.get(key);
+        return value === undefined ? undefined : structuredClone(value as T);
+      },
+      put(key: string, value: unknown): void {
+        values.set(key, structuredClone(value));
+      },
+      delete(key: string): void {
+        values.delete(key);
+      },
+    },
+    setAlarm(atMs: number): Promise<void> {
+      alarms.push(atMs);
+      return Promise.resolve();
+    },
+    deleteAlarm(): Promise<void> {
+      return Promise.resolve();
+    },
+    sync(): Promise<void> {
+      return Promise.resolve();
+    },
+    transactionSync<T>(callback: () => T): T {
+      return callback();
+    },
+  };
+  const ctx = {
+    id: { name },
+    storage,
+    exports: { ProcessorFacet: class {} },
+    facets: {
+      get: () => facetStub.current,
+      abort: () => {},
+    },
+    getWebSockets(): WebSocket[] {
+      return [];
+    },
+    waitUntil(work: Promise<unknown>): void {
+      backgroundWork.push(work);
+    },
+    blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T> {
+      const work = Promise.resolve().then(callback);
+      latestInitialization = work;
+      return work;
+    },
+    abort(): never {
+      throw new Error("test Durable Object aborted");
+    },
+  } as unknown as DurableObjectState;
+
+  return {
+    alarms,
+    facetStub,
+    close: () => db.close(),
+    ctx,
+    async waitForInitialization(): Promise<void> {
+      await latestInitialization;
+    },
+    async settle(): Promise<void> {
+      let seen = -1;
+      while (seen !== backgroundWork.length) {
+        seen = backgroundWork.length;
+        await Promise.allSettled([...backgroundWork]);
+        await Promise.resolve();
+      }
+    },
+  };
+}
+
+function wrapSqlStorage(db: DatabaseSync): SqlStorage {
+  return {
+    databaseSize: 0,
+    exec<T = unknown>(sql: string, ...bindings: (ArrayBuffer | null | number | string)[]) {
+      const rows = db
+        .prepare(sql)
+        .all(
+          ...bindings.map((binding) =>
+            binding instanceof ArrayBuffer ? new Uint8Array(binding) : binding,
+          ),
+        )
+        .map((row) => Object.fromEntries(Object.entries(row).map(fromNodeSqlValue)));
+      return { toArray: () => rows as T[] };
+    },
+  } as unknown as SqlStorage;
+}
+
+function fromNodeSqlValue([key, value]: [string, unknown]) {
+  if (value instanceof Uint8Array) {
+    return [key, value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength)];
+  }
+  return [key, value];
+}

--- a/apps/os/src/domains/streams/stream-durable-object.ts
+++ b/apps/os/src/domains/streams/stream-durable-object.ts
@@ -61,6 +61,7 @@ import { isWorkerBuildFailedError, WorkerBuildFailedError } from "../workers/art
 import { RepoNotSeededError } from "../repos/utils.ts";
 import type { StatefulDynamicWorkerRef } from "../workers/schemas.ts";
 import { buildCopyAppends } from "./copy-appends.ts";
+import { DoIceSwitch } from "./do-ice.ts";
 import {
   assertCoreProcessorCheckpointGrowthFits,
   STREAM_PAUSED_ERROR_PREFIX,
@@ -194,13 +195,20 @@ type StreamAlarmStorage = {
  */
 export class StreamAlarmArmer {
   readonly #storage: StreamAlarmStorage;
+  readonly #isIced: () => boolean;
   #armedForMs: number | null = null;
 
-  constructor(storage: StreamAlarmStorage) {
+  constructor(storage: StreamAlarmStorage, isIced: () => boolean = () => false) {
     this.#storage = storage;
+    this.#isIced = isIced;
   }
 
   armNoLaterThan(atMs: number): void {
+    // Iced environment (do-ice.ts): consume desires without planting the
+    // platform alarm, so no turn can perpetuate a wake loop. The desires'
+    // durable representations (cursor lag, facet slot, keepalive record)
+    // survive and are re-derived after un-icing.
+    if (this.#isIced()) return;
     const previous = this.#armedForMs;
     if (previous !== null && previous <= atMs) return;
     this.#armedForMs = atMs;
@@ -934,7 +942,13 @@ export class StreamDurableObject extends DurableObject<Env> {
   });
   /** In-memory throughput accounting (events/s, bytes in/out); resets with the incarnation. */
   readonly #metrics = new StreamRuntimeMetrics(Date.now());
-  readonly #alarmArmer = new StreamAlarmArmer(this.ctx.storage);
+  /** Environment-wide alarm circuit breaker (do-ice.ts); refreshed at boot
+   * and per alarm turn. `PROJECT_DIRECTORY` is absent in the standalone
+   * streams playground, which the switch treats as permanently un-iced. */
+  readonly #ice = new DoIceSwitch(
+    "PROJECT_DIRECTORY" in this.env ? this.env.PROJECT_DIRECTORY : undefined,
+  );
+  readonly #alarmArmer = new StreamAlarmArmer(this.ctx.storage, () => this.#ice.iced);
   readonly #deliveryAlarmBoundary = new StreamDeliveryAlarmBoundary({
     armAlarm: (atMs) => this.#alarmArmer.armNoLaterThan(atMs),
     now: () => Date.now(),
@@ -1132,7 +1146,14 @@ export class StreamDurableObject extends DurableObject<Env> {
     const loaded = this.#readCoreProcessorState();
     if (loaded.kind === "ready") {
       this.#coreProcessorState = loaded.state;
-      this.#finishInitialization();
+      // The ice refresh must precede the first turn's woken append/arm even
+      // on this fast path, so it rides a blockConcurrencyWhile too. Cost: one
+      // KV point read per boot, capped at READ_TIMEOUT_MS and fail-open
+      // (do-ice.ts) — a KV incident degrades to slower boots, never a wedge.
+      void this.ctx.blockConcurrencyWhile(async () => {
+        await this.#ice.refresh();
+        this.#finishInitialization();
+      });
       return;
     }
 
@@ -1144,6 +1165,10 @@ export class StreamDurableObject extends DurableObject<Env> {
     // initialization reset.
     this.#coreProcessorState = CoreProcessorContract.stateSchema.parse({});
     void this.ctx.blockConcurrencyWhile(async () => {
+      // Refresh the ice switch before the first turn: a hot (rebooting) fleet
+      // reads the flag on every boot, which is exactly when containment needs
+      // it. Bounded and fail-open inside refresh — see do-ice.ts.
+      await this.#ice.refresh();
       this.#coreProcessorState = await this.#recoverCoreProcessorStateFromEventLog();
       this.#finishInitialization();
     });
@@ -1242,6 +1267,11 @@ export class StreamDurableObject extends DurableObject<Env> {
         },
       ]);
     }
+    // Iced environment (do-ice.ts): no `woken` append. The append would be
+    // fresh delivery work — the very fuel the switch exists to cut off. After
+    // un-icing, the next boot appends `woken` normally and deliveries catch
+    // up from durable cursors.
+    if (this.#ice.iced) return;
     this.#append({ authority: "core-event" }, [
       {
         type: "events.iterate.com/stream/woken",
@@ -1260,6 +1290,20 @@ export class StreamDurableObject extends DurableObject<Env> {
    */
   async alarm(alarmInfo?: AlarmInvocationInfo) {
     this.#alarmArmer.markFired();
+    // Iced environment (do-ice.ts): consume the fire and do nothing — no
+    // facet replays, no reconcile, no re-arm. Resolving (not throwing) is
+    // what retires the platform alarm; the drained work is all re-derivable
+    // from durable state after un-icing. The check reads the cached flag so
+    // the alarm turn stays synchronous; the background refresh means a
+    // long-resident incarnation converges within one alarm cycle (fresh
+    // incarnations — the hot case in a runaway — read the flag at boot).
+    void this.#ice.refresh();
+    if (this.#ice.iced) {
+      console.warn("stream alarm consumed without work: environment is iced (do-ice)", {
+        path: this.name.path,
+      });
+      return undefined;
+    }
     let facetReplays: Promise<FacetAlarmReplayFailure[]> | undefined;
     this.#deliveryAlarmBoundary.runAlarmTurn(() => {
       facetReplays = this.#fireDueFacetAlarms(alarmInfo);

--- a/tasks/do-ice-circuit-breaker.md
+++ b/tasks/do-ice-circuit-breaker.md
@@ -1,0 +1,83 @@
+---
+status: in-progress
+size: medium
+---
+
+# DO ice switch: freeze an environment's alarm loops without destroying data
+
+## Status summary
+
+Spec fleshed out autonomously on the evening of 2026-09-02 (Misha AFK) during
+the DO duration runaway incident; assumptions marked **[assumption]** below.
+Implementation in progress on this branch.
+
+## Why
+
+During the 2026-09-01→02 preview runaway (~$300/hr list-price), the only
+containment lever was `erase-data` — destroy every DO in the slot. That is:
+
+- unusable on prd (real data),
+- a treadmill on previews: slots re-ignite within ~2h of any deploy + spec
+  run, even on healthy post-#2567 code (verified live on slots 3, 14, 8, 11
+  on 2026-09-02 evening — the wake loops need no external trigger).
+
+We need a reversible "big red button": flip a switch → the environment's
+self-perpetuating background work (alarm → wake → woken-append → deliver →
+re-arm) drains quiet within roughly one alarm cycle → debug calmly → flip
+back. Data intact. See `tasks/stream-do-wake-loop-runaway.md` for the loop
+mechanics this freezes (but does not fix).
+
+## Design
+
+One flag per environment: **iced**.
+
+- **Storage**: a single key in the project-directory KV namespace
+  (**[assumption]** — it exists in every env, is already bound to os, and is
+  wiped by erase-data which is the correct reset semantics). Value carries
+  `{icedAt, reason}` for the audit trail.
+- **Read path**: each DO incarnation reads the flag ONCE during boot
+  (non-blocking; default un-iced on read failure — the switch must never
+  become its own outage). Incarnations are short-lived precisely when the
+  fleet is hot, so propagation is fast where it matters; a long-lived
+  resident incarnation picks it up on its next alarm turn (the handler
+  re-reads at most every REFRESH_MS). **[assumption]** ~30s refresh floor.
+- **Enforcement points** (all fail-open, i.e. iced → do less, never throw):
+  1. `StreamDurableObject.alarm()`: mark fired, skip facet alarm replays and
+     reconcile, do NOT re-arm, return success — the platform alarm is
+     consumed and the loop's edge dies.
+  2. `StreamAlarmArmer`: arming becomes a no-op while iced (fetch/RPC turns
+     can't re-plant the alarm).
+  3. Processor keepalive + scheduler registry arming hooks: same no-op.
+  4. Boot `stream/woken` append: skipped while iced (stop minting new
+     delivery work; `created` birth events still append — creation is
+     user-facing).
+  5. Delivery retry arming (stream-event-sender): no-op while iced.
+- **What still works while iced**: reads, appends from real callers, RPC,
+  the UI. Only background self-perpetuation stops; deliveries lag by design
+  and catch up after un-icing (the durable cursors make that safe — this is
+  the same catch-up path as post-eviction recovery).
+- **Un-icing**: delete the KV key. Streams resume lazily: the next real
+  interaction (fetch/RPC/append) boots them, appends `woken`, re-establishes
+  deliveries from cursors. No mass thundering-herd wake on un-ice
+  (**[assumption]**: acceptable — active streams get traffic; idle wedged
+  streams staying asleep is the desired outcome).
+- **Operator surface**: `pnpm cli ice status|on|off --env <name> [--reason]`
+  (doppler-backed script pattern), plus the duration-probe alert message
+  (PR #2576) naming the command.
+
+## Checklist
+
+- [ ] `ice.ts` module: flag read/write helpers + per-incarnation cache
+- [ ] Enforcement in StreamDurableObject alarm turn + StreamAlarmArmer
+- [ ] Enforcement in keepalive/scheduler arming hooks
+- [ ] Skip boot woken-append while iced
+- [ ] Node-harness test: wedged-loop scenario drains on ice, resumes on
+      un-ice (real recovery machinery, no mocks)
+- [ ] CLI: `pnpm cli ice` on/off/status
+- [ ] Wire the runbook line into do-duration-probe alert text (PR #2576
+      follow-up if that merges first)
+
+## Implementation log
+
+- 2026-09-02 evening: worktree created, spec committed first per AFK
+  protocol.

--- a/tasks/do-ice-circuit-breaker.md
+++ b/tasks/do-ice-circuit-breaker.md
@@ -67,17 +67,26 @@ One flag per environment: **iced**.
 
 ## Checklist
 
-- [ ] `ice.ts` module: flag read/write helpers + per-incarnation cache
-- [ ] Enforcement in StreamDurableObject alarm turn + StreamAlarmArmer
-- [ ] Enforcement in keepalive/scheduler arming hooks
-- [ ] Skip boot woken-append while iced
-- [ ] Node-harness test: wedged-loop scenario drains on ice, resumes on
-      un-ice (real recovery machinery, no mocks)
-- [ ] CLI: `pnpm cli ice` on/off/status
+- [x] `do-ice.ts` module: flag read + per-incarnation cache _(src/domains/streams/do-ice.ts; 30s refresh floor, 500ms read cap, fail-open)_
+- [x] Enforcement in StreamDurableObject alarm turn + StreamAlarmArmer _(armer takes an `isIced` hook — the single choke point every alarm write funnels through; alarm() consumes fires from the cached flag so the turn stays synchronous)_
+- [x] ~~Enforcement in keepalive/scheduler arming hooks~~ _(unnecessary for streams: keepalive/facet desires all arm through the parent armer. SchedulerDurableObject arms via the shared registry and is deferred — it burned ~66 DO-hrs/3h vs the stream DO's 50k in the incident; noted as follow-up)_
+- [x] Skip boot woken-append while iced _(both boot paths now refresh the flag under blockConcurrencyWhile before finishInitialization — the checkpoint-ready fast path previously initialized synchronously; cost is one capped KV point read per boot)_
+- [x] Node-harness test: iced boot appends no woken/arms nothing, iced alarm consumed without facet replays, un-iced boot unchanged, flag-clear resumes next incarnation _(stream-do-ice.test.ts, real StreamDurableObject over the in-memory ctx fake)_
+- [x] CLI: `pnpm cli ice` on/off/status _(scripts/ice.ts via the KV REST control plane; live round-trip drilled on preview_3)_
 - [ ] Wire the runbook line into do-duration-probe alert text (PR #2576
       follow-up if that merges first)
+- [ ] Follow-up: same gate for SchedulerDurableObject (shared registry —
+      needs an OS-injectable hook, not KV logic in packages/iterate)
+- [ ] Follow-up: a live drain drill on a deliberately-wedged preview slot
+      (nothing was burning when this landed)
 
 ## Implementation log
 
 - 2026-09-02 evening: worktree created, spec committed first per AFK
   protocol.
+- Implementation + tests landed the same evening. Notable discovery: fresh
+  streams boot through the checkpoint-ready SYNCHRONOUS path (empty log ⇒
+  `kind: "ready"`), so the flag read had to gate both constructor lanes.
+  alarm() reads the cached flag (not awaited) to keep the pacing test's
+  synchronous-turn contract; residents converge one alarm cycle after a
+  flip, fresh boots immediately.


### PR DESCRIPTION
## What

A reversible per-environment circuit breaker for Durable Object alarm loops: flip a KV flag → stream/scheduler alarms stop re-arming, boot `woken` appends pause, and the fleet drains quiet within ~one alarm cycle — data intact, reversible by deleting the flag. The missing non-destructive containment lever from the 2026-09-01→02 preview duration runaway, where the only tool was `erase-data` (unusable on prd, and a treadmill on previews — slots re-ignite within ~2h of any deploy + spec run).

Spec: [tasks/do-ice-circuit-breaker.md](../blob/do-ice-circuit-breaker/tasks/do-ice-circuit-breaker.md) — committed first, assumptions marked, per the AFK protocol. Implementation follows on this branch.

Opened as the first commit so the spec is reviewable before/while the implementation lands. Related: #2576 (detection), tasks/stream-do-wake-loop-runaway.md (root fixes this does not attempt).

---
Coding agent session: `fc7df69e-30c5-4fe1-a51c-896c830389c4` (DO duration runaway investigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +112 -3 | +51 -3 🟩⬜⬜⬜⬜ |
| Tests | +243 -0 | +199 -0 🟩🟩🟩🟩🟩 |
| CI & scripts | +75 -0 | +50 -0 🟩⬜⬜⬜⬜ |
| Docs | +92 -0 | +78 -0 🟩🟩⬜⬜⬜ |
| **Total** | **+522 -3** | **+378 -3** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 39b0ddd and 92d6d3c, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-09-02T20:39:41.055Z",
      "deployedAt": "2026-09-02T18:58:35.160Z",
      "headSha": "92d6d3cff900831e77588c4264928adbe6dd6327",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-16.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/420656257619851",
      "shortSha": "92d6d3c",
      "cleanupDurationMs": 102510,
      "deployDurationMs": 93386,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 91748,
      "deployReadinessDurationMs": 1634,
      "deployedWorkerName": "os-preview-16",
      "deployedWorkerVersion": "b15ddc27-9523-44d6-9be2-2cb1c432ef05",
      "workerSizeKib": 20892.41,
      "workerGzipKib": 5265.24,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5276.02
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-09-02T20:38:02.439Z",
      "deployedAt": "2026-09-02T18:57:32.805Z",
      "headSha": "92d6d3cff900831e77588c4264928adbe6dd6327",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-16.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/420656257619851",
      "shortSha": "92d6d3c",
      "cleanupDurationMs": 3891,
      "deployDurationMs": 29923,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 29390,
      "deployReadinessDurationMs": 528,
      "deployedWorkerName": "docs-preview-16",
      "deployedWorkerVersion": "ef7b7256-cb02-425c-b42d-4debe468205e",
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-09-02T20:38:03.478Z",
      "deployedAt": "2026-09-02T18:57:40.277Z",
      "headSha": "92d6d3cff900831e77588c4264928adbe6dd6327",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-16.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/420656257619851",
      "shortSha": "92d6d3c",
      "cleanupDurationMs": 4929,
      "deployDurationMs": 37520,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 36861,
      "deployReadinessDurationMs": 653,
      "deployedWorkerName": "auth-preview-16",
      "deployedWorkerVersion": "89631348-598c-4c57-b861-77108db11f04",
      "workerSizeKib": 3989.98,
      "workerGzipKib": 817.19,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-09-02T20:38:03.671Z",
      "headSha": "92d6d3cff900831e77588c4264928adbe6dd6327",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-16.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/420656257619851",
      "shortSha": "92d6d3c",
      "cleanupDurationMs": 5120,
      "deployDurationMs": 22475,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 22469,
      "workerSizeKib": 5603.72,
      "workerGzipKib": 1586.22,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-09-02T20:37:59.639Z",
      "deployedAt": "2026-09-02T18:57:18.038Z",
      "headSha": "92d6d3cff900831e77588c4264928adbe6dd6327",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-16.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/420656257619851",
      "shortSha": "92d6d3c",
      "cleanupDurationMs": 1085,
      "deployDurationMs": 15175,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 14580,
      "deployReadinessDurationMs": 548,
      "deployedWorkerName": "dummy-petshop-preview-16",
      "deployedWorkerVersion": "d8348d0d-3d06-49e3-9228-e87755aa264e",
      "workerSizeKib": 1115.4,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "b717e505c46472150438e97f994eb4a2c283e0f8+c5abf1055de73f3b4ffbc5e5b742dff1f0b5ee52",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `92d6d3c` | [https://auth.iterate-preview-16.com](https://auth.iterate-preview-16.com) | 817.2 KiB | 37.5s |  |  | 4.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/420656257619851) | 2026-09-02T20:38:03.478Z | Preview app released. |
| Docs | released | `92d6d3c` | [https://docs-preview-16.iterate-dev-preview.workers.dev](https://docs-preview-16.iterate-dev-preview.workers.dev) | 866.2 KiB | 29.9s |  |  | 3.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/420656257619851) | 2026-09-02T20:38:02.439Z | Preview app released. |
| Dummy Petshop | released | `92d6d3c` | [https://dummy-petshop.iterate-preview-16.com](https://dummy-petshop.iterate-preview-16.com) | 198.3 KiB | 15.2s |  |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/420656257619851) | 2026-09-02T20:37:59.639Z | Preview app released. |
| OS | released | `92d6d3c` | [https://os.iterate-preview-16.com](https://os.iterate-preview-16.com) | 5.14 MiB (-10.8 KiB vs main) | 93.4s |  |  | 102.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/420656257619851) | 2026-09-02T20:39:41.055Z | Preview app released. |
| Streams Example App | released | `92d6d3c` | [https://streams.iterate-preview-16.com](https://streams.iterate-preview-16.com) | 1.55 MiB | 22.5s |  |  | 5.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/420656257619851) | 2026-09-02T20:38:03.671Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->