### PR TITLE
Flake reporter: tolerate birth conflicts, fix empty-owner fallback

### DIFF
--- a/packages/iterate/scripts/report-flake-records.ts
+++ b/packages/iterate/scripts/report-flake-records.ts
@@ -11,6 +11,7 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { connectItx } from "../src/node.ts";
+import { isIdempotencyConflict } from "../src/processors/index.ts";
 import {
   flakeDashboardCreationEvents,
   flakesStreamPath,
@@ -78,7 +79,13 @@ async function main(): Promise<void> {
   const runId = `${process.env.GITHUB_RUN_ID || "local"}-${process.env.GITHUB_RUN_ATTEMPT || "1"}`;
   // iterate-lint-disable-next-line terminology/no-metaphorical-lane-door-seam -- reads the existing TEST_TELEMETRY_LANE env var; renaming that wire name is tracked in tasks/rename-lane-vocabulary.md
   const suite = process.env.TEST_TELEMETRY_LANE || "unknown";
-  const [owner = "iterate", repo = "iterate"] = (process.env.GITHUB_REPOSITORY || "").split("/");
+  // `|| "iterate"`, not destructuring defaults: "".split("/") yields [""],
+  // an empty STRING, and a default only fires on undefined — an unset
+  // GITHUB_REPOSITORY once produced an owner of "" that failed the contract
+  // and poisoned the birth idempotency key on prd.
+  const [ownerPart, repoPart] = (process.env.GITHUB_REPOSITORY || "").split("/");
+  const owner = ownerPart || "iterate";
+  const repo = repoPart || "iterate";
 
   using project = connectItx({
     baseUrl,
@@ -87,14 +94,23 @@ async function main(): Promise<void> {
   });
   const stream = project.streams.get(flakesStreamPath);
   // Every reporter may offer the idempotency-keyed birth certificate; only
-  // the first ever lands.
-  await stream.append(
-    ...flakeDashboardCreationEvents({
-      repository: { owner, repo },
-      issueTitle: process.env.FLAKE_REPORT_ISSUE_TITLE || "Flake dashboard",
-      defaultBranch: process.env.FLAKE_REPORT_DEFAULT_BRANCH || "main",
-    }),
-  );
+  // the first ever lands. A same-key/DIFFERENT-body conflict also means the
+  // stream is already born (with someone else's config, or a historical
+  // body) — it must not abort the run-recorded append below, which is the
+  // actual payload. This is not hypothetical: a poisoned birth key on prd
+  // silently dropped every CI run's records until this tolerance existed.
+  await stream
+    .append(
+      ...flakeDashboardCreationEvents({
+        repository: { owner, repo },
+        issueTitle: process.env.FLAKE_REPORT_ISSUE_TITLE || "Flake dashboard",
+        defaultBranch: process.env.FLAKE_REPORT_DEFAULT_BRANCH || "main",
+      }),
+    )
+    .catch((error) => {
+      if (!isIdempotencyConflict(error)) throw error;
+      console.log("[flake-report] birth already claimed — proceeding to records");
+    });
   await stream.append({
     type: "events.iterate.com/flakes/run-recorded",
     idempotencyKey: `flakes/run:${runId}:${suite}`,


### PR DESCRIPTION
Two bugs found live on prd while bringing the flake dashboard up (the dashboard works — https://github.com/iterate/iterate/issues/2580 — but no CI run's records had ever landed):

1. **Birth offers aborted reports on idempotency conflict.** "Every caller may offer the birth" requires tolerating same-key conflicts once any birth body exists under the key — instead the conflict threw, the reporter's catch-all swallowed it, and every CI run's `run-recorded` append was skipped. Now: log and proceed.
2. **Empty-owner fallback.** `const [owner = "iterate"] = ("").split("/")` never applies the default — `"".split("/")` is `[""]`, an empty string, not `undefined`. An unset `GITHUB_REPOSITORY` (local runs) produced `owner: ""`, which failed the contract's `min(1)` and is how the prd birth key got poisoned. Now `||`-based.

Note: #2571 deletes this file entirely (webhook-pull ingestion); this PR unblocks CI flake data in the meantime, and the same birth-tolerance lesson is being applied to #2571's ingestion path separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session: 4fe3e39f-bdf2-4b87-8ed3-b77d4252fd95 — "createFlake helper + flake telemetry"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only CI script with fail-open behavior; changes narrow error handling and env parsing without touching auth or core product paths.
> 
> **Overview**
> Fixes two bugs in the CI flake reporter that prevented **run-recorded** events from ever landing on prd.
> 
> **Owner/repo defaults:** Replaces destructuring defaults on `GITHUB_REPOSITORY.split("/")` with `|| "iterate"` for owner and repo. An unset env yields `[""]`, so defaults never applied and `owner: ""` could fail contract validation and poison the birth idempotency key.
> 
> **Birth append tolerance:** Wraps the dashboard birth-certificate `stream.append` in a catch that treats `isIdempotencyConflict` as success (log and continue). A conflict used to abort before the per-run `run-recorded` append, so flake telemetry was dropped even when the stream was already initialized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22bea1a80d7943bac5440950fcdd3173ccffb1b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| CI & scripts | +25 -9 | +16 -8 🟩🟩🟩🟥🟥 |
| **Total** | **+25 -9** | **+16 -8** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 3d3df53 and 22bea1a, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-09-02T22:19:58.924Z",
      "deployedAt": "2026-09-02T22:14:15.916Z",
      "headSha": "22bea1a80d7943bac5440950fcdd3173ccffb1b5",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/309327634097132",
      "shortSha": "22bea1a",
      "cleanupDurationMs": 172172,
      "deployDurationMs": 79036,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 77271,
      "deployReadinessDurationMs": 1760,
      "deployedWorkerName": "os-preview-7",
      "deployedWorkerVersion": "e4acebdb-35f2-4c96-ba0b-4863921c8f94",
      "workerSizeKib": 20890.58,
      "workerGzipKib": 5264.5,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5276.01
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-09-02T22:17:09.573Z",
      "deployedAt": "2026-09-02T22:13:21.137Z",
      "headSha": "22bea1a80d7943bac5440950fcdd3173ccffb1b5",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-7.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/309327634097132",
      "shortSha": "22bea1a",
      "cleanupDurationMs": 2818,
      "deployDurationMs": 24029,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 22490,
      "deployReadinessDurationMs": 1535,
      "deployedWorkerName": "docs-preview-7",
      "deployedWorkerVersion": "0fe71449-1335-4e8a-afb3-fc1d76ea9ffc",
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-09-02T22:17:10.196Z",
      "deployedAt": "2026-09-02T22:13:31.313Z",
      "headSha": "22bea1a80d7943bac5440950fcdd3173ccffb1b5",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/309327634097132",
      "shortSha": "22bea1a",
      "cleanupDurationMs": 3441,
      "deployDurationMs": 33125,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 32665,
      "deployReadinessDurationMs": 456,
      "deployedWorkerName": "auth-preview-7",
      "deployedWorkerVersion": "ea079e31-e7df-4830-bcfa-b309b49f2645",
      "workerSizeKib": 3989.97,
      "workerGzipKib": 817.31,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-09-02T22:17:07.379Z",
      "deployedAt": "2026-09-02T22:13:07.502Z",
      "headSha": "22bea1a80d7943bac5440950fcdd3173ccffb1b5",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/309327634097132",
      "shortSha": "22bea1a",
      "cleanupDurationMs": 621,
      "deployDurationMs": 9064,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 8826,
      "deployReadinessDurationMs": 205,
      "deployedWorkerName": "dummy-petshop-preview-7",
      "deployedWorkerVersion": "3e2dd1ed-170e-48b1-98e4-ca484a387878",
      "workerSizeKib": 1115.4,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "b717e505c46472150438e97f994eb4a2c283e0f8+c5abf1055de73f3b4ffbc5e5b742dff1f0b5ee52",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `22bea1a` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 817.3 KiB | 33.1s |  |  | 3.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/309327634097132) | 2026-09-02T22:17:10.196Z | Preview app released. |
| Docs | released | `22bea1a` | [https://docs-preview-7.iterate-dev-preview.workers.dev](https://docs-preview-7.iterate-dev-preview.workers.dev) | 866.2 KiB | 24.0s |  |  | 2.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/309327634097132) | 2026-09-02T22:17:09.573Z | Preview app released. |
| Dummy Petshop | released | `22bea1a` | [https://dummy-petshop.iterate-preview-7.com](https://dummy-petshop.iterate-preview-7.com) | 198.3 KiB | 9.1s |  |  | 621ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/309327634097132) | 2026-09-02T22:17:07.379Z | Preview app released. |
| OS | released | `22bea1a` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 5.14 MiB (-11.5 KiB vs main) | 79.0s |  |  | 172.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/309327634097132) | 2026-09-02T22:19:58.924Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->