### PR TITLE
task: move playwright-wrapper-retry-pin to complete

### DIFF
--- a/tasks/complete/2026-09-04-playwright-wrapper-retry-pin.md
+++ b/tasks/complete/2026-09-04-playwright-wrapper-retry-pin.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: done
 size: small
 branch: playwright-wrapper-retry-pin
 ---


### PR DESCRIPTION
Housekeeping: #2594 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Session: 4fe3e39f-bdf2-4b87-8ed3-b77d4252fd95 ("flake dashboard follow-ups")_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Task-tracker metadata only; no runtime or test behavior changes in this PR.
> 
> **Overview**
> **Housekeeping only:** updates the tracked task in `tasks/complete/2026-09-04-playwright-wrapper-retry-pin.md` by changing frontmatter **`status` from `in-progress` to `done`**, reflecting that the Playwright wrapper retry-pin work landed in **#2594**.
> 
> No application or test code changes in this diff—the file already documents pinning **`retries: 0`** on Playwright-wrapped flake/failing tests via anonymous `test.describe.configure`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d007ff5c7f2ca3db3d2202351e4fa44e8247b111. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Docs | +1 -1 | +1 -1 🟩🟩🟩🟥🟥 |
| **Total** | **+1 -1** | **+1 -1** 🟩🟩🟩🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 8893551 and d007ff5, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->