### PR TITLE
Flake dashboard: 4-column table, clickable streak squares

### DIFF
--- a/packages/iterate/src/starter-apps/flake-dashboard/contract.ts
+++ b/packages/iterate/src/starter-apps/flake-dashboard/contract.ts
@@ -93,13 +93,18 @@ const TrackedTest = z.object({
   lastSeenOffset: z.record(z.string(), StreamOffset).default({}),
   /**
    * The last (up to) 10 recorded outcomes on any branch, oldest first — the
-   * render's emoji streak bar. All branches, like the counts: the specs and
-   * preview-e2e suites only run on pull requests, so a default-branch-only
-   * bar would stay empty forever for the suites where most flakes live. The numeric
-   * defaultBranchStreak below stays main-only and carries the
-   * transition-threshold counts past what 10 entries can show.
+   * render's emoji streak bar, each entry carrying the commit that produced
+   * it so the square can link straight to that commit's checks. All branches,
+   * like the counts: the specs and preview-e2e suites only run on pull
+   * requests, so a default-branch-only bar would stay empty forever for the
+   * suites where most flakes live. The numeric defaultBranchStreak below
+   * stays main-only and carries the transition-threshold counts past what 10
+   * entries can show.
    */
-  recent: z.array(FlakeOutcome).max(10).default([]),
+  recent: z
+    .array(z.object({ outcome: FlakeOutcome, commit: z.string().min(1).max(100) }))
+    .max(10)
+    .default([]),
   counts: z
     .object({
       pass: z.number().int().nonnegative().default(0),
@@ -191,7 +196,7 @@ export const CheckRunWebhookEvent = z.object({
 
 export const FlakeDashboardProcessorContract = defineProcessorContract({
   slug: "flake-dashboard",
-  version: "0.3.0",
+  version: "0.4.0",
   description:
     "Folds createFlake test outcomes reported by CI into per-test flake stats, renders the GitHub 'Flake dashboard' issue, and proposes data-provable lifecycle transitions.",
   stateSchema: FlakeDashboardState,

--- a/packages/iterate/src/starter-apps/flake-dashboard/flake-dashboard.test.ts
+++ b/packages/iterate/src/starter-apps/flake-dashboard/flake-dashboard.test.ts
@@ -106,7 +106,7 @@ test("a multi-suite test stays visible while any of its suites still carries it"
   expect(renderBody(h.state())).toContain("`flake sentinel`");
 });
 
-test("the recent column shows up to 10 outcomes from any branch as emojis, oldest first", async () => {
+test("streak squares show up to 10 outcomes from any branch, oldest first", async () => {
   const h = makeHarness();
   await h.append(birth(), runRecorded(0, [record("deploy", "flake-fail", { at: day(0) })]));
   for (let i = 1; i <= 8; i++) {
@@ -120,15 +120,33 @@ test("the recent column shows up to 10 outcomes from any branch as emojis, oldes
       branch: "some-pr",
     }),
   );
-  expect(renderBody(h.state())).toContain("🟥🟩🟩🟩🟩🟩🟩🟩🟩❌");
+  const row = renderBody(h.state())
+    .split("\n")
+    .find((line) => line.startsWith("`deploy`"))!;
+  // Squares in recorded order, each linking to the commit that produced it.
+  expect(row.match(/🟥|🟩|❌/gu)).toEqual(["🟥", ...Array<string>(8).fill("🟩"), "❌"]);
+  expect(row).toContain("[🟥](https://github.com/iterate/iterate/commit/commit-0)");
+  expect(row).toContain("[❌](https://github.com/iterate/iterate/commit/commit-99)");
+  // The numeric default-branch streak rides below the squares.
+  expect(row).toContain("<br>8× pass (main)");
 
   // An 11th outcome evicts the oldest: the bar caps at 10.
   await h.append(runRecorded(10, [record("deploy", "pass", { at: day(10) })]));
   expect(h.state().tests.deploy!.recent).toEqual([
-    ...Array<string>(8).fill("pass"),
-    "unexpected-error",
-    "pass",
+    ...Array.from({ length: 8 }, (_, i) => ({ outcome: "pass", commit: `commit-${i + 1}` })),
+    { outcome: "unexpected-error", commit: "commit-99" },
+    { outcome: "pass", commit: "commit-10" },
   ]);
+});
+
+test("info and stats render as line-per-fact cells with readable dates", async () => {
+  const h = makeHarness();
+  await h.append(birth(), runRecorded(1, [record("deploy", "flake-fail", { at: day(0) })]));
+  const row = renderBody(h.state())
+    .split("\n")
+    .find((line) => line.startsWith("`deploy`"))!;
+  expect(row).toContain("pattern: `/CPU startup time exceeded/`<br>suites: unit");
+  expect(row).toContain("runs: 1<br>flake rate: 100%<br>last flake: Jan 1, 12:00am");
 });
 
 test("default-branch streaks ignore other branches and reset on unexpected errors", async () => {

--- a/packages/iterate/src/starter-apps/flake-dashboard/worker.ts
+++ b/packages/iterate/src/starter-apps/flake-dashboard/worker.ts
@@ -330,7 +330,10 @@ export class FlakeDashboardProcessor extends StreamProcessor<
               ? existing.suites
               : [...(existing?.suites || []), event.payload.suite],
             lastSeenOffset: { ...existing?.lastSeenOffset, [event.payload.suite]: event.offset },
-            recent: [...(existing?.recent || []), record.outcome].slice(-10),
+            recent: [
+              ...(existing?.recent || []),
+              { outcome: record.outcome, commit: event.payload.commit },
+            ].slice(-10),
             counts: {
               pass: counts.pass + (record.outcome === "pass" ? 1 : 0),
               flakeFail: counts.flakeFail + (record.outcome === "flake-fail" ? 1 : 0),
@@ -561,6 +564,17 @@ async function renderFlakeDashboardIssue(
 
 const OUTCOME_EMOJI = { pass: "🟩", "flake-fail": "🟥", "unexpected-error": "❌" } as const;
 
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+/** "Sep 4, 7:16am" (UTC) — ISO timestamps read like log spam in the table. */
+function shortDate(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  const hours = date.getUTCHours();
+  const minutes = String(date.getUTCMinutes()).padStart(2, "0");
+  return `${MONTHS[date.getUTCMonth()]} ${date.getUTCDate()}, ${hours % 12 || 12}:${minutes}${hours >= 12 ? "pm" : "am"}`;
+}
+
 /** Exported for tests: the table is a pure projection of folded state. */
 export function renderBody(state: FlakeDashboardState): string {
   const tests = Object.entries(state.tests).sort(([a], [b]) => a.localeCompare(b));
@@ -583,34 +597,51 @@ export function renderBody(state: FlakeDashboardState): string {
     }),
   );
   const retiredCount = tests.length - visible.length;
+  const config = state.birthCertificate?.config;
   const rows = visible.map(([name, test]) => {
     const gated = test.counts.pass + test.counts.flakeFail;
     const rate = gated === 0 ? "—" : `${Math.round((test.counts.flakeFail / gated) * 100)}%`;
-    const streak =
-      test.defaultBranchStreak === null
-        ? "—"
-        : `${test.defaultBranchStreak.runs}× ${test.defaultBranchStreak.outcome}`;
-    return [
-      `\`${name}\``,
-      `\`/${test.pattern}/\``,
-      test.suites.join(", "),
-      String(gated + test.counts.unexpectedError),
-      rate,
-      test.lastFlakeAt || "never",
-      test.recent.length === 0
-        ? "—"
-        : test.recent.map((outcome) => OUTCOME_EMOJI[outcome]).join(""),
-      streak,
-      test.proposed.length === 0 ? "" : test.proposed.map((p) => p.split(":")[0]).join(", "),
-    ].join(" | ");
+    // Lines inside a cell are <br>-separated; a literal | in the pattern
+    // would end the cell, so it renders escaped.
+    const info = [
+      `pattern: \`/${test.pattern.replaceAll("|", "\\|")}/\``,
+      `suites: ${test.suites.join(", ")}`,
+      ...(test.proposed.length === 0
+        ? []
+        : [`proposed: ${test.proposed.map((p) => p.split(":")[0]).join(", ")}`]),
+    ].join("<br>");
+    const stats = [
+      `runs: ${gated + test.counts.unexpectedError}`,
+      `flake rate: ${rate}`,
+      `last flake: ${test.lastFlakeAt === null ? "never" : shortDate(test.lastFlakeAt)}`,
+    ].join("<br>");
+    // Tests only exist after birth, so config is always set here; the plain
+    // emoji fallback keeps the render total rather than throwing over a link.
+    const squares = test.recent
+      .map((entry) => {
+        const emoji = OUTCOME_EMOJI[entry.outcome];
+        if (config === undefined) return emoji;
+        const { owner, repo } = config.repository;
+        return `[${emoji}](https://github.com/${owner}/${repo}/commit/${entry.commit})`;
+      })
+      .join("");
+    const streak = [
+      squares || "—",
+      ...(test.defaultBranchStreak === null || config === undefined
+        ? []
+        : [
+            `${test.defaultBranchStreak.runs}× ${test.defaultBranchStreak.outcome} (${config.defaultBranch})`,
+          ]),
+    ].join("<br>");
+    return [`\`${name}\``, info, stats, streak].join(" | ");
   });
   return [
     DASHBOARD_MARKER,
-    "Per-test outcomes of every [`createFlake`](https://github.com/iterate/iterate/blob/main/packages/shared/src/test-support/flake-test.ts)-wrapped test, folded from CI-reported runs. Maintained automatically — edits to this body will be overwritten. Recent = last 10 recorded outcomes on any branch, oldest→newest (🟩 pass, 🟥 flake-fail, ❌ unexpected error).",
+    "Per-test outcomes of every [`createFlake`](https://github.com/iterate/iterate/blob/main/packages/shared/src/test-support/flake-test.ts)-wrapped test, folded from CI-reported runs. Maintained automatically — edits to this body will be overwritten. Streak = last 10 recorded outcomes on any branch, oldest→newest (🟩 pass, 🟥 flake-fail, ❌ unexpected error); each square links to the commit that produced it.",
     "",
-    "test | allowed pattern | suites | runs | flake rate | last flake | recent | default-branch streak | proposed",
-    "--- | --- | --- | --- | --- | --- | --- | --- | ---",
-    ...(rows.length === 0 ? ["_no flake tests recorded yet_ | | | | | | | |"] : rows),
+    "test | info | stats | streak",
+    "--- | --- | --- | ---",
+    ...(rows.length === 0 ? ["_no flake tests recorded yet_ | | |"] : rows),
     "",
     `_Last recorded outcome: ${lastRecordedAt || "none"}._`,
     ...(retiredCount === 0

--- a/packages/iterate/src/starter-apps/flake-dashboard/worker.ts
+++ b/packages/iterate/src/starter-apps/flake-dashboard/worker.ts
@@ -567,7 +567,7 @@ const OUTCOME_EMOJI = { pass: "🟩", "flake-fail": "🟥", "unexpected-error": 
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
 /** "Sep 4, 7:16am" (UTC) — ISO timestamps read like log spam in the table. */
-function shortDate(iso: string): string {
+function shortDate(iso: string) {
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return iso;
   const hours = date.getUTCHours();

--- a/tasks/complete/2026-09-04-flake-dashboard-table-polish.md
+++ b/tasks/complete/2026-09-04-flake-dashboard-table-polish.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 size: small
 branch: flake-dashboard-table-polish
 ---

--- a/tasks/flake-dashboard-table-polish.md
+++ b/tasks/flake-dashboard-table-polish.md
@@ -10,7 +10,9 @@ Misha reviewed a live mock on issue #2580 (2026-09-04) and approved the layout.
 
 ## Status
 
-Spec committed; implementation not started.
+Implemented: 4-column render, commit-linked squares, contract 0.4.0 (journal
+refold backfills links for existing history). 21/21 harness tests,
+typecheck/lint/knip clean. Awaiting CI + review.
 
 ## Motivation
 
@@ -21,22 +23,22 @@ produced that outcome, so eyeballing a red square is one click from the run.
 
 ## Checklist
 
-- [ ] Render: 4 columns per the approved mock —
+- [x] Render: 4 columns per the approved mock —
       `info` = `pattern: /…/` + `suites: …` + `proposed: …` (proposed line
       only when non-empty); `stats` = `runs:` + `flake rate:` + `last flake:`
       with human-readable UTC dates ("Sep 4, 7:16am"); `streak` = the emoji
       bar with the numeric default-branch streak as a second line
       (`8× pass (main)`) when present.
-- [ ] Clickable squares: `recent` entries become `{ outcome, commit }` folded
+- [x] Clickable squares: `recent` entries become `{ outcome, commit }` folded
       from the run-recorded payload's `commit`; render each square as
       `[🟩](https://github.com/<owner>/<repo>/commit/<sha>)` (owner/repo from
       the birth certificate). The commit page links on to its check runs.
       GitHub run/check URLs and Depot run URLs are NOT stored — the commit is
       already in every event and is stable vocabulary; deeper links can come
       later if commit pages prove one click too far.
-- [ ] Contract bump 0.3.0 → 0.4.0: recent's shape change refolds the journal,
+- [x] Contract bump 0.3.0 → 0.4.0: recent's shape change refolds the journal,
       which backfills commit links for all existing history.
-- [ ] Update flake-dashboard.test.ts render assertions.
+- [x] Update flake-dashboard.test.ts render assertions.
 
 ## Notes
 

--- a/tasks/flake-dashboard-table-polish.md
+++ b/tasks/flake-dashboard-table-polish.md
@@ -1,0 +1,46 @@
+---
+status: in-progress
+size: small
+branch: flake-dashboard-table-polish
+---
+
+# Flake dashboard: 4-column table, clickable streak squares
+
+Misha reviewed a live mock on issue #2580 (2026-09-04) and approved the layout.
+
+## Status
+
+Spec committed; implementation not started.
+
+## Motivation
+
+The 9-column table is ugly and mostly whitespace. Collapse to
+`test | info | stats | streak` with `<br>`-separated lines inside the info and
+stats cells. Bonus (requested): each 🟩/🟥/❌ square links to the commit that
+produced that outcome, so eyeballing a red square is one click from the run.
+
+## Checklist
+
+- [ ] Render: 4 columns per the approved mock —
+      `info` = `pattern: /…/` + `suites: …` + `proposed: …` (proposed line
+      only when non-empty); `stats` = `runs:` + `flake rate:` + `last flake:`
+      with human-readable UTC dates ("Sep 4, 7:16am"); `streak` = the emoji
+      bar with the numeric default-branch streak as a second line
+      (`8× pass (main)`) when present.
+- [ ] Clickable squares: `recent` entries become `{ outcome, commit }` folded
+      from the run-recorded payload's `commit`; render each square as
+      `[🟩](https://github.com/<owner>/<repo>/commit/<sha>)` (owner/repo from
+      the birth certificate). The commit page links on to its check runs.
+      GitHub run/check URLs and Depot run URLs are NOT stored — the commit is
+      already in every event and is stable vocabulary; deeper links can come
+      later if commit pages prove one click too far.
+- [ ] Contract bump 0.3.0 → 0.4.0: recent's shape change refolds the journal,
+      which backfills commit links for all existing history.
+- [ ] Update flake-dashboard.test.ts render assertions.
+
+## Notes
+
+- The live mock (issue edit 2026-09-04T08:39:56Z) is the source of truth for
+  layout; it gets overwritten by the next real render.
+- Emoji legend moves into the intro sentence ("Streak = last 10 recorded
+  outcomes on any branch, oldest→newest").


### PR DESCRIPTION
Collapses the flake dashboard's 9-column table to `test | info | stats | streak` (layout approved via a live mock on #2580), and makes every streak square clickable — each 🟩/🟥/❌ links to the commit that produced that outcome, so a red square is one click from its run.

Before:

> test | allowed pattern | suites | runs | flake rate | last flake | recent | default-branch streak | proposed

After:

> `photos share a mosaic row; …` | pattern: `/Timeout …/`<br>suites: specs | runs: 8<br>flake rate: 25%<br>last flake: Sep 3, 10:32pm | [🟩](…)[🟥](…)[🟥](…)[🟩](…)

Fold-side, `recent` entries carry the run's commit sha (already in every run-recorded event); the 0.3.0→0.4.0 contract bump refolds the journal so all existing history gets links backfilled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Session: 4fe3e39f-bdf2-4b87-8ed3-b77d4252fd95 ("flake dashboard follow-ups")_

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +65 -29 | +51 -24 🟩🟩🟩🟥🟥 |
| Tests | +23 -5 | +20 -5 🟩🟩⬜⬜⬜ |
| Docs | +48 -0 | +38 -0 🟩🟩🟩⬜⬜ |
| **Total** | **+136 -34** | **+109 -29** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 2d1874c and 9281618, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-09-04T09:01:26.688Z",
      "deployedAt": "2026-09-04T08:49:42.600Z",
      "headSha": "36e23a34b452e972ee21417a427948991211817e",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/66306562145657",
      "shortSha": "36e23a3",
      "cleanupDurationMs": 105625,
      "deployDurationMs": 76626,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 76584,
      "deployReadinessDurationMs": 39,
      "deployedWorkerName": "os-preview-3",
      "deployedWorkerVersion": "53601063-dcf4-4fd9-854d-57c8c45bda90",
      "workerSizeKib": 20950.36,
      "workerGzipKib": 5281.97,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5292.79
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-09-04T08:59:44.901Z",
      "deployedAt": "2026-09-04T08:48:49.231Z",
      "headSha": "36e23a34b452e972ee21417a427948991211817e",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-3.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/66306562145657",
      "shortSha": "36e23a3",
      "cleanupDurationMs": 3835,
      "deployDurationMs": 23452,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 23213,
      "deployReadinessDurationMs": 235,
      "deployedWorkerName": "docs-preview-3",
      "deployedWorkerVersion": "15e0538a-3fb4-41be-81c0-81384f084536",
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-09-04T08:59:45.376Z",
      "deployedAt": "2026-09-04T08:48:56.442Z",
      "headSha": "36e23a34b452e972ee21417a427948991211817e",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/66306562145657",
      "shortSha": "36e23a3",
      "cleanupDurationMs": 4307,
      "deployDurationMs": 30705,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 30423,
      "deployReadinessDurationMs": 278,
      "deployedWorkerName": "auth-preview-3",
      "deployedWorkerVersion": "9e054939-8ab3-4c5e-9ba1-d17c5583d9a1",
      "workerSizeKib": 4178.28,
      "workerGzipKib": 855.42,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-09-04T08:59:49.197Z",
      "deployedAt": "2026-09-04T08:48:50.408Z",
      "headSha": "36e23a34b452e972ee21417a427948991211817e",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/66306562145657",
      "shortSha": "36e23a3",
      "cleanupDurationMs": 8127,
      "deployDurationMs": 24973,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 24388,
      "deployReadinessDurationMs": 580,
      "deployedWorkerName": "streams-example-app-preview-3",
      "deployedWorkerVersion": "d464ff74-e474-4989-bd96-bb810eba25e4",
      "workerSizeKib": 5648.41,
      "workerGzipKib": 1597.97,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-09-04T08:59:42.339Z",
      "deployedAt": "2026-09-04T08:48:32.593Z",
      "headSha": "36e23a34b452e972ee21417a427948991211817e",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/66306562145657",
      "shortSha": "36e23a3",
      "cleanupDurationMs": 1265,
      "deployDurationMs": 6769,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 6541,
      "deployReadinessDurationMs": 190,
      "deployedWorkerName": "dummy-petshop-preview-3",
      "deployedWorkerVersion": "fc7b42c2-9ee4-4565-b731-a349da4ea7b6",
      "workerSizeKib": 1331.5,
      "workerGzipKib": 232.81,
      "deployedFingerprint": "c321865fd82cf1ce04086fcbe3c487f157babc45+c5abf1055de73f3b4ffbc5e5b742dff1f0b5ee52",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `36e23a3` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 855.4 KiB | 30.7s |  |  | 4.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/66306562145657) | 2026-09-04T08:59:45.376Z | Preview app released. |
| Docs | released | `36e23a3` | [https://docs-preview-3.iterate-dev-preview.workers.dev](https://docs-preview-3.iterate-dev-preview.workers.dev) | 866.2 KiB | 23.5s |  |  | 3.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/66306562145657) | 2026-09-04T08:59:44.901Z | Preview app released. |
| Dummy Petshop | released | `36e23a3` | [https://dummy-petshop.iterate-preview-3.com](https://dummy-petshop.iterate-preview-3.com) | 232.8 KiB | 6.8s |  |  | 1.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/66306562145657) | 2026-09-04T08:59:42.339Z | Preview app released. |
| OS | released | `36e23a3` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 5.16 MiB (-10.8 KiB vs main) | 76.6s |  |  | 105.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/66306562145657) | 2026-09-04T09:01:26.688Z | Preview app released. |
| Streams Example App | released | `36e23a3` | [https://streams.iterate-preview-3.com](https://streams.iterate-preview-3.com) | 1.56 MiB | 25.0s |  |  | 8.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/66306562145657) | 2026-09-04T08:59:49.197Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Schema and contract version change refolds live processor state and overwrites the auto-maintained GitHub issue body; behavior is localized to the flake-dashboard starter app with test coverage.
> 
> **Overview**
> Reworks the GitHub flake dashboard issue from a **9-column** layout to **`test | info | stats | streak`**, with multi-line cells (`<br>`) for pattern/suites/proposed, run counts, flake rate, and human-readable UTC **last flake** dates via new `shortDate`.
> 
> **Streak squares** are now markdown links to the commit that produced each outcome (`owner/repo` from the birth certificate). Folded state stores **`recent` as `{ outcome, commit }`** (from each `run-recorded` payload) instead of outcomes alone; the **processor contract bumps to 0.4.0** so journals refold and backfill commit SHAs for existing history.
> 
> Tests and intro copy were updated for the new table, link assertions, and streak legend.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92816189e87fee610adb9ab83198ed1bdfb86b86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->