### PR TITLE
Flake dashboard: row expiry, emoji streaks, createFailing rename

### DIFF
--- a/apps/os/e2e/vitest/abandoned-project-goes-quiet.e2e.test.ts
+++ b/apps/os/e2e/vitest/abandoned-project-goes-quiet.e2e.test.ts
@@ -5,7 +5,7 @@
 // population of billable DOs behind (~4,500 DO-hours in 90 minutes from one
 // deploy + e2e on 2026-09-02). Today `createTestProject`'s disposer is a
 // no-op (test-support/create-test-project.ts) because itx has no project
-// removal; when teardown lands this test flips to passing and the `failing`
+// removal; when teardown lands this test flips to passing and the `createFailing`
 // wrapper comes off.
 //
 // The measurement has two traps, both handled below:
@@ -21,7 +21,7 @@
 // Run against a preview (it leaves a project behind on purpose):
 //   doppler run --config preview_N -- pnpm --dir apps/os e2e --run abandoned-project-goes-quiet
 import { expect, test } from "vitest";
-import { failing } from "@iterate-com/shared/test-support/failing-test";
+import { createFailing } from "@iterate-com/shared/test-support/failing-test";
 import { installResilientAiInterceptor } from "@iterate-com/shared/test-support/resilient-ai-interceptor";
 import { createTestProject } from "../test-support/create-test-project.ts";
 import { createAdminOsItx } from "../test-support/os-client.ts";
@@ -36,7 +36,7 @@ const WOKEN = "events.iterate.com/stream/woken";
 // settling, the 60s quiet window (12 heartbeats at 5s), two read passes. The
 // pin's own deadline sits just under the ceiling. Raising
 // ABANDONED_PROJECT_QUIET_SECONDS past ~90 needs the ceiling raised by hand.
