### PR TITLE
Pin retries: 0 for playwright-wrapped flake/failing tests

### DIFF
--- a/packages/shared/src/test-support/failing-test.test.ts
+++ b/packages/shared/src/test-support/failing-test.test.ts
@@ -66,11 +66,21 @@ test("every outcome writes a kind-failing record when FLAKE_RECORD_DIR is set", 
 
 test("a playwright-shaped test object registers through .fail", async () => {
   const registered: unknown[][] = [];
+  const configured: unknown[] = [];
+  // A faithful playwright shape: describe invokes its body synchronously and
+  // carries configure, exactly like the real test object — the wrapper calls
+  // both unconditionally rather than hedging on their presence.
   const fakePlaywright = Object.assign(vi.fn(), {
     fail: (...args: unknown[]) => registered.push(args),
+    setTimeout: vi.fn(),
+    describe: Object.assign((body: () => void) => body(), {
+      configure: (options: unknown) => configured.push(options),
+    }),
   });
   createFailing(fakePlaywright, /pinned/)("name", async () => {});
   expect(registered).toHaveLength(1);
+  // Same zero-retry describe pin as createFlake — see that test for why.
+  expect(configured).toEqual([{ retries: 0 }]);
 });
 
 test("a body failing for a different reason returns success, so the native machinery goes red", async () => {

--- a/packages/shared/src/test-support/failing-test.ts
+++ b/packages/shared/src/test-support/failing-test.ts
@@ -1,4 +1,9 @@
 import { appendFlakeRecord, type FlakeRecord } from "./flake-record.ts";
+
+/** The playwright statics the wrappers rely on to pin retries per-registration. */
+type PlaywrightLikeDescribe = ((body: () => void) => void) & {
+  configure: (options: { retries: number }) => void;
+};
 /**
  * Pinned-bug tests: the body asserts the DESIRED behavior, and while the bug
  * exists it must fail with an error matching the given pattern.
@@ -150,7 +155,14 @@ export function createFailing<TestFn extends (...args: any[]) => any>(
       const callerOptions = args.length > 2 ? (args[1] as object) : {};
       return failer(args[0], { ...callerOptions, retry: 0 }, wrapped);
     }
-    return failer(...args.slice(0, -1), wrapped);
+    // playwright-like: pin retries structurally via an anonymous describe
+    // scope — same reasoning (and same cast) as createFlake, see
+    // ./flake-test.ts.
+    const playwrightLike = test as { describe: PlaywrightLikeDescribe };
+    return playwrightLike.describe(() => {
+      playwrightLike.describe.configure({ retries: 0 });
+      failer(...args.slice(0, -1), wrapped);
+    });
   };
   // The cast restates the contract the wrapper keeps by construction: it
   // forwards every argument unchanged except the trailing body, which it

--- a/packages/shared/src/test-support/failing-test.ts
+++ b/packages/shared/src/test-support/failing-test.ts
@@ -1,9 +1,4 @@
 import { appendFlakeRecord, type FlakeRecord } from "./flake-record.ts";
-
-/** The playwright statics the wrappers rely on to pin retries per-registration. */
-type PlaywrightLikeDescribe = ((body: () => void) => void) & {
-  configure: (options: { retries: number }) => void;
-};
 /**
  * Pinned-bug tests: the body asserts the DESIRED behavior, and while the bug
  * exists it must fail with an error matching the given pattern.
@@ -158,7 +153,11 @@ export function createFailing<TestFn extends (...args: any[]) => any>(
     // playwright-like: pin retries structurally via an anonymous describe
     // scope — same reasoning (and same cast) as createFlake, see
     // ./flake-test.ts.
-    const playwrightLike = test as { describe: PlaywrightLikeDescribe };
+    const playwrightLike = test as unknown as {
+      describe: ((body: () => void) => void) & {
+        configure: (options: { retries: number }) => void;
+      };
+    };
     return playwrightLike.describe(() => {
       playwrightLike.describe.configure({ retries: 0 });
       failer(...args.slice(0, -1), wrapped);

--- a/packages/shared/src/test-support/flake-test.test.ts
+++ b/packages/shared/src/test-support/flake-test.test.ts
@@ -118,11 +118,23 @@ test("registration lands on the runner's own expected-fail variant", async () =>
 
 test("a playwright-shaped test object registers through .fail", async () => {
   const registered: unknown[][] = [];
+  const configured: unknown[] = [];
+  // A faithful playwright shape: describe invokes its body synchronously and
+  // carries configure, exactly like the real test object — the wrapper calls
+  // both unconditionally rather than hedging on their presence.
   const fakePlaywright = Object.assign(vi.fn(), {
     fail: (...args: unknown[]) => registered.push(args),
+    setTimeout: vi.fn(),
+    describe: Object.assign((body: () => void) => body(), {
+      configure: (options: unknown) => configured.push(options),
+    }),
   });
   createFlake(fakePlaywright, /flaked/)("name", async () => {});
   expect(registered).toHaveLength(1);
+  // Registration happens inside a describe scope pinned to zero retries —
+  // playwright has no per-test retry option, and a retried RED outcome would
+  // double-record the run.
+  expect(configured).toEqual([{ retries: 0 }]);
 });
 
 test("a matching failure rethrows (green) and records a flake-fail line", async () => {

--- a/packages/shared/src/test-support/flake-test.ts
+++ b/packages/shared/src/test-support/flake-test.ts
@@ -45,11 +45,6 @@
  */
 import { appendFlakeRecord, type FlakeRecord } from "./flake-record.ts";
 
-/** The playwright statics the wrappers rely on to pin retries per-registration. */
-type PlaywrightLikeDescribe = ((body: () => void) => void) & {
-  configure: (options: { retries: number }) => void;
-};
-
 export function createFlake<TestFn extends (...args: any[]) => any>(
   test: TestFn,
   flake: RegExp,
@@ -149,7 +144,11 @@ export function createFlake<TestFn extends (...args: any[]) => any>(
     // unexpectedly") from being retried, which double-recorded the run and
     // could rescue it into a distorting green. The cast reaches playwright's
     // describe statics, which the wrapped TestFn type does not carry.
-    const playwrightLike = test as { describe: PlaywrightLikeDescribe };
+    const playwrightLike = test as unknown as {
+      describe: ((body: () => void) => void) & {
+        configure: (options: { retries: number }) => void;
+      };
+    };
     return playwrightLike.describe(() => {
       playwrightLike.describe.configure({ retries: 0 });
       failer(...args.slice(0, -1), wrapped);

--- a/packages/shared/src/test-support/flake-test.ts
+++ b/packages/shared/src/test-support/flake-test.ts
@@ -45,6 +45,11 @@
  */
 import { appendFlakeRecord, type FlakeRecord } from "./flake-record.ts";
 
+/** The playwright statics the wrappers rely on to pin retries per-registration. */
+type PlaywrightLikeDescribe = ((body: () => void) => void) & {
+  configure: (options: { retries: number }) => void;
+};
+
 export function createFlake<TestFn extends (...args: any[]) => any>(
   test: TestFn,
   flake: RegExp,
@@ -136,7 +141,19 @@ export function createFlake<TestFn extends (...args: any[]) => any>(
       const callerOptions = args.length > 2 ? (args[1] as object) : {};
       return failer(args[0], { ...callerOptions, retry: 0 }, wrapped);
     }
-    return failer(...args.slice(0, -1), wrapped);
+    // playwright-like: no per-test retry option exists, so pin retries
+    // structurally — an anonymous describe scope (empty title segment,
+    // dropped by titlePath().filter(Boolean), so the test's identity is
+    // unchanged) with retries pinned to zero. The green outcomes already
+    // satisfy test.fail unretried; this also stops the RED path ("passed
+    // unexpectedly") from being retried, which double-recorded the run and
+    // could rescue it into a distorting green. The cast reaches playwright's
+    // describe statics, which the wrapped TestFn type does not carry.
+    const playwrightLike = test as { describe: PlaywrightLikeDescribe };
+    return playwrightLike.describe(() => {
+      playwrightLike.describe.configure({ retries: 0 });
+      failer(...args.slice(0, -1), wrapped);
+    });
   };
   // Same contract-preserving cast as createFailing(): every argument forwards
   // unchanged except the trailing body.

--- a/tasks/playwright-wrapper-retry-pin.md
+++ b/tasks/playwright-wrapper-retry-pin.md
@@ -1,0 +1,43 @@
+---
+status: in-progress
+size: small
+branch: playwright-wrapper-retry-pin
+---
+
+# Pin retries: 0 for playwright-wrapped flake/failing tests
+
+Agreed in discussion 2026-09-04. Playwright has no per-test `retry` option
+(vitest does — the wrappers already pass `{ retry: 0 }` there), so the
+playwright branch of `createFlake`/`createFailing` registers inside an
+anonymous `test.describe` scope carrying
+`test.describe.configure({ retries: 0 })`.
+
+## Why
+
+The green paths were already structurally unretryable (both end in a throw
+that satisfies `test.fail`, and playwright only retries unexpected
+outcomes). The leak is the RED path: "passed unexpectedly" IS unexpected, so
+playwright retried it — double-recording ❌ and occasionally rescuing the run
+into a green that distorts the record stream. With the pin, both runners have
+identical semantics: a wrapped test never retries, period.
+
+An anonymous describe keeps identity intact: it contributes an empty title
+segment that `titlePath().filter(Boolean)` drops, so the leaf title — the
+dashboard row key — and reported fullName are unchanged.
+
+## Checklist
+
+- [ ] createFlake: playwright branch registers via anonymous describe +
+      `configure({ retries: 0 })`.
+- [ ] createFailing: same.
+- [ ] Faithful fakes, not production fallbacks (Misha's call): the unit-test
+      fake playwright objects grow `describe`/`describe.configure` (invoking
+      the callback synchronously), and the tests assert the configure call —
+      no `"describe" in test` hedging in the wrappers.
+
+## Notes
+
+- #2575 (open) restructures failing-test.ts's registration branch around
+  `"setTimeout" in test`; this PR keeps the existing `"fails" in test` split
+  and only wraps the else branch, so whichever lands second does a small
+  fix-up.

--- a/tasks/playwright-wrapper-retry-pin.md
+++ b/tasks/playwright-wrapper-retry-pin.md
@@ -27,10 +27,10 @@ dashboard row key — and reported fullName are unchanged.
 
 ## Checklist
 
-- [ ] createFlake: playwright branch registers via anonymous describe +
+- [x] createFlake: playwright branch registers via anonymous describe +
       `configure({ retries: 0 })`.
-- [ ] createFailing: same.
-- [ ] Faithful fakes, not production fallbacks (Misha's call): the unit-test
+- [x] createFailing: same.
+- [x] Faithful fakes, not production fallbacks (Misha's call): the unit-test
       fake playwright objects grow `describe`/`describe.configure` (invoking
       the callback synchronously), and the tests assert the configure call —
       no `"describe" in test` hedging in the wrappers.


### PR DESCRIPTION
Playwright has no per-test `retry` option, so the playwright branch of `createFlake`/`createFailing` now registers inside an anonymous `test.describe` scope with `configure({ retries: 0 })` — closing the red-path leak where a "passed unexpectedly" wrapped test got retried, double-recording ❌ and occasionally rescuing the run. Both runners now share one semantic: a wrapped test never retries.

The anonymous describe keeps the test's leaf title (the dashboard row key) and reported fullName unchanged — `titlePath().filter(Boolean)` drops the empty segment.

Fakes made faithful instead of adding wrapper fallbacks: the unit tests' fake playwright objects grow `describe`/`describe.configure` and assert the configure call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Session: 4fe3e39f-bdf2-4b87-8ed3-b77d4252fd95 ("flake dashboard follow-ups")_

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +29 -2 | +12 -2 🟩🟩⬜⬜⬜ |
| Tests | +22 -0 | +12 -0 🟩🟩⬜⬜⬜ |
| Docs | +43 -0 | +34 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+94 -2** | **+58 -2** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between f266ace and 9b0d826, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-09-04T17:20:48.467Z",
      "deployedAt": "2026-09-04T16:44:14.362Z",
      "headSha": "9b0d826dae1d117ce46576d9e7981e79e1a61e09",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/23323930402102",
      "shortSha": "9b0d826",
      "cleanupDurationMs": 8438,
      "deployDurationMs": 80056,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 78754,
      "deployReadinessDurationMs": 1299,
      "deployedWorkerName": "os-preview-7",
      "deployedWorkerVersion": "38badc5c-6c25-45ba-b247-df5d7d1079fc",
      "testDurationMs": 241202,
      "testRetries": "1 retried: agent-fake-model-chat.spec.ts › multi-turn chat with a sarcastic agent served by the spec's own fake-model interceptor › web (playwright x1) — TimeoutError: locator.waitFor: Timeout 1ms exceeded. Call log: \u001b[2m - waiting for getByText(/\"why are you like this\\?\" do you hear yourself/i) to be visible\u001b[22m \u001b[33m If this is a slow operation, update the product code to add a spinner while it's running. This will improve the user experience a...",
      "workerSizeKib": 20952.56,
      "workerGzipKib": 5282.67,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5293.36
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-09-04T17:20:44.154Z",
      "deployedAt": "2026-09-04T16:43:19.835Z",
      "headSha": "9b0d826dae1d117ce46576d9e7981e79e1a61e09",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-7.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/23323930402102",
      "shortSha": "9b0d826",
      "cleanupDurationMs": 4121,
      "deployDurationMs": 26742,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 24225,
      "deployReadinessDurationMs": 2514,
      "deployedWorkerName": "docs-preview-7",
      "deployedWorkerVersion": "9eb39143-b93f-44b3-8f47-d7e293c155d4",
      "testDurationMs": 3025,
      "testRetries": null,
      "workerSizeKib": 3637.46,
      "workerGzipKib": 866.22,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-09-04T17:20:41.051Z",
      "deployedAt": "2026-09-04T16:43:17.359Z",
      "headSha": "9b0d826dae1d117ce46576d9e7981e79e1a61e09",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/23323930402102",
      "shortSha": "9b0d826",
      "cleanupDurationMs": 1018,
      "deployDurationMs": 21997,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 21747,
      "deployReadinessDurationMs": 244,
      "deployedWorkerName": "semaphore-preview-7",
      "deployedWorkerVersion": "595833cf-20ec-4f3a-a16e-da1c3771a0b7",
      "testDurationMs": 50091,
      "testRetries": null,
      "workerSizeKib": 1960.48,
      "workerGzipKib": 453.78,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-09-04T17:20:44.916Z",
      "deployedAt": "2026-09-04T16:43:29.436Z",
      "headSha": "9b0d826dae1d117ce46576d9e7981e79e1a61e09",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/23323930402102",
      "shortSha": "9b0d826",
      "cleanupDurationMs": 4880,
      "deployDurationMs": 33888,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 33824,
      "deployReadinessDurationMs": 59,
      "deployedWorkerName": "auth-preview-7",
      "deployedWorkerVersion": "2857e015-7e42-4633-b305-46643fa1ec1f",
      "testDurationMs": 18498,
      "testRetries": null,
      "workerSizeKib": 4178.28,
      "workerGzipKib": 855.49,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-09-04T17:20:45.029Z",
      "deployedAt": "2026-09-04T16:43:27.875Z",
      "headSha": "9b0d826dae1d117ce46576d9e7981e79e1a61e09",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/23323930402102",
      "shortSha": "9b0d826",
      "cleanupDurationMs": 4992,
      "deployDurationMs": 32818,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 32261,
      "deployReadinessDurationMs": 550,
      "deployedWorkerName": "streams-example-app-preview-7",
      "deployedWorkerVersion": "abfa2a8e-7400-40b3-abd9-3cf5d60e7be2",
      "testDurationMs": 72419,
      "testRetries": null,
      "workerSizeKib": 5649.16,
      "workerGzipKib": 1598.27,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-09-04T17:20:42.356Z",
      "deployedAt": "2026-09-04T16:43:23.833Z",
      "headSha": "9b0d826dae1d117ce46576d9e7981e79e1a61e09",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-7.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/23323930402102",
      "shortSha": "9b0d826",
      "cleanupDurationMs": 1305,
      "deployDurationMs": 6399,
      "deployConfigDurationMs": 0,
      "deployCommandDurationMs": 6225,
      "deployReadinessDurationMs": 170,
      "deployedWorkerName": "dummy-petshop-preview-7",
      "deployedWorkerVersion": "9afa5cde-ba67-4ae0-8979-19dda7300582",
      "testDurationMs": 40614,
      "testRetries": null,
      "workerSizeKib": 1331.5,
      "workerGzipKib": 232.81,
      "deployedFingerprint": "c321865fd82cf1ce04086fcbe3c487f157babc45+c5abf1055de73f3b4ffbc5e5b742dff1f0b5ee52",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `9b0d826` | [https://auth.iterate-preview-7.com](https://auth.iterate-preview-7.com) | 855.5 KiB | 33.9s | 18.5s |  | 4.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/23323930402102) | 2026-09-04T17:20:44.916Z | Preview app released. |
| Docs | released | `9b0d826` | [https://docs-preview-7.iterate-dev-preview.workers.dev](https://docs-preview-7.iterate-dev-preview.workers.dev) | 866.2 KiB | 26.7s | 3.0s |  | 4.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/23323930402102) | 2026-09-04T17:20:44.154Z | Preview app released. |
| Dummy Petshop | released | `9b0d826` | [https://dummy-petshop.iterate-preview-7.com](https://dummy-petshop.iterate-preview-7.com) | 232.8 KiB | 6.4s | 40.6s |  | 1.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/23323930402102) | 2026-09-04T17:20:42.356Z | Preview app released. |
| OS | released | `9b0d826` | [https://os.iterate-preview-7.com](https://os.iterate-preview-7.com) | 5.16 MiB (-10.7 KiB vs main) | 80.1s | 241.2s | 1 retried: agent-fake-model-chat.spec.ts › multi-turn chat with a sarcastic agent served by the spec's own fake-model interceptor › web (playwright x1) — TimeoutError: locator.waitFor: Timeout 1ms exceeded. Call log: [2m - waiting for getByText(/"why are you like this\?" do you hear yourself/i) to be visible[22m [33m If this is a slow operation, update the product code to add a spinner while it's running. This will improve the user experience a... | 8.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/23323930402102) | 2026-09-04T17:20:48.467Z | Preview app released. |
| Semaphore | released | `9b0d826` | [https://semaphore.iterate-preview-7.com](https://semaphore.iterate-preview-7.com) | 453.8 KiB | 22.0s | 50.1s |  | 1.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/23323930402102) | 2026-09-04T17:20:41.051Z | Preview app released. |
| Streams Example App | released | `9b0d826` | [https://streams.iterate-preview-7.com](https://streams.iterate-preview-7.com) | 1.56 MiB | 32.8s | 72.4s |  | 5.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/23323930402102) | 2026-09-04T17:20:45.029Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to shared test-support registration for flake/failing wrappers; no production runtime paths, only CI telemetry and Playwright test semantics.
> 
> **Overview**
> Playwright has no per-test `retry: 0` like Vitest, so **`createFlake` and `createFailing`** now register Playwright-side tests inside an anonymous **`test.describe`** with **`describe.configure({ retries: 0 })`** instead of calling `test.fail` directly.
> 
> That closes a **RED-path retry leak**: when the wrapper inverts to success (“passed unexpectedly”), Playwright treated it as retryable, which **double-wrote flake/failing records** and could flip a run into a misleading green. Vitest behavior was already pinned; both runners now mean **one body execution per run**.
> 
> Unit tests use **Playwright-shaped fakes** with synchronous `describe` + `configure` and assert `{ retries: 0 }`. A **task note** documents rationale and checklist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b0d826dae1d117ce46576d9e7981e79e1a61e09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->