### PR TITLE
DO duration alerts: one daily Slack thread, no false FAILED, thresholds at ~$3/h

### DIFF
--- a/.depot/workflows/do-duration-probe.yml
+++ b/.depot/workflows/do-duration-probe.yml
@@ -9,8 +9,10 @@
 #      2026-09-01 stream-DO wake-loop runaway: ~$300/hour, noticed only on
 #      the bill after 28 hours — this workflow is the "never again")
 #
-# On breach, the alert script posts the probe report to Slack #error-pulse
-# and the run goes red.
+# Every run rewrites the headline of the day's thread in Slack #error-pulse
+# (one message per UTC day: latest hour, today's total, hours over the
+# ceiling, per account). A breach in the last two hours or a probe that could
+# not run is a reply in that thread, and the run goes red.
 #
 # Test the Slack hookup end to end (a tiny threshold forces an alert, marked
 # 🧪 TEST RUN in the message):
@@ -42,7 +44,7 @@ on:
       threshold-do-hours:
         description: >-
           Override BOTH accounts' active-time ceiling (DO-hours per hour).
-          Empty uses the per-account defaults (dev/preview 1000, prd 400).
+          Empty uses the per-account defaults (dev/preview 500, prd 600).
           Set 1 to force an alert and test the Slack hookup.
         type: string
         default: ""

