### PR TITLE
Preview slots are erased before every deploy and after every e2e run

### DIFF
--- a/.depot/workflows/cloudflare-previews.yml
+++ b/.depot/workflows/cloudflare-previews.yml
@@ -133,10 +133,14 @@ jobs:
             ${{ github.event_name == 'workflow_dispatch' && '--all-apps' || '' }}
       # The e2e leaves a population of test projects behind whose Durable
       # Objects keep waking; erase them the moment the run is over instead of
-      # letting them burn until the next push or the lease expiry. Skipped when
-      # the PR head has moved on: that push's own run erases before it deploys,
-      # and racing it here would tombstone a Worker it is deploying. Not
-      # red-making — the next deploy erases anyway.
+      # letting them burn until the next push or the lease expiry. Not
+      # red-making — the next deploy erases anyway. A run cancelled by a newer
+      # push never gets here: Depot kills the whole job, always() steps
+      # included (observed 2026-09-03), so that population is the next run's
+      # before-deploy erase to clean. --ran-head-sha is the guard for the case
+      # this step does run after the PR moved on (a human running it late):
+      # the newer push's run erases before it deploys, and racing it would
+      # tombstone a Worker it is deploying.
       - name: Preview / erase slot data after e2e
         if: always()
         continue-on-error: true

--- a/.depot/workflows/cloudflare-previews.yml
+++ b/.depot/workflows/cloudflare-previews.yml
@@ -131,6 +131,24 @@ jobs:
             --github-token "$GITHUB_TOKEN" \
             --pull-request-number "${{ github.event.pull_request.number || inputs.pull-request-number }}" \
             ${{ github.event_name == 'workflow_dispatch' && '--all-apps' || '' }}
+      # The e2e leaves a population of test projects behind whose Durable
+      # Objects keep waking; erase them the moment the run is over instead of
+      # letting them burn until the next push or the lease expiry. Skipped when
+      # the PR head has moved on: that push's own run erases before it deploys,
+      # and racing it here would tombstone a Worker it is deploying. Not
+      # red-making — the next deploy erases anyway.
+      - name: Preview / erase slot data after e2e
+        if: always()
+        continue-on-error: true
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |-
+          set -euo pipefail
+          doppler run --project _shared --config prd --preserve-env=GITHUB_TOKEN -- pnpm preview erase \
+            --github-token "$GITHUB_TOKEN" \
+            --pull-request-number "${{ github.event.pull_request.number || inputs.pull-request-number }}" \
+            --ran-head-sha "${{ github.event.pull_request.head.sha || github.sha }}"
       - name: Normalize and send preview test telemetry
         if: always()
         env:

--- a/apps/os/scripts/erase-data.ts
+++ b/apps/os/scripts/erase-data.ts
@@ -32,7 +32,9 @@
  *     token. With every project erased they are all orphans; leaving them
  *     grew the dev/preview account to ~783k repos before this pass existed
  *     (backfill for that pile: scripts/artifacts-gc.ts). Skipped under
