### PR TITLE
Repo commits: amendIfHead replaces the head when it still is the head

### DIFF
--- a/apps/os/src/domains/repos/lazy-repo-reader.test.ts
+++ b/apps/os/src/domains/repos/lazy-repo-reader.test.ts
@@ -515,6 +515,83 @@ describe("resilience and reach (round 2)", () => {
   });
 });
 
+describe("amendIfHead", () => {
+  test("amends when the head matches: same parents, new tree, head dropped from history", async () => {
+    const { head: seed, remote } = await seededRemote();
+    const { reader } = subject(remote);
+    await syncTip(reader);
+    const first = await reader.commitFiles({
+      author: AUTHOR,
+      changes: [{ content: "## today\n- one\n", path: "log.md" }],
+      message: "log",
+    });
+    expect(first).toMatchObject({ kind: "applied", parentCommitOid: seed });
+    if (first.kind !== "applied") throw new Error("unreachable");
+
+    const second = await reader.commitFiles({
+      amendIfHead: first.commitOid,
+      author: AUTHOR,
+      changes: [{ content: "## today\n- one\n- two\n", path: "log.md" }],
+      message: "log",
+    });
+    // The superseded tip is the commit the caller named — that is an amend.
+    expect(second).toMatchObject({ kind: "applied", parentCommitOid: first.commitOid });
+    if (second.kind !== "applied") throw new Error("unreachable");
+    // The remote's head is the amended commit, whose parent is the SEED —
+    // the first commit is gone from main's history.
+    expect(remote.refs.get("refs/heads/main")).toBe(second.commitOid);
+    expect(parseCommit(remote.objects.get(second.commitOid)!.payload).parents).toEqual([seed]);
+    await expect(reader.readPaths(["log.md"])).resolves.toEqual(["## today\n- one\n- two\n"]);
+    // The store's head follows too, so the next amend chains from here.
+    expect(reader.head()?.commitOid).toBe(second.commitOid);
+  });
+
+  test("stacks an ordinary commit when the head moved on", async () => {
+    const { remote } = await seededRemote();
+    const { reader } = subject(remote);
+    await syncTip(reader);
+    const first = await reader.commitFiles({
+      author: AUTHOR,
+      changes: [{ content: "## today\n- one\n", path: "log.md" }],
+      message: "log",
+    });
+    if (first.kind !== "applied") throw new Error("unreachable");
+    const intervening = await externalEdit(remote, "tasks/one.md", "# someone else\n");
+    await reader.syncToHead(intervening);
+
+    const second = await reader.commitFiles({
+      amendIfHead: first.commitOid,
+      author: AUTHOR,
+      changes: [{ content: "## today\n- one\n- two\n", path: "log.md" }],
+      message: "log",
+    });
+    expect(second).toMatchObject({ kind: "applied", parentCommitOid: intervening });
+    if (second.kind !== "applied") throw new Error("unreachable");
+    expect(parseCommit(remote.objects.get(second.commitOid)!.payload).parents).toEqual([
+      intervening,
+    ]);
+    await expect(reader.readPaths(["tasks/one.md", "log.md"])).resolves.toEqual([
+      "# someone else\n",
+      "## today\n- one\n- two\n",
+    ]);
+  });
+
+  test("an amend of the root commit yields a new root commit", async () => {
+    const { head: seed, remote } = await seededRemote();
+    const { reader } = subject(remote);
+    await syncTip(reader);
+    const outcome = await reader.commitFiles({
+      amendIfHead: seed,
+      author: AUTHOR,
+      changes: [{ content: "# one amended\n", path: "tasks/one.md" }],
+      message: "seed, amended",
+    });
+    expect(outcome).toMatchObject({ kind: "applied", parentCommitOid: seed });
+    if (outcome.kind !== "applied") throw new Error("unreachable");
+    expect(parseCommit(remote.objects.get(outcome.commitOid)!.payload).parents).toEqual([]);
+  });
+});
+
 describe("install-time guards (round 4)", () => {
   test("onApplied fires INSIDE the chain: a queued guarded sync sees the new floor and skips", async () => {
     const { head, remote } = await seededRemote();

--- a/apps/os/src/domains/repos/lazy-repo-reader.ts
+++ b/apps/os/src/domains/repos/lazy-repo-reader.ts
@@ -349,6 +349,7 @@ export function createLazyRepoReader(input: {
      */
     commitFiles: (
       input: {
+        amendIfHead?: string;
         author: { date: Date; email: string; name: string };
         changes: RepoFileChange[];
         message: string;
@@ -363,6 +364,7 @@ export function createLazyRepoReader(input: {
    * head B that slipped in between. */
   async function commitFilesLocked(
     input: {
+      amendIfHead?: string;
       author: { date: Date; email: string; name: string };
       changes: RepoFileChange[];
       message: string;
@@ -372,6 +374,21 @@ export function createLazyRepoReader(input: {
     {
       const head = store.head(branch);
       if (head === null) throw new Error("lazy commit requires a synced head");
+      // Amend: the new commit takes the head's PARENTS, so the head drops out
+      // of history. The push below still CASes head → new, which is what
+      // keeps "unless the head moved" atomic: a competing push rejects ours
+      // and the retry sees a head that no longer matches — an ordinary
+      // commit on top. The head commit object is always in the store (every
+      // sync and every push puts it there); should it be missing, the throw
+      // sends the caller to its clone fallback, which stacks an ordinary
+      // commit.
+      let parents = [head.commitOid];
+      if (input.amendIfHead === head.commitOid) {
+        const headCommit = await store.getObject(head.commitOid);
+        if (headCommit === null)
+          throw new Error(`head commit ${head.commitOid} is not in the store`);
+        parents = parseCommit(headCommit.payload).parents;
+      }
       const manifest = new Map(store.manifest(branch).map((file) => [file.path, file]));
       const oldDirs = new Map(store.dirTrees(branch).map((dir) => [dir.path, dir.treeOid]));
 
@@ -489,7 +506,7 @@ export function createLazyRepoReader(input: {
       const commitPayload = encodeCommit({
         author: input.author,
         message: input.message.endsWith("\n") ? input.message : `${input.message}\n`,
-        parents: [head.commitOid],
+        parents,
         tree: newRootOid,
       });
       const commitOid = await hashObject("commit", commitPayload);

--- a/apps/os/src/domains/repos/repo-durable-object.ts
+++ b/apps/os/src/domains/repos/repo-durable-object.ts
@@ -699,7 +699,12 @@ export class RepoDurableObject extends DurableObject<Env> {
 
   async #commitFiles(input: CommitRepoFilesInput): Promise<CommitRepoFilesResult> {
     await this.#flushPendingCommitCompleted();
-    const parsed = parseCommitFilesInput(input);
+    let parsed = parseCommitFilesInput(input);
+    if (parsed.amendIfHead !== undefined && this.getGithubLink() !== null) {
+      // Never rewrite a GitHub-linked repo: the mirror push cannot force with
+      // a lease, so history stays append-only there and the commit stacks.
+      parsed = { ...parsed, amendIfHead: undefined };
+    }
     const repo = await this.gitAccess();
     const branch = parsed.branch ?? repo.defaultBranch;
     if (branch === REPO_DEFAULT_BRANCH) {
@@ -721,6 +726,8 @@ export class RepoDurableObject extends DurableObject<Env> {
       }
       console.warn(`lazy commit fell back to the clone lane (safe): ${attempt.detail}`);
     }
+    // The clone fallback never amends (its git wrapper cannot re-parent); an
+    // ordinary commit on top is the degraded outcome, reported as such.
     const result = await commitFilesToArtifactRepo({
       author: parsed.author,
       branch,
@@ -752,6 +759,7 @@ export class RepoDurableObject extends DurableObject<Env> {
     await this.#flushPendingCommitCompleted();
 
     return {
+      amended: false,
       branch: result.branch,
       changedPaths: result.changedPaths,
       commitOid: result.commitOid,
@@ -776,6 +784,7 @@ export class RepoDurableObject extends DurableObject<Env> {
     const branch = REPO_DEFAULT_BRANCH;
     const reader = this.#lazyReader();
     const command = {
+      amendIfHead: parsed.amendIfHead,
       author: {
         date: new Date(),
         email: parsed.author?.email ?? ITERATE_GITHUB_BOT_COMMIT_AUTHOR.email,
@@ -844,7 +853,13 @@ export class RepoDurableObject extends DurableObject<Env> {
     if (outcome.changedPaths.length === 0) {
       return {
         kind: "completed",
-        result: { branch, changedPaths: [], commitOid: outcome.commitOid, noChanges: true },
+        result: {
+          amended: false,
+          branch,
+          changedPaths: [],
+          commitOid: outcome.commitOid,
+          noChanges: true,
+        },
       };
     }
 
@@ -874,6 +889,9 @@ export class RepoDurableObject extends DurableObject<Env> {
     return {
       kind: "completed",
       result: {
+        // Amended exactly when the tip this commit superseded is the one the
+        // caller named.
+        amended: outcome.parentCommitOid === parsed.amendIfHead,
         branch,
         changedPaths: outcome.changedPaths,
         commitOid: outcome.commitOid,
@@ -924,6 +942,7 @@ export class RepoDurableObject extends DurableObject<Env> {
     await this.#flushPendingCommitCompleted();
 
     return {
+      amended: false,
       branch: result.branch,
       changedPaths: result.changedPaths,
       commitOid: result.commitOid,
@@ -2133,6 +2152,7 @@ async function mutateArtifactRepo<Extra extends Record<string, unknown>>(input: 
     const [head] = await git.log({ depth: 1 });
     if (!head) throw new Error("Repo has no commits.");
     return {
+      amended: false,
       branch: input.branch,
       changedPaths,
       commitOid: head.oid,
@@ -2164,6 +2184,7 @@ async function mutateArtifactRepo<Extra extends Record<string, unknown>>(input: 
   }
 
   return {
+    amended: false,
     branch: input.branch,
     changedPaths,
     commitOid: commit.oid,
@@ -2304,6 +2325,7 @@ function parseCommitFilesInput(input: CommitRepoFilesInput): CommitRepoFilesInpu
       throw new Error("commitFiles author must include non-empty name and email.");
     }
   }
+  if (input.amendIfHead !== undefined) assertCommitOid(input.amendIfHead);
 
   return {
     ...input,

--- a/apps/os/src/domains/repos/types.ts
+++ b/apps/os/src/domains/repos/types.ts
@@ -29,6 +29,13 @@ export type RepoFileChange =
 
 /** Command object for committing a batch of repo file mutations. */
 export type CommitRepoFilesInput = {
+  /**
+   * When the branch head is exactly this commit oid, the new commit REPLACES
+   * it (same parents, this message) instead of stacking on top. If the head
+   * has moved on — or the repo is GitHub-linked, whose history stays
+   * append-only — an ordinary commit lands; the result's `amended` says which.
+   */
+  amendIfHead?: string;
   author?: { email: string; name: string };
   branch?: string;
   changes: RepoFileChange[];
@@ -37,6 +44,8 @@ export type CommitRepoFilesInput = {
 
 /** Result returned after a repo commit attempt, including no-op commits. */
 export type CommitRepoFilesResult = {
+  /** True when `amendIfHead` matched the head and the commit replaced it. */
+  amended: boolean;
   branch: string;
   changedPaths: string[];
   commitOid: string;

--- a/apps/os/src/domains/workspaces/types.ts
+++ b/apps/os/src/domains/workspaces/types.ts
@@ -40,6 +40,10 @@ export type WorkspaceStatus = {
 
 /** Input to `WorkspaceGit.commit` — one mount's changes become one commit on its repo's main. */
 export type WorkspaceCommitInput = {
+  /** Replace the repo's head commit when it is exactly this oid instead of
+   * stacking on it — see the repo's `commitFiles`. The result's `amended`
+   * says which happened. */
+  amendIfHead?: string;
   author?: { email: string; name: string };
   message: string;
   /** The mount to commit (its mount path). Optional when exactly one mount is dirty. */
@@ -48,6 +52,8 @@ export type WorkspaceCommitInput = {
 
 /** Result of `WorkspaceGit.commit` — the commit landed on the scoped mount's repo main. */
 export type WorkspaceCommitResult = {
+  /** True when `amendIfHead` matched the head and the commit replaced it. */
+  amended: boolean;
   branch: string;
   /** Committed paths, spelled as absolute WORKSPACE paths (mount point included). */
   changedPaths: string[];

--- a/apps/os/src/domains/workspaces/workspace-core.test.ts
+++ b/apps/os/src/domains/workspaces/workspace-core.test.ts
@@ -58,7 +58,7 @@ function fakeKv() {
  * APPLY to the tree (content and deletions) exactly like production main, so
  * post-commit fall-through assertions test the real read-your-write shape. */
 function fakeRepo(tree: Record<string, string>) {
-  const commits: { changes: unknown[]; message: string }[] = [];
+  const commits: { amendIfHead?: string; changes: unknown[]; message: string }[] = [];
   const snapshotCalls: string[][] = [];
   const repo: MountRepoAccess = {
     readFile: async ({ encoding, path }) => {
@@ -88,13 +88,20 @@ function fakeRepo(tree: Record<string, string>) {
       return { commitOid: "head-oid", files };
     },
     commitFiles: async (input) => {
-      commits.push({ changes: input.changes, message: input.message });
+      commits.push({
+        amendIfHead: input.amendIfHead,
+        changes: input.changes,
+        message: input.message,
+      });
       for (const change of input.changes) {
         if ("delete" in change && change.delete) delete tree[change.path];
         else if ("content" in change) tree[change.path] = change.content;
         else if ("contentBase64" in change) tree[change.path] = atob(change.contentBase64);
       }
       return {
+        // The fake's head is always "head-oid"; matching it is what a real
+        // repo would call an amend.
+        amended: input.amendIfHead === "head-oid",
         branch: "main",
         changedPaths: input.changes.map((change) => change.path),
         commitOid: `commit-${commits.length}`,
@@ -307,6 +314,19 @@ describe("git status, commit, and log", () => {
     await expect(core.readFile(`${SCRATCH_ROOT}/notes.txt`)).resolves.toBe("survives");
     const statusAfter = await core.gitStatus();
     expect(statusAfter.mounts.find((mount) => mount.path === "/config")?.changes).toEqual([]);
+  });
+
+  test("commit forwards amendIfHead to the repo and reports whether it amended", async () => {
+    const { config, core } = subject();
+    await core.writeFile("/config/log.md", "## 2026-09-02\n- first\n");
+    const first = await core.gitCommit({ amendIfHead: "not-the-head", message: "log" });
+    expect(first.amended).toBe(false);
+    expect(config.commits[0]).toMatchObject({ amendIfHead: "not-the-head", message: "log" });
+
+    await core.writeFile("/config/log.md", "## 2026-09-02\n- first\n- second\n");
+    const second = await core.gitCommit({ amendIfHead: "head-oid", message: "log" });
+    expect(second.amended).toBe(true);
+    expect(config.commits[1]).toMatchObject({ amendIfHead: "head-oid" });
   });
 
   test("commit refuses to span mounts and names the scope choices", async () => {

--- a/apps/os/src/domains/workspaces/workspace-core.ts
+++ b/apps/os/src/domains/workspaces/workspace-core.ts
@@ -51,10 +51,17 @@ export interface MountRepoAccess {
     files: Record<string, string>;
   }>;
   commitFiles(input: {
+    amendIfHead?: string;
     author?: { email: string; name: string };
     changes: RepoFileChange[];
     message: string;
-  }): Promise<{ branch: string; changedPaths: string[]; commitOid: string; noChanges: boolean }>;
+  }): Promise<{
+    amended: boolean;
+    branch: string;
+    changedPaths: string[];
+    commitOid: string;
+    noChanges: boolean;
+  }>;
   log(input: { branch?: string; limit?: number }): Promise<{
     commits: {
       author: { email: string; name: string };
@@ -826,6 +833,7 @@ export class WorkspaceCore {
       }
 
       const result = await this.#repo(mount.repoPath).commitFiles({
+        amendIfHead: input.amendIfHead,
         author: input.author ?? DEFAULT_COMMIT_AUTHOR,
         changes: repoChanges,
         message: input.message,
@@ -847,6 +855,7 @@ export class WorkspaceCore {
       }
 
       return {
+        amended: result.amended,
         branch: result.branch,
         changedPaths: result.changedPaths
           .map((path) => `${mountPath}/${path.replace(/^\//, "")}`)

--- a/apps/os/src/itx-api-graph.generated.ts
+++ b/apps/os/src/itx-api-graph.generated.ts
@@ -1929,7 +1929,7 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
     name: "CommitRepoFilesInput",
     kind: "typeAlias",
     sourceText:
-      "/** Command object for committing a batch of repo file mutations. */\nexport type CommitRepoFilesInput = {\n  author?: { email: string; name: string };\n  branch?: string;\n  changes: RepoFileChange[];\n  message: string;\n};",
+      "/** Command object for committing a batch of repo file mutations. */\nexport type CommitRepoFilesInput = {\n  /**\n   * When the branch head is exactly this commit oid, the new commit REPLACES\n   * it (same parents, this message) instead of stacking on top. If the head\n   * has moved on — or the repo is GitHub-linked, whose history stays\n   * append-only — an ordinary commit lands; the result's `amended` says which.\n   */\n  amendIfHead?: string;\n  author?: { email: string; name: string };\n  branch?: string;\n  changes: RepoFileChange[];\n  message: string;\n};",
     summary: "Command object for committing a batch of repo file mutations.",
     memberSummaries: {},
     referencedTypeNames: ["RepoFileChange"],
@@ -1938,7 +1938,7 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
     name: "CommitRepoFilesResult",
     kind: "typeAlias",
     sourceText:
-      "/** Result returned after a repo commit attempt, including no-op commits. */\nexport type CommitRepoFilesResult = {\n  branch: string;\n  changedPaths: string[];\n  commitOid: string;\n  noChanges: boolean;\n};",
+      "/** Result returned after a repo commit attempt, including no-op commits. */\nexport type CommitRepoFilesResult = {\n  /** True when `amendIfHead` matched the head and the commit replaced it. */\n  amended: boolean;\n  branch: string;\n  changedPaths: string[];\n  commitOid: string;\n  noChanges: boolean;\n};",
     summary: "Result returned after a repo commit attempt, including no-op commits.",
     memberSummaries: {},
     referencedTypeNames: [],
@@ -2713,7 +2713,7 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
     name: "WorkspaceCommitInput",
     kind: "typeAlias",
     sourceText:
-      "/** Input to `WorkspaceGit.commit` — one mount's changes become one commit on its repo's main. */\nexport type WorkspaceCommitInput = {\n  author?: { email: string; name: string };\n  message: string;\n  /** The mount to commit (its mount path). Optional when exactly one mount is dirty. */\n  scope?: string;\n};",
+      "/** Input to `WorkspaceGit.commit` — one mount's changes become one commit on its repo's main. */\nexport type WorkspaceCommitInput = {\n  /** Replace the repo's head commit when it is exactly this oid instead of\n   * stacking on it — see the repo's `commitFiles`. The result's `amended`\n   * says which happened. */\n  amendIfHead?: string;\n  author?: { email: string; name: string };\n  message: string;\n  /** The mount to commit (its mount path). Optional when exactly one mount is dirty. */\n  scope?: string;\n};",
     summary:
       "Input to `WorkspaceGit.commit` — one mount's changes become one commit on its repo's main.",
     memberSummaries: {},
@@ -2723,7 +2723,7 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
     name: "WorkspaceCommitResult",
     kind: "typeAlias",
     sourceText:
-      "/** Result of `WorkspaceGit.commit` — the commit landed on the scoped mount's repo main. */\nexport type WorkspaceCommitResult = {\n  branch: string;\n  /** Committed paths, spelled as absolute WORKSPACE paths (mount point included). */\n  changedPaths: string[];\n  commitOid: string;\n  /** The mount the commit was scoped to (its workspace path). */\n  mount: string;\n  repoPath: string;\n};",
+      "/** Result of `WorkspaceGit.commit` — the commit landed on the scoped mount's repo main. */\nexport type WorkspaceCommitResult = {\n  /** True when `amendIfHead` matched the head and the commit replaced it. */\n  amended: boolean;\n  branch: string;\n  /** Committed paths, spelled as absolute WORKSPACE paths (mount point included). */\n  changedPaths: string[];\n  commitOid: string;\n  /** The mount the commit was scoped to (its workspace path). */\n  mount: string;\n  repoPath: string;\n};",
     summary: "Result of `WorkspaceGit.commit` — the commit landed on the scoped mount's repo main.",
     memberSummaries: {},
     referencedTypeNames: [],

--- a/apps/os/src/itx-api.generated.ts
+++ b/apps/os/src/itx-api.generated.ts
@@ -3619,6 +3619,13 @@ export type RepoCreateInput =
 
 /** Command object for committing a batch of repo file mutations. */
 export type CommitRepoFilesInput = {
+  /**
+   * When the branch head is exactly this commit oid, the new commit REPLACES
+   * it (same parents, this message) instead of stacking on top. If the head
+   * has moved on — or the repo is GitHub-linked, whose history stays
+   * append-only — an ordinary commit lands; the result's `amended` says which.
+   */
+  amendIfHead?: string;
   author?: { email: string; name: string };
   branch?: string;
   changes: RepoFileChange[];
@@ -3627,6 +3634,8 @@ export type CommitRepoFilesInput = {
 
 /** Result returned after a repo commit attempt, including no-op commits. */
 export type CommitRepoFilesResult = {
+  /** True when `amendIfHead` matched the head and the commit replaced it. */
+  amended: boolean;
   branch: string;
   changedPaths: string[];
   commitOid: string;
@@ -5442,6 +5451,10 @@ export type WorkspaceStatus = {
 
 /** Input to `WorkspaceGit.commit` — one mount's changes become one commit on its repo's main. */
 export type WorkspaceCommitInput = {
+  /** Replace the repo's head commit when it is exactly this oid instead of
+   * stacking on it — see the repo's `commitFiles`. The result's `amended`
+   * says which happened. */
+  amendIfHead?: string;
   author?: { email: string; name: string };
   message: string;
   /** The mount to commit (its mount path). Optional when exactly one mount is dirty. */
@@ -5450,6 +5463,8 @@ export type WorkspaceCommitInput = {
 
 /** Result of `WorkspaceGit.commit` — the commit landed on the scoped mount's repo main. */
 export type WorkspaceCommitResult = {
+  /** True when `amendIfHead` matched the head and the commit replaced it. */
+  amended: boolean;
   branch: string;
   /** Committed paths, spelled as absolute WORKSPACE paths (mount point included). */
   changedPaths: string[];

--- a/packages/iterate/src/itx-api.generated.ts
+++ b/packages/iterate/src/itx-api.generated.ts
@@ -3619,6 +3619,13 @@ export type RepoCreateInput =
 
 /** Command object for committing a batch of repo file mutations. */
 export type CommitRepoFilesInput = {
+  /**
+   * When the branch head is exactly this commit oid, the new commit REPLACES
+   * it (same parents, this message) instead of stacking on top. If the head
+   * has moved on — or the repo is GitHub-linked, whose history stays
+   * append-only — an ordinary commit lands; the result's `amended` says which.
+   */
+  amendIfHead?: string;
   author?: { email: string; name: string };
   branch?: string;
   changes: RepoFileChange[];
@@ -3627,6 +3634,8 @@ export type CommitRepoFilesInput = {
 
 /** Result returned after a repo commit attempt, including no-op commits. */
 export type CommitRepoFilesResult = {
+  /** True when `amendIfHead` matched the head and the commit replaced it. */
+  amended: boolean;
   branch: string;
   changedPaths: string[];
   commitOid: string;
@@ -5442,6 +5451,10 @@ export type WorkspaceStatus = {
 
 /** Input to `WorkspaceGit.commit` — one mount's changes become one commit on its repo's main. */
 export type WorkspaceCommitInput = {
+  /** Replace the repo's head commit when it is exactly this oid instead of
+   * stacking on it — see the repo's `commitFiles`. The result's `amended`
+   * says which happened. */
+  amendIfHead?: string;
   author?: { email: string; name: string };
   message: string;
   /** The mount to commit (its mount path). Optional when exactly one mount is dirty. */
@@ -5450,6 +5463,8 @@ export type WorkspaceCommitInput = {
 
 /** Result of `WorkspaceGit.commit` — the commit landed on the scoped mount's repo main. */
 export type WorkspaceCommitResult = {
+  /** True when `amendIfHead` matched the head and the commit replaced it. */
+  amended: boolean;
   branch: string;
   /** Committed paths, spelled as absolute WORKSPACE paths (mount point included). */
   changedPaths: string[];


### PR DESCRIPTION
`repo.commitFiles` and `workspace.git.commit` take an optional `amendIfHead`: a commit oid. When the branch head is exactly that commit at write time, the new commit takes the head's parents instead of stacking on it, so the head drops out of history. When the head has moved on, an ordinary commit lands on top. The result says which happened.

```ts
const head = (await ws.git.log({ limit: 1 }))[0]?.commitOid;
const result = await ws.git.commit({ message: "Notes: 2026-09-04", scope: "/repos/config", amendIfHead: head });
result.amended; // true → the head was replaced; false → an ordinary commit stacked
```

Content is never at stake, only the shape of history. Two places never amend and report `amended: false`:

- **GitHub-linked repos.** Rewriting main there would need a force push, and the mirror push (isomorphic-git, no expected old oid) cannot make a force push a compare-and-swap. History stays append-only on linked repos.
- **The clone fallback.** Its git wrapper cannot re-parent a commit; an ordinary commit on top is the degraded outcome.

Split out of #2578 (the Notes view), which needs this for its "one commit per day" auto-commit. This is the platform half on its own; the app half follows separately and smaller.

## Risk map

- **`lazy-repo-reader.ts`, the amend itself.** Correctness rests on the existing CAS push (head → new): a competing push rejects ours and the retry sees a head that no longer matches, so "still the head" cannot race another writer. The head commit object is read from the store for its parents; every sync and every push stores it, and a missing one throws, which sends the Durable Object to its clone fallback (stacks, `amended: false`). Covered by unit tests: amend replaces the head, stacks after an intervening external commit, amend of the root commit yields a new root.
- **`repo-durable-object.ts`, `amended` derivation.** The lazy outcome already reports the tip it superseded; amended is exactly "that tip is the one the caller named". No-change commits report `amended: false`.
- **On merge:** nothing changes for callers that do not pass `amendIfHead`. The result gains a required `amended` field; `itx-api.generated.ts` regenerated.

Review order: `lazy-repo-reader.ts` → `repo-durable-object.ts` → the two `types.ts` and `workspace-core.ts` (pass-through) → tests → generated files.

## Testing

- `lazy-repo-reader.test.ts`: 3 new cases against the in-memory remote (amend, stack after intervening commit, root amend).
- `workspace-core.test.ts`: `amendIfHead` forwarded to the repo, `amended` reported back.
- `pnpm typecheck`, `pnpm lint`, formatted; `pnpm generate:itx-api` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — https://claude.ai/code/session_016Wjk1kkBAjCkHSzRWxKYmY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core git write paths (lazy CAS commits and history shape); mitigated by existing compare-and-swap, GitHub-link stripping, and explicit `amended` reporting, but incorrect amend logic could still corrupt branch history on non-linked repos.
> 
> **Overview**
> Adds optional **`amendIfHead`** to `repo.commitFiles` and **`workspace.git.commit`**. When the branch tip is exactly that commit oid at write time, the lazy commit lane builds a new commit with the head’s **parents** (dropping the named tip from history) and CAS-pushes as usual; if the head moved, behavior is a normal stack-on-top commit.
> 
> Commit results now include a required **`amended`** flag (`true` only when the superseded tip equals `amendIfHead`). **GitHub-linked** repos ignore amend (append-only mirror); the **clone fallback** always stacks and reports `amended: false`. Input validation requires a full 40-char oid for `amendIfHead`.
> 
> Unit tests cover amend, stack-after-intervening commit, and root amend; workspace tests verify pass-through. Generated itx API types are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c420dba7623747be70a0936e4513de440f0c179a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +67 -4 | +28 -3 🟩🟩⬜⬜⬜ |
| Tests | +99 -2 | +86 -2 🟩🟩🟩🟩🟩 |
| Generated | +34 -4 | +4 -4 🟩⬜⬜⬜⬜ |
| **Total** | **+200 -10** | **+118 -9** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between e281655 and c420dba, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-09-04T12:05:26.894Z",
      "deployedAt": "2026-09-04T10:53:40.062Z",
      "headSha": "c420dba7623747be70a0936e4513de440f0c179a",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/96644732668040",
      "shortSha": "c420dba",
      "cleanupDurationMs": 97699,
      "deployDurationMs": 75046,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 73954,
      "deployReadinessDurationMs": 1089,
      "deployedWorkerName": "os-preview-8",
      "deployedWorkerVersion": "5d3bd2fc-d1e2-41fc-abf6-afdd92da147b",
      "testDurationMs": 309997,
      "testRetries": "3 retried: a disposed test project stops waking its Durable Objects (vitest x1) · the source-version pin tells a facet that recycled from one the commit rebuilt (vitest x1) · a userspace facet rebuilds on a source commit and only on a source commit (vitest x1)",
      "workerSizeKib": 20952.56,
      "workerGzipKib": 5282.67,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5292.84
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-09-04T12:03:53.092Z",
      "deployedAt": "2026-09-04T10:52:50.358Z",
      "headSha": "c420dba7623747be70a0936e4513de440f0c179a",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-8.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/96644732668040",
      "shortSha": "c420dba",
      "cleanupDurationMs": 3895,
      "deployDurationMs": 24501,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 24248,
      "deployReadinessDurationMs": 249,
      "deployedWorkerName": "docs-preview-8",
      "deployedWorkerVersion": "c94088e5-c81d-4214-8619-0ef0c24d5e3c",
      "testDurationMs": 6742,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-09-04T12:03:50.613Z",
      "deployedAt": "2026-09-04T10:52:49.742Z",
      "headSha": "c420dba7623747be70a0936e4513de440f0c179a",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/96644732668040",
      "shortSha": "c420dba",
      "cleanupDurationMs": 1411,
      "deployDurationMs": 23796,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 23631,
      "deployReadinessDurationMs": 160,
      "deployedWorkerName": "semaphore-preview-8",
      "deployedWorkerVersion": "2573956b-97c0-40bf-8b1f-ad11ee4b788a",
      "testDurationMs": 55620,
      "testRetries": null,
      "workerSizeKib": 1960.48,
      "workerGzipKib": 453.78,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-09-04T12:03:54.257Z",
      "deployedAt": "2026-09-04T10:52:56.714Z",
      "headSha": "c420dba7623747be70a0936e4513de440f0c179a",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/96644732668040",
      "shortSha": "c420dba",
      "cleanupDurationMs": 5055,
      "deployDurationMs": 30906,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 30602,
      "deployReadinessDurationMs": 300,
      "deployedWorkerName": "auth-preview-8",
      "deployedWorkerVersion": "9d09278f-b047-48a4-80b3-bcb938999ab4",
      "testDurationMs": 22816,
      "testRetries": null,
      "workerSizeKib": 4178.28,
      "workerGzipKib": 855.16,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-09-04T12:03:53.938Z",
      "deployedAt": "2026-09-04T10:52:49.889Z",
      "headSha": "c420dba7623747be70a0936e4513de440f0c179a",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/96644732668040",
      "shortSha": "c420dba",
      "cleanupDurationMs": 4733,
      "deployDurationMs": 24133,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 23776,
      "deployReadinessDurationMs": 352,
      "deployedWorkerName": "streams-example-app-preview-8",
      "deployedWorkerVersion": "28649ae1-88c7-4cf7-9cf8-cd3b14498c12",
      "testDurationMs": 62774,
      "testRetries": null,
      "workerSizeKib": 5649.16,
      "workerGzipKib": 1598.27,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-09-04T12:03:51.989Z",
      "deployedAt": "2026-09-04T10:52:55.322Z",
      "headSha": "c420dba7623747be70a0936e4513de440f0c179a",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/96644732668040",
      "shortSha": "c420dba",
      "cleanupDurationMs": 1376,
      "deployDurationMs": 5579,
      "deployConfigDurationMs": 0,
      "deployCommandDurationMs": 5415,
      "deployReadinessDurationMs": 161,
      "deployedWorkerName": "dummy-petshop-preview-8",
      "deployedWorkerVersion": "9f65f355-11e1-4462-b109-60d1a15f96fa",
      "testDurationMs": 46730,
      "testRetries": null,
      "workerSizeKib": 1331.5,
      "workerGzipKib": 232.81,
      "deployedFingerprint": "c321865fd82cf1ce04086fcbe3c487f157babc45+c5abf1055de73f3b4ffbc5e5b742dff1f0b5ee52",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `c420dba` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 855.2 KiB | 30.9s | 22.8s |  | 5.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/96644732668040) | 2026-09-04T12:03:54.257Z | Preview app released. |
| Docs | released | `c420dba` | [https://docs-preview-8.iterate-dev-preview.workers.dev](https://docs-preview-8.iterate-dev-preview.workers.dev) | 866.2 KiB | 24.5s | 6.7s |  | 3.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/96644732668040) | 2026-09-04T12:03:53.092Z | Preview app released. |
| Dummy Petshop | released | `c420dba` | [https://dummy-petshop.iterate-preview-8.com](https://dummy-petshop.iterate-preview-8.com) | 232.8 KiB | 5.6s | 46.7s |  | 1.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/96644732668040) | 2026-09-04T12:03:51.989Z | Preview app released. |
| OS | released | `c420dba` | [https://os.iterate-preview-8.com](https://os.iterate-preview-8.com) | 5.16 MiB (-10.2 KiB vs main) | 75.0s | 310.0s | 3 retried: a disposed test project stops waking its Durable Objects (vitest x1) · the source-version pin tells a facet that recycled from one the commit rebuilt (vitest x1) · a userspace facet rebuilds on a source commit and only on a source commit (vitest x1) | 97.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/96644732668040) | 2026-09-04T12:05:26.894Z | Preview app released. |
| Semaphore | released | `c420dba` | [https://semaphore.iterate-preview-8.com](https://semaphore.iterate-preview-8.com) | 453.8 KiB | 23.8s | 55.6s |  | 1.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/96644732668040) | 2026-09-04T12:03:50.613Z | Preview app released. |
| Streams Example App | released | `c420dba` | [https://streams.iterate-preview-8.com](https://streams.iterate-preview-8.com) | 1.56 MiB | 24.1s | 62.8s |  | 4.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/96644732668040) | 2026-09-04T12:03:53.938Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->