### PR TITLE
Flake ingestion: check_run trigger + Depot artifact pull (workflow_run never fires)

### DIFF
--- a/apps/os/src/domains/repos/config-repo-template.generated.ts
+++ b/apps/os/src/domains/repos/config-repo-template.generated.ts
@@ -966,8 +966,12 @@ export const PROJECT_REPO_INITIAL_FILES: Array<{ content: string; path: string }
       "      repoPath: \"/repos/config\",\n" +
       "    },\n" +
       "  });\n" +
-      "  /** /flakes -> GitHub \"Flake dashboard\" issue. Inert if /flakes stream never receives events. */\n" +
-      "  #flakeDashboardApp = FlakeDashboardApp.create(this.env);\n" +
+      "  /** /flakes -> GitHub \"Flake dashboard\" issue. Inert if /flakes stream never receives events.\n" +
+      "   * `depot` is THIS project's CI artifact store — edit per project (or drop\n" +
+      "   * it to disable check_run ingestion). */\n" +
+      "  #flakeDashboardApp = FlakeDashboardApp.create(this.env, {\n" +
+      "    depot: { orgId: \"0p91s0lz49\", secretPath: \"/secrets/depot-ci-token\" },\n" +
+      "  });\n" +
       "  #docsApp = DocsApp.create(this.env, {\n" +
       "    auth: { policy: \"project-member\" },\n" +
       "    proxy: {\n" +

--- a/configs/default/worker.ts
+++ b/configs/default/worker.ts
@@ -36,8 +36,12 @@ export default class ProjectWorker extends IterateWorkerEntrypoint {
       repoPath: "/repos/config",
     },
   });