--- a/apps/os/scripts/do-duration-probe.ts
+++ b/apps/os/scripts/do-duration-probe.ts
@@ -75,7 +75,7 @@ async function cfGraphql<T>(input: {
   return body.data;
 }
 
-export type ActiveTimeBreachRow = { hour: string; doHours: number };
+export type ActiveTimeRow = { hour: string; doHours: number };
 export type PinnedInvocationRow = {
   date: string;
   script: string;
@@ -85,7 +85,12 @@ export type PinnedInvocationRow = {
 /** The machine-readable result printed as one JSON line under `--json`,
  * consumed by scripts/ci/do-duration-alert.ts to build the Slack message. */
 export type ProbeSummary = {
-  activeTime: { ceilingDoHours: number; breachedHours: ActiveTimeBreachRow[] };
+  activeTime: {
+    ceilingDoHours: number;
+    /** Every hour of the lookback that had any DO activity, oldest first. */
+    hours: ActiveTimeRow[];
+    breachedHours: ActiveTimeRow[];
+  };
   pinnedInvocations: { thresholdHours: number; rows: PinnedInvocationRow[] };
 };
 
@@ -95,7 +100,7 @@ async function checkAccountActiveTime(input: {
   apiToken: string;
   lookbackHours: number;
   maxAccountDoHours: number;
-}): Promise<ActiveTimeBreachRow[]> {
+}): Promise<{ hours: ActiveTimeRow[]; breachedHours: ActiveTimeRow[] }> {
   const query = `
     query DoActiveTimeProbe($accountTag: string!, $start: Time!) {
       viewer {
@@ -123,16 +128,15 @@ async function checkAccountActiveTime(input: {
   }>({ apiToken: input.apiToken, query, variables: { accountTag: input.accountTag, start } });
 
   const rows = data.viewer.accounts[0]?.durableObjectsPeriodicGroups ?? [];
-  // An empty series is never "quiet": both accounts have DO activity every
-  // hour (prd's chronic baseline alone is ~120 DO-hours/hour), so no rows
-  // means dataset lag, a wrong account tag, or a broken token. Fail loudly —
-  // the alert wrapper reports a thrown probe as "FAILED to run" — instead of
-  // exiting zero as if under the ceiling.
+  // An empty series CAN be quiet: since preview slots are erased after every
+  // run (#2585), dev/preview has no DO activity at all overnight, and this
+  // dataset drops a deleted namespace's history retroactively. But it can
+  // also be a wrong account tag or a broken token, which must not pass as
+  // "under the ceiling". Tell them apart with a call that does not depend on
+  // activity: the account's DO namespace listing answers with the same
+  // credentials whether or not anything ran.
   if (rows.length === 0) {
-    throw new Error(
-      `no durableObjectsPeriodicGroups rows for account ${input.accountTag} in the last ` +
-        `${input.lookbackHours}h — analytics lag or misconfiguration, not evidence of quiet`,
-    );
+    await proveCredentials(input);
   }
   const byHour = new Map<string, number>();
   for (const row of rows) {
@@ -142,10 +146,26 @@ async function checkAccountActiveTime(input: {
   // µs of 128MB-DO active time per hour → "DO-hours" (1 DO continuously active
   // for the hour). Cloudflare bills duration at $12.50/M GB-s; 1 DO-hour =
   // 0.125GB * 3600s = 450 GB-s ≈ $0.0056.
-  return [...byHour.entries()]
+  const hours = [...byHour.entries()]
     .map(([hour, activeTimeUs]) => ({ hour, doHours: Math.round(activeTimeUs / 3600e6) }))
-    .filter((row) => row.doHours > input.maxAccountDoHours)
     .sort((a, b) => a.hour.localeCompare(b.hour));
+  return { hours, breachedHours: hours.filter((row) => row.doHours > input.maxAccountDoHours) };
+}
+
+async function proveCredentials(input: { accountTag: string; apiToken: string }): Promise<void> {
+  const response = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${input.accountTag}/workers/durable_objects/namespaces?per_page=1`,
+    { headers: { Authorization: `Bearer ${input.apiToken}` } },
+  );
+  // The REST envelope is `{ success, errors }`; only `success` is read.
+  const body = (await response.json()) as { success: boolean; errors: Array<{ message: string }> };
+  if (!body.success) {
+    throw new Error(
+      `no durableObjectsPeriodicGroups rows for account ${input.accountTag} AND the DO namespace ` +
+        `listing failed (${body.errors.map((e) => e.message).join("; ") || response.status}) — ` +
+        `misconfiguration, not quiet`,
+    );
+  }
 }
 
 async function main(): Promise<void> {
@@ -161,7 +181,7 @@ async function main(): Promise<void> {
   const report = json ? console.error : console.log;
   const thresholdMicros = thresholdHours * 3.6e9; // hours → microseconds
 
-  const breachedHours = await checkAccountActiveTime({
+  const { hours, breachedHours } = await checkAccountActiveTime({
     accountTag,
     apiToken,
     lookbackHours,
@@ -170,7 +190,7 @@ async function main(): Promise<void> {
   if (breachedHours.length === 0) {
     report(
       `✅ DO active-time probe clean: no hour in the last ${lookbackHours}h exceeded ` +
-        `${maxAccountDoHours} account-wide DO-hours.`,
+        `${maxAccountDoHours} account-wide DO-hours (${hours.length} hour(s) with any activity).`,
     );
   } else {
     process.exitCode = 1;
@@ -263,7 +283,7 @@ async function main(): Promise<void> {
 
   if (json) {
     const summary: ProbeSummary = {
-      activeTime: { ceilingDoHours: maxAccountDoHours, breachedHours },
+      activeTime: { ceilingDoHours: maxAccountDoHours, hours, breachedHours },
       pinnedInvocations: { thresholdHours, rows: flagged },
     };
     console.log(JSON.stringify(summary));

--- a/apps/os/scripts/do-duration-probe.ts
+++ b/apps/os/scripts/do-duration-probe.ts
@@ -157,7 +157,11 @@ async function proveCredentials(input: { accountTag: string; apiToken: string })
     `https://api.cloudflare.com/client/v4/accounts/${input.accountTag}/workers/durable_objects/namespaces?per_page=1`,
     { headers: { Authorization: `Bearer ${input.apiToken}` } },
   );
-  // The REST envelope is `{ success, errors }`; only `success` is read.
+  // Cloudflare's REST API always answers with a `{ success, errors }`
+  // envelope; the asserted shape is that envelope and only `success` is
+  // read. Nothing validates it at runtime, like cfGraphql above: if the
+  // shape ever drifts, `success` reads as undefined — falsy — and this
+  // throws, so a drift fails the probe loudly rather than passing as quiet.
   const body = (await response.json()) as { success: boolean; errors: Array<{ message: string }> };
   if (!body.success) {
     throw new Error(

--- a/scripts/ci/do-duration-alert.test.ts
+++ b/scripts/ci/do-duration-alert.test.ts
@@ -1,0 +1,132 @@
+import { expect, test } from "vitest";
+import { renderDailyThread } from "./do-duration-alert.ts";
+
+const now = new Date("2026-09-04T05:41:00Z");
+const runUrl = "https://github.com/iterate/iterate/actions/runs/1";
+const links =
+  "<https://github.com/iterate/iterate/tree/main/apps/os/tasks/do-duration-leak|incident docs> <https://github.com/iterate/iterate/actions/runs/1|workflow run> ($12.50/M GB-s, 1000 DO-hours ≈ $5.60)";
+
+test("a chronic breach is the headline's business; only a breach in the last two hours is a reply", () => {
+  const thread = renderDailyThread({
+    now,
+    runUrl,
+    testRun: false,
+    readings: [
+      {
+        label: "dev/preview",
+        ceilingDoHours: 500,
+        failure: null,
+        summary: {
+          // Erased slots: nothing ran overnight, and the last activity was yesterday.
+          activeTime: {
+            ceilingDoHours: 500,
+            hours: [{ hour: "2026-09-03T23:00:00Z", doHours: 1 }],
+            breachedHours: [],
+          },
+          pinnedInvocations: { thresholdHours: 1, rows: [] },
+        },
+      },
+      {
+        label: "prd",
+        ceilingDoHours: 600,
+        failure: null,
+        summary: {
+          activeTime: {
+            ceilingDoHours: 600,
+            hours: [
+              { hour: "2026-09-03T23:00:00Z", doHours: 542 },
+              { hour: "2026-09-04T00:00:00Z", doHours: 539 },
+              { hour: "2026-09-04T01:00:00Z", doHours: 536 },
+              { hour: "2026-09-04T02:00:00Z", doHours: 537 },
+              { hour: "2026-09-04T03:00:00Z", doHours: 542 },
+              { hour: "2026-09-04T04:00:00Z", doHours: 812 },
+              { hour: "2026-09-04T05:00:00Z", doHours: 401 },
+            ],
+            breachedHours: [{ hour: "2026-09-04T04:00:00Z", doHours: 812 }],
+          },
+          pinnedInvocations: {
+            thresholdHours: 1,
+            rows: [
+              { date: "2026-09-04", script: "os-prd", wallTimeP99Hours: 1.94, requests: 1200 },
+            ],
+          },
+        },
+      },
+    ],
+  });
+
+  expect(thread.headline).toBe(
+    [
+      "📒 Durable Objects — 2026-09-04 (UTC) · updated 05:41",
+      "dev/preview: ✅ 23:00 → 1 DO-hours (~$0.01/h) · today 0 DO-hours ≈ $0.00 · 0/0 h over 500",
+      "prd: 🚨 05:00 → 401 DO-hours (~$2.26/h) · today 3,367 DO-hours ≈ $19 · 1/6 h over 600 · pinned: os-prd P99=1.94h",
+      links,
+    ].join("\n"),
+  );
+  expect(thread.replies).toEqual([
+    [
+      "🚨 Durable Objects hours over 600. account: prd.",
+      "Latest: 04:00 → 812 DO-hours (~$4.57/h)",
+      "Also pinned: os-prd  wallTimeP99=1.94h",
+      links,
+    ].join("\n"),
+  ]);
+});
+
+test("an hour over the ceiling earlier today stays in the headline count without a fresh reply", () => {
+  const thread = renderDailyThread({
+    now,
+    runUrl,
+    testRun: false,
+    readings: [
+      {
+        label: "dev/preview",
+        ceilingDoHours: 500,
+        failure: null,
+        summary: {
+          activeTime: {
+            ceilingDoHours: 500,
+            hours: [
+              { hour: "2026-09-04T01:00:00Z", doHours: 2225 },
+              { hour: "2026-09-04T02:00:00Z", doHours: 40 },
+              { hour: "2026-09-04T04:00:00Z", doHours: 3 },
+            ],
+            breachedHours: [{ hour: "2026-09-04T01:00:00Z", doHours: 2225 }],
+          },
+          pinnedInvocations: { thresholdHours: 1, rows: [] },
+        },
+      },
+    ],
+  });
+
+  expect(thread.replies).toEqual([]);
+  expect(thread.headline).toContain(
+    "dev/preview: ✅ 04:00 → 3 DO-hours (~$0.02/h) · today 2,268 DO-hours ≈ $13 · 1/3 h over 500",
+  );
+});
+
+test("a probe that could not run is said so in the headline and as a reply, never as a clean account", () => {
+  const thread = renderDailyThread({
+    now,
+    runUrl: null,
+    testRun: true,
+    readings: [
+      {
+        label: "dev/preview",
+        ceilingDoHours: 1,
+        failure: "Cloudflare GraphQL errors: authentication error",
+        summary: null,
+      },
+    ],
+  });
+
+  expect(thread.headline).toBe(
+    [
+      "🧪 TEST RUN — 📒 Durable Objects — 2026-09-04 (UTC) · updated 05:41",
+      "dev/preview: ⚠️ probe failed this run — Cloudflare GraphQL errors: authentication error",
+      "<https://github.com/iterate/iterate/tree/main/apps/os/tasks/do-duration-leak|incident docs> ($12.50/M GB-s, 1000 DO-hours ≈ $5.60)",
+    ].join("\n"),
+  );
+  expect(thread.replies).toHaveLength(1);
+  expect(thread.replies[0]).toContain("⚠️ DO duration probe FAILED to run. account: dev/preview.");
+});

--- a/scripts/ci/do-duration-alert.ts
+++ b/scripts/ci/do-duration-alert.ts
@@ -1,13 +1,17 @@
 // Hourly Durable Objects cost alarm (do-duration-probe.yml). Runs the
 // duration probe (apps/os/scripts/do-duration-probe.ts --json) against both
-// Cloudflare accounts and posts one concise Slack message PER BREACHED
-// ACCOUNT — the account is the routing information an operator needs first.
+// Cloudflare accounts and keeps ONE Slack thread per UTC day in #error-pulse:
+// the headline is rewritten every hour with each account's picture (latest
+// hour, today's total, hours over the ceiling), and anything that needs a
+// human — an hour over the ceiling, a probe that could not run — is a reply
+// in that thread. The channel itself sees one message a day.
 // Exists because the 2026-09-01 preview stream-DO wake loop burned ~$300/hour
 // for 28 hours before a human noticed it on the bill.
 //
 //   pnpm tsx scripts/ci/do-duration-alert.ts run
 //   pnpm tsx scripts/ci/do-duration-alert.ts run --threshold-do-hours 1   # force an alert (Slack hookup test)
 import { execFileSync } from "node:child_process";
+import type { WebClient } from "@slack/web-api";
 import { createBuiltInPrompts, createCli, isAgent, yamlTableConsoleLogger } from "trpc-cli";
 import { isMainModule } from "../../packages/shared/src/dev/is-main-module.ts";
 import type { ProbeSummary } from "../../apps/os/scripts/do-duration-probe.ts";
@@ -15,23 +19,42 @@ import { getRunUrl } from "./github.ts";
 import { getSlackClient, slackChannelIds } from "./slack.ts";
 
 const DOCS_URL = "https://github.com/iterate/iterate/tree/main/apps/os/tasks/do-duration-leak";
+/** $12.50 per million GB-seconds at 128 MB: one DO-hour is 450 GB-s. */
+const USD_PER_DO_HOUR = 0.005625;
+/** The probe runs at :41 and analytics lag ~15–20 minutes, so the previous
+ * hour is complete and the current one partial: a breach in either is "now".
+ * Older breaches are today's history — in the headline, not re-alerted. */
+const RECENT_HOURS = 2;
+/** Long enough that every hour of the current UTC day is in the summary. */
+const LOOKBACK_HOURS = 26;
 
 const ACCOUNTS = [
   {
     dopplerConfig: "dev",
     label: "dev/preview",
-    // Healthy baseline is <10 DO-hours/hour (previews idle between spec runs);
-    // the incident ran 20,000-57,000. Plenty of headroom for legit spikes.
-    maxAccountDoHours: 1000,
+    // Healthy is 0–100 DO-hours/hour now that preview slots are erased after
+    // every run (#2585); one slot relit by a finished run is 2,000–4,000. The
+    // incident ran 20,000–57,000. ≈ $2.80/hour.
+    maxAccountDoHours: 500,
   },
   {
     dopplerConfig: "prd",
     label: "prd",
-    // Baseline ~120 DO-hours/hour as of 2026-09-02 (chronic; see
-    // apps/os/tasks/do-duration-leak/). Alert on ~3x that.
-    maxAccountDoHours: 400,
+    // Pre-incident baseline ~100 DO-hours/hour. Since 2026-09-03 11:00 the
+    // standalone project-worker/IterateContextDurableObject sits ~540 on top
+    // (not this repo's; routed to its owner) — ≈ $3/hour, visible in the
+    // headline every hour without a reply. ≈ $3.40/hour ceiling.
+    maxAccountDoHours: 600,
   },
 ];
+
+export type AccountReading = {
+  label: string;
+  ceilingDoHours: number;
+  summary: ProbeSummary | null;
+  /** Why the probe printed no summary (bad creds, GraphQL outage). */
+  failure: string | null;
+};
 
 export async function run(options: {
   /** Override BOTH accounts' active-time ceiling (DO-hours/hour). Set very low
@@ -41,86 +64,145 @@ export async function run(options: {
   const override = options.thresholdDoHours;
   // Absent outside GitHub Actions (local runs of this script).
   const runUrl = process.env.GITHUB_RUN_ID ? getRunUrl() : null;
-  const testPrefix = override === undefined ? "" : `🧪 TEST RUN — `;
+  const now = new Date();
 
-  const alerts: string[] = [];
+  const readings: AccountReading[] = [];
   for (const account of ACCOUNTS) {
-    const ceiling = override === undefined ? account.maxAccountDoHours : override;
-    let stdout = "";
-    let breached = false;
-    try {
-      stdout = execFileSync(
-        "doppler",
-        // prettier-ignore
-        [
-          "run", "--project", "os", "--config", account.dopplerConfig, "--",
-          "pnpm", "tsx", "apps/os/scripts/do-duration-probe.ts",
-          "--hours", "3", "--max-account-do-hours", String(ceiling), "--json",
-        ],
-        { encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] },
-      );
-    } catch (error: any) {
-      breached = true;
-      stdout = error.stdout || "";
-    }
-    const summary = parseSummary(stdout);
-    if (summary === undefined) {
-      // The probe crashed before printing its summary (bad creds, GraphQL
-      // outage). Say so rather than silently skipping the account.
-      alerts.push(
-        `${testPrefix}🚨 DO duration probe FAILED to run. account: ${account.label}.\n` +
-          `${links(runUrl)}`,
-      );
-      continue;
-    }
-    if (!breached) continue;
-    alerts.push(formatAlert({ label: account.label, summary, testPrefix, runUrl }));
+    const ceilingDoHours = override === undefined ? account.maxAccountDoHours : override;
+    readings.push({
+      label: account.label,
+      ceilingDoHours,
+      ...probe(account.dopplerConfig, ceilingDoHours),
+    });
   }
 
-  for (const text of alerts) console.log(`\n${text}\n`);
-  if (alerts.length === 0) {
-    console.log("✅ both accounts clean");
-    return { breached: false };
-  }
+  const thread = renderDailyThread({ now, readings, runUrl, testRun: override !== undefined });
+  console.log(`\n${thread.headline}\n`);
+  for (const reply of thread.replies) console.log(`\n${reply}\n`);
 
   const slack = getSlackClient();
-  for (const text of alerts) {
-    await slack.chat.postMessage({ channel: slackChannelIds["#error-pulse"], text });
+  const channel = slackChannelIds["#error-pulse"];
+  const headlineTs = await findOrCreateHeadline({
+    slack,
+    channel,
+    now,
+    headline: thread.headline,
+    testRun: override !== undefined,
+  });
+  for (const text of thread.replies) {
+    await slack.chat.postMessage({ channel, thread_ts: headlineTs, text });
+  }
+  await slack.chat.update({ channel, ts: headlineTs, text: thread.headline });
+
+  if (thread.replies.length === 0) {
+    console.log("✅ both accounts under their ceilings; headline updated");
+    return { breached: false };
   }
   // Throw (after the Slack posts) so the workflow run goes red: trpc-cli
   // exits 0 on a normal return even with process.exitCode set — verified on
   // the 2026-09-02 dispatch test, where a breach concluded "success".
-  throw new Error(`DO duration alarm breached (${alerts.length} alert(s)); Slack alerts posted`);
+  throw new Error(
+    `DO duration alarm: ${thread.replies.length} alert(s) posted to the daily thread`,
+  );
 }
 
-function formatAlert(input: {
-  label: string;
-  summary: ProbeSummary;
-  testPrefix: string;
-  runUrl: string | null;
-}) {
-  const { activeTime, pinnedInvocations } = input.summary;
-  const lines: string[] = [];
-  const latestHour = activeTime.breachedHours.at(-1);
-  if (latestHour) {
-    lines.push(
-      `${input.testPrefix}🚨 Durable Objects hours exceed threshold of ${activeTime.ceilingDoHours}. account: ${input.label}.`,
-      `Latest: ${latestHour.hour}  ${latestHour.doHours} DO-hours (~$${Math.round(latestHour.doHours * 0.005625)}/h)`,
+function probe(dopplerConfig: string, ceilingDoHours: number) {
+  let stdout = "";
+  let stderr = "";
+  try {
+    stdout = execFileSync(
+      "doppler",
+      // prettier-ignore
+      [
+        "run", "--project", "os", "--config", dopplerConfig, "--",
+        "pnpm", "tsx", "apps/os/scripts/do-duration-probe.ts",
+        "--hours", String(LOOKBACK_HOURS), "--max-account-do-hours", String(ceilingDoHours), "--json",
+      ],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
     );
-  } else {
-    // Only the pinned-invocation signature tripped (leaked RPC session).
-    const worst = pinnedInvocations.rows[0]!;
-    lines.push(
-      `${input.testPrefix}🚨 Durable Object invocation pinned over ${pinnedInvocations.thresholdHours}h (leaked RPC session). account: ${input.label}.`,
-      `Worst: ${worst.script}  wallTimeP99=${worst.wallTimeP99Hours}h  reqs=${worst.requests}`,
-    );
+  } catch (error: any) {
+    // The probe exits non-zero on a breach AND on a crash; the summary line
+    // below tells them apart.
+    stdout = error.stdout || "";
+    stderr = error.stderr || "";
   }
-  if (latestHour && pinnedInvocations.rows.length > 0) {
-    const worst = pinnedInvocations.rows[0]!;
-    lines.push(`Also pinned: ${worst.script}  wallTimeP99=${worst.wallTimeP99Hours}h`);
+  if (stderr) console.error(stderr);
+  const lastLine = stdout.trim().split("\n").at(-1) || "";
+  try {
+    // The probe's --json contract: its LAST stdout line is one ProbeSummary
+    // (apps/os/scripts/do-duration-probe.ts prints it after the human report
+    // moves to stderr). Anything else — a crash before the summary, a stray
+    // line — fails JSON.parse and is reported as a probe failure, so a wrong
+    // shape cannot masquerade as a clean account.
+    return { summary: JSON.parse(lastLine) as ProbeSummary, failure: null };
+  } catch {
+    const reason = stderr.trim().split("\n").filter(Boolean).at(-1) || "printed no summary";
+    return { summary: null, failure: reason.slice(0, 200) };
+  }
+}
+
+/**
+ * The day's Slack thread as text: a headline that is the whole picture at a
+ * glance, and the replies this run has to add (only what a human should look
+ * at now). Pure, so the wording is testable.
+ */
+export function renderDailyThread(input: {
+  now: Date;
+  readings: AccountReading[];
+  runUrl: string | null;
+  testRun: boolean;
+}) {
+  const date = input.now.toISOString().slice(0, 10);
+  const time = input.now.toISOString().slice(11, 16);
+  const recentSince = new Date(input.now.getTime() - RECENT_HOURS * 3600_000).toISOString();
+  const testPrefix = input.testRun ? "🧪 TEST RUN — " : "";
+  const usd = (doHours: number) =>
+    `$${(doHours * USD_PER_DO_HOUR).toFixed(doHours * USD_PER_DO_HOUR < 10 ? 2 : 0)}`;
+  const hourOf = (row: { hour: string; doHours: number }) =>
+    `${row.hour.slice(11, 16)} → ${row.doHours.toLocaleString("en-US")} DO-hours (~${usd(row.doHours)}/h)`;
+
+  const lines = [`${testPrefix}📒 Durable Objects — ${date} (UTC) · updated ${time}`];
+  const replies: string[] = [];
+  for (const reading of input.readings) {
+    if (reading.summary === null) {
+      lines.push(`${reading.label}: ⚠️ probe failed this run — ${reading.failure}`);
+      replies.push(
+        `${testPrefix}⚠️ DO duration probe FAILED to run. account: ${reading.label}.\n${reading.failure}\n${links(input.runUrl)}`,
+      );
+      continue;
+    }
+    const { activeTime, pinnedInvocations } = reading.summary;
+    const today = activeTime.hours.filter((row) => row.hour.startsWith(date));
+    const todayTotal = today.reduce((total, row) => total + row.doHours, 0);
+    const breachedToday = activeTime.breachedHours.filter((row) => row.hour.startsWith(date));
+    const recent = activeTime.breachedHours.filter((row) => row.hour >= recentSince);
+    const latest = activeTime.hours.at(-1);
+    const status = recent.length > 0 ? "🚨" : "✅";
+    const parts = [
+      `${reading.label}: ${status} ${latest ? hourOf(latest) : "no DO activity in the lookback"}`,
+      `today ${todayTotal.toLocaleString("en-US")} DO-hours ≈ ${usd(todayTotal)}`,
+      `${breachedToday.length}/${today.length} h over ${reading.ceilingDoHours}`,
+    ];
+    const pinned = pinnedInvocations.rows[0];
+    if (pinned) parts.push(`pinned: ${pinned.script} P99=${pinned.wallTimeP99Hours}h`);
+    lines.push(parts.join(" · "));
+
+    const worst = recent.at(-1);
+    if (worst) {
+      replies.push(
+        [
+          `${testPrefix}🚨 Durable Objects hours over ${reading.ceilingDoHours}. account: ${reading.label}.`,
+          `Latest: ${hourOf(worst)}`,
+          pinned ? `Also pinned: ${pinned.script}  wallTimeP99=${pinned.wallTimeP99Hours}h` : null,
+          links(input.runUrl),
+        ]
+          .filter(Boolean)
+          .join("\n"),
+      );
+    }
   }
   lines.push(links(input.runUrl));
-  return lines.join("\n");
+  return { date, headline: lines.join("\n"), replies };
 }
 
 function links(runUrl: string | null) {
@@ -133,18 +215,42 @@ function links(runUrl: string | null) {
     .join(" ");
 }
 
-function parseSummary(stdout: string) {
-  const lastLine = stdout.trim().split("\n").at(-1) || "";
-  try {
-    // The probe's --json contract: its LAST stdout line is one ProbeSummary
-    // (apps/os/scripts/do-duration-probe.ts prints it after the human report
-    // moves to stderr). Anything else — a crash before the summary, a stray
-    // line — fails JSON.parse and is reported as "probe FAILED to run" by the
-    // caller, so a wrong shape cannot masquerade as a clean account.
-    return JSON.parse(lastLine) as ProbeSummary;
-  } catch {
-    return undefined;
-  }
+/**
+ * Today's headline message, created on the day's first run. Found by text:
+ * the bot's own messages since 00:00 UTC whose text carries the day stamp
+ * (Slack rewrites emoji as :shortcodes: in history, so the stamp is matched
+ * without it). A forced-threshold test run keeps its own thread: it must
+ * never rewrite the real day's headline with test text.
+ */
+async function findOrCreateHeadline(input: {
+  slack: WebClient;
+  channel: string;
+  now: Date;
+  headline: string;
+  testRun: boolean;
+}): Promise<string> {
+  const date = input.now.toISOString().slice(0, 10);
+  const dayStart = Date.parse(`${date}T00:00:00Z`) / 1000;
+  const history = await input.slack.conversations.history({
+    channel: input.channel,
+    oldest: String(dayStart),
+    limit: 200,
+  });
+  const stamp = `Durable Objects — ${date}`;
+  const existing = (history.messages || []).find(
+    (message) =>
+      message.bot_id &&
+      message.ts &&
+      message.text?.includes(stamp) &&
+      message.text.includes("TEST RUN") === input.testRun,
+  );
+  if (existing?.ts) return existing.ts;
+  const posted = await input.slack.chat.postMessage({
+    channel: input.channel,
+    text: input.headline,
+  });
+  if (!posted.ts) throw new Error("Slack accepted the headline but returned no ts");
+  return posted.ts;
 }
 
 if (isMainModule(import.meta.url)) {

--- a/tasks/complete/2026-09-04-do-alert-daily-thread.md
+++ b/tasks/complete/2026-09-04-do-alert-daily-thread.md
@@ -1,5 +1,5 @@
 ---
-status: ready
+status: complete
 size: small
 ---
 
@@ -9,7 +9,7 @@ size: small
 
 Spec'd 2026-09-04 from the first night of hourly alerts in #error-pulse
 (screenshot: prd breached every hour at ~540 DO-hours, dev/preview reported
-"probe FAILED to run" twice). Implemented on this branch; a forced 🧪 TEST RUN from CI produced the daily thread in #error-pulse (headline + 2 threaded replies + in-place headline edit), read back through the Slack API. Left: watching the first real scheduled runs.
+"probe FAILED to run" twice). Implemented on this branch; a forced 🧪 TEST RUN from CI produced the daily thread in #error-pulse (headline + 2 threaded replies + in-place headline edit), read back through the Slack API. Merged in #2590; the 37 hourly alert messages from the prior 48h were deleted from #error-pulse by hand after merge.
 
 ## Why
 

--- a/tasks/do-alert-daily-thread.md
+++ b/tasks/do-alert-daily-thread.md
@@ -1,0 +1,46 @@
+---
+status: ready
+size: small
+---
+
+# DO duration alerter: one daily thread, no false "FAILED", sane thresholds
+
+## Status summary
+
+Spec'd 2026-09-04 from the first night of hourly alerts in #error-pulse
+(screenshot: prd breached every hour at ~540 DO-hours, dev/preview reported
+"probe FAILED to run" twice). Implementation on this branch.
+
+## Why
+
+The hourly probe (#2576) posts one top-level Slack message per breached
+account per hour, so a chronic breach (prd's `project-worker` namespace,
+~540 DO-hours/h ≈ $3/h since 2026-09-03 11:00) is 24 channel messages a day
+saying the same thing. And after #2585 (slots erased after every run),
+dev/preview legitimately has **zero** `durableObjectsPeriodicGroups` rows
+overnight; the probe's "an empty series is never quiet" guard now fires as
+"FAILED to run" every quiet hour.
+
+## What changes
+
+- [ ] One headline message per UTC day in #error-pulse (`📒 Durable Objects
+      — YYYY-MM-DD`), found via `conversations.history` or created on first
+      run; every alert (breach, pinned invocation, probe failure) is a reply
+      in that thread; the headline is rewritten on every run, breached or
+      not, with today's picture per account: latest hour, hours over the
+      ceiling today, today's total DO-hours and ≈$, probe failures.
+- [ ] The probe reports every hour of the lookback in its summary (not only
+      breached ones), and the alerter looks back 26h so "today" is complete.
+- [ ] Empty series: prove the credentials and account with a call that does
+      not depend on activity (the DO namespace list), then treat no rows as
+      0 DO-hours. Throw only when that proof fails.
+- [ ] Thresholds: dev/preview 1000 → 500 (~$2.80/h; healthy is 0–100 now, a
+      relit slot is 2–4k); prd 400 → 600 (~$3.40/h; the pre-incident baseline
+      is ~100, with `project-worker` ~540 — under it, so the chronic case is
+      visible in the headline without an hourly reply).
+- [ ] Unit test for the headline/reply text from fixed summaries.
+
+## Out of scope
+
+- Fixing `project-worker/IterateContextDurableObject` itself (not in this
+  repo; routed to its owner).

--- a/tasks/do-alert-daily-thread.md
+++ b/tasks/do-alert-daily-thread.md
@@ -9,7 +9,7 @@ size: small
 
 Spec'd 2026-09-04 from the first night of hourly alerts in #error-pulse
 (screenshot: prd breached every hour at ~540 DO-hours, dev/preview reported
-"probe FAILED to run" twice). Implementation on this branch.
+"probe FAILED to run" twice). Implemented on this branch; a forced 🧪 TEST RUN from CI produced the daily thread in #error-pulse (headline + 2 threaded replies + in-place headline edit), read back through the Slack API. Left: watching the first real scheduled runs.
 
 ## Why
 
@@ -23,22 +23,23 @@ overnight; the probe's "an empty series is never quiet" guard now fires as
 
 ## What changes
 
-- [ ] One headline message per UTC day in #error-pulse (`📒 Durable Objects
+- [x] One headline message per UTC day in #error-pulse (`📒 Durable Objects
       — YYYY-MM-DD`), found via `conversations.history` or created on first
       run; every alert (breach, pinned invocation, probe failure) is a reply
       in that thread; the headline is rewritten on every run, breached or
       not, with today's picture per account: latest hour, hours over the
       ceiling today, today's total DO-hours and ≈$, probe failures.
-- [ ] The probe reports every hour of the lookback in its summary (not only
+      _(`renderDailyThread` + `findOrCreateHeadline` in scripts/ci/do-duration-alert.ts; a TEST RUN keeps its own thread)_
+- [x] The probe reports every hour of the lookback in its summary (not only
       breached ones), and the alerter looks back 26h so "today" is complete.
-- [ ] Empty series: prove the credentials and account with a call that does
+- [x] Empty series: prove the credentials and account with a call that does
       not depend on activity (the DO namespace list), then treat no rows as
       0 DO-hours. Throw only when that proof fails.
-- [ ] Thresholds: dev/preview 1000 → 500 (~$2.80/h; healthy is 0–100 now, a
+- [x] Thresholds: dev/preview 1000 → 500 (~$2.80/h; healthy is 0–100 now, a
       relit slot is 2–4k); prd 400 → 600 (~$3.40/h; the pre-incident baseline
       is ~100, with `project-worker` ~540 — under it, so the chronic case is
       visible in the headline without an hourly reply).
-- [ ] Unit test for the headline/reply text from fixed summaries.
+- [x] Unit test for the headline/reply text from fixed summaries _(scripts/ci/do-duration-alert.test.ts)_
 
 ## Out of scope
 


### PR DESCRIPTION
The hourly Durable Objects cost probe (#2576) posted one top-level #error-pulse message per breached account per hour, and since #2585 reported dev/preview as "probe FAILED to run" on every quiet hour. After this PR the channel gets **one message per UTC day**, and the false failure is gone.

## What changes

**One daily thread.** Every hourly run rewrites the day's headline (found by its date stamp, created on the day's first run). Only what needs a human is a reply in the thread: an hour over the ceiling within the last two hours, or a probe that could not run. A chronic breach is therefore one channel message a day, not 24. The headline reads like this:

```
📒 Durable Objects — 2026-09-04 (UTC) · updated 05:41
dev/preview: ✅ 04:00 → 3 DO-hours (~$0.02/h) · today 2,268 DO-hours ≈ $13 · 1/3 h over 500
prd: 🚨 05:00 → 401 DO-hours (~$2.26/h) · today 3,367 DO-hours ≈ $19 · 1/6 h over 600 · pinned: os-prd P99=1.94h
incident docs · workflow run ($12.50/M GB-s, 1000 DO-hours ≈ $5.60)
```

A forced-threshold 🧪 TEST RUN keeps its own thread so it never rewrites the real day's headline.

**"FAILED to run" was a false alarm.** Since #2585 erases preview slots after every run, dev/preview legitimately has zero `durableObjectsPeriodicGroups` rows overnight (confirmed: 0 rows for every hour 00:00–04:00Z on Sep 4). The probe's "an empty series is never quiet" guard threw on exactly that. It now proves the credentials with the DO namespace listing, which answers regardless of activity, and treats no rows as 0 DO-hours. A wrong account or token still fails loudly (verified with a bogus account id: "not authorized for that account").

**Ceilings, and the recommendation behind them.** One DO-hour ≈ $0.0056, so "$3/hour" ≈ 535 DO-hours.

| account | was | now | why |
| --- | --- | --- | --- |
| dev/preview | 1000 | **500** (~$2.80/h) | healthy is 0–100 now that slots are erased after every run; one slot relit by a finished run is 2,000–4,000, so it is still caught |
| prd | 400 | **600** (~$3.40/h) | pre-incident baseline ~100; the standalone `project-worker/IterateContextDurableObject` (not in this repo, since Sep 3 11:00) puts it at 480–800, so prd will still be flagged in its ~800 hours until that Worker's owner acts, but as a thread reply |

**Plumbing.** The probe's `--json` summary now carries every hour of the lookback (not only breached ones) and the alerter looks back 26h, so the day's totals are complete. Three unit tests pin the headline and reply wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CreJMLijARf7t4P1LyHTwi

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +132 -0 | +124 -0 🟩🟩🟩⬜⬜ |
| CI & scripts | +236 -104 | +157 -78 🟩🟩🟩🟥🟥 |
| Docs | +47 -0 | +38 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+415 -104** | **+319 -78** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 2d1874c and ccc808a, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-09-04T11:14:44.954Z",
      "deployedAt": "2026-09-04T11:02:57.578Z",
      "headSha": "9c63a6ab9ad56c8bb36b30c5a5581ce3fbfed123",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/379570754257",
      "shortSha": "9c63a6a",
      "cleanupDurationMs": 98616,
      "deployDurationMs": 47066,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 46082,
      "deployReadinessDurationMs": 981,
      "deployedWorkerName": "os-preview-6",
      "deployedWorkerVersion": "2957e72a-aa23-4948-ae4e-a01ec04002af",
      "testDurationMs": 297090,
      "testRetries": "4 retried: a disposed test project stops waking its Durable Objects (vitest x1) · the source-version pin tells a facet that recycled from one the commit rebuilt (vitest x1) · a userspace facet rebuilds on a source commit and only on a source commit (vitest x1) · agent-script-reuse.spec.ts › a repeat request reuses the previous turn's journaled script instead of re-deriving it › web (playwright x1) — TimeoutError: locator.click: Timeout 1000ms exceeded. Call log: \u001b[2m - waiting for getByRole('button', { name: 'Send message' })\u001b[22m \u001b[2m - locator resolved to <button tabindex=\"0\" type=\"button\" data-slot=\"button\" title=\"Send message\" class=\"group/button inline-flex shrink-0 items-center justify...",
      "workerSizeKib": 20950.36,
      "workerGzipKib": 5281.97,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5292.84
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-09-04T11:13:10.281Z",
      "deployedAt": "2026-09-04T11:02:22.891Z",
      "headSha": "9c63a6ab9ad56c8bb36b30c5a5581ce3fbfed123",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-6.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/379570754257",
      "shortSha": "9c63a6a",
      "cleanupDurationMs": 3940,
      "deployDurationMs": 11721,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 11391,
      "deployReadinessDurationMs": 325,
      "deployedWorkerName": "docs-preview-6",
      "deployedWorkerVersion": "d4ac3f9e-0b01-4b3f-94a6-523a4a4106b7",
      "testDurationMs": 2320,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-09-04T11:13:10.297Z",
      "deployedAt": "2026-09-04T11:02:31.838Z",
      "headSha": "9c63a6ab9ad56c8bb36b30c5a5581ce3fbfed123",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/379570754257",
      "shortSha": "9c63a6a",
      "cleanupDurationMs": 3955,
      "deployDurationMs": 20382,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 20337,
      "deployReadinessDurationMs": 40,
      "deployedWorkerName": "auth-preview-6",
      "deployedWorkerVersion": "b1c3e0e3-6915-4b06-9676-a5e62089285d",
      "testDurationMs": 16935,
      "testRetries": null,
      "workerSizeKib": 4178.28,
      "workerGzipKib": 855.24,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-09-04T11:13:10.859Z",
      "deployedAt": "2026-09-04T11:02:23.738Z",
      "headSha": "9c63a6ab9ad56c8bb36b30c5a5581ce3fbfed123",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/379570754257",
      "shortSha": "9c63a6a",
      "cleanupDurationMs": 4515,
      "deployDurationMs": 13603,
      "deployConfigDurationMs": 7,
      "deployCommandDurationMs": 12235,
      "deployReadinessDurationMs": 1361,
      "deployedWorkerName": "streams-example-app-preview-6",
      "deployedWorkerVersion": "462a9212-0cdc-479e-becd-3967e934fc89",
      "testDurationMs": 80680,
      "testRetries": null,
      "workerSizeKib": 5648.41,
      "workerGzipKib": 1597.97,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-09-04T11:13:06.975Z",
      "deployedAt": "2026-09-04T09:00:53.554Z",
      "headSha": "9c63a6ab9ad56c8bb36b30c5a5581ce3fbfed123",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/379570754257",
      "shortSha": "9c63a6a",
      "cleanupDurationMs": 628,
      "deployDurationMs": 140,
      "deployConfigDurationMs": 0,
      "deployReuseProofDurationMs": 137,
      "deployedWorkerName": "dummy-petshop-preview-6",
      "deployedWorkerVersion": "506a5044-1399-4fbf-89a8-eba6fd954d5a",
      "testDurationMs": 6139,
      "testRetries": null,
      "workerSizeKib": 1331.5,
      "workerGzipKib": 232.81,
      "deployedFingerprint": "c321865fd82cf1ce04086fcbe3c487f157babc45+c5abf1055de73f3b4ffbc5e5b742dff1f0b5ee52",
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-09-04T11:13:08.107Z",
      "deployedAt": "2026-09-04T11:02:26.005Z",
      "headSha": "9c63a6ab9ad56c8bb36b30c5a5581ce3fbfed123",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/379570754257",
      "shortSha": "9c63a6a",
      "cleanupDurationMs": 1132,
      "deployDurationMs": 14677,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 14505,
      "deployReadinessDurationMs": 168,
      "deployedWorkerName": "semaphore-preview-6",
      "deployedWorkerVersion": "803d6b56-d68c-4695-a84a-533c5a86c250",
      "testDurationMs": 74141,
      "testRetries": null,
      "workerSizeKib": 1960.48,
      "workerGzipKib": 453.78,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `9c63a6a` | [https://auth.iterate-preview-6.com](https://auth.iterate-preview-6.com) | 855.2 KiB | 20.4s | 16.9s |  | 4.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/379570754257) | 2026-09-04T11:13:10.297Z | Preview app released. |
| Docs | released | `9c63a6a` | [https://docs-preview-6.iterate-dev-preview.workers.dev](https://docs-preview-6.iterate-dev-preview.workers.dev) | 866.2 KiB | 11.7s | 2.3s |  | 3.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/379570754257) | 2026-09-04T11:13:10.281Z | Preview app released. |
| Dummy Petshop | released | `9c63a6a` | [https://dummy-petshop.iterate-preview-6.com](https://dummy-petshop.iterate-preview-6.com) | 232.8 KiB | 140ms | 6.1s |  | 628ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/379570754257) | 2026-09-04T11:13:06.975Z | Preview app released. |
| OS | released | `9c63a6a` | [https://os.iterate-preview-6.com](https://os.iterate-preview-6.com) | 5.16 MiB (-10.9 KiB vs main) | 47.1s | 297.1s | 4 retried: a disposed test project stops waking its Durable Objects (vitest x1) · the source-version pin tells a facet that recycled from one the commit rebuilt (vitest x1) · a userspace facet rebuilds on a source commit and only on a source commit (vitest x1) · agent-script-reuse.spec.ts › a repeat request reuses the previous turn's journaled script instead of re-deriving it › web (playwright x1) — TimeoutError: locator.click: Timeout 1000ms exceeded. Call log: [2m - waiting for getByRole('button', { name: 'Send message' })[22m [2m - locator resolved to <button tabindex="0" type="button" data-slot="button" title="Send message" class="group/button inline-flex shrink-0 items-center justify... | 98.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/379570754257) | 2026-09-04T11:14:44.954Z | Preview app released. |
| Semaphore | released | `9c63a6a` | [https://semaphore.iterate-preview-6.com](https://semaphore.iterate-preview-6.com) | 453.8 KiB | 14.7s | 74.1s |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/379570754257) | 2026-09-04T11:13:08.107Z | Preview app released. |
| Streams Example App | released | `9c63a6a` | [https://streams.iterate-preview-6.com](https://streams.iterate-preview-6.com) | 1.56 MiB | 13.6s | 80.7s |  | 4.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/379570754257) | 2026-09-04T11:13:10.859Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production cost-monitoring alerting, Slack threading, and breach thresholds; mis-tuned “recent breach” logic or headline lookup could delay or reshape when operators get paged.
> 
> **Overview**
> **#error-pulse** no longer gets a new top-level message per breached account each hour. The hourly workflow now maintains **one Slack thread per UTC day**: each run finds or creates the dated headline, posts thread replies only for breaches in the **last two hours** or probe failures, then **updates the headline** with per-account status (latest hour, today’s DO-hours and cost, hours over ceiling). Forced 🧪 TEST RUNs use a separate thread so they do not overwrite the real day’s message.
> 
> The probe’s `--json` **`ProbeSummary`** now includes **all active hours** in the lookback (not just breaches). The alerter uses a **26h** lookback. **Empty Cloudflare analytics** after preview slot teardown is treated as quiet: credentials are validated via the **DO namespace list** API before accepting zero rows; misconfiguration still fails loudly.
> 
> **Ceilings** are retuned (dev/preview **500**, prd **600**, workflow docs aligned). **`renderDailyThread`** is covered by new Vitest cases for headline vs reply behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccc808a425c852ad782ce52154545eae2116c0d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->