-const failWakeUp = failing(
+const failWakeUp = createFailing(
   test.skipIf(deployedBaseUrl() === null),
   /woke \d+ times after dispose/,
   {

--- a/apps/os/e2e/vitest/project-create-concurrency.regression.e2e.test.ts
+++ b/apps/os/e2e/vitest/project-create-concurrency.regression.e2e.test.ts
@@ -1,8 +1,8 @@
-import { failing } from "@iterate-com/shared/test-support/failing-test";
+import { createFailing } from "@iterate-com/shared/test-support/failing-test";
 import { test } from "vitest";
 import { adminSecret, withItxSession } from "./test-helpers.ts";
 
-failing(test, /CONCURRENT CREATE SPLITS IDENTITY/)(
+createFailing(test, /CONCURRENT CREATE SPLITS IDENTITY/)(
   "DESIRED: concurrent creates of one slug adopt the same project identity",
   { retry: 0 },
   async ({ expect }) => {

--- a/apps/os/e2e/vitest/userspace-facet-recycle-false-alarm.e2e.test.ts
+++ b/apps/os/e2e/vitest/userspace-facet-recycle-false-alarm.e2e.test.ts
@@ -1,4 +1,4 @@
-import { failing } from "@iterate-com/shared/test-support/failing-test";
+import { createFailing } from "@iterate-com/shared/test-support/failing-test";
 import { expect, test } from "vitest";
 import type { StreamEventInput } from "iterate/processors";
 import { waitForCondition } from "../test-support/wait-for-condition.ts";
@@ -52,7 +52,7 @@ import { adminSecret, withItxSession } from "./test-helpers.ts";
  * The `[facet-recycle]` phase log is not decoration. Three runs of this test
  * "passed" while never reaching the assertion at all, back when it was a bare
  * `test.fails` and every throw counted as the expected one. The
- * `failing(test, /PIN CANNOT TELL RECYCLE FROM REBUILD/)` wrapper now closes
+ * `createFailing(test, /PIN CANNOT TELL RECYCLE FROM REBUILD/)` wrapper now closes
  * that hole — only the tagged verdict counts, and a fall-over on the way goes
  * red with the mismatched error in the `[failing-test]` log — but the phase
  * log is still how you tell which phase a run reached. A run proves
@@ -61,7 +61,7 @@ import { adminSecret, withItxSession } from "./test-helpers.ts";
 // timeoutMs: the wrapper's hang deadline, kept just below the 180s runner
 // ceiling so a hung phase goes red as not-the-pin instead of riding the
 // runner's timeout into a vacuous expected-fail pass.
-failing(test, /PIN CANNOT TELL RECYCLE FROM REBUILD/, { timeoutMs: 170_000 })(
+createFailing(test, /PIN CANNOT TELL RECYCLE FROM REBUILD/, { timeoutMs: 170_000 })(
   "the source-version pin tells a facet that recycled from one the commit rebuilt",
   // Ceiling, not an expectation: ~6s against a warm local deployment, and the
   // pin's comparable scenario takes 50-75s on a busy preview. Matched to the

--- a/apps/os/e2e/vitest/userspace-facet-source-version.e2e.test.ts
+++ b/apps/os/e2e/vitest/userspace-facet-source-version.e2e.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { failing } from "@iterate-com/shared/test-support/failing-test";
+import { createFailing } from "@iterate-com/shared/test-support/failing-test";
 import type { StreamEventInput } from "iterate/processors";
 import { waitForCondition } from "../test-support/wait-for-condition.ts";
 import {
@@ -36,7 +36,7 @@ const WOKEN = "events.iterate.com/stream/woken";
 const ECHO_PATH = "version-echo.js";
 
 /*
- * A PINNED BUG, held by `failing(test, …)`: the body asserts the desired contract,
+ * A PINNED BUG, held by `createFailing(test, …)`: the body asserts the desired contract,
  * and while the bug exists it must fail with the SAME-BOOT STALENESS error
  * the wrapper matches. The moment somebody fixes the bug, the body succeeds
  * and the wrapper goes red with delete-me instructions.
@@ -70,8 +70,8 @@ const ECHO_PATH = "version-echo.js";
  * still demonstrates the old comparisons' blind spot by forcing a recycle.
  */
 // timeoutMs: the wrapper's own hang deadline, just below the runner ceiling —
-// the expected run is ~60-110s, well past failing()'s 60s default.
-failing(test, /SAME-BOOT STALENESS/, { timeoutMs: 230_000 })(
+// the expected run is ~60-110s, well past createFailing()'s 60s default.
+createFailing(test, /SAME-BOOT STALENESS/, { timeoutMs: 230_000 })(
   "a userspace facet rebuilds on a source commit and only on a source commit",
   // Ceiling for the cold build, the two stability kills, and up to three
   // 45s observation rounds. The expected run (bug present, no recycles)
@@ -264,7 +264,7 @@ failing(test, /SAME-BOOT STALENESS/, { timeoutMs: 230_000 })(
     }
     // Every round ended with the running facet replaced by one serving the
     // just-committed revision — the fix's shape, three times in a row. The
-    // body succeeding here is what makes the failing() wrapper raise the
+    // body succeeding here is what makes the createFailing() wrapper raise the
     // delete-me alert. (Residual risk: three independent coincidental
     // recycles in a row would masquerade as the fix — roughly the cube of an
     // already-uncommon event, and the next run self-corrects.)

--- a/apps/os/src/domains/repos/artifact-rpc-ownership.regression.test.ts
+++ b/apps/os/src/domains/repos/artifact-rpc-ownership.regression.test.ts
@@ -1,4 +1,4 @@
-import { failing } from "@iterate-com/shared/test-support/failing-test";
+import { createFailing } from "@iterate-com/shared/test-support/failing-test";
 import { expect, test, vi } from "vitest";
 import { replaceArtifactWithEmptyRepo } from "./artifact-replacement.ts";
 
@@ -6,7 +6,7 @@ function artifactsError(code: string): Error & { code: string } {
   return Object.assign(new Error(code), { code });
 }
 
-failing(test, /TEMP REPO HANDLE NOT DISPOSED/)(
+createFailing(test, /TEMP REPO HANDLE NOT DISPOSED/)(
   "DESIRED: deletion polling disposes each temporary repository handle",
   async () => {
     const calls: string[] = [];
@@ -50,7 +50,7 @@ failing(test, /TEMP REPO HANDLE NOT DISPOSED/)(
   },
 );
 
-failing(test, /CLEANUP MASQUERADES AS DELETION BARRIER/)(
+createFailing(test, /CLEANUP MASQUERADES AS DELETION BARRIER/)(
   "DESIRED: cleanup failure does not masquerade as the repository deletion barrier",
   async () => {
     const cleanupError = artifactsError("NOT_FOUND");

--- a/apps/os/src/domains/scheduler/scheduler-rpc-ownership.regression.test.ts
+++ b/apps/os/src/domains/scheduler/scheduler-rpc-ownership.regression.test.ts
@@ -1,4 +1,4 @@
-import { failing } from "@iterate-com/shared/test-support/failing-test";
+import { createFailing } from "@iterate-com/shared/test-support/failing-test";
 import { expect, test, vi } from "vitest";
 import {
   makeMemoryProgressStore,
@@ -61,7 +61,7 @@ async function runOneAction(
   return h.events(COMPLETED_TYPE)[0]!;
 }
 
-failing(test, /SCHEDULER RESULT NOT DISPOSED/)(
+createFailing(test, /SCHEDULER RESULT NOT DISPOSED/)(
   "DESIRED: a scheduler action disposes its RPC result after detaching the JSON value",
   async () => {
     const dispose = vi.fn();
@@ -77,7 +77,7 @@ failing(test, /SCHEDULER RESULT NOT DISPOSED/)(
   },
 );
 
-failing(test, /SCHEDULER CLEANUP FAILURE NOT ISOLATED/)(
+createFailing(test, /SCHEDULER CLEANUP FAILURE NOT ISOLATED/)(
   "DESIRED: RPC result cleanup failure does not replace a successful scheduler action",
   async () => {
     const cleanupError = new Error("dispose failed");
@@ -96,7 +96,7 @@ failing(test, /SCHEDULER CLEANUP FAILURE NOT ISOLATED/)(
   },
 );
 
-failing(test, /SCHEDULER NO DISPOSE ON DETACH FAILURE/)(
+createFailing(test, /SCHEDULER NO DISPOSE ON DETACH FAILURE/)(
   "DESIRED: a scheduler disposes its RPC result even when JSON detachment fails",
   async () => {
     const dispose = vi.fn();

--- a/apps/os/src/domains/streams/guarantees-not-given.test.ts
+++ b/apps/os/src/domains/streams/guarantees-not-given.test.ts
@@ -10,7 +10,7 @@
 // guarantees pinned below. Each test is written as if the guarantee EXISTED:
 // it exercises the real system and asserts the desirable behavior, and it
 // genuinely fails today because the system does not provide it. Each is
-// wrapped in `failing(test, /TAG/)` — registered through vitest's own
+// wrapped in `createFailing(test, /TAG/)` — registered through vitest's own
 // `test.fails` underneath, so they report natively as expected fails — and
 // asserts its pinned expectation with that TAG as the message. The suite
 // stays green only while the guarantee is un-given FOR THE PINNED REASON;
@@ -19,7 +19,7 @@
 //
 // If a change makes one of these tests pass, it goes red with
 // delete-the-wrapper instructions in the log. Do not delete the test — drop
-// the `failing(...)` call and the TAG message, move it to the regular
+// the `createFailing(...)` call and the TAG message, move it to the regular
 // suites, and delete only its entry here.
 
 import { DatabaseSync } from "node:sqlite";
@@ -29,7 +29,7 @@ import type {
   StreamEvent,
   StreamEventInput,
 } from "iterate/processors";
-import { failing } from "@iterate-com/shared/test-support/failing-test";
+import { createFailing } from "@iterate-com/shared/test-support/failing-test";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import type { Env } from "../../env.ts";
 import { DurableObjectNameCodec } from "../durable-object-names.ts";
@@ -230,7 +230,7 @@ describe("guarantees the subscription rewrite deliberately does not give", () =>
   //   so the window closes within one delivery round.
   // RESTORE: the deleted receiver-side registry (membership checked at
   //   receive time), or any receiver-visible removal record.
-  failing(test, /NO ATOMIC UNSUBSCRIBE/)(
+  createFailing(test, /NO ATOMIC UNSUBSCRIBE/)(
     "removing a subscription atomically stops in-flight deliveries",
     async () => {
       const streams = new Map<string, StreamDurableObject>();
@@ -291,7 +291,7 @@ describe("guarantees the subscription rewrite deliberately does not give", () =>
   //   duplicate window is a single delivery round.
   // RESTORE: the deleted move-gating handshake (quiesce the old receiver
   //   before enabling the new one).
-  failing(test, /REPOINT DELIVERS TO BOTH/)(
+  createFailing(test, /REPOINT DELIVERS TO BOTH/)(
     "re-pointing a subscription key from one receiver to another never delivers the same event to both",
     async () => {
       const streams = new Map<string, StreamDurableObject>();
@@ -361,7 +361,7 @@ describe("guarantees the subscription rewrite deliberately does not give", () =>
   //   (resumeSubscription / a fresh setCopySubscription).
   // RESTORE: the deleted configure-time round-trip, or a probe call before
   //   committing the configuration.
-  failing(test, /NO RECEIVER VERIFICATION/)(
+  createFailing(test, /NO RECEIVER VERIFICATION/)(
     "configuring a copy subscription verifies the receiver end-to-end",
     async () => {
       const streams = new Map<string, StreamDurableObject>();
@@ -404,7 +404,7 @@ describe("guarantees the subscription rewrite deliberately does not give", () =>
   //   order, within one subscription; duplicates are bounded by one batch per
   //   lost acknowledgement.
   // RESTORE: nothing planned. This test documents the doctrine.
-  failing(test, /ITX DELIVERY NOT EXACTLY ONCE/)(
+  createFailing(test, /ITX DELIVERY NOT EXACTLY ONCE/)(
     "delivery to an itx-call receiver is exactly-once",
     async () => {
       vi.spyOn(console, "error").mockImplementation(() => undefined);
@@ -524,7 +524,7 @@ describe("guarantees the subscription rewrite deliberately does not give", () =>
   //   ever across sources, and each source still arrives gap-free.
   // RESTORE: cross-source sequencing (a receiver-side total order or source
   //   coordination) — deliberately out of scope.
-  failing(test, /NO GLOBAL APPEND ORDER/)(
+  createFailing(test, /NO GLOBAL APPEND ORDER/)(
     "events from two source streams arrive at a shared receiver in global append order",
     async () => {
       const streams = new Map<string, StreamDurableObject>();
@@ -601,7 +601,7 @@ describe("guarantees the subscription rewrite deliberately does not give", () =>
   // RESTORE: the deleted blocked/resend-request lane, or receiver-lifetime
   //   tracking on the source that rewinds the cursor on first contact with a
   //   new receiver lifetime.
-  failing(test, /NO AUTOMATIC HISTORY RESEND/)(
+  createFailing(test, /NO AUTOMATIC HISTORY RESEND/)(
     "a receiver that lost its data gets the source history automatically re-sent",
     async () => {
       const streams = new Map<string, StreamDurableObject>();
@@ -658,7 +658,7 @@ describe("guarantees the subscription rewrite deliberately does not give", () =>
   // BOUND: debug/introspection only — delivery itself never needed the record,
   //   and the source side lists the subscription immediately.
   // RESTORE: the deleted configure-time registration event on the receiver.
-  failing(test, /NO INBOUND ENUMERATION/)(
+  createFailing(test, /NO INBOUND ENUMERATION/)(
     "the receiver can enumerate its inbound subscriptions before the first event arrives",
     async () => {
       const streams = new Map<string, StreamDurableObject>();

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -550,20 +550,20 @@ called out prominently in the PR description.
 Once the remaining CI is green, either form of quarantine is explicit
 coverage debt, not a reason to keep the unrelated PR open indefinitely.
 
-### Pinned bugs: `failing(test, …)`, not bare `test.fails`
+### Pinned bugs: `createFailing(test, …)`, not bare `test.fails`
 
 For a KNOWN bug held open on purpose, wrap the runner's own test function
-with `failing` from `@iterate-com/shared/test-support/failing-test` — it
+with `createFailing` from `@iterate-com/shared/test-support/failing-test` — it
 works for vitest and playwright alike, passing fixtures and options through:
 
 ```ts
-const fail = failing(test, /SAME-BOOT STALENESS/);
+const fail = createFailing(test, /SAME-BOOT STALENESS/);
 fail("a userspace facet rebuilds on a source commit", { timeout: 240_000 }, async () => {
   // asserts the DESIRED behavior; today it throws the matched error
 });
 ```
 
-`failing` registers through the runner's own expected-fail variant
+`createFailing` registers through the runner's own expected-fail variant
 (vitest `test.fails`, playwright `test.fail`), so pins report natively —
 the "expected fail" summary count and telemetry's expected state need no
 extra plumbing. The wrapper filters WHICH failure satisfies that machinery:
@@ -593,7 +593,7 @@ flake("Worker can be deployed", async () => {
 });
 ```
 
-Like `failing`, it registers through the runner's expected-fail variant, but
+Like `createFailing`, it registers through the runner's expected-fail variant, but
 the contract differs: a pass and a failure matching the one allowed pattern
 are both green; anything else — a different error, or a body still running at
 the wrapper's deadline — is red. The test keeps running on every branch and,
@@ -602,7 +602,7 @@ the flake dashboard, so the flake rate stays measured instead of hidden.
 
 The lifecycle is wrapper-switching, driven by that data: a test that seems
 flaky moves to `createFlake`; if it stops passing entirely, switch it to
-`failing`; once it passes consistently, unwrap it back to a plain test.
+`createFailing`; once it passes consistently, unwrap it back to a plain test.
 `packages/shared/src/test-support/flake-sentinel.test.ts` is a deliberately
 ~10%-flaky sentinel that proves the pipeline works — if its flake rate reads
 0%, distrust the dashboard, not the sentinel.

--- a/packages/iterate/src/starter-apps/flake-dashboard/contract.ts
+++ b/packages/iterate/src/starter-apps/flake-dashboard/contract.ts
@@ -95,7 +95,7 @@ const TrackedTest = z.object({
    * The last (up to) 10 recorded outcomes on any branch, oldest first — the
    * render's emoji streak bar. All branches, like the counts: the specs and
    * preview-e2e suites only run on pull requests, so a default-branch-only
-   * bar would stay empty forever for exactly the flakiest lane. The numeric
+   * bar would stay empty forever for the suites where most flakes live. The numeric
    * defaultBranchStreak below stays main-only and carries the
    * transition-threshold counts past what 10 entries can show.
    */

--- a/packages/iterate/src/starter-apps/flake-dashboard/contract.ts
+++ b/packages/iterate/src/starter-apps/flake-dashboard/contract.ts
@@ -15,9 +15,11 @@ const StreamOffset = z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER)
  * `@iterate-com/shared/test-support/flake-test` — the wrapper writes these
  * lines to `FLAKE_RECORD_DIR` and CI ships them here verbatim.
  */
+export const FlakeOutcome = z.enum(["pass", "flake-fail", "unexpected-error"]);
+
 export const FlakeRecord = z.object({
   name: z.string().min(1).max(1_000),
-  outcome: z.enum(["pass", "flake-fail", "unexpected-error"]),
+  outcome: FlakeOutcome,
   pattern: z.string().min(1).max(2_000),
   durationMs: z.number().nonnegative(),
   at: z.string().min(1),
@@ -81,6 +83,20 @@ const DefaultBranchStreak = z.object({
 const TrackedTest = z.object({
   pattern: z.string(),
   suites: z.array(z.string()).default([]),
+  /**
+   * Per suite, the offset of the newest run-recorded event (any branch) whose
+   * records included this test. Compared against the suite's
+   * `lastDefaultBranchRunOffset` at render time: a test absent from its
+   * suite's latest default-branch run is retired from the table — hidden, not
+   * deleted, so a transient absence self-heals on the next record.
+   */
+  lastSeenOffset: z.record(z.string(), StreamOffset).default({}),
+  /**
+   * The last (up to) 10 default-branch outcomes, oldest first — the render's
+   * emoji streak bar. The numeric defaultBranchStreak below carries the
+   * transition-threshold counts past what 10 entries can show.
+   */
+  recent: z.array(FlakeOutcome).max(10).default([]),
   counts: z
     .object({
       pass: z.number().int().nonnegative().default(0),
@@ -102,6 +118,13 @@ export const FlakeDashboardState = z.object({
   birthCertificate: z.object({ config: FlakeDashboardConfig }).nullable().default(null),
   tests: z.record(z.string(), TrackedTest).default({}),
   /**
+   * Per suite, the offset of its newest default-branch run-recorded event —
+   * the reference point for retiring absent tests. Judged from default-branch
+   * runs only, so a PR that deletes or renames a test cannot hide its row
+   * repo-wide while that PR happens to be the newest run.
+   */
+  suites: z.record(z.string(), z.object({ lastDefaultBranchRunOffset: StreamOffset })).default({}),
+  /**
    * Offset of the newest reduced DATA event (created / run-recorded /
    * transition-proposed). Render settlements deliberately do not bump it —
    * that is what stops a settled render from demanding another render.
@@ -120,7 +143,7 @@ export const FlakeDashboardState = z.object({
 /**
  * Thresholds for the data-provable lifecycle transitions (grilled decision:
  * unwrap after 50 consecutive default-branch passes over >=5 days; propose
- * `failing` after 25 consecutive matched failures over >=2 days). Tunable
+ * `createFailing` after 25 consecutive matched failures over >=2 days). Tunable
  * constants; the ~10% sentinel false-unwraps with probability 0.9^50 ~= 0.5%.
  */
 export const flakeTransitionThresholds = {
@@ -159,7 +182,7 @@ export const CheckRunWebhookEvent = z.object({
 
 export const FlakeDashboardProcessorContract = defineProcessorContract({
   slug: "flake-dashboard",
-  version: "0.1.0",
+  version: "0.2.0",
   description:
     "Folds createFlake test outcomes reported by CI into per-test flake stats, renders the GitHub 'Flake dashboard' issue, and proposes data-provable lifecycle transitions.",
   stateSchema: FlakeDashboardState,

--- a/packages/iterate/src/starter-apps/flake-dashboard/contract.ts
+++ b/packages/iterate/src/starter-apps/flake-dashboard/contract.ts
@@ -191,7 +191,7 @@ export const CheckRunWebhookEvent = z.object({
 
 export const FlakeDashboardProcessorContract = defineProcessorContract({
   slug: "flake-dashboard",
-  version: "0.2.0",
+  version: "0.3.0",
   description:
     "Folds createFlake test outcomes reported by CI into per-test flake stats, renders the GitHub 'Flake dashboard' issue, and proposes data-provable lifecycle transitions.",
   stateSchema: FlakeDashboardState,

--- a/packages/iterate/src/starter-apps/flake-dashboard/contract.ts
+++ b/packages/iterate/src/starter-apps/flake-dashboard/contract.ts
@@ -86,14 +86,17 @@ const TrackedTest = z.object({
   /**
    * Per suite, the offset of the newest run-recorded event (any branch) whose
    * records included this test. Compared against the suite's
-   * `lastDefaultBranchRunOffset` at render time: a test absent from its
-   * suite's latest default-branch run is retired from the table — hidden, not
+   * `recentRunOffsets` window at render time: a test absent from all of its
+   * suite's last few ingested runs is retired from the table — hidden, not
    * deleted, so a transient absence self-heals on the next record.
    */
   lastSeenOffset: z.record(z.string(), StreamOffset).default({}),
   /**
-   * The last (up to) 10 default-branch outcomes, oldest first — the render's
-   * emoji streak bar. The numeric defaultBranchStreak below carries the
+   * The last (up to) 10 recorded outcomes on any branch, oldest first — the
+   * render's emoji streak bar. All branches, like the counts: the specs and
+   * preview-e2e suites only run on pull requests, so a default-branch-only
+   * bar would stay empty forever for exactly the flakiest lane. The numeric
+   * defaultBranchStreak below stays main-only and carries the
    * transition-threshold counts past what 10 entries can show.
    */
   recent: z.array(FlakeOutcome).max(10).default([]),
@@ -118,12 +121,18 @@ export const FlakeDashboardState = z.object({
   birthCertificate: z.object({ config: FlakeDashboardConfig }).nullable().default(null),
   tests: z.record(z.string(), TrackedTest).default({}),
   /**
-   * Per suite, the offset of its newest default-branch run-recorded event —
-   * the reference point for retiring absent tests. Judged from default-branch
-   * runs only, so a PR that deletes or renames a test cannot hide its row
-   * repo-wide while that PR happens to be the newest run.
+   * Per suite, the offsets of its newest (up to 3) run-recorded events across
+   * ALL branches, oldest first — the reference window for retiring absent
+   * tests. All branches because the specs and preview-e2e suites only ever
+   * run on pull requests (cloudflare-previews.yml has no push trigger), so a
+   * default-branch reference point would never exist for them and their rows
+   * could never retire. A window of 3 rather than the single latest run so
+   * one PR push that deletes or renames a test — or a partial, push-cancelled
+   * run — cannot hide a row repo-wide by itself.
    */
-  suites: z.record(z.string(), z.object({ lastDefaultBranchRunOffset: StreamOffset })).default({}),
+  suites: z
+    .record(z.string(), z.object({ recentRunOffsets: z.array(StreamOffset).max(3).default([]) }))
+    .default({}),
   /**
    * Offset of the newest reduced DATA event (created / run-recorded /
    * transition-proposed). Render settlements deliberately do not bump it —

--- a/packages/iterate/src/starter-apps/flake-dashboard/flake-dashboard.test.ts
+++ b/packages/iterate/src/starter-apps/flake-dashboard/flake-dashboard.test.ts
@@ -33,27 +33,40 @@ test("folds CI-reported records into per-test stats", async () => {
   });
 });
 
-test("a renamed test's old row retires on the next default-branch suite run, but a PR run cannot retire it", async () => {
+test("a renamed test's old row retires once absent from 3 suite runs, not before", async () => {
+  // The specs suite runs on PR branches only (cloudflare-previews.yml has no
+  // push trigger), so expiry must work from PR-branch runs alone — but a
+  // 3-run window means no single PR push can hide a row by itself.
   const h = makeHarness();
   await h.append(
     birth(),
-    runRecorded(1, [record("old name", "flake-fail", { at: day(0) })], { suite: "specs" }),
-  );
-  expect(renderBody(h.state())).toContain("`old name`");
-
-  // Someone renames the test on a PR branch: that branch's runs carry only
-  // the new name, but a PR must not hide the old row repo-wide.
-  await h.append(
-    runRecorded(2, [record("new name", "pass", { at: day(1) })], {
+    runRecorded(1, [record("old name", "flake-fail", { at: day(0) })], {
       suite: "specs",
-      branch: "rename-pr",
+      branch: "some-pr",
     }),
   );
   expect(renderBody(h.state())).toContain("`old name`");
 
-  // The rename lands on main: the next default-branch specs run retires the
-  // old row — hidden from the table, never deleted from state.
-  await h.append(runRecorded(3, [record("new name", "pass", { at: day(2) })], { suite: "specs" }));
+  // Two runs carrying only the new name: the old row is still within the
+  // suite's 3-run window, so it stays.
+  for (const n of [2, 3]) {
+    await h.append(
+      runRecorded(n, [record("new name", "pass", { at: day(n) })], {
+        suite: "specs",
+        branch: "rename-pr",
+      }),
+    );
+  }
+  expect(renderBody(h.state())).toContain("`old name`");
+
+  // The third absent run pushes the old name out of the window: retired —
+  // hidden from the table, never deleted from state.
+  await h.append(
+    runRecorded(4, [record("new name", "pass", { at: day(4) })], {
+      suite: "specs",
+      branch: "another-pr",
+    }),
+  );
   const body = renderBody(h.state());
   expect(body).not.toContain("`old name`");
   expect(body).toContain("`new name`");
@@ -61,18 +74,18 @@ test("a renamed test's old row retires on the next default-branch suite run, but
   expect(h.state().tests["old name"]).toBeDefined();
 });
 
-test("a transiently-absent test returns with its history intact", async () => {
+test("a transiently-absent test survives the window and returns with its history intact", async () => {
   const h = makeHarness();
   await h.append(
     birth(),
     runRecorded(1, [record("deploy", "flake-fail", { at: day(0) })]),
-    // A partial run (a push-cancelled suite that died before this test)
-    // retires the row for one render...
+    // A partial run (a push-cancelled suite that died before this test) does
+    // not retire the row — one absent run is inside the 3-run window...
     runRecorded(2, [record("boot", "pass", { at: day(1) })]),
   );
-  expect(renderBody(h.state())).not.toContain("`deploy`");
-  // ...and the next record brings it straight back, counts and all — expiry
-  // is a projection choice over the log, nothing was deleted.
+  expect(renderBody(h.state())).toContain("`deploy`");
+  // ...and its next record resets the window, counts accumulated across the
+  // gap — expiry is a projection choice over the log, nothing was deleted.
   await h.append(runRecorded(3, [record("deploy", "pass", { at: day(2) })]));
   expect(renderBody(h.state())).toContain("`deploy`");
   expect(h.state().tests.deploy!.counts).toMatchObject({ pass: 1, flakeFail: 1 });
@@ -84,30 +97,37 @@ test("a multi-suite test stays visible while any of its suites still carries it"
     birth(),
     runRecorded(1, [record("flake sentinel", "pass", { at: day(0) })], { suite: "unit" }),
     runRecorded(2, [record("flake sentinel", "pass", { at: day(0) })], { suite: "local-smoke" }),
-    // A later unit run without the sentinel: still present in local-smoke's
-    // latest run, so the row stays.
+    // Three unit runs without the sentinel retire it from unit's window —
+    // but it is still in local-smoke's latest run, so the row stays.
     runRecorded(3, [record("boot", "pass", { at: day(1) })], { suite: "unit" }),
+    runRecorded(4, [record("boot", "pass", { at: day(1) })], { suite: "unit" }),
+    runRecorded(5, [record("boot", "pass", { at: day(1) })], { suite: "unit" }),
   );
   expect(renderBody(h.state())).toContain("`flake sentinel`");
 });
 
-test("the recent column shows up to 10 default-branch outcomes as emojis, oldest first", async () => {
+test("the recent column shows up to 10 outcomes from any branch as emojis, oldest first", async () => {
   const h = makeHarness();
   await h.append(birth(), runRecorded(0, [record("deploy", "flake-fail", { at: day(0) })]));
-  for (let i = 1; i <= 9; i++) {
+  for (let i = 1; i <= 8; i++) {
     await h.append(runRecorded(i, [record("deploy", "pass", { at: day(i) })]));
   }
-  // A PR-branch outcome never enters the bar.
+  // A PR-branch outcome enters the bar too — the specs suites only ever run
+  // on PRs, so a main-only bar would stay empty for the flakiest lane.
   await h.append(
-    runRecorded(99, [record("deploy", "unexpected-error", { at: day(10) })], {
+    runRecorded(99, [record("deploy", "unexpected-error", { at: day(9) })], {
       branch: "some-pr",
     }),
   );
-  expect(renderBody(h.state())).toContain("🟥🟩🟩🟩🟩🟩🟩🟩🟩🟩");
+  expect(renderBody(h.state())).toContain("🟥🟩🟩🟩🟩🟩🟩🟩🟩❌");
 
-  // An 11th default-branch outcome evicts the oldest: the bar caps at 10.
-  await h.append(runRecorded(10, [record("deploy", "pass", { at: day(11) })]));
-  expect(h.state().tests.deploy!.recent).toEqual(Array<string>(10).fill("pass"));
+  // An 11th outcome evicts the oldest: the bar caps at 10.
+  await h.append(runRecorded(10, [record("deploy", "pass", { at: day(10) })]));
+  expect(h.state().tests.deploy!.recent).toEqual([
+    ...Array<string>(8).fill("pass"),
+    "unexpected-error",
+    "pass",
+  ]);
 });
 
 test("default-branch streaks ignore other branches and reset on unexpected errors", async () => {

--- a/packages/iterate/src/starter-apps/flake-dashboard/flake-dashboard.test.ts
+++ b/packages/iterate/src/starter-apps/flake-dashboard/flake-dashboard.test.ts
@@ -7,7 +7,7 @@ import {
   CheckRunWebhookEvent,
   type FlakeDashboardState,
 } from "./contract.ts";
-import { FlakeDashboardApp, FlakeDashboardProcessor } from "./worker.ts";
+import { FlakeDashboardApp, FlakeDashboardProcessor, renderBody } from "./worker.ts";
 
 test("folds CI-reported records into per-test stats", async () => {
   const h = makeHarness();
@@ -31,6 +31,83 @@ test("folds CI-reported records into per-test stats", async () => {
     },
     boot: { counts: { pass: 1 } },
   });
+});
+
+test("a renamed test's old row retires on the next default-branch suite run, but a PR run cannot retire it", async () => {
+  const h = makeHarness();
+  await h.append(
+    birth(),
+    runRecorded(1, [record("old name", "flake-fail", { at: day(0) })], { suite: "specs" }),
+  );
+  expect(renderBody(h.state())).toContain("`old name`");
+
+  // Someone renames the test on a PR branch: that branch's runs carry only
+  // the new name, but a PR must not hide the old row repo-wide.
+  await h.append(
+    runRecorded(2, [record("new name", "pass", { at: day(1) })], {
+      suite: "specs",
+      branch: "rename-pr",
+    }),
+  );
+  expect(renderBody(h.state())).toContain("`old name`");
+
+  // The rename lands on main: the next default-branch specs run retires the
+  // old row — hidden from the table, never deleted from state.
+  await h.append(runRecorded(3, [record("new name", "pass", { at: day(2) })], { suite: "specs" }));
+  const body = renderBody(h.state());
+  expect(body).not.toContain("`old name`");
+  expect(body).toContain("`new name`");
+  expect(body).toContain("1 retired test hidden");
+  expect(h.state().tests["old name"]).toBeDefined();
+});
+
+test("a transiently-absent test returns with its history intact", async () => {
+  const h = makeHarness();
+  await h.append(
+    birth(),
+    runRecorded(1, [record("deploy", "flake-fail", { at: day(0) })]),
+    // A partial run (a push-cancelled suite that died before this test)
+    // retires the row for one render...
+    runRecorded(2, [record("boot", "pass", { at: day(1) })]),
+  );
+  expect(renderBody(h.state())).not.toContain("`deploy`");
+  // ...and the next record brings it straight back, counts and all — expiry
+  // is a projection choice over the log, nothing was deleted.
+  await h.append(runRecorded(3, [record("deploy", "pass", { at: day(2) })]));
+  expect(renderBody(h.state())).toContain("`deploy`");
+  expect(h.state().tests.deploy!.counts).toMatchObject({ pass: 1, flakeFail: 1 });
+});
+
+test("a multi-suite test stays visible while any of its suites still carries it", async () => {
+  const h = makeHarness();
+  await h.append(
+    birth(),
+    runRecorded(1, [record("flake sentinel", "pass", { at: day(0) })], { suite: "unit" }),
+    runRecorded(2, [record("flake sentinel", "pass", { at: day(0) })], { suite: "local-smoke" }),
+    // A later unit run without the sentinel: still present in local-smoke's
+    // latest run, so the row stays.
+    runRecorded(3, [record("boot", "pass", { at: day(1) })], { suite: "unit" }),
+  );
+  expect(renderBody(h.state())).toContain("`flake sentinel`");
+});
+
+test("the recent column shows up to 10 default-branch outcomes as emojis, oldest first", async () => {
+  const h = makeHarness();
+  await h.append(birth(), runRecorded(0, [record("deploy", "flake-fail", { at: day(0) })]));
+  for (let i = 1; i <= 9; i++) {
+    await h.append(runRecorded(i, [record("deploy", "pass", { at: day(i) })]));
+  }
+  // A PR-branch outcome never enters the bar.
+  await h.append(
+    runRecorded(99, [record("deploy", "unexpected-error", { at: day(10) })], {
+      branch: "some-pr",
+    }),
+  );
+  expect(renderBody(h.state())).toContain("🟥🟩🟩🟩🟩🟩🟩🟩🟩🟩");
+
+  // An 11th default-branch outcome evicts the oldest: the bar caps at 10.
+  await h.append(runRecorded(10, [record("deploy", "pass", { at: day(11) })]));
+  expect(h.state().tests.deploy!.recent).toEqual(Array<string>(10).fill("pass"));
 });
 
 test("default-branch streaks ignore other branches and reset on unexpected errors", async () => {

--- a/packages/iterate/src/starter-apps/flake-dashboard/flake-dashboard.test.ts
+++ b/packages/iterate/src/starter-apps/flake-dashboard/flake-dashboard.test.ts
@@ -112,8 +112,9 @@ test("the recent column shows up to 10 outcomes from any branch as emojis, oldes
   for (let i = 1; i <= 8; i++) {
     await h.append(runRecorded(i, [record("deploy", "pass", { at: day(i) })]));
   }
-  // A PR-branch outcome enters the bar too — the specs suites only ever run
-  // on PRs, so a main-only bar would stay empty for the flakiest lane.
+  // A PR-branch outcome enters the bar too — the specs and preview-e2e
+  // suites only ever run on PRs, so a main-only bar would stay empty for
+  // the suites where most flakes live.
   await h.append(
     runRecorded(99, [record("deploy", "unexpected-error", { at: day(9) })], {
       branch: "some-pr",

--- a/packages/iterate/src/starter-apps/flake-dashboard/worker.ts
+++ b/packages/iterate/src/starter-apps/flake-dashboard/worker.ts
@@ -330,9 +330,7 @@ export class FlakeDashboardProcessor extends StreamProcessor<
               ? existing.suites
               : [...(existing?.suites || []), event.payload.suite],
             lastSeenOffset: { ...existing?.lastSeenOffset, [event.payload.suite]: event.offset },
-            recent: onDefaultBranch
-              ? [...(existing?.recent || []), record.outcome].slice(-10)
-              : existing?.recent || [],
+            recent: [...(existing?.recent || []), record.outcome].slice(-10),
             counts: {
               pass: counts.pass + (record.outcome === "pass" ? 1 : 0),
               flakeFail: counts.flakeFail + (record.outcome === "flake-fail" ? 1 : 0),
@@ -346,12 +344,15 @@ export class FlakeDashboardProcessor extends StreamProcessor<
             proposed: existing?.proposed || [],
           };
         }
-        const suites = onDefaultBranch
-          ? {
-              ...state.suites,
-              [event.payload.suite]: { lastDefaultBranchRunOffset: event.offset },
-            }
-          : state.suites;
+        const suites = {
+          ...state.suites,
+          [event.payload.suite]: {
+            recentRunOffsets: [
+              ...(state.suites[event.payload.suite]?.recentRunOffsets || []),
+              event.offset,
+            ].slice(-3),
+          },
+        };
         return { ...state, tests, suites, lastDataOffset: event.offset };
       }
 
@@ -568,15 +569,18 @@ export function renderBody(state: FlakeDashboardState): string {
     .sort()
     .at(-1);
   // The test name is the identity: a renamed or deleted test is simply absent
-  // from its suite's latest default-branch run, and its row retires. Hidden,
-  // never deleted — the events stay in the log, so a transiently-absent test
-  // (a crashed suite, a PR experiment) returns with full history on its next
-  // record, and a genuinely retired name stays readable in the issue's edit
-  // history.
+  // from its suite's recent runs, and its row retires. A test stays visible
+  // while it appeared in at least one of the last 3 ingested runs of one of
+  // its suites (any branch — the specs and preview-e2e suites never run on
+  // main, see the suites field's contract docstring). Hidden, never deleted —
+  // the events stay in the log, so a transiently-absent test (a crashed
+  // suite, a PR experiment) returns with full history on its next record, and
+  // a genuinely retired name stays readable in the issue's edit history.
   const visible = tests.filter(([, test]) =>
-    Object.entries(test.lastSeenOffset).some(
-      ([suite, seen]) => seen >= (state.suites[suite]?.lastDefaultBranchRunOffset || 0),
-    ),
+    Object.entries(test.lastSeenOffset).some(([suite, seen]) => {
+      const windowStart = state.suites[suite]?.recentRunOffsets[0];
+      return windowStart === undefined || seen >= windowStart;
+    }),
   );
   const retiredCount = tests.length - visible.length;
   const rows = visible.map(([name, test]) => {
@@ -602,7 +606,7 @@ export function renderBody(state: FlakeDashboardState): string {
   });
   return [
     DASHBOARD_MARKER,
-    "Per-test outcomes of every [`createFlake`](https://github.com/iterate/iterate/blob/main/packages/shared/src/test-support/flake-test.ts)-wrapped test, folded from CI-reported runs. Maintained automatically — edits to this body will be overwritten. Recent = last 10 default-branch outcomes, oldest→newest (🟩 pass, 🟥 flake-fail, ❌ unexpected error).",
+    "Per-test outcomes of every [`createFlake`](https://github.com/iterate/iterate/blob/main/packages/shared/src/test-support/flake-test.ts)-wrapped test, folded from CI-reported runs. Maintained automatically — edits to this body will be overwritten. Recent = last 10 recorded outcomes on any branch, oldest→newest (🟩 pass, 🟥 flake-fail, ❌ unexpected error).",
     "",
     "test | allowed pattern | suites | runs | flake rate | last flake | recent | default-branch streak | proposed",
     "--- | --- | --- | --- | --- | --- | --- | --- | ---",
@@ -612,7 +616,7 @@ export function renderBody(state: FlakeDashboardState): string {
     ...(retiredCount === 0
       ? []
       : [
-          `_${retiredCount} retired ${retiredCount === 1 ? "test" : "tests"} hidden (no longer present in the latest default-branch run of their suite)._`,
+          `_${retiredCount} retired ${retiredCount === 1 ? "test" : "tests"} hidden (absent from the last 3 runs of their suite)._`,
         ]),
   ].join("\n");
 }

--- a/packages/iterate/src/starter-apps/flake-dashboard/worker.ts
+++ b/packages/iterate/src/starter-apps/flake-dashboard/worker.ts
@@ -329,6 +329,10 @@ export class FlakeDashboardProcessor extends StreamProcessor<
             suites: existing?.suites.includes(event.payload.suite)
               ? existing.suites
               : [...(existing?.suites || []), event.payload.suite],
+            lastSeenOffset: { ...existing?.lastSeenOffset, [event.payload.suite]: event.offset },
+            recent: onDefaultBranch
+              ? [...(existing?.recent || []), record.outcome].slice(-10)
+              : existing?.recent || [],
             counts: {
               pass: counts.pass + (record.outcome === "pass" ? 1 : 0),
               flakeFail: counts.flakeFail + (record.outcome === "flake-fail" ? 1 : 0),
@@ -342,7 +346,13 @@ export class FlakeDashboardProcessor extends StreamProcessor<
             proposed: existing?.proposed || [],
           };
         }
-        return { ...state, tests, lastDataOffset: event.offset };
+        const suites = onDefaultBranch
+          ? {
+              ...state.suites,
+              [event.payload.suite]: { lastDefaultBranchRunOffset: event.offset },
+            }
+          : state.suites;
+        return { ...state, tests, suites, lastDataOffset: event.offset };
       }
 
       case flakeEventTypes.transitionProposed: {
@@ -548,13 +558,28 @@ async function renderFlakeDashboardIssue(
   return { status: "succeeded", issueNumber: created.data.number, issueUrl: created.data.html_url };
 }
 
-function renderBody(state: FlakeDashboardState): string {
+const OUTCOME_EMOJI = { pass: "🟩", "flake-fail": "🟥", "unexpected-error": "❌" } as const;
+
+/** Exported for tests: the table is a pure projection of folded state. */
+export function renderBody(state: FlakeDashboardState): string {
   const tests = Object.entries(state.tests).sort(([a], [b]) => a.localeCompare(b));
   const lastRecordedAt = tests
     .map(([, test]) => test.lastRecordedAt)
     .sort()
     .at(-1);
-  const rows = tests.map(([name, test]) => {
+  // The test name is the identity: a renamed or deleted test is simply absent
+  // from its suite's latest default-branch run, and its row retires. Hidden,
+  // never deleted — the events stay in the log, so a transiently-absent test
+  // (a crashed suite, a PR experiment) returns with full history on its next
+  // record, and a genuinely retired name stays readable in the issue's edit
+  // history.
+  const visible = tests.filter(([, test]) =>
+    Object.entries(test.lastSeenOffset).some(
+      ([suite, seen]) => seen >= (state.suites[suite]?.lastDefaultBranchRunOffset || 0),
+    ),
+  );
+  const retiredCount = tests.length - visible.length;
+  const rows = visible.map(([name, test]) => {
     const gated = test.counts.pass + test.counts.flakeFail;
     const rate = gated === 0 ? "—" : `${Math.round((test.counts.flakeFail / gated) * 100)}%`;
     const streak =
@@ -568,19 +593,27 @@ function renderBody(state: FlakeDashboardState): string {
       String(gated + test.counts.unexpectedError),
       rate,
       test.lastFlakeAt || "never",
+      test.recent.length === 0
+        ? "—"
+        : test.recent.map((outcome) => OUTCOME_EMOJI[outcome]).join(""),
       streak,
       test.proposed.length === 0 ? "" : test.proposed.map((p) => p.split(":")[0]).join(", "),
     ].join(" | ");
   });
   return [
     DASHBOARD_MARKER,
-    "Per-test outcomes of every [`createFlake`](https://github.com/iterate/iterate/blob/main/packages/shared/src/test-support/flake-test.ts)-wrapped test, folded from CI-reported runs. Maintained automatically — edits to this body will be overwritten.",
+    "Per-test outcomes of every [`createFlake`](https://github.com/iterate/iterate/blob/main/packages/shared/src/test-support/flake-test.ts)-wrapped test, folded from CI-reported runs. Maintained automatically — edits to this body will be overwritten. Recent = last 10 default-branch outcomes, oldest→newest (🟩 pass, 🟥 flake-fail, ❌ unexpected error).",
     "",
-    "test | allowed pattern | suites | runs | flake rate | last flake | default-branch streak | proposed",
-    "--- | --- | --- | --- | --- | --- | --- | ---",
-    ...(rows.length === 0 ? ["_no flake tests recorded yet_ | | | | | | |"] : rows),
+    "test | allowed pattern | suites | runs | flake rate | last flake | recent | default-branch streak | proposed",
+    "--- | --- | --- | --- | --- | --- | --- | --- | ---",
+    ...(rows.length === 0 ? ["_no flake tests recorded yet_ | | | | | | | |"] : rows),
     "",
     `_Last recorded outcome: ${lastRecordedAt || "none"}._`,
+    ...(retiredCount === 0
+      ? []
+      : [
+          `_${retiredCount} retired ${retiredCount === 1 ? "test" : "tests"} hidden (no longer present in the latest default-branch run of their suite)._`,
+        ]),
   ].join("\n");
 }
 

--- a/packages/shared/src/test-support/failing-test.test.ts
+++ b/packages/shared/src/test-support/failing-test.test.ts
@@ -1,10 +1,10 @@
 import { expect, test, vi } from "vitest";
-import { expectFailure, failing } from "./failing-test.ts";
+import { expectFailure, createFailing } from "./failing-test.ts";
 
 // The wrapper in real use, registered through vitest itself: this lands on
 // vitest's native `test.fails`, so it reports in the "expected fail" summary
 // count, and it is green because its body throws the pinned error.
-const fail = failing(test, /foo bar exploded/);
+const fail = createFailing(test, /foo bar exploded/);
 fail("a body failing for the pinned reason passes", async () => {
   throw new Error("boom: foo bar exploded (as pinned)");
 });
@@ -17,7 +17,7 @@ test("registration lands on the runner's own expected-fail variant", async () =>
       registered.push({ args: args.slice(0, -1), body: args.at(-1) as any }),
   });
 
-  failing(fakeVitest, /pinned/)("name", { timeout: 123 }, async (fixtures: any) => {
+  createFailing(fakeVitest, /pinned/)("name", { timeout: 123 }, async (fixtures: any) => {
     throw new Error(`pinned, saw fixture ${fixtures.page}`);
   });
 
@@ -41,7 +41,7 @@ test("a playwright-shaped test object registers through .fail", async () => {
   const fakePlaywright = Object.assign(vi.fn(), {
     fail: (...args: unknown[]) => registered.push(args),
   });
-  failing(fakePlaywright, /pinned/)("name", async () => {});
+  createFailing(fakePlaywright, /pinned/)("name", async () => {});
   expect(registered).toHaveLength(1);
 });
 
@@ -52,7 +52,7 @@ test("a body failing for a different reason returns success, so the native machi
     const fake = Object.assign(vi.fn(), {
       fails: (...args: unknown[]) => registered.push(args.at(-1) as any),
     });
-    failing(fake, /foo bar exploded/)("name", async () => {
+    createFailing(fake, /foo bar exploded/)("name", async () => {
       throw new Error("ECONNREFUSED: the test infra broke");
     });
 
@@ -77,13 +77,13 @@ test("a body that succeeds returns success with delete-the-wrapper instructions 
     const fake = Object.assign(vi.fn(), {
       fails: (...args: unknown[]) => registered.push(args.at(-1) as any),
     });
-    failing(fake, /foo bar exploded/)("name", async () => {
+    createFailing(fake, /foo bar exploded/)("name", async () => {
       expect(1 + 1).toBe(2);
     });
 
     await expect(registered[0]!()).resolves.toBeUndefined();
     expect(consoleError).toHaveBeenCalledWith(
-      expect.stringMatching(/should have failed .* delete the failing\(\) wrapper/s),
+      expect.stringMatching(/should have failed .* delete the createFailing\(\) wrapper/s),
     );
   } finally {
     consoleError.mockRestore();
@@ -97,7 +97,7 @@ test("a hung body reports as not-the-pinned-failure at the wrapper's own deadlin
     const fake = Object.assign(vi.fn(), {
       fails: (...args: unknown[]) => registered.push(args.at(-1) as any),
     });
-    failing(fake, /pinned/, { timeoutMs: 50 })("name", async () => new Promise(() => {}));
+    createFailing(fake, /pinned/, { timeoutMs: 50 })("name", async () => new Promise(() => {}));
 
     // Without the wrapper's own deadline this would ride to the RUNNER's test
     // timeout, which the expected-fail machinery counts as the pin holding —
@@ -126,6 +126,6 @@ test("expectFailure: success throws with delete-the-wrapper instructions", async
       expect(1 + 1).toBe(2);
     }),
   ).rejects.toThrow(
-    /should have failed with \/foo bar exploded\/ but it succeeded.*delete the failing\(\) wrapper/,
+    /should have failed with \/foo bar exploded\/ but it succeeded.*delete the createFailing\(\) wrapper/,
   );
 });

--- a/packages/shared/src/test-support/failing-test.ts
+++ b/packages/shared/src/test-support/failing-test.ts
@@ -2,7 +2,7 @@
  * Pinned-bug tests: the body asserts the DESIRED behavior, and while the bug
  * exists it must fail with an error matching the given pattern.
  *
- * `failing` registers the test through the runner's own expected-fail variant
+ * `createFailing` registers the test through the runner's own expected-fail variant
  * — vitest spells it `test.fails`, playwright `test.fail` — so the pin is
  * native as far as reporting goes: it shows up in the "expected fail" summary
  * count, telemetry classifies it as expected-to-fail, and nothing downstream
@@ -10,7 +10,7 @@
  * failure is allowed to satisfy that machinery:
  *
  * ```ts
- * const fail = failing(test, /SAME-BOOT STALENESS/);
+ * const fail = createFailing(test, /SAME-BOOT STALENESS/);
  * fail("a userspace facet rebuilds on a source commit", { timeout: 240_000 }, async () => {
  *   // asserts the DESIRED behavior; today it throws the matched error
  * });
@@ -46,7 +46,7 @@
  * apps/os/e2e/vitest/userspace-facet-source-version.e2e.test.ts for the
  * worked example (its predecessor bare `test.fails` false-alarmed 7+ times).
  */
-export function failing<TestFn extends (...args: any[]) => any>(
+export function createFailing<TestFn extends (...args: any[]) => any>(
   test: TestFn,
   failure: RegExp,
   options?: { timeoutMs: number },
@@ -55,13 +55,13 @@ export function failing<TestFn extends (...args: any[]) => any>(
   const failer: unknown = "fails" in test ? test.fails : "fail" in test ? test.fail : undefined;
   if (typeof failer !== "function") {
     throw new Error(
-      "failing(test, pattern): test has neither .fails (vitest) nor .fail (playwright)",
+      "createFailing(test, pattern): test has neither .fails (vitest) nor .fail (playwright)",
     );
   }
   const register = (...args: any[]) => {
     const body = args.at(-1);
     if (typeof body !== "function") {
-      throw new Error("failing(test, pattern): the last argument must be the test body");
+      throw new Error("createFailing(test, pattern): the last argument must be the test body");
     }
     // The body's own arguments pass through untouched — playwright fixtures
     // ({ page, ... }, testInfo), vitest context — whatever the wrapped test
@@ -99,14 +99,14 @@ export function failing<TestFn extends (...args: any[]) => any>(
       if (outcome.kind === "timed-out") {
         console.error(
           `[failing-test] The body is still running after ${timeoutMs}ms — a hang is not the ` +
-            `pinned failure. Raise failing()'s options.timeoutMs (keeping it below the runner's ` +
+            `pinned failure. Raise createFailing()'s options.timeoutMs (keeping it below the runner's ` +
             `test timeout) if the pin legitimately needs longer.`,
         );
         return; // same inversion: success → the expected-fail machinery goes red
       }
       console.error(
         `[failing-test] The test should have failed with /${failure.source}/ but it succeeded. ` +
-          `If the pinned bug is fixed, delete the failing() wrapper and keep the body as a plain test.`,
+          `If the pinned bug is fixed, delete the createFailing() wrapper and keep the body as a plain test.`,
       );
       // Fall through to success for the same reason as above.
     };
@@ -129,7 +129,7 @@ export function failing<TestFn extends (...args: any[]) => any>(
 
 /**
  * Assert that a body fails for exactly the given reason — the standalone
- * sibling of {@link failing} for use INSIDE a plain test, where throwing (not
+ * sibling of {@link createFailing} for use INSIDE a plain test, where throwing (not
  * inverted success) is the right failure signal.
  */
 export async function expectFailure(options: { failure: RegExp }, body: () => Promise<unknown>) {
@@ -147,6 +147,6 @@ export async function expectFailure(options: { failure: RegExp }, body: () => Pr
   // mistaken for a candidate failure.
   throw new Error(
     `The test should have failed with /${options.failure.source}/ but it succeeded. ` +
-      `If the pinned bug is fixed, delete the failing() wrapper and keep the body as a plain test.`,
+      `If the pinned bug is fixed, delete the createFailing() wrapper and keep the body as a plain test.`,
   );
 }

--- a/packages/shared/src/test-support/flake-test.ts
+++ b/packages/shared/src/test-support/flake-test.ts
@@ -3,7 +3,7 @@
  * exactly one error pattern is tolerated as "the flake". Anything else is a
  * real failure.
  *
- * The sibling of `failing` (./failing-test.ts) — same registration trick,
+ * The sibling of `createFailing` (./failing-test.ts) — same registration trick,
  * different contract. `createFlake` registers through the runner's own
  * expected-fail variant (vitest `test.fails`, playwright `test.fail`) and
  * inverts outcomes so that:
@@ -31,9 +31,9 @@
  * without the variable record nothing.
  *
  * Lifecycle (see docs/testing.md): a test that seems flaky moves from a plain
- * test to `createFlake`; if it stops passing entirely, switch to `failing`;
+ * test to `createFlake`; if it stops passing entirely, switch to `createFailing`;
  * once it passes consistently, unwrap it back to a plain test. Wrapping is a
- * human/agent diagnosis; the unwrap and switch-to-`failing` directions are
+ * human/agent diagnosis; the unwrap and switch-to-`createFailing` directions are
  * proposed automatically from the recorded data.
  *
  * There is no retry and no repetition: one body execution per run, one
@@ -146,7 +146,7 @@ export function createFlake<TestFn extends (...args: any[]) => any>(
     }
     return failer(...args.slice(0, -1), wrapped);
   };
-  // Same contract-preserving cast as failing(): every argument forwards
+  // Same contract-preserving cast as createFailing(): every argument forwards
   // unchanged except the trailing body.
   return register as TestFn;
 }

--- a/tasks/flake-dashboard-streaks.md
+++ b/tasks/flake-dashboard-streaks.md
@@ -13,7 +13,12 @@ Three follow-ups from the first live week of the flake dashboard (#2580), agreed
 Implemented and pushed; awaiting CI + review. All checklist items done: expiry
 + emoji bar in the dashboard reducer/render (contract 0.2.0), createFailing
 rename across 10 files + docs. 20/20 dashboard tests, shared + renamed-callsite
-suites green, typecheck/lint/knip clean.
+suites green, typecheck/lint/knip clean. Bugbot found the default-branch
+expiry judgment never fires for PR-only suites (specs/preview-e2e); reworked
+to a 3-run any-branch window, tests updated.
+
+Known follow-up (pre-existing, out of scope): `defaultBranchStreak` — and
+therefore transition proposals — also never fires for PR-only suites.
 
 ## Motivation
 
@@ -32,19 +37,24 @@ history the next time it records.
 
 ## Checklist
 
-- [x] Row expiry (absence-based, N=1, default-branch-judged): a test row
-      renders only if, for at least one of its suites, the test was present in
-      the latest **default-branch** `run-recorded` event of that suite.
-      Reduce-side: state gains per-suite `lastDefaultBranchRunOffset`, and each
-      tracked test gains per-suite `lastSeenOffset` (bumped by any branch's
-      run, so a test added on a PR shows immediately via `>=`). Judging absence
-      from default-branch runs only means a PR that deletes/renames a test
-      cannot hide the row repo-wide while the PR is the newest run.
+- [x] Row expiry (absence-based): a test row renders only if it appeared in
+      at least one of the last **3** `run-recorded` events (any branch) of one
+      of its suites. _Originally specced as default-branch-judged with N=1;
+      bugbot correctly flagged that specs/preview-e2e only run on PRs
+      (cloudflare-previews.yml has no push trigger), so a default-branch
+      reference point would never exist for them and the motivating
+      chat-photos row could never retire. The 3-run window replaces the
+      default-branch guard as the protection against one PR push hiding a row
+      repo-wide. State: per-suite `recentRunOffsets` (≤3) + per-test
+      `lastSeenOffset`._
 - [x] Expired rows are hidden from the table, not dropped from state. Footer
       gains a one-liner: `_N retired tests hidden (no longer present in the
       latest default-branch run of their suite)._` when N > 0.
-- [x] Emoji streak column: each tracked test keeps its last 10
-      **default-branch** outcomes (ring buffer in reduced state, oldest first).
+- [x] Emoji streak column: each tracked test keeps its last 10 outcomes
+      from **any branch** (ring buffer in reduced state, oldest first).
+      _Any-branch for the same reason as expiry: PR-only suites would
+      otherwise have permanently empty bars; matches the all-branch counts and
+      flake-rate columns. `defaultBranchStreak` stays main-only._
       Render as a `recent` column: 🟩 pass, 🟥 flake-fail, ❌ unexpected-error,
       oldest→newest. The existing numeric `default-branch streak` column stays
       (it carries the transition-threshold counts past 10).

--- a/tasks/flake-dashboard-streaks.md
+++ b/tasks/flake-dashboard-streaks.md
@@ -1,0 +1,87 @@
+---
+status: in-progress
+size: small
+branch: flake-dashboard-streaks
+---
+
+# Flake dashboard: row expiry, emoji streaks, createFailing rename
+
+Three follow-ups from the first live week of the flake dashboard (#2580), agreed in discussion 2026-09-03.
+
+## Status
+
+Spec committed; implementation not started.
+
+## Motivation
+
+Renaming the chat-photos test in PR #2584 split its dashboard row in two: the
+old name (`multiple photos share a mosaic row; …`) is frozen at 1 run / 100%
+forever, next to the new name's row. More generally, deleted tests never leave
+the table.
+
+Decision: **the test name is the identity, and rows expire by absence.** No
+rename detection, no lineage linking, no stable-id API. A rename resets the
+streak — you touched the test, so fresh stats are honest — and history stays
+readable in the issue's edit history and replayable from the immutable
+`/flakes` event log. Expiry is a pure projection choice in the reducer/render:
+nothing is deleted, so a transiently-absent row comes back with its full
+history the next time it records.
+
+## Checklist
+
+- [ ] Row expiry (absence-based, N=1, default-branch-judged): a test row
+      renders only if, for at least one of its suites, the test was present in
+      the latest **default-branch** `run-recorded` event of that suite.
+      Reduce-side: state gains per-suite `lastDefaultBranchRunOffset`, and each
+      tracked test gains per-suite `lastSeenOffset` (bumped by any branch's
+      run, so a test added on a PR shows immediately via `>=`). Judging absence
+      from default-branch runs only means a PR that deletes/renames a test
+      cannot hide the row repo-wide while the PR is the newest run.
+- [ ] Expired rows are hidden from the table, not dropped from state. Footer
+      gains a one-liner: `_N retired tests hidden (no longer present in the
+      latest default-branch run of their suite)._` when N > 0.
+- [ ] Emoji streak column: each tracked test keeps its last 10
+      **default-branch** outcomes (ring buffer in reduced state, oldest first).
+      Render as a `recent` column: 🟩 pass, 🟥 flake-fail, ❌ unexpected-error,
+      oldest→newest. The existing numeric `default-branch streak` column stays
+      (it carries the transition-threshold counts past 10).
+- [ ] Contract: new fields with defaults so existing prd state parses
+      untouched; bump contract version 0.1.0 → 0.2.0.
+- [ ] Harness tests in flake-dashboard.test.ts: rename splits then retires the
+      old row on the next default-branch suite run; transient absence
+      (PR-branch run without the test) does NOT retire; retired row revives
+      with history intact when the name records again; emoji bar renders and
+      caps at 10.
+- [ ] `failing(…)` → `createFailing(…)` rename for consistency with
+      `createFlake` (both are two-level: `createX(test, …)` returns the
+      registrar). Rename the export in
+      packages/shared/src/test-support/failing-test.ts, update the
+      docstring + log-message strings ("delete the createFailing() wrapper"),
+      and all callsites (9 files, see notes). Filename stays failing-test.ts.
+      No deprecated alias — few callsites, and an alias defeats the
+      less-confusing goal.
+- [ ] Sweep doc references to `failing(` (docs/testing.md etc.).
+
+## Non-goals / explicitly rejected
+
+- Rename detection or a stable-id param on createFlake/createFailing.
+- Deleting expired tests from reduced state (a lazy GC can come later if state
+  size ever matters; the log is the source of truth regardless).
+- Renaming the `switch-to-failing` transition enum value or any durable event
+  shape — event values are append-only vocabulary.
+
+## Notes
+
+- `failing(` callsites on main: failing-test.ts, failing-test.test.ts,
+  flake-test.ts (docstring), userspace-facet-source-version.e2e.test.ts,
+  userspace-facet-recycle-false-alarm.e2e.test.ts,
+  project-create-concurrency.regression.e2e.test.ts,
+  abandoned-project-goes-quiet.e2e.test.ts,
+  oversized-settlement-isolate.e2e.test.ts, artifact-rpc-ownership /
+  scheduler-rpc-ownership / guarantees-not-given / oversized-settlement-crash
+  tests.
+- Conflict heads-up: PR #2575 (oversized-settlement-repro) edits
+  failing-test.ts (adds the vitest `retry: 0` pin) and
+  oversized-settlement-isolate.e2e.test.ts. This branch keeps its
+  failing-test.ts diff to the mechanical rename only, so the merge either way
+  is small; whichever lands second merges main and fixes up.

--- a/tasks/flake-dashboard-streaks.md
+++ b/tasks/flake-dashboard-streaks.md
@@ -10,7 +10,10 @@ Three follow-ups from the first live week of the flake dashboard (#2580), agreed
 
 ## Status
 
-Spec committed; implementation not started.
+Implemented and pushed; awaiting CI + review. All checklist items done: expiry
++ emoji bar in the dashboard reducer/render (contract 0.2.0), createFailing
+rename across 10 files + docs. 20/20 dashboard tests, shared + renamed-callsite
+suites green, typecheck/lint/knip clean.
 
 ## Motivation
 
@@ -29,7 +32,7 @@ history the next time it records.
 
 ## Checklist
 
-- [ ] Row expiry (absence-based, N=1, default-branch-judged): a test row
+- [x] Row expiry (absence-based, N=1, default-branch-judged): a test row
       renders only if, for at least one of its suites, the test was present in
       the latest **default-branch** `run-recorded` event of that suite.
       Reduce-side: state gains per-suite `lastDefaultBranchRunOffset`, and each
@@ -37,22 +40,22 @@ history the next time it records.
       run, so a test added on a PR shows immediately via `>=`). Judging absence
       from default-branch runs only means a PR that deletes/renames a test
       cannot hide the row repo-wide while the PR is the newest run.
-- [ ] Expired rows are hidden from the table, not dropped from state. Footer
+- [x] Expired rows are hidden from the table, not dropped from state. Footer
       gains a one-liner: `_N retired tests hidden (no longer present in the
       latest default-branch run of their suite)._` when N > 0.
-- [ ] Emoji streak column: each tracked test keeps its last 10
+- [x] Emoji streak column: each tracked test keeps its last 10
       **default-branch** outcomes (ring buffer in reduced state, oldest first).
       Render as a `recent` column: 🟩 pass, 🟥 flake-fail, ❌ unexpected-error,
       oldest→newest. The existing numeric `default-branch streak` column stays
       (it carries the transition-threshold counts past 10).
-- [ ] Contract: new fields with defaults so existing prd state parses
+- [x] Contract: new fields with defaults so existing prd state parses
       untouched; bump contract version 0.1.0 → 0.2.0.
-- [ ] Harness tests in flake-dashboard.test.ts: rename splits then retires the
+- [x] Harness tests in flake-dashboard.test.ts: rename splits then retires the
       old row on the next default-branch suite run; transient absence
       (PR-branch run without the test) does NOT retire; retired row revives
       with history intact when the name records again; emoji bar renders and
       caps at 10.
-- [ ] `failing(…)` → `createFailing(…)` rename for consistency with
+- [x] `failing(…)` → `createFailing(…)` rename for consistency with
       `createFlake` (both are two-level: `createX(test, …)` returns the
       registrar). Rename the export in
       packages/shared/src/test-support/failing-test.ts, update the
@@ -60,7 +63,7 @@ history the next time it records.
       and all callsites (9 files, see notes). Filename stays failing-test.ts.
       No deprecated alias — few callsites, and an alias defeats the
       less-confusing goal.
-- [ ] Sweep doc references to `failing(` (docs/testing.md etc.).
+- [x] Sweep doc references to `failing(` (docs/testing.md etc.).
 
 ## Non-goals / explicitly rejected
 


### PR DESCRIPTION
Three follow-ups from the flake dashboard's (#2580) first live week. Task file with full spec in the first commit.

## Row expiry

Renaming chat-photos in #2584 split its row: the old name sits at 1 run / 100% forever. Fix: **the test name is the identity, and rows expire by absence** — no rename detection, no stable-id API. A row renders only if the test was present in the latest *default-branch* run of at least one of its suites.

Because the table is a projection over the immutable `/flakes` log, expiry hides rather than deletes: a transiently-absent test (crashed suite, PR experiment) comes back with its full history on its next record. History for genuinely retired names stays in the issue's edit history and the log.

## Emoji streaks

The streak column gains a recent-history bar — last 10 default-branch outcomes, oldest→newest:

> `🟩🟩🟥🟩🟩🟩🟩🟩🟩🟩` (🟩 pass, 🟥 flake-fail, ❌ unexpected error)

The numeric streak stays; transition thresholds count to 50, past what 10 emojis can show.

## `failing()` → `createFailing()`

```ts
// before
const fail = failing(test, /out of memory/i);
// after — consistent with createFlake: createX(test, …) returns the registrar
const fail = createFailing(test, /out of memory/i);
```

Mechanical rename across all callsites, no alias. Heads-up: #2575 also touches failing-test.ts; this branch keeps its diff there rename-only so the merge either way is trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Session: 4fe3e39f-bdf2-4b87-8ed3-b77d4252fd95 ("flake dashboard follow-ups")_

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +92 -23 | +48 -15 🟩🟩⬜⬜⬜ |
| Tests | +138 -40 | +107 -33 🟩🟩🟩🟩🟥 |
| Docs | +106 -6 | +92 -6 🟩🟩🟩🟩⬜ |
| **Total** | **+336 -69** | **+247 -54** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between f7ae1ee and f2d53b3, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-09-04T06:19:04.115Z",
      "deployedAt": "2026-09-03T23:34:09.815Z",
      "headSha": "f2d53b3ae091eec22ae4ad4142b995c2f6b54f7f",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/124550292730741",
      "shortSha": "f2d53b3",
      "cleanupDurationMs": 99675,
      "deployDurationMs": 52114,
      "deployConfigDurationMs": 1,
      "deployCommandDurationMs": 50249,
      "deployReadinessDurationMs": 1862,
      "deployedWorkerName": "os-preview-12",
      "deployedWorkerVersion": "e2fdae53-6b79-4870-a183-ba40f5659ca3",
      "testDurationMs": 300674,
      "testRetries": "3 retried: a disposed test project stops waking its Durable Objects (vitest x1) · the source-version pin tells a facet that recycled from one the commit rebuilt (vitest x1) · a userspace facet rebuilds on a source commit and only on a source commit (vitest x1)",
      "workerSizeKib": 20950.36,
      "workerGzipKib": 5281.97,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5292.83
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-09-04T06:17:28.237Z",
      "deployedAt": "2026-09-03T23:33:42.752Z",
      "headSha": "f2d53b3ae091eec22ae4ad4142b995c2f6b54f7f",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-12.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/124550292730741",
      "shortSha": "f2d53b3",
      "cleanupDurationMs": 3795,
      "deployDurationMs": 26794,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 23183,
      "deployReadinessDurationMs": 3606,
      "deployedWorkerName": "docs-preview-12",
      "deployedWorkerVersion": "e7cbdde3-bad6-4099-a7ef-98aa1d22ddb7",
      "testDurationMs": 2784,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-09-04T06:17:25.091Z",
      "deployedAt": "2026-09-03T23:04:24.347Z",
      "headSha": "619f4399f5331529bf94aa5ddb678c1312db4426",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/124550292730741",
      "shortSha": "619f439",
      "cleanupDurationMs": 647,
      "deployDurationMs": 28062,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 27860,
      "deployReadinessDurationMs": 197,
      "deployedWorkerName": "semaphore-preview-12",
      "deployedWorkerVersion": "2c14a430-d2c0-4ac2-a474-0a285c6d90df",
      "testDurationMs": 22369,
      "testRetries": null,
      "workerSizeKib": 1960.48,
      "workerGzipKib": 453.78,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-09-04T06:17:29.162Z",
      "deployedAt": "2026-09-03T23:33:50.025Z",
      "headSha": "f2d53b3ae091eec22ae4ad4142b995c2f6b54f7f",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/124550292730741",
      "shortSha": "f2d53b3",
      "cleanupDurationMs": 4715,
      "deployDurationMs": 30745,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 30455,
      "deployReadinessDurationMs": 286,
      "deployedWorkerName": "auth-preview-12",
      "deployedWorkerVersion": "2328777c-93b3-4726-aab6-ef03aa3d21f1",
      "testDurationMs": 21841,
      "testRetries": null,
      "workerSizeKib": 4178.28,
      "workerGzipKib": 855.2,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-09-04T06:17:29.514Z",
      "deployedAt": "2026-09-03T23:33:45.138Z",
      "headSha": "f2d53b3ae091eec22ae4ad4142b995c2f6b54f7f",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/124550292730741",
      "shortSha": "f2d53b3",
      "cleanupDurationMs": 5066,
      "deployDurationMs": 26214,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 25566,
      "deployReadinessDurationMs": 642,
      "deployedWorkerName": "streams-example-app-preview-12",
      "deployedWorkerVersion": "42aa4651-10c2-4db4-831a-bb5c4ec9d100",
      "testDurationMs": 89861,
      "testRetries": null,
      "workerSizeKib": 5648.41,
      "workerGzipKib": 1597.97,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-09-04T06:17:25.988Z",
      "deployedAt": "2026-09-03T23:33:26.020Z",
      "headSha": "f2d53b3ae091eec22ae4ad4142b995c2f6b54f7f",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/124550292730741",
      "shortSha": "f2d53b3",
      "cleanupDurationMs": 892,
      "deployDurationMs": 6594,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 6417,
      "deployReadinessDurationMs": 140,
      "deployedWorkerName": "dummy-petshop-preview-12",
      "deployedWorkerVersion": "88eda9dd-c8d6-4c64-b0ee-fc9eef12bcd8",
      "testDurationMs": 46248,
      "testRetries": null,
      "workerSizeKib": 1331.5,
      "workerGzipKib": 232.81,
      "deployedFingerprint": "c321865fd82cf1ce04086fcbe3c487f157babc45+c5abf1055de73f3b4ffbc5e5b742dff1f0b5ee52",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `f2d53b3` | [https://auth.iterate-preview-12.com](https://auth.iterate-preview-12.com) | 855.2 KiB | 30.7s | 21.8s |  | 4.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/124550292730741) | 2026-09-04T06:17:29.162Z | Preview app released. |
| Docs | released | `f2d53b3` | [https://docs-preview-12.iterate-dev-preview.workers.dev](https://docs-preview-12.iterate-dev-preview.workers.dev) | 866.2 KiB | 26.8s | 2.8s |  | 3.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/124550292730741) | 2026-09-04T06:17:28.237Z | Preview app released. |
| Dummy Petshop | released | `f2d53b3` | [https://dummy-petshop.iterate-preview-12.com](https://dummy-petshop.iterate-preview-12.com) | 232.8 KiB | 6.6s | 46.2s |  | 892ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/124550292730741) | 2026-09-04T06:17:25.988Z | Preview app released. |
| OS | released | `f2d53b3` | [https://os.iterate-preview-12.com](https://os.iterate-preview-12.com) | 5.16 MiB (-10.9 KiB vs main) | 52.1s | 300.7s | 3 retried: a disposed test project stops waking its Durable Objects (vitest x1) · the source-version pin tells a facet that recycled from one the commit rebuilt (vitest x1) · a userspace facet rebuilds on a source commit and only on a source commit (vitest x1) | 99.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/124550292730741) | 2026-09-04T06:19:04.115Z | Preview app released. |
| Semaphore | released | `619f439` | [https://semaphore.iterate-preview-12.com](https://semaphore.iterate-preview-12.com) | 453.8 KiB | 28.1s | 22.4s |  | 647ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/124550292730741) | 2026-09-04T06:17:25.091Z | Preview app released. |
| Streams Example App | released | `f2d53b3` | [https://streams.iterate-preview-12.com](https://streams.iterate-preview-12.com) | 1.56 MiB | 26.2s | 89.9s |  | 5.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/124550292730741) | 2026-09-04T06:17:29.514Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to flake-dashboard rendering/state folding and a mechanical test-helper rename; state schema uses defaults for backward compatibility with no auth or production runtime paths touched.
> 
> **Overview**
> Improves the **flake dashboard** GitHub issue projection and aligns pinned-bug test helpers with `createFlake`.
> 
> **Flake dashboard (contract 0.3.0):** Tracked tests now keep per-suite `lastSeenOffset`, a rolling **last 10 outcomes** (`recent`, any branch), and per-suite **last 3 run-recorded offsets**. `renderBody` hides rows absent from that window (rename/delete) while **keeping state**; the table adds a **recent** emoji column and a footer count of hidden retired tests. Ingestion updates these fields on each `run-recorded` event; new unit tests cover rename retirement, transient absence, multi-suite visibility, and the 10-outcome cap.
> 
> **Test support:** Renames **`failing` → `createFailing`** everywhere (shared helper, docs, e2e/regression pins, log messages). No deprecated alias.
> 
> Adds a **task file** documenting the spec and the PR-only-suite fix (3-run any-branch window vs default-branch-only expiry).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2d53b3ae091eec22ae4ad4142b995c2f6b54f7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->