-  /** /flakes -> GitHub "Flake dashboard" issue. Inert if /flakes stream never receives events. */
-  #flakeDashboardApp = FlakeDashboardApp.create(this.env);
+  /** /flakes -> GitHub "Flake dashboard" issue. Inert if /flakes stream never receives events.
+   * `depot` is THIS project's CI artifact store — edit per project (or drop
+   * it to disable check_run ingestion). */
+  #flakeDashboardApp = FlakeDashboardApp.create(this.env, {
+    depot: { orgId: "0p91s0lz49", secretPath: "/secrets/depot-ci-token" },
+  });
   #docsApp = DocsApp.create(this.env, {
     auth: { policy: "project-member" },
     proxy: {

--- a/packages/iterate/src/starter-apps/flake-dashboard/contract.ts
+++ b/packages/iterate/src/starter-apps/flake-dashboard/contract.ts
@@ -130,21 +130,23 @@ export const flakeTransitionThresholds = {
 
 /**
  * The exact shape of a delivered event this app ingests: a platform-verified
- * GitHub webhook for a COMPLETED workflow_run on a connection stream. Zod
+ * GitHub webhook for a COMPLETED check_run on a connection stream. This
+ * repo's test suites run on Depot CI, whose jobs are GitHub check runs (NOT
+ * GitHub Actions workflow runs — `workflow_run` never fires for them). Zod
  * strips the rest of GitHub's (huge) payload; only these fields are read.
  */
-export const WorkflowRunWebhookEvent = z.object({
+export const CheckRunWebhookEvent = z.object({
   type: z.literal("events.iterate.com/github/webhook-received"),
   path: z.string().regex(/^\/integrations\/github\/[^/]+$/),
   payload: z.object({
-    delivery: z.object({ name: z.literal("workflow_run") }),
+    delivery: z.object({ name: z.literal("check_run") }),
     body: z.object({
       action: z.literal("completed"),
-      workflow_run: z.object({
-        id: z.number().int().positive(),
-        run_attempt: z.number().int().positive().optional(),
-        head_branch: z.string().nullish(),
-        head_sha: z.string().nullish(),
+      check_run: z.object({
+        // Cancelled/skipped checks upload no fresh artifacts worth scanning.
+        conclusion: z.enum(["success", "failure"]),
+        head_sha: z.string().min(1),
+        check_suite: z.object({ head_branch: z.string().nullish() }).optional(),
       }),
       repository: z.object({
         name: z.string().min(1),

--- a/packages/iterate/src/starter-apps/flake-dashboard/flake-dashboard.test.ts
+++ b/packages/iterate/src/starter-apps/flake-dashboard/flake-dashboard.test.ts
@@ -236,8 +236,8 @@ function day(days: number) {
 test("a completed workflow_run's flake artifacts become one run-recorded event per suite", async () => {
   const { itx, appended } = fakeItx({
     artifacts: [
-      { artifact_id: "art-71", name: "flake-records-unit", size_bytes: 1000, attempt: 2 },
-      { artifact_id: "art-72", name: "unit-test-telemetry", size_bytes: 1000 },
+      { artifactId: "art-71", name: "flake-records-unit", sizeBytes: 1000, attempt: 2 },
+      { artifactId: "art-72", name: "unit-test-telemetry", sizeBytes: 1000 },
     ],
     zips: {
       // Two files exercising both zip entry kinds our reader supports:
@@ -282,7 +282,7 @@ test("a completed workflow_run's flake artifacts become one run-recorded event p
 
 test("runs without flake artifacts append nothing, not even a birth", async () => {
   const { itx, appended } = fakeItx({
-    artifacts: [{ artifact_id: "art-72", name: "unit-test-telemetry", size_bytes: 1000 }],
+    artifacts: [{ artifactId: "art-72", name: "unit-test-telemetry", sizeBytes: 1000 }],
     zips: {},
   });
   await makeApp(itx).processEvent(webhookEvent());
@@ -315,9 +315,7 @@ test("a birth conflict means already born and the records still append", async (
   // The poisoned-prd lesson: once ANY body exists under the birth key, every
   // later offer conflicts — that must never cost the run's records.
   const { itx, appended } = fakeItx({
-    artifacts: [
-      { artifact_id: "art-71", name: "flake-records-unit", size_bytes: 1000, attempt: 2 },
-    ],
+    artifacts: [{ artifactId: "art-71", name: "flake-records-unit", sizeBytes: 1000, attempt: 2 }],
     zips: {
       "art-71": zipSync({ "r.jsonl": strToU8(JSON.stringify(record("flake sentinel", "pass"))) }),
     },
@@ -340,9 +338,7 @@ test("a webhook without depot config is skipped without touching itx", async () 
 
 test("an idempotency conflict on run-recorded means already ingested and does not throw", async () => {
   const { itx, appended } = fakeItx({
-    artifacts: [
-      { artifact_id: "art-71", name: "flake-records-unit", size_bytes: 1000, attempt: 2 },
-    ],
+    artifacts: [{ artifactId: "art-71", name: "flake-records-unit", sizeBytes: 1000, attempt: 2 }],
     zips: {
       "art-71": zipSync({ "r.jsonl": strToU8(JSON.stringify(record("flake sentinel", "pass"))) }),
     },
@@ -377,7 +373,7 @@ test("oversized artifacts are skipped with a warning", async () => {
   try {
     const { itx, appended } = fakeItx({
       artifacts: [
-        { artifact_id: "art-71", name: "flake-records-unit", size_bytes: 50 * 1024 * 1024 },
+        { artifactId: "art-71", name: "flake-records-unit", sizeBytes: 50 * 1024 * 1024 },
       ],
       zips: {},
     });
@@ -437,7 +433,7 @@ function makeApp(itx: any) {
 }
 
 function fakeItx(setup: {
-  artifacts: { artifact_id: string; name: string; size_bytes: number; attempt?: number }[];
+  artifacts: { artifactId: string; name: string; sizeBytes: number; attempt?: number }[];
   zips: Record<string, Uint8Array>;
   failAppendsMatching?: RegExp;
 }) {
@@ -446,11 +442,11 @@ function fakeItx(setup: {
   // plain fetch; the stub answers both by URL shape.
   vi.stubGlobal("fetch", async (url: string, init?: any) => {
     const method = String(url).split("/").pop();
-    if (method === "ListRuns") return jsonResponse({ runs: [{ run_id: "run-77" }] });
+    if (method === "ListRuns") return jsonResponse({ runs: [{ runId: "run-77" }] });
     if (method === "ListArtifacts") return jsonResponse({ artifacts: setup.artifacts });
     if (method === "GetArtifactDownloadURL") {
-      const { artifact_id } = JSON.parse(init.body);
-      return jsonResponse({ url: `https://signed.example/${artifact_id}` });
+      const { artifactId } = JSON.parse(init.body);
+      return jsonResponse({ url: `https://signed.example/${artifactId}` });
     }
     if (String(url).startsWith("https://signed.example/")) {
       const id = String(url).split("/").pop()!;

--- a/packages/iterate/src/starter-apps/flake-dashboard/flake-dashboard.test.ts
+++ b/packages/iterate/src/starter-apps/flake-dashboard/flake-dashboard.test.ts
@@ -329,6 +329,15 @@ test("a birth conflict means already born and the records still append", async (
   ]);
 });
 
+test("a webhook without depot config is skipped without touching itx", async () => {
+  const { itx, appended } = fakeItx({ artifacts: [], zips: {} });
+  itx.secrets.get = () => {
+    throw new Error("must not be called");
+  };
+  await expect(makeApp(itx).raw.processEvent(webhookEvent())).resolves.toBeUndefined();
+  expect(appended).toEqual([]);
+});
+
 test("an idempotency conflict on run-recorded means already ingested and does not throw", async () => {
   const { itx, appended } = fakeItx({
     artifacts: [
@@ -419,7 +428,12 @@ function makeApp(itx: any) {
   // Just enough ctx for the base constructor's alarm overlay; the ingestion
   // path never touches storage or alarms.
   const ctx = { storage: { kv: { put() {}, get() {} }, setAlarm() {}, deleteAlarm() {} } };
-  return new FlakeDashboardApp(ctx as any, { ITX: { get: async () => itx } } as any);
+  const app = new FlakeDashboardApp(ctx as any, { ITX: { get: async () => itx } } as any);
+  return {
+    processEvent: (event: any) =>
+      app.processEvent(event, { depot: { orgId: "org-1", secretPath: "/secrets/depot-ci-token" } }),
+    raw: app,
+  };
 }
 
 function fakeItx(setup: {

--- a/packages/iterate/src/starter-apps/flake-dashboard/flake-dashboard.test.ts
+++ b/packages/iterate/src/starter-apps/flake-dashboard/flake-dashboard.test.ts
@@ -4,7 +4,7 @@ import { makeProcessorHarness } from "../../processors/testing.ts";
 import {
   FlakeDashboardProcessorContract,
   flakeEventTypes,
-  WorkflowRunWebhookEvent,
+  CheckRunWebhookEvent,
   type FlakeDashboardState,
 } from "./contract.ts";
 import { FlakeDashboardApp, FlakeDashboardProcessor } from "./worker.ts";
@@ -236,13 +236,13 @@ function day(days: number) {
 test("a completed workflow_run's flake artifacts become one run-recorded event per suite", async () => {
   const { itx, appended } = fakeItx({
     artifacts: [
-      { id: 71, name: "flake-records-unit", size_in_bytes: 1000 },
-      { id: 72, name: "unit-test-telemetry", size_in_bytes: 1000 },
+      { artifact_id: "art-71", name: "flake-records-unit", size_bytes: 1000, attempt: 2 },
+      { artifact_id: "art-72", name: "unit-test-telemetry", size_bytes: 1000 },
     ],
     zips: {
       // Two files exercising both zip entry kinds our reader supports:
       // deflate-compressed (fflate's default) and stored (level 0).
-      71: zipSync({
+      "art-71": zipSync({
         "flake-records-123.jsonl": strToU8(
           [
             JSON.stringify(record("flake sentinel", "pass")),
@@ -266,9 +266,9 @@ test("a completed workflow_run's flake artifacts become one run-recorded event p
     "events.iterate.com/flakes/run-recorded",
   ]);
   expect(appended[1]).toMatchObject({
-    idempotencyKey: "flakes/run:9001-2:unit",
+    idempotencyKey: "flakes/run:run-77-2:unit",
     payload: {
-      runId: "9001-2",
+      runId: "run-77-2",
       suite: "unit",
       branch: "main",
       commit: "abc123",
@@ -282,27 +282,28 @@ test("a completed workflow_run's flake artifacts become one run-recorded event p
 
 test("runs without flake artifacts append nothing, not even a birth", async () => {
   const { itx, appended } = fakeItx({
-    artifacts: [{ id: 72, name: "unit-test-telemetry", size_in_bytes: 1000 }],
+    artifacts: [{ artifact_id: "art-72", name: "unit-test-telemetry", size_bytes: 1000 }],
     zips: {},
   });
   await makeApp(itx).processEvent(webhookEvent());
   expect(appended).toEqual([]);
 });
 
-test("the webhook schema accepts only completed workflow_run deliveries on connection streams", () => {
-  expect(WorkflowRunWebhookEvent.safeParse(webhookEvent())).toMatchObject({
-    success: true,
-    data: { payload: { body: { workflow_run: { id: 9001 } } } },
-  });
-  expect(WorkflowRunWebhookEvent.safeParse(webhookEvent({ path: "/flakes" })).success).toBe(false);
-  expect(
-    WorkflowRunWebhookEvent.safeParse(webhookEvent({ deliveryName: "check_run" })).success,
-  ).toBe(false);
-  expect(WorkflowRunWebhookEvent.safeParse(webhookEvent({ action: "requested" })).success).toBe(
+test("the webhook schema accepts only completed check_run deliveries on connection streams", () => {
+  expect(CheckRunWebhookEvent.safeParse(webhookEvent({ conclusion: "cancelled" })).success).toBe(
     false,
   );
+  expect(CheckRunWebhookEvent.safeParse(webhookEvent())).toMatchObject({
+    success: true,
+    data: { payload: { body: { check_run: { head_sha: "abc123" } } } },
+  });
+  expect(CheckRunWebhookEvent.safeParse(webhookEvent({ path: "/flakes" })).success).toBe(false);
   expect(
-    WorkflowRunWebhookEvent.safeParse({
+    CheckRunWebhookEvent.safeParse(webhookEvent({ deliveryName: "workflow_run" })).success,
+  ).toBe(false);
+  expect(CheckRunWebhookEvent.safeParse(webhookEvent({ action: "created" })).success).toBe(false);
+  expect(
+    CheckRunWebhookEvent.safeParse({
       type: "events.iterate.com/flakes/run-recorded",
       path: "/integrations/github/install-1",
       payload: {},
@@ -314,9 +315,11 @@ test("a birth conflict means already born and the records still append", async (
   // The poisoned-prd lesson: once ANY body exists under the birth key, every
   // later offer conflicts — that must never cost the run's records.
   const { itx, appended } = fakeItx({
-    artifacts: [{ id: 71, name: "flake-records-unit", size_in_bytes: 1000 }],
+    artifacts: [
+      { artifact_id: "art-71", name: "flake-records-unit", size_bytes: 1000, attempt: 2 },
+    ],
     zips: {
-      71: zipSync({ "r.jsonl": strToU8(JSON.stringify(record("flake sentinel", "pass"))) }),
+      "art-71": zipSync({ "r.jsonl": strToU8(JSON.stringify(record("flake sentinel", "pass"))) }),
     },
     failAppendsMatching: /flakes\/created/,
   });
@@ -328,9 +331,11 @@ test("a birth conflict means already born and the records still append", async (
 
 test("an idempotency conflict on run-recorded means already ingested and does not throw", async () => {
   const { itx, appended } = fakeItx({
-    artifacts: [{ id: 71, name: "flake-records-unit", size_in_bytes: 1000 }],
+    artifacts: [
+      { artifact_id: "art-71", name: "flake-records-unit", size_bytes: 1000, attempt: 2 },
+    ],
     zips: {
-      71: zipSync({ "r.jsonl": strToU8(JSON.stringify(record("flake sentinel", "pass"))) }),
+      "art-71": zipSync({ "r.jsonl": strToU8(JSON.stringify(record("flake sentinel", "pass"))) }),
     },
     failAppendsMatching: /run-recorded/,
   });
@@ -345,13 +350,13 @@ test("an ingest failure logs and drops instead of propagating into event deliver
     // A poisoned webhook that throws mid-ingest must not reject: a throw out
     // of the app's processEvent would fail the whole delivery batch and
     // retry the same webhook forever.
-    itx.integrations.github.get = () => {
-      throw new Error("GitHub is down");
+    itx.secrets.get = () => {
+      throw new Error("Depot token unavailable");
     };
     await expect(makeApp(itx).processEvent(webhookEvent())).resolves.toBeUndefined();
     expect(consoleError).toHaveBeenCalledWith(
-      expect.stringMatching(/ingestion failed for run 9001/),
-      expect.objectContaining({ message: "GitHub is down" }),
+      expect.stringMatching(/ingestion failed for sha abc123/),
+      expect.objectContaining({ message: "Depot token unavailable" }),
     );
   } finally {
     consoleError.mockRestore();
@@ -362,7 +367,9 @@ test("oversized artifacts are skipped with a warning", async () => {
   const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
   try {
     const { itx, appended } = fakeItx({
-      artifacts: [{ id: 71, name: "flake-records-unit", size_in_bytes: 50 * 1024 * 1024 }],
+      artifacts: [
+        { artifact_id: "art-71", name: "flake-records-unit", size_bytes: 50 * 1024 * 1024 },
+      ],
       zips: {},
     });
     await makeApp(itx).processEvent(webhookEvent());
@@ -375,19 +382,23 @@ test("oversized artifacts are skipped with a warning", async () => {
 
 // --- helpers ---
 
-function webhookEvent(overrides?: { path?: string; deliveryName?: string; action?: string }) {
+function webhookEvent(overrides?: {
+  path?: string;
+  deliveryName?: string;
+  action?: string;
+  conclusion?: string;
+}) {
   return {
     type: "events.iterate.com/github/webhook-received",
     path: overrides?.path || "/integrations/github/install-1",
     payload: {
-      delivery: { name: overrides?.deliveryName || "workflow_run" },
+      delivery: { name: overrides?.deliveryName || "check_run" },
       body: {
         action: overrides?.action || "completed",
-        workflow_run: {
-          id: 9001,
-          run_attempt: 2,
-          head_branch: "main",
+        check_run: {
+          conclusion: overrides?.conclusion || "success",
           head_sha: "abc123",
+          check_suite: { head_branch: "main" },
         },
         repository: {
           name: "iterate",
@@ -412,29 +423,30 @@ function makeApp(itx: any) {
 }
 
 function fakeItx(setup: {
-  artifacts: { id: number; name: string; size_in_bytes: number }[];
-  zips: Record<number, Uint8Array>;
+  artifacts: { artifact_id: string; name: string; size_bytes: number; attempt?: number }[];
+  zips: Record<string, Uint8Array>;
   failAppendsMatching?: RegExp;
 }) {
   const appended: any[] = [];
+  // The worker talks to Depot's Connect API and the signed download URL over
+  // plain fetch; the stub answers both by URL shape.
+  vi.stubGlobal("fetch", async (url: string, init?: any) => {
+    const method = String(url).split("/").pop();
+    if (method === "ListRuns") return jsonResponse({ runs: [{ run_id: "run-77" }] });
+    if (method === "ListArtifacts") return jsonResponse({ artifacts: setup.artifacts });
+    if (method === "GetArtifactDownloadURL") {
+      const { artifact_id } = JSON.parse(init.body);
+      return jsonResponse({ url: `https://signed.example/${artifact_id}` });
+    }
+    if (String(url).startsWith("https://signed.example/")) {
+      const id = String(url).split("/").pop()!;
+      return new Response(setup.zips[id]!.slice().buffer as ArrayBuffer);
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  });
   const itx = {
     [Symbol.dispose]() {},
-    integrations: {
-      github: {
-        get: () => ({
-          octokit: {
-            paginate: async () => setup.artifacts,
-            rest: {
-              actions: {
-                downloadArtifact: async ({ artifact_id }: any) => ({
-                  data: setup.zips[artifact_id]!.buffer,
-                }),
-              },
-            },
-          },
-        }),
-      },
-    },
+    secrets: { get: () => ({ reveal: async () => "depot-test-token" }) },
     streams: {
       get: () => ({
         append: async (...events: any[]) => {
@@ -451,4 +463,8 @@ function fakeItx(setup: {
     },
   } as any;
   return { itx, appended };
+}
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), { headers: { "content-type": "application/json" } });
 }

--- a/packages/iterate/src/starter-apps/flake-dashboard/index.ts
+++ b/packages/iterate/src/starter-apps/flake-dashboard/index.ts
@@ -1,6 +1,6 @@
 import type { DynamicWorkerCapability, ItxBinding, StreamEvent } from "../../sdk.ts";
 import { flakeDashboardWorkerRef, flakesStreamPath } from "./app-ref.ts";
-import { WorkflowRunWebhookEvent } from "./contract.ts";
+import { CheckRunWebhookEvent } from "./contract.ts";
 import type { FlakeDashboardApp as FlakeDashboardWorker } from "./worker.ts";
 
 export { flakeDashboardCreationEvents, flakesStreamPath } from "./app-ref.ts";
@@ -12,7 +12,7 @@ export const FlakeDashboardApp = {
         // Pure routing: /flakes events and completed workflow_run webhooks
         // (CI's credential-free reporting signal) both dispatch to the
         // worker's processEvent; everything else returns before itx opens.
-        if (event.path !== flakesStreamPath && !WorkflowRunWebhookEvent.safeParse(event).success) {
+        if (event.path !== flakesStreamPath && !CheckRunWebhookEvent.safeParse(event).success) {
           return;
         }
         using project = await env.ITX.get();

--- a/packages/iterate/src/starter-apps/flake-dashboard/index.ts
+++ b/packages/iterate/src/starter-apps/flake-dashboard/index.ts
@@ -1,12 +1,17 @@
 import type { DynamicWorkerCapability, ItxBinding, StreamEvent } from "../../sdk.ts";
 import { flakeDashboardWorkerRef, flakesStreamPath } from "./app-ref.ts";
 import { CheckRunWebhookEvent } from "./contract.ts";
-import type { FlakeDashboardApp as FlakeDashboardWorker } from "./worker.ts";
+import type { DepotIngestionConfig, FlakeDashboardApp as FlakeDashboardWorker } from "./worker.ts";
 
 export { flakeDashboardCreationEvents, flakesStreamPath } from "./app-ref.ts";
 
 export const FlakeDashboardApp = {
-  create(env: { ITX: Pick<ItxBinding, "get"> }) {
+  /**
+   * `config.depot` points ingestion at the project's own CI artifact store;
+   * omit it to run the dashboard without check_run ingestion (records can
+   * still arrive by any other append to /flakes).
+   */
+  create(env: { ITX: Pick<ItxBinding, "get"> }, config?: { depot?: DepotIngestionConfig }) {
     return {
       async processEvent(event: StreamEvent): Promise<void> {
         // Pure routing: /flakes events and completed workflow_run webhooks
@@ -23,7 +28,7 @@ export const FlakeDashboardApp = {
         using worker = project.workers.get(flakeDashboardWorkerRef) as DynamicWorkerCapability<
           Pick<FlakeDashboardWorker, "processEvent">
         >;
-        await worker.processEvent(event);
+        await worker.processEvent(event, { depot: config?.depot });
       },
     };
   },

--- a/packages/iterate/src/starter-apps/flake-dashboard/worker.ts
+++ b/packages/iterate/src/starter-apps/flake-dashboard/worker.ts
@@ -71,7 +71,7 @@ export class FlakeDashboardApp extends StreamProcessorDurableObject<FlakeDashboa
   ): Promise<void> {
     const webhook = CheckRunWebhookEvent.safeParse(event);
     if (webhook.success) {
-      if (options?.depot === undefined) {
+      if (!options?.depot) {
         // Platform-direct delivery, or a config worker mounted without CI
         // ingestion: nothing to pull from.
         return;

--- a/packages/iterate/src/starter-apps/flake-dashboard/worker.ts
+++ b/packages/iterate/src/starter-apps/flake-dashboard/worker.ts
@@ -136,21 +136,23 @@ export class FlakeDashboardApp extends StreamProcessorDurableObject<FlakeDashboa
 
     // sha matches either the run's merge sha or its head sha, so PR-triggered
     // and push-triggered runs both resolve.
-    const runs = await depotRpc<{ runs?: { run_id: string }[] }>("ListRuns", {
+    // Connect's JSON protocol emits proto3 canonical camelCase field names
+    // (verified against the live API) — snake_case reads come back undefined.
+    const runs = await depotRpc<{ runs?: { runId: string }[] }>("ListRuns", {
       repo: `${params.owner}/${params.repo}`,
       sha: checkRun.head_sha,
       status: ["finished", "failed"],
-      page_size: 10,
+      pageSize: 10,
     });
     for (const run of runs.runs || []) {
       const listed = await depotRpc<{
         artifacts?: {
-          artifact_id: string;
+          artifactId: string;
           name: string;
-          size_bytes?: string | number;
+          sizeBytes?: string | number;
           attempt?: number;
         }[];
-      }>("ListArtifacts", { run_id: run.run_id, page_size: 100 });
+      }>("ListArtifacts", { runId: run.runId, pageSize: 100 });
       const flakeArtifacts = (listed.artifacts || []).filter((artifact) =>
         artifact.name.startsWith(ARTIFACT_PREFIX),
       );
@@ -175,15 +177,15 @@ export class FlakeDashboardApp extends StreamProcessorDurableObject<FlakeDashboa
       }
 
       for (const artifact of flakeArtifacts) {
-        if (Number(artifact.size_bytes || 0) > MAX_ARTIFACT_BYTES) {
+        if (Number(artifact.sizeBytes || 0) > MAX_ARTIFACT_BYTES) {
           console.warn(
-            `[flake-ingest] skipping oversized artifact ${artifact.name} (${artifact.size_bytes} bytes)`,
+            `[flake-ingest] skipping oversized artifact ${artifact.name} (${artifact.sizeBytes} bytes)`,
           );
           continue;
         }
         const suite = artifact.name.slice(ARTIFACT_PREFIX.length);
         const download = await depotRpc<{ url?: string }>("GetArtifactDownloadURL", {
-          artifact_id: artifact.artifact_id,
+          artifactId: artifact.artifactId,
         });
         if (!download.url) {
           console.warn(`[flake-ingest] no download url for artifact ${artifact.name}`);
@@ -224,7 +226,7 @@ export class FlakeDashboardApp extends StreamProcessorDurableObject<FlakeDashboa
           );
         if (records.length === 0) continue;
 
-        const runId = `${run.run_id}-${artifact.attempt || 1}`;
+        const runId = `${run.runId}-${artifact.attempt || 1}`;
         try {
           await stream.append({
             type: "events.iterate.com/flakes/run-recorded",

--- a/packages/iterate/src/starter-apps/flake-dashboard/worker.ts
+++ b/packages/iterate/src/starter-apps/flake-dashboard/worker.ts
@@ -23,9 +23,17 @@ import {
 } from "./contract.ts";
 
 const ARTIFACT_PREFIX = "flake-records-";
-/** Where the Depot org API read token lives as a project secret (ops-created). */
-const DEPOT_TOKEN_SECRET_PATH = "/secrets/depot-ci-token";
-const DEPOT_ORG_ID = "0p91s0lz49";
+
+/**
+ * Where a project's CI artifacts live. Supplied by the config worker
+ * (FlakeDashboardApp.create's config) — the starter app itself carries no
+ * organization identity. secretPath names a project secret holding a
+ * Depot org API read token.
+ */
+export interface DepotIngestionConfig {
+  orgId: string;
+  secretPath: string;
+}
 const MAX_ARTIFACT_BYTES = 5 * 1024 * 1024;
 
 /**
@@ -57,15 +65,23 @@ export class FlakeDashboardApp extends StreamProcessorDurableObject<FlakeDashboa
    * re-reads committed events from the stream and owns validation, ordering,
    * checkpointing, and dedupe.
    */
-  override async processEvent(event: StreamEvent): Promise<void> {
+  override async processEvent(
+    event: StreamEvent,
+    options?: { depot?: DepotIngestionConfig },
+  ): Promise<void> {
     const webhook = CheckRunWebhookEvent.safeParse(event);
     if (webhook.success) {
+      if (options?.depot === undefined) {
+        // Platform-direct delivery, or a config worker mounted without CI
+        // ingestion: nothing to pull from.
+        return;
+      }
       // Telemetry must never wedge event delivery: a throw from ingestion
       // would fail the delivery batch and retry the same poisoned webhook
       // forever, stalling every app behind it. Any failure — Depot down, an
       // unreadable zip — logs and drops this run's records.
       try {
-        await this.#ingestCheckRunFlakeArtifacts(webhook.data);
+        await this.#ingestCheckRunFlakeArtifacts(webhook.data, options.depot);
       } catch (error) {
         console.error(
           `[flake-ingest] ingestion failed for sha ${webhook.data.payload.body.check_run.head_sha} (records dropped):`,
@@ -92,19 +108,20 @@ export class FlakeDashboardApp extends StreamProcessorDurableObject<FlakeDashboa
    */
   async #ingestCheckRunFlakeArtifacts(
     webhook: (typeof CheckRunWebhookEvent)["_output"],
+    depot: DepotIngestionConfig,
   ): Promise<void> {
     const { check_run: checkRun, repository } = webhook.payload.body;
     const params = { owner: repository.owner.login, repo: repository.name };
     using itx = await this.env.ITX.get();
-    const token = await itx.secrets.get(DEPOT_TOKEN_SECRET_PATH).reveal();
+    const token = await itx.secrets.get(depot.secretPath).reveal();
 
-    const depot = async <T>(method: string, body: unknown): Promise<T> => {
+    const depotRpc = async <T>(method: string, body: unknown): Promise<T> => {
       const response = await fetch(`https://api.depot.dev/depot.ci.v1.CIService/${method}`, {
         method: "POST",
         headers: {
           "content-type": "application/json",
           authorization: `Bearer ${token}`,
-          "x-depot-org": DEPOT_ORG_ID,
+          "x-depot-org": depot.orgId,
         },
         body: JSON.stringify(body),
       });
@@ -119,14 +136,14 @@ export class FlakeDashboardApp extends StreamProcessorDurableObject<FlakeDashboa
 
     // sha matches either the run's merge sha or its head sha, so PR-triggered
     // and push-triggered runs both resolve.
-    const runs = await depot<{ runs?: { run_id: string }[] }>("ListRuns", {
+    const runs = await depotRpc<{ runs?: { run_id: string }[] }>("ListRuns", {
       repo: `${params.owner}/${params.repo}`,
       sha: checkRun.head_sha,
       status: ["finished", "failed"],
       page_size: 10,
     });
     for (const run of runs.runs || []) {
-      const listed = await depot<{
+      const listed = await depotRpc<{
         artifacts?: {
           artifact_id: string;
           name: string;
@@ -165,7 +182,7 @@ export class FlakeDashboardApp extends StreamProcessorDurableObject<FlakeDashboa
           continue;
         }
         const suite = artifact.name.slice(ARTIFACT_PREFIX.length);
-        const download = await depot<{ url?: string }>("GetArtifactDownloadURL", {
+        const download = await depotRpc<{ url?: string }>("GetArtifactDownloadURL", {
           artifact_id: artifact.artifact_id,
         });
         if (!download.url) {

--- a/packages/iterate/src/starter-apps/flake-dashboard/worker.ts
+++ b/packages/iterate/src/starter-apps/flake-dashboard/worker.ts
@@ -17,12 +17,15 @@ import {
   flakeEventTypes,
   FlakeRecord,
   flakeTransitionThresholds,
-  WorkflowRunWebhookEvent,
+  CheckRunWebhookEvent,
   type FlakeDashboardRenderResult,
   type FlakeDashboardState,
 } from "./contract.ts";
 
 const ARTIFACT_PREFIX = "flake-records-";
+/** Where the Depot org API read token lives as a project secret (ops-created). */
+const DEPOT_TOKEN_SECRET_PATH = "/secrets/depot-ci-token";
+const DEPOT_ORG_ID = "0p91s0lz49";
 const MAX_ARTIFACT_BYTES = 5 * 1024 * 1024;
 
 /**
@@ -55,17 +58,17 @@ export class FlakeDashboardApp extends StreamProcessorDurableObject<FlakeDashboa
    * checkpointing, and dedupe.
    */
   override async processEvent(event: StreamEvent): Promise<void> {
-    const webhook = WorkflowRunWebhookEvent.safeParse(event);
+    const webhook = CheckRunWebhookEvent.safeParse(event);
     if (webhook.success) {
       // Telemetry must never wedge event delivery: a throw from ingestion
       // would fail the delivery batch and retry the same poisoned webhook
-      // forever, stalling every app behind it. Any failure — GitHub down, an
+      // forever, stalling every app behind it. Any failure — Depot down, an
       // unreadable zip — logs and drops this run's records.
       try {
-        await this.#ingestWorkflowRunFlakeArtifacts(webhook.data);
+        await this.#ingestCheckRunFlakeArtifacts(webhook.data);
       } catch (error) {
         console.error(
-          `[flake-ingest] ingestion failed for run ${webhook.data.payload.body.workflow_run.id} (records dropped):`,
+          `[flake-ingest] ingestion failed for sha ${webhook.data.payload.body.check_run.head_sha} (records dropped):`,
           error,
         );
       }
@@ -77,113 +80,156 @@ export class FlakeDashboardApp extends StreamProcessorDurableObject<FlakeDashboa
   }
 
   /**
-   * Artifact-pull ingestion for flake telemetry: fetch the completed run's
-   * `flake-records-<suite>` artifacts with the App's own installation token,
-   * parse the recorder lines, and append one run-recorded event per artifact
-   * to /flakes. Redeliveries are harmless: the append is idempotency-keyed on
-   * run+attempt+suite, and a same-key conflict means already ingested.
+   * Artifact-pull ingestion for flake telemetry. This repo's suites run on
+   * Depot CI, so a completed check_run is the signal: resolve the Depot run
+   * by commit sha, list its `flake-records-<suite>` artifacts, fetch each
+   * via a short-lived signed URL, and append one run-recorded event per
+   * artifact to /flakes. CI holds no iterate credential; the Depot read
+   * token is a platform-held project secret. Any check_run completing on the
+   * same Depot run re-scans it — repeated appends dedupe on the
+   * run+attempt+suite idempotency key, so redeliveries and sibling checks
+   * are harmless.
    */
-  async #ingestWorkflowRunFlakeArtifacts(
-    webhook: (typeof WorkflowRunWebhookEvent)["_output"],
+  async #ingestCheckRunFlakeArtifacts(
+    webhook: (typeof CheckRunWebhookEvent)["_output"],
   ): Promise<void> {
-    const connection = webhook.path.split("/")[3]!;
-    const { workflow_run: run, repository } = webhook.payload.body;
+    const { check_run: checkRun, repository } = webhook.payload.body;
     const params = { owner: repository.owner.login, repo: repository.name };
     using itx = await this.env.ITX.get();
-    const octokit = itx.integrations.github.get(connection).octokit;
-    const artifacts = await octokit.paginate(
-      "GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts",
-      { ...params, run_id: run.id, per_page: 100 },
-    );
-    const flakeArtifacts = artifacts.filter((artifact) =>
-      artifact.name.startsWith(ARTIFACT_PREFIX),
-    );
-    if (flakeArtifacts.length === 0) return;
+    const token = await itx.secrets.get(DEPOT_TOKEN_SECRET_PATH).reveal();
 
-    const stream = itx.streams.get(flakesStreamPath);
-    // Idempotency-keyed birth: whoever ingests first births the dashboard,
-    // pinned to the repository the records came from. A same-key/different-
-    // body conflict also means already born — it must not abort the record
-    // appends below (a poisoned birth key on prd once silently dropped every
-    // CI run's records this way).
-    try {
-      await stream.append(
-        ...flakeDashboardCreationEvents({
-          repository: params,
-          issueTitle: "Flake dashboard",
-          defaultBranch: repository.default_branch || "main",
-        }),
-      );
-    } catch (error) {
-      if (!isIdempotencyConflict(error)) throw error;
-    }
-
-    for (const artifact of flakeArtifacts) {
-      if (artifact.size_in_bytes > MAX_ARTIFACT_BYTES) {
-        console.warn(
-          `[flake-ingest] skipping oversized artifact ${artifact.name} (${artifact.size_in_bytes} bytes)`,
-        );
-        continue;
-      }
-      const suite = artifact.name.slice(ARTIFACT_PREFIX.length);
-      const download = await octokit.rest.actions.downloadArtifact({
-        ...params,
-        artifact_id: artifact.id,
-        archive_format: "zip",
+    const depot = async <T>(method: string, body: unknown): Promise<T> => {
+      const response = await fetch(`https://api.depot.dev/depot.ci.v1.CIService/${method}`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${token}`,
+          "x-depot-org": DEPOT_ORG_ID,
+        },
+        body: JSON.stringify(body),
       });
-      // Octokit types the redirect-following response data as `unknown`; for
-      // archive_format "zip" it is the archive bytes as an ArrayBuffer at
-      // runtime. unzip() throws on anything else, and the catch in
-      // processEvent turns that into a logged drop, not a stalled batch.
-      const files = await unzip(new Uint8Array(download.data as ArrayBuffer));
-      const records = Object.entries(files)
-        .filter(([name]) => name.endsWith(".jsonl"))
-        .flatMap(([name, bytes]) =>
-          new TextDecoder()
-            .decode(bytes)
-            .split("\n")
-            .filter((line) => line.trim() !== "")
-            .flatMap((line) => {
-              // A torn line from a crashed test worker skips, never aborts.
-              let json: unknown;
-              try {
-                json = JSON.parse(line);
-              } catch {
-                console.warn(`[flake-ingest] skipping malformed line in ${artifact.name}/${name}`);
-                return [];
-              }
-              const parsed = FlakeRecord.safeParse(json);
-              if (!parsed.success) {
-                console.warn(`[flake-ingest] skipping malformed line in ${artifact.name}/${name}`);
-                return [];
-              }
-              return [parsed.data];
-            }),
-        );
-      if (records.length === 0) continue;
+      if (!response.ok) {
+        throw new Error(`depot ${method} failed: HTTP ${response.status} ${await response.text()}`);
+      }
+      // Connect's JSON protocol returns the response message as a plain JSON
+      // object; the assertion states which message this method returns — the
+      // fields read below are checked for presence before use.
+      return (await response.json()) as T;
+    };
 
-      const runId = `${run.id}-${run.run_attempt || 1}`;
+    // sha matches either the run's merge sha or its head sha, so PR-triggered
+    // and push-triggered runs both resolve.
+    const runs = await depot<{ runs?: { run_id: string }[] }>("ListRuns", {
+      repo: `${params.owner}/${params.repo}`,
+      sha: checkRun.head_sha,
+      status: ["finished", "failed"],
+      page_size: 10,
+    });
+    for (const run of runs.runs || []) {
+      const listed = await depot<{
+        artifacts?: {
+          artifact_id: string;
+          name: string;
+          size_bytes?: string | number;
+          attempt?: number;
+        }[];
+      }>("ListArtifacts", { run_id: run.run_id, page_size: 100 });
+      const flakeArtifacts = (listed.artifacts || []).filter((artifact) =>
+        artifact.name.startsWith(ARTIFACT_PREFIX),
+      );
+      if (flakeArtifacts.length === 0) continue;
+
+      const stream = itx.streams.get(flakesStreamPath);
+      // Idempotency-keyed birth: whoever ingests first births the dashboard,
+      // pinned to the repository the records came from. A same-key/different-
+      // body conflict also means already born — it must not abort the record
+      // appends below (a poisoned birth key on prd once silently dropped
+      // every CI run's records this way).
       try {
-        await stream.append({
-          type: "events.iterate.com/flakes/run-recorded",
-          idempotencyKey: `flakes/run:${runId}:${suite}`,
-          payload: {
-            runId,
-            suite,
-            branch: run.head_branch || "unknown",
-            commit: run.head_sha || "unknown",
-            records,
-          },
-        });
+        await stream.append(
+          ...flakeDashboardCreationEvents({
+            repository: params,
+            issueTitle: "Flake dashboard",
+            defaultBranch: repository.default_branch || "main",
+          }),
+        );
       } catch (error) {
-        // Same key, different body: the run+attempt+suite is already
-        // ingested (a webhook redelivery racing a slow first attempt) — the
-        // first committed fact wins.
         if (!isIdempotencyConflict(error)) throw error;
       }
-      console.log(
-        `[flake-ingest] ingested ${records.length} records from ${artifact.name} (run ${runId})`,
-      );
+
+      for (const artifact of flakeArtifacts) {
+        if (Number(artifact.size_bytes || 0) > MAX_ARTIFACT_BYTES) {
+          console.warn(
+            `[flake-ingest] skipping oversized artifact ${artifact.name} (${artifact.size_bytes} bytes)`,
+          );
+          continue;
+        }
+        const suite = artifact.name.slice(ARTIFACT_PREFIX.length);
+        const download = await depot<{ url?: string }>("GetArtifactDownloadURL", {
+          artifact_id: artifact.artifact_id,
+        });
+        if (!download.url) {
+          console.warn(`[flake-ingest] no download url for artifact ${artifact.name}`);
+          continue;
+        }
+        const zipResponse = await fetch(download.url);
+        if (!zipResponse.ok) {
+          throw new Error(`artifact download failed: HTTP ${zipResponse.status}`);
+        }
+        const files = await unzip(new Uint8Array(await zipResponse.arrayBuffer()));
+        const records = Object.entries(files)
+          .filter(([name]) => name.endsWith(".jsonl"))
+          .flatMap(([name, bytes]) =>
+            new TextDecoder()
+              .decode(bytes)
+              .split("\n")
+              .filter((line) => line.trim() !== "")
+              .flatMap((line) => {
+                // A torn line from a crashed test worker skips, never aborts.
+                let json: unknown;
+                try {
+                  json = JSON.parse(line);
+                } catch {
+                  console.warn(
+                    `[flake-ingest] skipping malformed line in ${artifact.name}/${name}`,
+                  );
+                  return [];
+                }
+                const parsed = FlakeRecord.safeParse(json);
+                if (!parsed.success) {
+                  console.warn(
+                    `[flake-ingest] skipping malformed line in ${artifact.name}/${name}`,
+                  );
+                  return [];
+                }
+                return [parsed.data];
+              }),
+          );
+        if (records.length === 0) continue;
+
+        const runId = `${run.run_id}-${artifact.attempt || 1}`;
+        try {
+          await stream.append({
+            type: "events.iterate.com/flakes/run-recorded",
+            idempotencyKey: `flakes/run:${runId}:${suite}`,
+            payload: {
+              runId,
+              suite,
+              branch: checkRun.check_suite?.head_branch || "unknown",
+              commit: checkRun.head_sha,
+              records,
+            },
+          });
+        } catch (error) {
+          // Same key, different body: the run+attempt+suite is already
+          // ingested (a sibling check_run racing this one) — the first
+          // committed fact wins.
+          if (!isIdempotencyConflict(error)) throw error;
+        }
+        console.log(
+          `[flake-ingest] ingested ${records.length} records from ${artifact.name} (run ${runId})`,
+        );
+      }
     }
   }
 

--- a/tasks/flake-checkrun-ingestion.md
+++ b/tasks/flake-checkrun-ingestion.md
@@ -1,0 +1,27 @@
+---
+status: in-progress
+size: medium
+---
+
+# Flake ingestion: check_run trigger + Depot artifact pull
+
+**Status summary:** Supersedes #2571's `workflow_run` design, which never fires for this repo: the test suites run on Depot CI, whose jobs are GitHub *check runs*, not GitHub Actions workflow runs — no `workflow_run` webhook, and `upload-artifact` lands in Depot's store, not GitHub's. Verified empirically: GitHub's workflow-runs API lists only `.github/workflows` (pkg.pr.new, Claude Assistant). Since #2571 merged, no CI flake records flow at all (the push-lane reporter is deleted).
+
+## Design (all facts verified against depot/cli source + a live prd webhook sample)
+
+- **Trigger:** `github/webhook-received` with `delivery.name === "check_run"`, `action === "completed"`, conclusion success/failure. Live sample carries everything needed: `check_run.head_sha`, `check_run.check_suite.head_branch`, `repository.full_name`. Suite-agnostic — a new suite needs only an artifact upload step, no server change.
+- **Resolution:** Depot Connect RPC as plain JSON POSTs from the worker (`https://api.depot.dev/depot.ci.v1.CIService/<Method>`, `Authorization: Bearer <token>` + `x-depot-org`): `ListRuns {repo, sha}` (sha matches either merge sha or head_sha) → `run_id` → `ListArtifacts` → filter `flake-records-*` → `GetArtifactDownloadURL` → short-lived signed HTTPS URL → fetch zip → existing unzip/parse/append path.
+- **Auth:** a Depot org API token as a platform-held project secret (`/secrets/depot-ci-token`), revealed at ingest time. CI still holds zero iterate credentials; the *project* holding a Depot read credential is the accepted trust shape.
+- **Idempotency:** run-recorded keys stay `flakes/run:<depot run_id>-<artifact.attempt>:<suite>`. Multiple check_runs completing on one Depot run each trigger a scan — repeated downloads are bounded (5MB cap, few checks per run) and repeated appends dedupe on the key.
+
+## Checklist
+
+- [ ] contract.ts: `CheckRunWebhookEvent` replaces `WorkflowRunWebhookEvent`
+- [ ] worker.ts: ingestion reworked — depot RPC calls, secret reveal, run resolution; unzip/parse/append unchanged
+- [ ] Tests reworked: check_run webhook shape, stubbed fetch for the depot RPCs + signed download, zip fixtures kept
+- [ ] tasks/flake-webhook-ingestion.md post-merge ops corrected (its confirmation steps can never pass)
+
+## Post-merge ops
+
+- [ ] Create the project secret: an org API token from Depot (same kind as `DEPOT_CI_TELEMETRY_TOKEN` in Doppler `_shared/preview`) stored as `/secrets/depot-ci-token` on the iterate prd project
+- [ ] After the next prd deploy + config-worker rebuild, confirm a real CI run's records arrive via check_run ingestion, then delete the `FLAKE_REPORT_*` Doppler secrets (push-lane fully retired)

--- a/tasks/flake-webhook-ingestion.md
+++ b/tasks/flake-webhook-ingestion.md
@@ -26,6 +26,8 @@ The push lane made CI hold the project API key — the project's root credential
 
 ## Post-merge ops
 
+> **Superseded by `tasks/flake-checkrun-ingestion.md`:** the confirmation steps below can never pass — Depot CI jobs are check runs, so `workflow_run` webhooks never fire for the test suites. The check_run + Depot-artifact-pull design replaces this lane's trigger; the CI-side artifact upload steps remain correct.
+
 - [ ] Unset `FLAKE_REPORT_*` in `_shared/prd` Doppler (push-lane reporter is gone) — and consider rotating the project API key (a fragment echoed into a local session transcript during setup)
 - [ ] Update the live iterate project's config worker to the new package build (the mount is already live; the mapper rides the same `iterate@main` bump)
 - [ ] Confirm ingestion on a real CI run: `flakes/run-recorded` appears after the workflow_run webhook, issue updates


### PR DESCRIPTION
Fixes #2571's design flaw: this repo's test suites run on Depot CI, whose jobs are GitHub **check runs** — GitHub Actions \`workflow_run\` webhooks never fire for them, and their \`upload-artifact\` output lands in Depot's artifact store, not GitHub's. The merged ingestion was listening for a webhook that can never mention our tests; CI flake records have not flowed since the push-lane reporter was deleted.

New shape (verified against depot/cli source and a live prd webhook sample): a completed \`check_run\` webhook (already delivered to the connection stream — no App changes) resolves the Depot run by commit sha (\`ListRuns\`), lists its \`flake-records-*\` artifacts, fetches each via a signed URL (\`GetArtifactDownloadURL\`), and feeds the existing unzip/parse/append path. Auth is a Depot org token held as a **project secret** — CI continues to hold zero iterate credentials.

Spec: \`tasks/flake-checkrun-ingestion.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session: 4fe3e39f-bdf2-4b87-8ed3-b77d4252fd95 — "createFlake helper + flake telemetry"

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +186 -114 | +128 -93 🟩🟩🟩🟥🟥 |
| Tests | +76 -50 | +66 -48 🟩🟩🟥⬜⬜ |
| Docs | +29 -0 | +20 -0 🟩⬜⬜⬜⬜ |
| Other | +6 -2 | +3 -1 🟩⬜⬜⬜⬜ |
| Generated | +6 -2 | +6 -2 🟩⬜⬜⬜⬜ |
| **Total** | **+303 -168** | **+223 -144** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between f3d8fe6 and b3eb13f, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-09-03T11:33:18.227Z",
      "deployedAt": "2026-09-03T11:02:45.367Z",
      "headSha": "b3eb13fb92c34fdb7b9541daf1aa2973de79e384",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/588256234771524",
      "shortSha": "b3eb13f",
      "cleanupDurationMs": 98965,
      "deployDurationMs": 48226,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 46856,
      "deployReadinessDurationMs": 1366,
      "deployedWorkerName": "os-preview-9",
      "deployedWorkerVersion": "35228cf3-08c6-4581-8269-15900f9d419c",
      "testDurationMs": 293695,
      "testRetries": "2 retried: the source-version pin tells a facet that recycled from one the commit rebuilt (vitest x1) · a userspace facet rebuilds on a source commit and only on a source commit (vitest x1)",
      "workerSizeKib": 20891.45,
      "workerGzipKib": 5265.05,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5276.83
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-09-03T11:31:42.480Z",
      "deployedAt": "2026-09-03T11:02:23.951Z",
      "headSha": "b3eb13fb92c34fdb7b9541daf1aa2973de79e384",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-9.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/588256234771524",
      "shortSha": "b3eb13f",
      "cleanupDurationMs": 3214,
      "deployDurationMs": 25691,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 25437,
      "deployReadinessDurationMs": 249,
      "deployedWorkerName": "docs-preview-9",
      "deployedWorkerVersion": "85e59f30-1506-455a-96bd-5ee9396c5544",
      "testDurationMs": 2739,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-09-03T11:31:43.650Z",
      "deployedAt": "2026-09-03T11:02:31.545Z",
      "headSha": "b3eb13fb92c34fdb7b9541daf1aa2973de79e384",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/588256234771524",
      "shortSha": "b3eb13f",
      "cleanupDurationMs": 4382,
      "deployDurationMs": 33364,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 33029,
      "deployReadinessDurationMs": 329,
      "deployedWorkerName": "auth-preview-9",
      "deployedWorkerVersion": "515b38ae-db0c-41d2-8dfd-bce2767aaa26",
      "testDurationMs": 21908,
      "testRetries": null,
      "workerSizeKib": 3989.97,
      "workerGzipKib": 817.31,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-09-03T11:31:40.237Z",
      "deployedAt": "2026-09-03T09:44:55.503Z",
      "headSha": "b3eb13fb92c34fdb7b9541daf1aa2973de79e384",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-9.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/588256234771524",
      "shortSha": "b3eb13f",
      "cleanupDurationMs": 966,
      "deployDurationMs": 51,
      "deployConfigDurationMs": 6,
      "deployReuseProofDurationMs": 10,
      "deployedWorkerName": "dummy-petshop-preview-9",
      "deployedWorkerVersion": "824be7fe-1fc7-4ddc-bfe6-e13a1d4b9eef",
      "testDurationMs": 13361,
      "testRetries": null,
      "workerSizeKib": 1115.4,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "b717e505c46472150438e97f994eb4a2c283e0f8+c5abf1055de73f3b4ffbc5e5b742dff1f0b5ee52",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `b3eb13f` | [https://auth.iterate-preview-9.com](https://auth.iterate-preview-9.com) | 817.3 KiB | 33.4s | 21.9s |  | 4.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/588256234771524) | 2026-09-03T11:31:43.650Z | Preview app released. |
| Docs | released | `b3eb13f` | [https://docs-preview-9.iterate-dev-preview.workers.dev](https://docs-preview-9.iterate-dev-preview.workers.dev) | 866.2 KiB | 25.7s | 2.7s |  | 3.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/588256234771524) | 2026-09-03T11:31:42.480Z | Preview app released. |
| Dummy Petshop | released | `b3eb13f` | [https://dummy-petshop.iterate-preview-9.com](https://dummy-petshop.iterate-preview-9.com) | 198.3 KiB | 51ms | 13.4s |  | 966ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/588256234771524) | 2026-09-03T11:31:40.237Z | Preview app released. |
| OS | released | `b3eb13f` | [https://os.iterate-preview-9.com](https://os.iterate-preview-9.com) | 5.14 MiB (-11.8 KiB vs main) | 48.2s | 293.7s | 2 retried: the source-version pin tells a facet that recycled from one the commit rebuilt (vitest x1) · a userspace facet rebuilds on a source commit and only on a source commit (vitest x1) | 99.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/588256234771524) | 2026-09-03T11:33:18.227Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CI ingestion pipeline and introduces external Depot API + secret reveal on webhook delivery; failures are logged and dropped to avoid wedging delivery, but misconfigured secrets or org IDs would silently stop flake records until fixed.
> 
> **Overview**
> **Restores CI flake telemetry** by replacing the broken `workflow_run` → GitHub Actions artifact path with **completed `check_run` webhooks** and **Depot CI artifact pull** (Depot jobs never emit `workflow_run`, and artifacts live in Depot, not GitHub).
> 
> The flake-dashboard contract now validates `CheckRunWebhookEvent` (completed check, success/failure only). Ingestion resolves Depot runs by commit SHA via Connect JSON RPC (`ListRuns` → `ListArtifacts` → signed zip download), then reuses the existing unzip/parse/`run-recorded` append logic with idempotency keys based on Depot `runId` + artifact attempt. Auth uses a **project secret** (`DepotIngestionConfig`: `orgId` + `secretPath`); omitting `depot` in `FlakeDashboardApp.create` leaves check_run ingestion inert.
> 
> Default and generated config workers pass a concrete `depot` block for this repo. Tests stub Depot `fetch` instead of Octokit; docs add `tasks/flake-checkrun-ingestion.md` and mark the old workflow_run ops steps superseded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3eb13fb92c34fdb7b9541daf1aa2973de79e384. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->