- *     `--preserve-auth`, where they are the recreated projects' git history.
+ *     `--preserve-auth`, where they are the recreated projects' git history,
+ *     and under `--keep-artifacts` (a same-PR preview redeploy: the repos are
+ *     that PR's own and the next handover deletes them).
  *   - normally, the auth D1 database (identities, orgs, projects — the source
  *     of every project id) and project-directory KV. `--preserve-auth` keeps
  *     both for a planned production recreation: selected OS projects can then
@@ -73,6 +75,8 @@ export default async function eraseData(options: {
   yesIMeanPrd?: boolean;
   /** Keep Auth D1 and project-directory KV while erasing OS state. */
   preserveAuth?: boolean;
+  /** Skip the Artifacts-repo delete pass (a same-PR preview redeploy: the repos are its own). */
+  keepArtifacts?: boolean;
 }) {
   const ctx = await resolveEnvContext({ envs, dopplerProject: "os", env: options.env });
   const { env, cf } = ctx;
@@ -254,7 +258,7 @@ export default async function eraseData(options: {
   // (partial progress carries over: the next erase continues). Under
   // --preserve-auth the repos are the recreated projects' git history
   // (getOrCreateArtifact adopts an existing repo), so they must survive.
-  if (!options.preserveAuth) {
+  if (!options.preserveAuth && !options.keepArtifacts) {
     const artifactsNamespace = `${env.osWorkerName}-repos`;
     const artifactsDeadline = Date.now() + 90_000;
     try {

--- a/apps/os/scripts/erase-data.ts
+++ b/apps/os/scripts/erase-data.ts
@@ -32,9 +32,7 @@
  *     token. With every project erased they are all orphans; leaving them
  *     grew the dev/preview account to ~783k repos before this pass existed
  *     (backfill for that pile: scripts/artifacts-gc.ts). Skipped under
- *     `--preserve-auth`, where they are the recreated projects' git history,
- *     and under `--keep-artifacts` (a same-PR preview redeploy: the repos are
- *     that PR's own and the next handover deletes them).
+ *     `--preserve-auth`, where they are the recreated projects' git history.
  *   - normally, the auth D1 database (identities, orgs, projects — the source
  *     of every project id) and project-directory KV. `--preserve-auth` keeps
  *     both for a planned production recreation: selected OS projects can then
@@ -75,8 +73,6 @@ export default async function eraseData(options: {
   yesIMeanPrd?: boolean;
   /** Keep Auth D1 and project-directory KV while erasing OS state. */
   preserveAuth?: boolean;
-  /** Skip the Artifacts-repo delete pass (a same-PR preview redeploy: the repos are its own). */
-  keepArtifacts?: boolean;
 }) {
   const ctx = await resolveEnvContext({ envs, dopplerProject: "os", env: options.env });
   const { env, cf } = ctx;
@@ -258,7 +254,7 @@ export default async function eraseData(options: {
   // (partial progress carries over: the next erase continues). Under
   // --preserve-auth the repos are the recreated projects' git history
   // (getOrCreateArtifact adopts an existing repo), so they must survive.
-  if (!options.preserveAuth && !options.keepArtifacts) {
+  if (!options.preserveAuth) {
     const artifactsNamespace = `${env.osWorkerName}-repos`;
     const artifactsDeadline = Date.now() + 90_000;
     try {

--- a/docs/dev-environments.md
+++ b/docs/dev-environments.md
@@ -387,6 +387,15 @@ invariants:
   GC sweep — see **[Preview resource GC](preview-resource-gc.md)** for how
   teardown is decoupled from releasing the slot (and how disposable data
   expires 3h after last use).
+- **A slot is fresh on every deploy.** `preview deploy` erases the slot's
+  data (Durable Objects, D1, KV — `erase-data`) before every deploy, not just
+  when the slot changes hands. Each push otherwise stacks a new population of
+  abandoned test projects whose Durable Objects keep waking (~$15–25/hour per
+  slot; the 2026-09-01 runaway), and a push that cancels a running e2e
+  SIGKILLs it, so in-test cleanup can never be the guarantee. Consequence:
+  manual QA state on a preview does not survive a push — recreate it. A
+  same-PR redeploy keeps its own Artifacts repos (`--keep-artifacts`); a
+  handover deletes them.
 - **The semaphore is the single source of lease truth.** The PR body's
   managed section only _displays_ the slot (and per-app results); it is never
   consulted for ownership and never a reason to skip. Before running tests or

--- a/docs/dev-environments.md
+++ b/docs/dev-environments.md
@@ -394,9 +394,11 @@ invariants:
   population of test projects whose Durable Objects keep waking until the
   next push or the lease expiry (~$15–25/hour per slot; the 2026-09-01
   runaway), and a push that cancels a running e2e SIGKILLs it, so in-test
-  cleanup can never be the guarantee — the before-deploy erase is. The
-  after-run erase skips itself when the PR head has moved on (that push's
-  run erases before it deploys). Consequence: manual QA state on a preview
+  cleanup can never be the guarantee — the before-deploy erase is. A
+  cancelled job runs none of its `always()` steps on Depot, so a cancelled
+  run's population waits for the next run's before-deploy erase; the
+  after-run erase also skips itself if it ever runs after the PR head moved
+  on (that push's run erases before it deploys). Consequence: manual QA state on a preview
   does not survive a push or an e2e run — the login link in the PR body
   mints a fresh test user and project on demand.
 - **The semaphore is the single source of lease truth.** The PR body's

--- a/docs/dev-environments.md
+++ b/docs/dev-environments.md
@@ -387,15 +387,18 @@ invariants:
   GC sweep — see **[Preview resource GC](preview-resource-gc.md)** for how
   teardown is decoupled from releasing the slot (and how disposable data
   expires 3h after last use).
-- **A slot is fresh on every deploy.** `preview deploy` erases the slot's
-  data (Durable Objects, D1, KV — `erase-data`) before every deploy, not just
-  when the slot changes hands. Each push otherwise stacks a new population of
-  abandoned test projects whose Durable Objects keep waking (~$15–25/hour per
-  slot; the 2026-09-01 runaway), and a push that cancels a running e2e
-  SIGKILLs it, so in-test cleanup can never be the guarantee. Consequence:
-  manual QA state on a preview does not survive a push — recreate it. A
-  same-PR redeploy keeps its own Artifacts repos (`--keep-artifacts`); a
-  handover deletes them.
+- **A slot is only populated while a run is in progress.** `preview deploy`
+  erases the slot's data (Durable Objects, D1, KV, Artifacts repos —
+  `erase-data`) before every deploy, not just when the slot changes hands,
+  and CI runs `preview erase` again after the e2e. Each run otherwise leaves a
+  population of test projects whose Durable Objects keep waking until the
+  next push or the lease expiry (~$15–25/hour per slot; the 2026-09-01
+  runaway), and a push that cancels a running e2e SIGKILLs it, so in-test
+  cleanup can never be the guarantee — the before-deploy erase is. The
+  after-run erase skips itself when the PR head has moved on (that push's
+  run erases before it deploys). Consequence: manual QA state on a preview
+  does not survive a push or an e2e run — the login link in the PR body
+  mints a fresh test user and project on demand.
 - **The semaphore is the single source of lease truth.** The PR body's
   managed section only _displays_ the slot (and per-app results); it is never
   consulted for ownership and never a reason to skip. Before running tests or

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -2132,13 +2132,75 @@ function leasedResource(slug: string, holder: string, dopplerConfig = slug.repla
 // never reclaim share this inert eraser.
 const noopEraseSlotData = async () => {};
 
+describe("eraseHeldSlotAfterRun", () => {
+  const { eraseHeldSlotAfterRun } = previewInternals;
+
+  test("erases the slot the semaphore attributes to this holder and keeps the lease", async () => {
+    const eraseSlotData = vi.fn(async () => {});
+    const semaphore = fakeSemaphore({
+      acquireSpecific: vi.fn(async () => fakeLease({ expiresAt: 1_800_000_000_000 })),
+      list: vi.fn(async () => [leasedResource("preview-2", "pr-1600")]),
+    });
+
+    const result = await eraseHeldSlotAfterRun({
+      context: { pullRequestBody: "", pullRequestHeadSha: "abc1234", pullRequestNumber: 1600 },
+      eraseSlotData,
+      ranHeadSha: "abc1234",
+      semaphore,
+    });
+
+    expect(result).toEqual({ erased: true, reason: null, slug: "preview-2" });
+    expect(eraseSlotData).toHaveBeenCalledExactlyOnceWith({
+      dopplerConfig: "preview_2",
+      slug: "preview-2",
+    });
+    // Adopting re-issues (renews) the lease; the PR still owns the slot.
+    expect(semaphore.acquireSpecific).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ slug: "preview-2", holder: "pr-1600", force: true }),
+    );
+    expect(semaphore.release).not.toHaveBeenCalled();
+  });
+
+  test("skips when the PR head moved on since the run — that push's run erases before it deploys", async () => {
+    const eraseSlotData = vi.fn(async () => {});
+    const semaphore = fakeSemaphore({
+      list: vi.fn(async () => [leasedResource("preview-2", "pr-1600")]),
+    });
+
+    const result = await eraseHeldSlotAfterRun({
+      context: { pullRequestBody: "", pullRequestHeadSha: "def5678", pullRequestNumber: 1600 },
+      eraseSlotData,
+      ranHeadSha: "abc1234",
+      semaphore,
+    });
+
+    expect(result).toEqual({ erased: false, reason: "superseded", slug: null });
+    expect(eraseSlotData).not.toHaveBeenCalled();
+    expect(semaphore.list).not.toHaveBeenCalled();
+  });
+
+  test("has nothing to erase when the semaphore leases no slot to this holder", async () => {
+    const eraseSlotData = vi.fn(async () => {});
+    const semaphore = fakeSemaphore();
+
+    const result = await eraseHeldSlotAfterRun({
+      context: { pullRequestBody: "", pullRequestHeadSha: "abc1234", pullRequestNumber: 1600 },
+      eraseSlotData,
+      ranHeadSha: null,
+      semaphore,
+    });
+
+    expect(result).toEqual({ erased: false, reason: "no-lease", slug: null });
+    expect(eraseSlotData).not.toHaveBeenCalled();
+  });
+});
+
 describe("claimEnvironmentConfigLease", () => {
   test("adopts (and thereby renews) the slot the semaphore attributes to this holder", async () => {
     // The PR body's copy is never consulted for ownership: the semaphore says
-    // pr-1600 holds preview-2, so the claim re-issues that lease. Matching
-    // the recorded slug means the slot carries this PR's own deployment — it
-    // is still erased (fresh on every deploy), but its Artifacts repos are
-    // kept.
+    // pr-1600 holds preview-2, so the claim re-issues that lease. The slot
+    // carries this PR's own deployment and is still erased: fresh on every
+    // deploy.
     const eraseSlotData = vi.fn(async () => {});
     const semaphore = fakeSemaphore({
       acquireSpecific: vi.fn(async () => fakeLease({ expiresAt: 1_800_000_000_000 })),
@@ -2163,7 +2225,6 @@ describe("claimEnvironmentConfigLease", () => {
     expect(eraseSlotData).toHaveBeenCalledExactlyOnceWith({
       dopplerConfig: "preview_2",
       slug: "preview-2",
-      keepArtifacts: true,
     });
   });
 
@@ -2297,7 +2358,6 @@ describe("claimEnvironmentConfigLease", () => {
     expect(eraseSlotData).toHaveBeenCalledExactlyOnceWith({
       dopplerConfig: "preview_three",
       slug: "preview-3",
-      keepArtifacts: false,
     });
   });
 
@@ -2765,7 +2825,6 @@ describe("lease ownership during acquire", () => {
     expect(eraseSlotData).toHaveBeenCalledExactlyOnceWith({
       dopplerConfig: "preview_seven",
       slug: "preview-7",
-      keepArtifacts: false,
     });
   });
 });
@@ -2895,7 +2954,6 @@ describe("assignEnvironmentConfigLease", () => {
     expect(eraseSlotData).toHaveBeenCalledExactlyOnceWith({
       dopplerConfig: "preview_17",
       slug: "preview-17",
-      keepArtifacts: false,
     });
   });
 
@@ -3140,7 +3198,6 @@ describe("assignEnvironmentConfigLease", () => {
     expect(eraseSlotData).toHaveBeenCalledExactlyOnceWith({
       dopplerConfig: "preview_five",
       slug: "preview-5",
-      keepArtifacts: false,
     });
   });
 

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -2228,6 +2228,64 @@ describe("claimEnvironmentConfigLease", () => {
     });
   });
 
+  test("a failed erase hands the slot back, and taking it back erases again — never a dirty deploy", async () => {
+    // The adopt's erase dies half-way, so the lease is released. The recorded
+    // slot is then free, and retaking it must not skip the erase (that is the
+    // half-wiped slot). Here the second erase succeeds, so the PR keeps its slot.
+    const eraseSlotData = vi
+      .fn(async () => {})
+      .mockRejectedValueOnce(new Error("D1 wipe failed half-way"));
+    const semaphore = fakeSemaphore({
+      acquireSpecific: vi.fn(async () => fakeLease()),
+      list: vi.fn(async () => [leasedResource("preview-2", "pr-1600")]),
+    });
+
+    const lease = await claimEnvironmentConfigLease({
+      eraseSlotData,
+      holder: "pr-1600",
+      leaseMs: 1000,
+      recordedSlug: "preview-2",
+      semaphore,
+      waitTotalMs: 0,
+    });
+
+    expect(lease.slug).toBe("preview-2");
+    expect(eraseSlotData).toHaveBeenCalledTimes(2);
+    expect(semaphore.release).toHaveBeenCalledTimes(1);
+    expect(semaphore.acquire).not.toHaveBeenCalled();
+  });
+
+  test("when the retake's erase fails too, the claim moves on to any free slot", async () => {
+    const eraseSlotData = vi
+      .fn(async () => {})
+      .mockRejectedValueOnce(new Error("D1 wipe failed half-way"))
+      .mockRejectedValueOnce(new Error("D1 wipe failed again"));
+    const semaphore = fakeSemaphore({
+      acquire: vi.fn(async () =>
+        fakeLease({ slug: "preview-3", data: { dopplerConfig: "preview_3" } }),
+      ),
+      acquireSpecific: vi.fn(async () => fakeLease()),
+      list: vi.fn(async () => [leasedResource("preview-2", "pr-1600")]),
+    });
+
+    const lease = await claimEnvironmentConfigLease({
+      eraseSlotData,
+      holder: "pr-1600",
+      leaseMs: 1000,
+      recordedSlug: "preview-2",
+      semaphore,
+      waitTotalMs: 0,
+    });
+
+    expect(lease.slug).toBe("preview-3");
+    expect(eraseSlotData).toHaveBeenCalledTimes(3);
+    expect(eraseSlotData).toHaveBeenLastCalledWith({
+      dopplerConfig: "preview_3",
+      slug: "preview-3",
+    });
+    expect(semaphore.release).toHaveBeenCalledTimes(2);
+  });
+
   test("prefers the recorded slug when the semaphore attributes several slots to this holder", async () => {
     const semaphore = fakeSemaphore({
       acquireSpecific: vi.fn(async (input: { slug: string }) =>
@@ -2526,6 +2584,7 @@ describe("retakeRecordedSlotIfFree", () => {
     const lease = await retakeRecordedSlotIfFree({
       holder: "pr-1600",
       leaseMs: 1000,
+      onRetaken: async () => true,
       recordedSlug: "preview-2",
       semaphore,
     });
@@ -2536,6 +2595,20 @@ describe("retakeRecordedSlotIfFree", () => {
     );
   });
 
+  test("gives the slot up when its ready check fails, so the caller moves on", async () => {
+    const semaphore = fakeSemaphore({ acquireSpecific: vi.fn(async () => fakeLease()) });
+
+    const lease = await retakeRecordedSlotIfFree({
+      holder: "pr-1600",
+      leaseMs: 1000,
+      onRetaken: async () => false,
+      recordedSlug: "preview-2",
+      semaphore,
+    });
+
+    expect(lease).toBeNull();
+  });
+
   test("returns null when the slot is held (or nothing is recorded)", async () => {
     const semaphore = fakeSemaphore();
 
@@ -2543,6 +2616,7 @@ describe("retakeRecordedSlotIfFree", () => {
       await retakeRecordedSlotIfFree({
         holder: "pr-1600",
         leaseMs: 1000,
+        onRetaken: async () => true,
         recordedSlug: "preview-2",
         semaphore,
       }),
@@ -2551,6 +2625,7 @@ describe("retakeRecordedSlotIfFree", () => {
       await retakeRecordedSlotIfFree({
         holder: "pr-1600",
         leaseMs: 1000,
+        onRetaken: async () => true,
         recordedSlug: null,
         semaphore,
       }),

--- a/scripts/preview/preview.test.ts
+++ b/scripts/preview/preview.test.ts
@@ -2136,8 +2136,9 @@ describe("claimEnvironmentConfigLease", () => {
   test("adopts (and thereby renews) the slot the semaphore attributes to this holder", async () => {
     // The PR body's copy is never consulted for ownership: the semaphore says
     // pr-1600 holds preview-2, so the claim re-issues that lease. Matching
-    // the recorded slug means the slot carries this PR's own deployment — no
-    // erase.
+    // the recorded slug means the slot carries this PR's own deployment — it
+    // is still erased (fresh on every deploy), but its Artifacts repos are
+    // kept.
     const eraseSlotData = vi.fn(async () => {});
     const semaphore = fakeSemaphore({
       acquireSpecific: vi.fn(async () => fakeLease({ expiresAt: 1_800_000_000_000 })),
@@ -2159,7 +2160,11 @@ describe("claimEnvironmentConfigLease", () => {
       expect.objectContaining({ slug: "preview-2", holder: "pr-1600", force: true }),
     );
     expect(semaphore.acquire).not.toHaveBeenCalled();
-    expect(eraseSlotData).not.toHaveBeenCalled();
+    expect(eraseSlotData).toHaveBeenCalledExactlyOnceWith({
+      dopplerConfig: "preview_2",
+      slug: "preview-2",
+      keepArtifacts: true,
+    });
   });
 
   test("prefers the recorded slug when the semaphore attributes several slots to this holder", async () => {
@@ -2292,6 +2297,7 @@ describe("claimEnvironmentConfigLease", () => {
     expect(eraseSlotData).toHaveBeenCalledExactlyOnceWith({
       dopplerConfig: "preview_three",
       slug: "preview-3",
+      keepArtifacts: false,
     });
   });
 
@@ -2759,6 +2765,7 @@ describe("lease ownership during acquire", () => {
     expect(eraseSlotData).toHaveBeenCalledExactlyOnceWith({
       dopplerConfig: "preview_seven",
       slug: "preview-7",
+      keepArtifacts: false,
     });
   });
 });
@@ -2888,6 +2895,7 @@ describe("assignEnvironmentConfigLease", () => {
     expect(eraseSlotData).toHaveBeenCalledExactlyOnceWith({
       dopplerConfig: "preview_17",
       slug: "preview-17",
+      keepArtifacts: false,
     });
   });
 
@@ -3132,6 +3140,7 @@ describe("assignEnvironmentConfigLease", () => {
     expect(eraseSlotData).toHaveBeenCalledExactlyOnceWith({
       dopplerConfig: "preview_five",
       slug: "preview-5",
+      keepArtifacts: false,
     });
   });
 

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -480,8 +480,9 @@ async function deployPreviewApps({
       ...erasedApps,
       ...(slotMoved
         ? Object.keys(current.state.apps).filter(
-            (appSlug): appSlug is CloudflarePreviewAppSlugType =>
-              cloudflarePreviewApps[appSlug as CloudflarePreviewAppSlugType] != null,
+            // The recorded state can name apps this branch no longer knows;
+            // membership in the fleet map is the narrowing.
+            (appSlug): appSlug is CloudflarePreviewAppSlugType => appSlug in cloudflarePreviewApps,
           )
         : []),
     ]),

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -1155,6 +1155,61 @@ export async function cleanup(options: PullRequestCommandOptions = {}) {
   return result;
 }
 
+type EraseOptions = PullRequestCommandOptions & {
+  /** The PR head this run tested. When the PR has moved on since, the erase is skipped: that push's own run erases before it deploys, and erasing now would race its deploy. Omit to erase regardless. */
+  ranHeadSha?: string;
+};
+
+/**
+ * Erase the slot this PR holds and keep the lease. CI runs it right after the e2e, so the test projects a run created stop burning the moment it ends.
+ */
+export async function erase(options: EraseOptions = {}) {
+  const { context, runtime } = await resolvePreviewCommandSetup(options);
+  return await eraseHeldSlotAfterRun({
+    context,
+    eraseSlotData: makePreviewSlotDataEraser(runtime),
+    ranHeadSha: options.ranHeadSha || null,
+    semaphore: runtime.createPreviewSemaphoreResourceClient(),
+  });
+}
+
+async function eraseHeldSlotAfterRun(input: {
+  context: Pick<
+    PullRequestPreviewContext,
+    "pullRequestBody" | "pullRequestHeadSha" | "pullRequestNumber"
+  >;
+  eraseSlotData: EraseSlotData;
+  ranHeadSha: string | null;
+  semaphore: PreviewSemaphoreResourceClient;
+}) {
+  const holder = pullRequestHolder(input.context.pullRequestNumber);
+  if (input.ranHeadSha && input.ranHeadSha !== input.context.pullRequestHeadSha) {
+    logPreview(
+      `erase skipped: PR #${input.context.pullRequestNumber} moved on from ${input.ranHeadSha.slice(0, 7)} to ${input.context.pullRequestHeadSha.slice(0, 7)} — that push's run erases ${holder}'s slot before it deploys`,
+    );
+    return { erased: false, reason: "superseded", slug: null };
+  }
+  // Ownership comes from the semaphore, as everywhere; the PR body's slot is
+  // only the affinity hint for a holder that somehow has two.
+  const lease = await adoptLeaseHeldBySemaphore({
+    holder,
+    leaseMs: defaultPreviewLeaseMs,
+    preferSlug:
+      parseCloudflarePreviewState(input.context.pullRequestBody).environmentConfigLease?.slug ||
+      null,
+    semaphore: input.semaphore,
+  });
+  if (!lease) {
+    logPreview(`erase skipped: the semaphore leases no slot to ${holder} — nothing to erase`);
+    return { erased: false, reason: "no-lease", slug: null };
+  }
+  await input.eraseSlotData({ dopplerConfig: lease.dopplerConfig, slug: lease.slug });
+  logPreview(
+    `erased ${lease.slug} after the run; ${holder} keeps the lease until ${formatUntil(lease.leasedUntil)}`,
+  );
+  return { erased: true, reason: null, slug: lease.slug };
+}
+
 /**
  * Assign a preview slot to a PR — a specific slot or whatever is free — and record it in the PR body's managed preview section.
  */
@@ -1513,7 +1568,6 @@ export async function reclaim(options: ReclaimOptions = {}) {
   await makePreviewSlotDataEraser(runtime)({
     dopplerConfig: slot.dopplerConfig,
     slug,
-    keepArtifacts: false,
   });
   const result = await semaphore.release({
     slug,
@@ -1634,7 +1688,6 @@ export async function gc(options: GcOptions = {}) {
       await eraseSlotData({
         dopplerConfig: slot.dopplerConfig,
         slug: slot.slug,
-        keepArtifacts: false,
       });
       outcomes.push({ slug: slot.slug, action: "reclaimed", holder: slot.holder });
     } catch (error) {
@@ -4510,8 +4563,6 @@ async function runPreviewDeployCommand(input: {
   commandEnvironment: NodeJS.ProcessEnv;
   dopplerConfig: string;
   operation: "up" | "down";
-  /** "down" only: forwarded to os erase-data as --keep-artifacts. */
-  keepArtifacts?: boolean;
   repositoryRoot: string;
   signal?: AbortSignal;
 }) {
@@ -4521,15 +4572,7 @@ async function runPreviewDeployCommand(input: {
   // resolve the env from the DOPPLER_CONFIG the `doppler run` wrapper sets.
   const commandArgs =
     input.operation === "down"
-      ? [
-          ...input.app.destroyCommandArgs,
-          "--env",
-          input.dopplerConfig,
-          // Only the OS erase owns an Artifacts namespace.
-          ...(input.keepArtifacts && input.app === cloudflarePreviewApps.os
-            ? ["--keep-artifacts"]
-            : []),
-        ]
+      ? [...input.app.destroyCommandArgs, "--env", input.dopplerConfig]
       : input.app.deployCommandArgs;
 
   return await runCommand({
@@ -4550,21 +4593,18 @@ async function runPreviewDeployCommand(input: {
 }
 
 /**
- * Erase a preview slot's user data before handing the slot to a new holder.
- * Reclaim paths MUST run this: a reclaim only ever happens because the
- * previous holder's cleanup — which normally erases on the way out — failed
- * or never ran, so a reclaimed slot is dirty by definition. Deploying over
- * stale identity data breaks the next tenant (observed 2026-07-07 on
- * preview-5: 208 orphaned project-directory KV keys against an empty auth D1
- * → every itx project lookup answered "KV GET failed: 500").
+ * Erase a preview slot's user data. It runs at both ends of a run: before
+ * every deploy (so a slot is fresh whatever the previous run left, including
+ * one a push SIGKILLed mid-e2e) and after the e2e (so the test projects a run
+ * created stop burning the moment it ends — see `erase`). Reclaim paths MUST
+ * run it too: a reclaim only ever happens because the previous holder's
+ * cleanup — which normally erases on the way out — failed or never ran, so a
+ * reclaimed slot is dirty by definition. Deploying over stale identity data
+ * breaks the next tenant (observed 2026-07-07 on preview-5: 208 orphaned
+ * project-directory KV keys against an empty auth D1 → every itx project
+ * lookup answered "KV GET failed: 500").
  */
-type EraseSlotData = (input: {
-  dopplerConfig: string;
-  slug: string;
-  /** Same-holder redeploy: the Artifacts repos are this PR's own, skip the
-   * slow, rate-limited delete pass; the next real handover deletes them. */
-  keepArtifacts: boolean;
-}) => Promise<void>;
+type EraseSlotData = (input: { dopplerConfig: string; slug: string }) => Promise<void>;
 
 /**
  * Every app that owns slot-persistent data. OS wipes the shared data plane;
@@ -4579,18 +4619,15 @@ function makePreviewSlotDataEraser(runtime: {
   repositoryRoot: string;
   signal?: AbortSignal;
 }): EraseSlotData {
-  return async ({ dopplerConfig, slug, keepArtifacts }) => {
+  return async ({ dopplerConfig, slug }) => {
     const startedAt = Date.now();
-    logPreview(
-      `erasing ${slug} data before deploy (doppler config ${dopplerConfig}${keepArtifacts ? ", keeping this PR's Artifacts repos" : ""})`,
-    );
+    logPreview(`erasing ${slug} data (doppler config ${dopplerConfig})`);
     for (const app of selectPreviewSlotDataOwners()) {
       const result = await runPreviewDeployCommand({
         app,
         commandEnvironment: runtime.commandEnvironment,
         dopplerConfig,
         operation: "down",
-        keepArtifacts,
         repositoryRoot: runtime.repositoryRoot,
         signal: runtime.signal,
       });
@@ -4981,7 +5018,6 @@ function parsePullRequestHolder(holder: string | null | undefined) {
  */
 async function eraseAcquiredSlotOrGiveItBack(input: {
   eraseSlotData: EraseSlotData;
-  keepArtifacts: boolean;
   lease: { data: Record<string, unknown>; leaseId: string; slug: string; type: string };
   semaphore: PreviewSemaphoreResourceClient;
 }) {
@@ -4989,7 +5025,6 @@ async function eraseAcquiredSlotOrGiveItBack(input: {
     await input.eraseSlotData({
       dopplerConfig: parseEnvironmentConfigLeaseData(input.lease.data).dopplerConfig,
       slug: input.lease.slug,
-      keepArtifacts: input.keepArtifacts,
     });
     return true;
   } catch (error) {
@@ -5054,7 +5089,6 @@ async function acquireAnyEnvironmentConfigLease(input: {
       if (
         await eraseAcquiredSlotOrGiveItBack({
           eraseSlotData: input.eraseSlotData,
-          keepArtifacts: false,
           lease: acquired,
           semaphore: input.semaphore,
         })
@@ -5156,7 +5190,6 @@ async function claimEnvironmentConfigLease(input: {
     onAdopted: (lease) =>
       eraseAcquiredSlotOrGiveItBack({
         eraseSlotData: input.eraseSlotData,
-        keepArtifacts: lease.slug === input.recordedSlug,
         lease,
         semaphore: input.semaphore,
       }),
@@ -5217,12 +5250,10 @@ async function assignEnvironmentConfigLease(input: {
       holder: input.holder,
       leaseMs: input.leaseMs,
       // Every adoption erases — a preview slot is fresh on every deploy (see
-      // claimEnvironmentConfigLease). This PR's own recorded slot keeps its
-      // Artifacts repos; an unrecorded one is of unknown provenance.
+      // claimEnvironmentConfigLease).
       onAdopted: (lease) =>
         eraseAcquiredSlotOrGiveItBack({
           eraseSlotData: input.eraseSlotData,
-          keepArtifacts: lease.slug === input.recordedSlug,
           lease,
           semaphore: input.semaphore,
         }),
@@ -5300,7 +5331,6 @@ async function assignEnvironmentConfigLease(input: {
       // --force eviction, where the acquired slot holds the evicted PR's data.
       const clean = await eraseAcquiredSlotOrGiveItBack({
         eraseSlotData: input.eraseSlotData,
-        keepArtifacts: false,
         lease: acquired,
         semaphore: input.semaphore,
       });
@@ -6260,6 +6290,7 @@ export const previewInternals = {
   classifyLeaseForReclaim,
   describeEnvironmentConfigLeases,
   describeForcePushCompareHazard,
+  eraseHeldSlotAfterRun,
   describeLostSlotOwnership,
   describePreviewSlotChange,
   diagnosePreviewFleetCapacity,

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -468,21 +468,34 @@ async function deployPreviewApps({
   // the diff-selected apps: anything left undeployed would keep old-slot URLs
   // and e2e would run against another slot's deployment.
   const previousSlug = current.state.environmentConfigLease?.slug ?? null;
-  const appsToDeploy =
-    previousSlug && previousSlug !== environmentConfigLease.slug
-      ? expandPreviewDependencies([
-          ...new Set([
-            ...selectedApps.map((app) => app.slug),
-            ...Object.keys(current.state.apps).filter(
-              (appSlug): appSlug is CloudflarePreviewAppSlugType =>
-                cloudflarePreviewApps[appSlug as CloudflarePreviewAppSlugType] != null,
-            ),
-          ]),
-        ]).map((appSlug) => cloudflarePreviewApps[appSlug])
-      : selectedApps;
-  if (appsToDeploy.length > selectedApps.length) {
+  const slotMoved = previousSlug !== null && previousSlug !== environmentConfigLease.slug;
+  // Every claim erased the slot (fresh-per-deploy contract), so the apps whose
+  // state that wiped must redeploy regardless of the diff: OS is parked at
+  // 503 by its tombstone deploy, the streams playground lost its DO
+  // namespace, and auth's D1 lost the OS client it re-seeds on deploy.
+  const erasedApps = [...selectPreviewSlotDataOwners().map((app) => app.slug), "auth" as const];
+  const appsToDeploy = expandPreviewDependencies([
+    ...new Set([
+      ...selectedApps.map((app) => app.slug),
+      ...erasedApps,
+      ...(slotMoved
+        ? Object.keys(current.state.apps).filter(
+            (appSlug): appSlug is CloudflarePreviewAppSlugType =>
+              cloudflarePreviewApps[appSlug as CloudflarePreviewAppSlugType] != null,
+          )
+        : []),
+    ]),
+  ]).map((appSlug) => cloudflarePreviewApps[appSlug]);
+  if (slotMoved) {
     logPreview(
       `slot changed from ${previousSlug} to ${environmentConfigLease.slug}: redeploying every previously recorded app (${appsToDeploy.map((app) => app.slug).join(", ")}) so nothing keeps pointing at the old slot`,
+    );
+  } else if (appsToDeploy.length > selectedApps.length) {
+    logPreview(
+      `slot erased before deploy: also redeploying ${appsToDeploy
+        .filter((app) => !selectedApps.includes(app))
+        .map((app) => app.slug)
+        .join(", ")}`,
     );
   }
   // A successful claim clears exhaustion/takeover banners; a slot move
@@ -1497,7 +1510,11 @@ export async function reclaim(options: ReclaimOptions = {}) {
   if (!taken) {
     throw new Error(`Could not take ${slug} from ${slot.holder ?? "its holder"} — retry.`);
   }
-  await makePreviewSlotDataEraser(runtime)({ dopplerConfig: slot.dopplerConfig, slug });
+  await makePreviewSlotDataEraser(runtime)({
+    dopplerConfig: slot.dopplerConfig,
+    slug,
+    keepArtifacts: false,
+  });
   const result = await semaphore.release({
     slug,
     type: ENVIRONMENT_CONFIG_LEASE_RESOURCE_TYPE,
@@ -1614,7 +1631,11 @@ export async function gc(options: GcOptions = {}) {
       logPreview(
         `gc: reclaiming ${slot.slug} — lease from ${slot.holder ?? "unknown"} expired ${formatDurationMs(now - slot.leasedUntil)} ago; erasing`,
       );
-      await eraseSlotData({ dopplerConfig: slot.dopplerConfig, slug: slot.slug });
+      await eraseSlotData({
+        dopplerConfig: slot.dopplerConfig,
+        slug: slot.slug,
+        keepArtifacts: false,
+      });
       outcomes.push({ slug: slot.slug, action: "reclaimed", holder: slot.holder });
     } catch (error) {
       logPreview(
@@ -4489,6 +4510,8 @@ async function runPreviewDeployCommand(input: {
   commandEnvironment: NodeJS.ProcessEnv;
   dopplerConfig: string;
   operation: "up" | "down";
+  /** "down" only: forwarded to os erase-data as --keep-artifacts. */
+  keepArtifacts?: boolean;
   repositoryRoot: string;
   signal?: AbortSignal;
 }) {
@@ -4498,7 +4521,15 @@ async function runPreviewDeployCommand(input: {
   // resolve the env from the DOPPLER_CONFIG the `doppler run` wrapper sets.
   const commandArgs =
     input.operation === "down"
-      ? [...input.app.destroyCommandArgs, "--env", input.dopplerConfig]
+      ? [
+          ...input.app.destroyCommandArgs,
+          "--env",
+          input.dopplerConfig,
+          // Only the OS erase owns an Artifacts namespace.
+          ...(input.keepArtifacts && input.app === cloudflarePreviewApps.os
+            ? ["--keep-artifacts"]
+            : []),
+        ]
       : input.app.deployCommandArgs;
 
   return await runCommand({
@@ -4527,7 +4558,13 @@ async function runPreviewDeployCommand(input: {
  * preview-5: 208 orphaned project-directory KV keys against an empty auth D1
  * → every itx project lookup answered "KV GET failed: 500").
  */
-type EraseSlotData = (input: { dopplerConfig: string; slug: string }) => Promise<void>;
+type EraseSlotData = (input: {
+  dopplerConfig: string;
+  slug: string;
+  /** Same-holder redeploy: the Artifacts repos are this PR's own, skip the
+   * slow, rate-limited delete pass; the next real handover deletes them. */
+  keepArtifacts: boolean;
+}) => Promise<void>;
 
 /**
  * Every app that owns slot-persistent data. OS wipes the shared data plane;
@@ -4542,15 +4579,18 @@ function makePreviewSlotDataEraser(runtime: {
   repositoryRoot: string;
   signal?: AbortSignal;
 }): EraseSlotData {
-  return async ({ dopplerConfig, slug }) => {
+  return async ({ dopplerConfig, slug, keepArtifacts }) => {
     const startedAt = Date.now();
-    logPreview(`erasing ${slug} data before handover (doppler config ${dopplerConfig})`);
+    logPreview(
+      `erasing ${slug} data before deploy (doppler config ${dopplerConfig}${keepArtifacts ? ", keeping this PR's Artifacts repos" : ""})`,
+    );
     for (const app of selectPreviewSlotDataOwners()) {
       const result = await runPreviewDeployCommand({
         app,
         commandEnvironment: runtime.commandEnvironment,
         dopplerConfig,
         operation: "down",
+        keepArtifacts,
         repositoryRoot: runtime.repositoryRoot,
         signal: runtime.signal,
       });
@@ -4925,9 +4965,14 @@ function parsePullRequestHolder(holder: string | null | undefined) {
  * Erase a just-acquired slot before it is handed to the caller, giving the
  * lease back on failure. Returns true when the slot is clean and ours.
  *
- * This runs on EVERY handover — plain acquire included, not just reclaims —
- * so slot cleanliness is an invariant of entry rather than an assumption
- * about how the previous tenant exited. Every exit path that skips the
+ * This runs on EVERY claim — a renewed lease this PR already held included,
+ * not just handovers and reclaims — so a preview slot is fresh on every
+ * deploy, never just on entry. Within one PR each push otherwise stacks a
+ * new population of abandoned test projects (whose Durable Objects keep
+ * waking, ~$15-25/hour per slot; the 2026-09-01 runaway) on the last push's,
+ * and a push that cancels the running e2e SIGKILLs it, so in-test finalizers
+ * can never be the guarantee — the next deploy is. Cross-push manual QA
+ * state on a preview is gone by design: recreate after pushing. Every exit path that skips the
  * cleanup erase (failed cleanup + 24h lease expiry, `release --force`, a run
  * cancelled mid-claim) becomes harmless: whoever picks the slot up next
  * wipes it first. A failed erase releases the lease rather than handing out
@@ -4936,6 +4981,7 @@ function parsePullRequestHolder(holder: string | null | undefined) {
  */
 async function eraseAcquiredSlotOrGiveItBack(input: {
   eraseSlotData: EraseSlotData;
+  keepArtifacts: boolean;
   lease: { data: Record<string, unknown>; leaseId: string; slug: string; type: string };
   semaphore: PreviewSemaphoreResourceClient;
 }) {
@@ -4943,6 +4989,7 @@ async function eraseAcquiredSlotOrGiveItBack(input: {
     await input.eraseSlotData({
       dopplerConfig: parseEnvironmentConfigLeaseData(input.lease.data).dopplerConfig,
       slug: input.lease.slug,
+      keepArtifacts: input.keepArtifacts,
     });
     return true;
   } catch (error) {
@@ -5007,6 +5054,7 @@ async function acquireAnyEnvironmentConfigLease(input: {
       if (
         await eraseAcquiredSlotOrGiveItBack({
           eraseSlotData: input.eraseSlotData,
+          keepArtifacts: false,
           lease: acquired,
           semaphore: input.semaphore,
         })
@@ -5106,13 +5154,12 @@ async function claimEnvironmentConfigLease(input: {
     holder: input.holder,
     leaseMs: input.leaseMs,
     onAdopted: (lease) =>
-      lease.slug === input.recordedSlug
-        ? Promise.resolve(true)
-        : eraseAcquiredSlotOrGiveItBack({
-            eraseSlotData: input.eraseSlotData,
-            lease,
-            semaphore: input.semaphore,
-          }),
+      eraseAcquiredSlotOrGiveItBack({
+        eraseSlotData: input.eraseSlotData,
+        keepArtifacts: lease.slug === input.recordedSlug,
+        lease,
+        semaphore: input.semaphore,
+      }),
     preferSlug: input.recordedSlug,
     semaphore: input.semaphore,
   });
@@ -5169,14 +5216,16 @@ async function assignEnvironmentConfigLease(input: {
     (await adoptLeaseHeldBySemaphore({
       holder: input.holder,
       leaseMs: input.leaseMs,
+      // Every adoption erases — a preview slot is fresh on every deploy (see
+      // claimEnvironmentConfigLease). This PR's own recorded slot keeps its
+      // Artifacts repos; an unrecorded one is of unknown provenance.
       onAdopted: (lease) =>
-        lease.slug === input.recordedSlug
-          ? Promise.resolve(true)
-          : eraseAcquiredSlotOrGiveItBack({
-              eraseSlotData: input.eraseSlotData,
-              lease,
-              semaphore: input.semaphore,
-            }),
+        eraseAcquiredSlotOrGiveItBack({
+          eraseSlotData: input.eraseSlotData,
+          keepArtifacts: lease.slug === input.recordedSlug,
+          lease,
+          semaphore: input.semaphore,
+        }),
       preferSlug: input.recordedSlug,
       semaphore: input.semaphore,
     })) ??
@@ -5251,6 +5300,7 @@ async function assignEnvironmentConfigLease(input: {
       // --force eviction, where the acquired slot holds the evicted PR's data.
       const clean = await eraseAcquiredSlotOrGiveItBack({
         eraseSlotData: input.eraseSlotData,
+        keepArtifacts: false,
         lease: acquired,
         semaphore: input.semaphore,
       });

--- a/scripts/preview/preview.ts
+++ b/scripts/preview/preview.ts
@@ -152,6 +152,9 @@ export async function testTarget(options: TestTargetOptions) {
     (await retakeRecordedSlotIfFree({
       holder,
       leaseMs: defaultPreviewLeaseMs,
+      // Tests only renew — the deployment on a lapsed-but-free slot is this
+      // PR's own, and nothing is deployed after this.
+      onRetaken: async () => true,
       recordedSlug: displaySlot?.slug ?? null,
       semaphore,
     }));
@@ -866,6 +869,9 @@ async function testPreviewApps({
     (await retakeRecordedSlotIfFree({
       holder,
       leaseMs: defaultPreviewLeaseMs,
+      // Tests only renew — the deployment on a lapsed-but-free slot is this
+      // PR's own, and nothing is deployed after this.
+      onRetaken: async () => true,
       recordedSlug: displaySlot?.slug ?? null,
       semaphore,
     }));
@@ -1246,32 +1252,30 @@ export async function assign(options: AssignOptions = {}) {
     wantedSlug,
   });
 
-  // Anything but a kept/renewed lease breaks continuous ownership: even a
-  // re-acquisition of the SAME slug means someone else may have deployed over
-  // this PR's apps in the interim, so recorded deployments cannot be trusted.
-  const needsRedeploy = result.outcome !== "kept";
+  // Every outcome needs a redeploy now: taking a slot erases it, and that
+  // includes keeping the one this PR already held (fresh on every acquire).
+  // A changed slug additionally means the recorded apps point at the wrong
+  // hostname.
   const redeployMessage = result.changedFromSlug
     ? `Slot reassigned from ${result.changedFromSlug} to ${result.lease.slug}; run preview deploy to redeploy here.`
-    : `Slot ${result.lease.slug} was re-acquired after this PR's lease lapsed — previous deployments there may have been replaced. Run preview deploy to redeploy.`;
+    : result.outcome === "kept"
+      ? `Slot ${result.lease.slug} kept and erased — taking a slot always erases it. Run preview deploy to redeploy.`
+      : `Slot ${result.lease.slug} was re-acquired after this PR's lease lapsed — previous deployments there may have been replaced. Run preview deploy to redeploy.`;
   const update = await updatePreviewState(context, (state) => ({
     ...state,
     environmentConfigLease: toSlotDisplay(result.lease),
-    notice: needsRedeploy
-      ? `${redeployMessage} (preview assign at ${new Date().toISOString()})`
-      : null,
-    apps: needsRedeploy
-      ? Object.fromEntries(
-          Object.entries(state.apps).map(([appSlug, entry]) => [
-            appSlug,
-            {
-              ...entry,
-              status: "claim-failed" as const,
-              message: redeployMessage,
-              updatedAt: new Date().toISOString(),
-            },
-          ]),
-        )
-      : state.apps,
+    notice: `${redeployMessage} (preview assign at ${new Date().toISOString()})`,
+    apps: Object.fromEntries(
+      Object.entries(state.apps).map(([appSlug, entry]) => [
+        appSlug,
+        {
+          ...entry,
+          status: "claim-failed" as const,
+          message: redeployMessage,
+          updatedAt: new Date().toISOString(),
+        },
+      ]),
+    ),
   }));
   logPreview(
     `PR body updated: PR #${context.pullRequestNumber} now records ${result.lease.slug} (doppler config ${result.lease.dopplerConfig})`,
@@ -1286,7 +1290,7 @@ export async function assign(options: AssignOptions = {}) {
     outcome: result.outcome,
     previousSlot: result.changedFromSlug,
     previousLeaseReleased: result.previousLeaseReleased,
-    appsMarkedForRedeploy: needsRedeploy ? Object.keys(update.state.apps) : [],
+    appsMarkedForRedeploy: Object.keys(update.state.apps),
     nextStep: `doppler run --project _shared --config prd -- pnpm preview deploy --pull-request-number ${context.pullRequestNumber}`,
   };
 }
@@ -4137,6 +4141,7 @@ async function cleanupPreviewForPullRequest(
     (await retakeRecordedSlotIfFree({
       holder,
       leaseMs: defaultPreviewLeaseMs,
+      onRetaken: async () => true,
       recordedSlug: displaySlot?.slug ?? null,
       semaphore,
     }));
@@ -5204,6 +5209,12 @@ async function claimEnvironmentConfigLease(input: {
   const retaken = await retakeRecordedSlotIfFree({
     holder: input.holder,
     leaseMs: input.leaseMs,
+    onRetaken: (lease) =>
+      eraseAcquiredSlotOrGiveItBack({
+        eraseSlotData: input.eraseSlotData,
+        lease,
+        semaphore: input.semaphore,
+      }),
     recordedSlug: input.recordedSlug,
     semaphore: input.semaphore,
   });
@@ -5264,6 +5275,12 @@ async function assignEnvironmentConfigLease(input: {
     (await retakeRecordedSlotIfFree({
       holder: input.holder,
       leaseMs: input.leaseMs,
+      onRetaken: (lease) =>
+        eraseAcquiredSlotOrGiveItBack({
+          eraseSlotData: input.eraseSlotData,
+          lease,
+          semaphore: input.semaphore,
+        }),
       recordedSlug: input.recordedSlug,
       semaphore: input.semaphore,
     }));
@@ -5482,12 +5499,18 @@ async function adoptLeaseHeldBySemaphore(input: {
  * lives on recordedSlug, and if the semaphore says nobody holds that slot,
  * take it back. Non-force, so the semaphore still arbitrates — a slot someone
  * else holds returns null and the caller refuses or moves elsewhere; the
- * recorded slug is only a hint about where to look, never authority. No
- * erase: the deployment on the slot is this PR's own.
+ * recorded slug is only a hint about where to look, never authority.
+ *
+ * onRetaken is the same ready check as adopt's onAdopted: deploy paths erase
+ * there (the slot carries this PR's last population — or a half-finished
+ * erase whose failure just handed the lease back — and a slot is fresh on
+ * every deploy); returning false gives up on the slot so the caller moves on
+ * to any free one. Cleanup passes a no-op: it erases as the teardown itself.
  */
 async function retakeRecordedSlotIfFree(input: {
   holder: string;
   leaseMs: number;
+  onRetaken: (lease: PreviewSemaphoreLease) => Promise<boolean>;
   recordedSlug: string | null;
   semaphore: PreviewSemaphoreResourceClient;
 }): Promise<EnvironmentConfigLease | null> {
@@ -5507,6 +5530,9 @@ async function retakeRecordedSlotIfFree(input: {
   logPreview(
     `lease re-acquired: ${retaken.slug} had lapsed but was still free; ${input.holder} holds it again until ${formatUntil(retaken.expiresAt)}`,
   );
+  if (!(await input.onRetaken(retaken))) {
+    return null;
+  }
   return toEnvironmentConfigLease(retaken);
 }
 

--- a/tasks/preview-erase-before-deploy.md
+++ b/tasks/preview-erase-before-deploy.md
@@ -28,22 +28,24 @@ state is gone by design (recreate the project after pushing).
 
 ## What changes
 
-- [ ] `scripts/preview/preview.ts`: the same-holder **re-issue** path (lease
+- [x] `scripts/preview/preview.ts`: the same-holder **re-issue** path (lease
       renewed, no handover) runs the same erase as the acquire path,
       through the existing `eraseAcquiredSlotOrGiveItBack` machinery (a
       failed erase gives the lease back rather than deploying dirty).
-- [ ] After an erase the deploy plan must include `auth` (erase wipes the
-      auth D1, so the OS client must be re-seeded) — same as the acquire
-      path already forces **[assumption: verify how acquire forces it]**.
-- [ ] Skip the Artifacts-repo delete pass on same-holder redeploys
-      **[assumption]**: those repos are the PR's own, the pass is the slow,
-      rate-limited part of erase-data, and the next real handover deletes
-      them anyway. Needs an `erase-data` flag (e.g. `--keep-artifacts`).
-- [ ] Concurrency: erase must never race a deploy to the same slot. The
-      workflow group is per PR (`cloudflare-previews-<pr>`,
-      cancel-in-progress) — one PR = one slot, so per-PR serialises per-slot
-      **[assumption: confirm nothing else deploys to a leased slot]**.
-- [ ] `docs/dev-environments.md` / preview docs: state the contract.
+      _(both `claimEnvironmentConfigLease` and `assignEnvironmentConfigLease`
+      dropped the recorded-slug short-circuit in `onAdopted`)_
+- [x] After an erase the deploy plan includes `auth` (erase wipes the
+      auth D1, so the OS client must be re-seeded) _(the acquire path never
+      forced it — it relied on the diff; now every claim adds the erased data
+      owners os + streams-example-app plus auth to `appsToDeploy`)_
+- [x] Skip the Artifacts-repo delete pass on same-holder redeploys _(`erase-data
+      --keep-artifacts`, passed when the adopted slot is the PR body's recorded
+      one; handovers and GC reclaims still delete)_
+- [x] Concurrency: the workflow group is per PR (`cloudflare-previews-<pr>`,
+      cancel-in-progress) and the semaphore gives a slot to one holder, so
+      per-PR serialises per-slot; the GC sweep only touches expired leases
+      (`preview gc`, non-force acquire) — it cannot erase a live tenant.
+- [x] `docs/dev-environments.md`: the contract, under the lease model.
 - [ ] Verify on this PR's own slot: DO-hours on the slot after push N+1
       never include push N's population (namespace ids change each erase;
       the old namespace shows as deleted in analytics).

--- a/tasks/preview-erase-before-deploy.md
+++ b/tasks/preview-erase-before-deploy.md
@@ -1,0 +1,61 @@
+---
+status: ready
+size: small
+---
+
+# Erase a preview slot before EVERY deploy, not just on handover
+
+## Status summary
+
+Spec'd 2026-09-03 from the DO duration runaway follow-ups. Implementation on
+this branch. Assumptions tagged **[assumption]**.
+
+## Why
+
+Every preview deploy + e2e run leaves hundreds of abandoned projects whose
+Durable Objects keep waking (heartbeats, stream alarm loops) — ~$15–25/hr per
+slot until erased (`tasks/stream-do-wake-loop-runaway.md`, PR #2583's pin).
+Today the slot is erased only on **handover** (a new holder acquiring it).
+Within one PR, every push stacks a fresh population on the previous one, and
+each deploy re-arms the old populations' backoffs. Worse: a push during a
+running e2e SIGKILLs it (`cancel-in-progress`), so in-test `using`
+finalizers never run for the cancelled attempt — teardown inside tests can
+never be the guarantee. The next deploy has to be.
+
+New contract: **a preview slot is fresh on every push.** Nothing survives a
+deploy that a fresh deploy wouldn't have produced. Cross-push manual QA
+state is gone by design (recreate the project after pushing).
+
+## What changes
+
+- [ ] `scripts/preview/preview.ts`: the same-holder **re-issue** path (lease
+      renewed, no handover) runs the same erase as the acquire path,
+      through the existing `eraseAcquiredSlotOrGiveItBack` machinery (a
+      failed erase gives the lease back rather than deploying dirty).
+- [ ] After an erase the deploy plan must include `auth` (erase wipes the
+      auth D1, so the OS client must be re-seeded) — same as the acquire
+      path already forces **[assumption: verify how acquire forces it]**.
+- [ ] Skip the Artifacts-repo delete pass on same-holder redeploys
+      **[assumption]**: those repos are the PR's own, the pass is the slow,
+      rate-limited part of erase-data, and the next real handover deletes
+      them anyway. Needs an `erase-data` flag (e.g. `--keep-artifacts`).
+- [ ] Concurrency: erase must never race a deploy to the same slot. The
+      workflow group is per PR (`cloudflare-previews-<pr>`,
+      cancel-in-progress) — one PR = one slot, so per-PR serialises per-slot
+      **[assumption: confirm nothing else deploys to a leased slot]**.
+- [ ] `docs/dev-environments.md` / preview docs: state the contract.
+- [ ] Verify on this PR's own slot: DO-hours on the slot after push N+1
+      never include push N's population (namespace ids change each erase;
+      the old namespace shows as deleted in analytics).
+
+## Out of scope
+
+- The leftovers of a PR's *last* push (GC reclaims ~3h after the lease
+  lapses) — the self-wake horizon / teardown cover that.
+- dev and prd — nothing erases there; that is the horizon's job.
+
+## Cost
+
+One erase per push: tombstone deploy + D1/KV wipe (+ auth redeploy). Roughly
+a couple of minutes on the preview critical path; the Artifacts pass skip
+keeps it from being more.

--- a/tasks/preview-erase-before-deploy.md
+++ b/tasks/preview-erase-before-deploy.md
@@ -61,3 +61,9 @@ state is gone by design (recreate the project after pushing).
 One erase per push: tombstone deploy + D1/KV wipe (+ auth redeploy). Roughly
 a couple of minutes on the preview critical path; the Artifacts pass skip
 keeps it from being more.
+
+## Implementation log
+
+- 2026-09-03: first push landed on preview-1 as a handover (erase 106s), then
+  the OS deploy hit Cloudflare's startup-limits validation coin flip. This
+  push is the same-holder redeploy that proves the new path.

--- a/tasks/preview-erase-before-deploy.md
+++ b/tasks/preview-erase-before-deploy.md
@@ -66,9 +66,12 @@ demand.
       never include push N's population _(runs 2–4 on preview-1 each logged
       one erase before deploy; the pre-erase StreamDurableObject namespace
       disappears from the account's namespace list after each erase)_
-- [ ] Watch the first after-run erases in CI: the step must log
-      `erased preview-N after the run` on a finished run and `erase skipped:
-      … moved on` on a run cancelled by a push.
+- [x] Watch the first after-run erases in CI _(runs 5–7 each logged `erased
+      preview-1 after the run`, two of them after a failed deploy step. Run 8,
+      cancelled by a push mid-e2e, ran none of its `always()` steps — Depot
+      kills the job outright — so the `erase skipped: … moved on` branch is
+      never reached from CI; it stays as the guard for a human running
+      `preview erase` after the head moved on)_
 
 ## Out of scope
 

--- a/tasks/preview-erase-before-deploy.md
+++ b/tasks/preview-erase-before-deploy.md
@@ -3,12 +3,15 @@ status: ready
 size: small
 ---
 
-# Erase a preview slot before EVERY deploy, not just on handover
+# Erase a preview slot before EVERY deploy and after every e2e run
 
 ## Status summary
 
-Spec'd 2026-09-03 from the DO duration runaway follow-ups. Implementation on
-this branch. Assumptions tagged **[assumption]**.
+Spec'd 2026-09-03 from the DO duration runaway follow-ups. Implemented on
+this branch: erase before every deploy (proved on this PR's own slot), erase
+after the e2e (`preview erase`, an `always()` workflow step), no
+`--keep-artifacts`. Left: watching the first runs of the after-run step.
+Assumptions tagged **[assumption]**.
 
 ## Why
 
@@ -22,9 +25,14 @@ running e2e SIGKILLs it (`cancel-in-progress`), so in-test `using`
 finalizers never run for the cancelled attempt — teardown inside tests can
 never be the guarantee. The next deploy has to be.
 
-New contract: **a preview slot is fresh on every push.** Nothing survives a
-deploy that a fresh deploy wouldn't have produced. Cross-push manual QA
-state is gone by design (recreate the project after pushing).
+New contract: **a preview slot is only populated while a run is in
+progress.** Nothing survives a deploy that a fresh deploy wouldn't have
+produced, and nothing a run created survives the run (the before-deploy
+erase covers the runs a push SIGKILLed; the after-run erase covers the ones
+that finished — 2026-09-03: one finished run of #2575 left 2,225 DO-hours
+in a single hour on preview-15). Cross-push manual QA state is gone by
+design; the PR body's login link mints a fresh test user and project on
+demand.
 
 ## What changes
 
@@ -38,32 +46,46 @@ state is gone by design (recreate the project after pushing).
       auth D1, so the OS client must be re-seeded) _(the acquire path never
       forced it — it relied on the diff; now every claim adds the erased data
       owners os + streams-example-app plus auth to `appsToDeploy`)_
-- [x] Skip the Artifacts-repo delete pass on same-holder redeploys _(`erase-data
-      --keep-artifacts`, passed when the adopted slot is the PR body's recorded
-      one; handovers and GC reclaims still delete)_
+- ~~Skip the Artifacts-repo delete pass on same-holder redeploys~~ _(built as
+      `--keep-artifacts`, then removed: every repo is an orphan once the
+      projects are erased, the flag only deferred ~90s of deletion to the next
+      handover, and with the after-run erase the before-deploy pass finds
+      almost nothing anyway)_
+- [x] Erase after the e2e too: `preview erase` adopts the slot the semaphore
+      says this PR holds, erases it and keeps the lease; the workflow runs it
+      as an `always()` step right after `preview run`, `continue-on-error`
+      (the next deploy erases anyway). Skips itself with `--ran-head-sha`
+      when the PR head moved on, so it never races the newer push's deploy
+      _(`eraseHeldSlotAfterRun` in preview.ts; three unit tests)_
 - [x] Concurrency: the workflow group is per PR (`cloudflare-previews-<pr>`,
       cancel-in-progress) and the semaphore gives a slot to one holder, so
       per-PR serialises per-slot; the GC sweep only touches expired leases
       (`preview gc`, non-force acquire) — it cannot erase a live tenant.
 - [x] `docs/dev-environments.md`: the contract, under the lease model.
-- [ ] Verify on this PR's own slot: DO-hours on the slot after push N+1
-      never include push N's population (namespace ids change each erase;
-      the old namespace shows as deleted in analytics).
+- [x] Verify on this PR's own slot: DO-hours on the slot after push N+1
+      never include push N's population _(runs 2–4 on preview-1 each logged
+      one erase before deploy; the pre-erase StreamDurableObject namespace
+      disappears from the account's namespace list after each erase)_
+- [ ] Watch the first after-run erases in CI: the step must log
+      `erased preview-N after the run` on a finished run and `erase skipped:
+      … moved on` on a run cancelled by a push.
 
 ## Out of scope
 
-- The leftovers of a PR's *last* push (GC reclaims ~3h after the lease
-  lapses) — the self-wake horizon / teardown cover that.
-- dev and prd — nothing erases there; that is the horizon's job.
+- dev and prd — nothing erases there; that is the self-wake horizon's job.
 
 ## Cost
 
-One erase per push: tombstone deploy + D1/KV wipe (+ auth redeploy). Roughly
-a couple of minutes on the preview critical path; the Artifacts pass skip
-keeps it from being more.
+Two erases per run (before deploy, after e2e): tombstone deploy + D1/KV wipe
++ Artifacts repos (+ auth redeploy). About 20s each once the after-run erase
+keeps the Artifacts backlog small; ~100s when it has one to work through.
 
 ## Implementation log
 
 - 2026-09-03: first push landed on preview-1 as a handover (erase 106s), then
   the OS deploy hit Cloudflare's startup-limits validation coin flip. This
   push is the same-holder redeploy that proves the new path.
+- 2026-09-03 (later): run 4 green. Then a finished run of another PR
+  (#2575) burned 2,225 DO-hours in one hour on preview-15 until erased by
+  hand — the after-run erase was added for exactly that, and
+  `--keep-artifacts` dropped with it.


### PR DESCRIPTION
## What

Makes "a preview slot is only populated while a run is in progress" the contract: erased before every deploy **and** after every e2e run. Today `erase-data` runs only when a slot changes hands; within one PR every push stacks a fresh population of abandoned test projects (whose Durable Objects wake forever — ~$15–25/hr per slot, see #2583's pin and the 2026-09-01 runaway) on top of the last push's. And because a new push SIGKILLs the running e2e (`cancel-in-progress`), in-test finalizers can never be the guarantee — the next deploy has to be.

After this: the same-holder re-issue path erases exactly like the acquire path (failed erase → lease given back, never a dirty deploy); the deploy plan includes `auth` after an erase (its D1 was wiped); the Artifacts-repo delete pass is skipped on same-holder redeploys (they're the PR's own repos and it's the slow, rate-limited part).

Trade-off stated plainly: cross-push manual QA state on a preview is gone by design.

Task file: `tasks/preview-erase-before-deploy.md`. **Implemented.**

## How

- `claimEnvironmentConfigLease` / `assignEnvironmentConfigLease`: `onAdopted` no longer short-circuits when the adopted slot is the PR body's recorded one — every claim goes through `eraseAcquiredSlotOrGiveItBack` (a failed erase gives the lease back; never a dirty deploy).
- `deployPreviewApps`: after every claim the deploy plan adds the apps whose state the erase wiped — `os` (parked at 503 by the tombstone deploy), `streams-example-app` (its DO namespace), and `auth` (its D1 lost the OS client) — regardless of the diff. The acquire path never forced this before; it relied on the diff selecting them.
- `erase-data --keep-artifacts`: skips the Artifacts-repo delete pass. Passed for same-PR redeploys (the repos are the PR's own); handovers and GC reclaims still delete.
- `docs/dev-environments.md`: the contract, under the lease model.

## Risk map

- Riskiest: the plan change. Every push now deploys os + streams-example-app + auth even when the diff didn't touch them (a couple of minutes). If auth's redeploy ever fails to re-seed the OS client, sign-in on the preview breaks — the same failure mode as today's erase-on-acquire, now exercised on every push instead of on handovers.
- What to expect on merge: preview state does not survive a push. Anyone using a preview for multi-push manual QA will notice immediately; that is the contract.
- `preview erase` (new): adopts the slot the semaphore says the PR holds, erases it, keeps the lease. The workflow runs it as an `if: always()` step right after `preview run` (`continue-on-error`: the next deploy erases anyway). With `--ran-head-sha` it skips itself when the PR head has moved on, so it never races the newer push's own before-deploy erase. Why: a *finished* run's population burns until the next push or the lease expiry — one run of #2575 left 2,225 DO-hours in a single hour on preview-15 today.
- `--keep-artifacts` is gone. Every Artifacts repo is an orphan once the projects are erased; the flag only deferred ~90s of deletion to the next handover, and with an after-run erase the before-deploy pass has almost nothing left to do.
- Concurrency is unchanged: one PR ↔ one slot via the semaphore, workflow group per PR with cancel-in-progress, GC only touches expired leases.
- Review order: `preview.ts` `onAdopted` sites → `appsToDeploy` in `deployPreviewApps` → `erase-data.ts` flag → tests (three expectations gained `keepArtifacts`) → docs.

## Verification

From this PR's own preview runs on preview-1:

**Push 1 (handover, `97c8ebb`):**
```
[preview] erasing preview-1 data before deploy (doppler config preview_1)
[preview] erased preview-1 data (106.0s)
[preview] lease acquired: preview-1 held by pr-2585 …
```

**Push 2 (same holder, recorded slot, `0247953`) — the path this PR adds:**
```
[preview] lease held: the semaphore attributes preview-1 to pr-2585; re-issued (renewed) …
> tsx ./scripts/erase-data.ts --env preview_1 --keep-artifacts
[preview] erasing preview-1 data before deploy (doppler config preview_1, keeping this PR's Artifacts repos)
[preview] erased preview-1 data (15.7s)
```

15.7s vs 106s: the Artifacts-pass skip is ~90s per push. (The plan line reads all six apps on both runs because the previous deploy had failed and the retry selection already covered everything; the `also redeploying …` line only appears when the diff alone would have left auth/os/streams out.)

**Run 7 (after-run erase, `b73cfc5`): green** — before-deploy erase 107.6s, `deploy finished: 6 ok, 0 failed`, `tests finished: 6 passed, 0 failed`, then the new step: `erased preview-1 after the run; pr-2585 keeps the lease`. Runs 5 and 6 on the same commit failed their deploys (a pkg.pr.new outage, then the startup-CPU flake) and the `always()` step still erased after both — the step runs whatever the run's outcome.

**Run 4 (re-dispatched): green** — `deploy finished: 6 ok, 0 failed`, `tests finished: 6 passed, 0 failed` (84 web + 31 mobile Playwright, 207 vitest). This run took the full-erase path (114s, Artifacts repos dropped) because the body's managed state block was unparseable at run start — my own doing, not the script's: I had round-tripped the body through `gh api --jq .body`, which rewrites the JSON escape `\u001b` (ANSI codes inside run 3's failed-test message) as `\^[`. The script handled it the safe way: adopted via the semaphore, erased, redeployed, rewrote the block cleanly.

**Run 3 (re-dispatched, same holder):** deploy `6 ok, 0 failed` — erase 19.7s with `--keep-artifacts`, os/auth/streams-example-app redeployed, e2e ran on the fresh slot. Exactly one erase per run (the test step's lease renewal never erases, by design — checked in the log).

Runs 1 and 2 had hit Cloudflare's startup-limits validation on the os deploy (`Your Worker failed validation because it exceeded startup limits`) — the known deploy coin flip, unrelated to this diff; the fourth occurrence across three PRs today, which suggests main's os worker is sitting close to the limit (#2561's zod bump is the fix in flight).

---
Coding agent session: `fc7df69e-30c5-4fe1-a51c-896c830389c4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CreJMLijARf7t4P1LyHTwi

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +145 -4 | +119 -1 🟩🟩🟩⬜⬜ |
| CI & scripts | +194 -64 | +133 -49 🟩🟩🟩🟩🟥 |
| Docs | +108 -0 | +94 -0 🟩🟩🟩⬜⬜ |
| **Total** | **+447 -68** | **+346 -50** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 3e52f2a and 708cda3, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-09-03T22:46:06.619Z",
      "deployedAt": "2026-09-03T22:29:04.174Z",
      "headSha": "708cda37d179a0db9ea92ac119d761b3cfbcbbcd",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/77043868907972",
      "shortSha": "708cda3",
      "cleanupDurationMs": 100419,
      "deployDurationMs": 44626,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 43041,
      "deployReadinessDurationMs": 1582,
      "deployedWorkerName": "os-preview-1",
      "deployedWorkerVersion": "63d53bfa-58c7-49db-b519-e63e2c5e8f9f",
      "testDurationMs": 320725,
      "testRetries": "3 retried: a disposed test project stops waking its Durable Objects (vitest x1) · the source-version pin tells a facet that recycled from one the commit rebuilt (vitest x1) · a userspace facet rebuilds on a source commit and only on a source commit (vitest x1)",
      "workerSizeKib": 20891.45,
      "workerGzipKib": 5265.05,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5292.83
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-09-03T22:44:30.251Z",
      "deployedAt": "2026-09-03T22:28:46.359Z",
      "headSha": "708cda37d179a0db9ea92ac119d761b3cfbcbbcd",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-1.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/77043868907972",
      "shortSha": "708cda3",
      "cleanupDurationMs": 4048,
      "deployDurationMs": 34849,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 25224,
      "deployReadinessDurationMs": 9620,
      "deployedWorkerName": "docs-preview-1",
      "deployedWorkerVersion": "a501fcbe-9e67-4ae8-946f-f19984a6aa9b",
      "testDurationMs": 2656,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-09-03T22:44:27.274Z",
      "deployedAt": "2026-09-03T22:28:43.191Z",
      "headSha": "708cda37d179a0db9ea92ac119d761b3cfbcbbcd",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/77043868907972",
      "shortSha": "708cda3",
      "cleanupDurationMs": 1070,
      "deployDurationMs": 22244,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 22054,
      "deployReadinessDurationMs": 185,
      "deployedWorkerName": "semaphore-preview-1",
      "deployedWorkerVersion": "a3501ffe-fe18-439a-8843-d1895c52cc37",
      "testDurationMs": 80551,
      "testRetries": null,
      "workerSizeKib": 1915.87,
      "workerGzipKib": 441.25,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-09-03T22:44:31.098Z",
      "deployedAt": "2026-09-03T22:28:50.482Z",
      "headSha": "708cda37d179a0db9ea92ac119d761b3cfbcbbcd",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/77043868907972",
      "shortSha": "708cda3",
      "cleanupDurationMs": 4891,
      "deployDurationMs": 29418,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 29345,
      "deployReadinessDurationMs": 68,
      "deployedWorkerName": "auth-preview-1",
      "deployedWorkerVersion": "56c22de3-bf00-438e-8603-a8a18a816bd8",
      "testDurationMs": 8756,
      "testRetries": null,
      "workerSizeKib": 3989.97,
      "workerGzipKib": 817.49,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-09-03T22:44:31.494Z",
      "deployedAt": "2026-09-03T22:28:48.662Z",
      "headSha": "708cda37d179a0db9ea92ac119d761b3cfbcbbcd",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/77043868907972",
      "shortSha": "708cda3",
      "cleanupDurationMs": 5286,
      "deployDurationMs": 28321,
      "deployConfigDurationMs": 7,
      "deployCommandDurationMs": 27523,
      "deployReadinessDurationMs": 791,
      "deployedWorkerName": "streams-example-app-preview-1",
      "deployedWorkerVersion": "97bbe9a7-0c37-43c4-9241-3221dbb7c6f5",
      "testDurationMs": 120065,
      "testRetries": null,
      "workerSizeKib": 5602.75,
      "workerGzipKib": 1585.81,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-09-03T22:44:28.683Z",
      "deployedAt": "2026-09-03T22:16:53.997Z",
      "headSha": "708cda37d179a0db9ea92ac119d761b3cfbcbbcd",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/77043868907972",
      "shortSha": "708cda3",
      "cleanupDurationMs": 1408,
      "deployDurationMs": 99,
      "deployConfigDurationMs": 0,
      "deployReuseProofDurationMs": 96,
      "deployedWorkerName": "dummy-petshop-preview-1",
      "deployedWorkerVersion": "64e13f30-8947-4dc7-a6f0-ca85c8a7a132",
      "testDurationMs": 7320,
      "testRetries": null,
      "workerSizeKib": 1115.4,
      "workerGzipKib": 198.29,
      "deployedFingerprint": "b717e505c46472150438e97f994eb4a2c283e0f8+c5abf1055de73f3b4ffbc5e5b742dff1f0b5ee52",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `708cda3` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 817.5 KiB | 29.4s | 8.8s |  | 4.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/77043868907972) | 2026-09-03T22:44:31.098Z | Preview app released. |
| Docs | released | `708cda3` | [https://docs-preview-1.iterate-dev-preview.workers.dev](https://docs-preview-1.iterate-dev-preview.workers.dev) | 866.2 KiB | 34.8s | 2.7s |  | 4.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/77043868907972) | 2026-09-03T22:44:30.251Z | Preview app released. |
| Dummy Petshop | released | `708cda3` | [https://dummy-petshop.iterate-preview-1.com](https://dummy-petshop.iterate-preview-1.com) | 198.3 KiB | 99ms | 7.3s |  | 1.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/77043868907972) | 2026-09-03T22:44:28.683Z | Preview app released. |
| OS | released | `708cda3` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 5.14 MiB (-27.8 KiB vs main) | 44.6s | 320.7s | 3 retried: a disposed test project stops waking its Durable Objects (vitest x1) · the source-version pin tells a facet that recycled from one the commit rebuilt (vitest x1) · a userspace facet rebuilds on a source commit and only on a source commit (vitest x1) | 100.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/77043868907972) | 2026-09-03T22:46:06.619Z | Preview app released. |
| Semaphore | released | `708cda3` | [https://semaphore.iterate-preview-1.com](https://semaphore.iterate-preview-1.com) | 441.3 KiB | 22.2s | 80.6s |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/77043868907972) | 2026-09-03T22:44:27.274Z | Preview app released. |
| Streams Example App | released | `708cda3` | [https://streams.iterate-preview-1.com](https://streams.iterate-preview-1.com) | 1.55 MiB | 28.3s | 120.1s |  | 5.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/77043868907972) | 2026-09-03T22:44:31.494Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Every preview push now redeploys os/auth/streams regardless of diff; auth must re-seed after D1 wipe or sign-in breaks, and the erase-after-e2e step can race if head-SHA guarding is wrong.
> 
> **Overview**
> Preview slots now follow a **fresh-per-run** contract: data is wiped before every deploy (including when the same PR renews its lease) and again after e2e, so abandoned test Durable Objects stop burning cost between pushes.
> 
> **`preview.ts`** removes the same-holder skip on lease adoption—every claim goes through `eraseAcquiredSlotOrGiveItBack` (failed erase releases the lease). Deploy planning always includes **os**, **streams-example-app**, and **auth** after an erase, not only when the slot changes. A new **`preview erase`** command (`eraseHeldSlotAfterRun`) clears the held slot while keeping the lease; it no-ops when `--ran-head-sha` does not match the current PR head.
> 
> **CI** adds an `always()` post-e2e step that runs `preview erase` (`continue-on-error`). **Docs** and a task file document the behavior and the trade-off that manual QA state on a preview does not survive a push or e2e run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 708cda37d179a0db9ea92ac119d761b3cfbcbbcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->