### PR TITLE
Preserve isolate OOM errors in oversized-stream failure pin

### DIFF
--- a/apps/os/e2e/vitest/oversized-settlement-isolate.e2e.test.ts
+++ b/apps/os/e2e/vitest/oversized-settlement-isolate.e2e.test.ts
@@ -39,8 +39,17 @@ failReset("a stream survives being evicted after journaling oversized events", a
     });
   }
 
-  // .kill() aborts like a platform eviction (abort reported through the call and touches no storage.
-  await expect(stream.kill(), "kill() reports its own abort").rejects.toThrow(/kill requested/);
+  // kill() aborts like a platform eviction, without touching storage. The isolate
+  // can already be out of memory when this call arrives. Preserve that original
+  // error for failReset: rejects.toThrow wraps and truncates it, hiding the pin.
+  await stream.kill().then(
+    () => {
+      throw new Error("kill() should reject with its own abort");
+    },
+    (error: unknown) => {
+      if (!/kill requested/i.test(String(error))) throw error;
+    },
+  );
 
   // Read a few times. Each read filtered to small wake events, so the cost is the boot, not the response.
   // A boot that dies replaying the journal throws the ooom+reset instead - a bad bug, at least on 2026-09-04.


### PR DESCRIPTION
The oversized-stream regression can run out of isolate memory during `kill()`, before its post-eviction reads. The `rejects.toThrow(/kill requested/)` assertion wraps and truncates that OOM into a different error, so `createFailing` reports “Expect test to fail” even though the memory bug is still present ([preview evidence](https://depot.dev/orgs/0p91s0lz49/workflows/3hfmg77nzq?job=3mhhb27zn9&attempt=0260hhzq4h)).

Consume only the expected `kill requested` abort and rethrow every other rejection unchanged. The existing reset regex can then recognize OOM at this point; unrelated failures and an unexpectedly successful `kill()` remain red. Post-eviction wake assertions are unchanged.

Validation: `pnpm install`, `pnpm typecheck`, `pnpm lint`, `pnpm knip`, `pnpm format`, and `pnpm test` passed. A focused execution of the changed block checked the expected abort, both reset spellings, an unrelated rejection (all rethrown errors retain identity), and unexpected resolution. Preview 16 passed: the oversized-stream expected-failure test completed in 30.3s with the isolate OOM still present; the full OS Vitest suite and all 85 browser tests passed ([preview logs](https://depot.dev/orgs/0p91s0lz49/workflows/wnmnvtd72k?job=s9hbrg2kr9)).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to assertion style in one e2e file; no production or runtime behavior changes.
> 
> **Overview**
> The oversized-stream isolate e2e pin expects an **OOM/reset** failure after eviction reads; when the isolate is already out of memory during **`kill()`**, Vitest’s **`rejects.toThrow(/kill requested/)`** wraps the rejection and **hides** that signal from **`createFailing`**.
> 
> The test now handles **`stream.kill()`** with an explicit **`.then` / rejection handler**: accept only the expected **`kill requested`** abort, **rethrow everything else unchanged**, and fail if **`kill()`** resolves. Comments were updated to document why. Post-eviction wake assertions are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c825a94e3394ebb04c8d1259da38229bf01aae8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +11 -2 | +8 -1 🟩🟩🟩🟩🟥 |
| **Total** | **+11 -2** | **+8 -1** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between d8d5a31 and c825a94, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-09-08T14:05:06.086Z",
      "deployedAt": "2026-09-08T13:41:10.251Z",
      "headSha": "c825a94e3394ebb04c8d1259da38229bf01aae8d",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-16.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/352129391959357",
      "shortSha": "c825a94",
      "cleanupDurationMs": 101366,
      "deployDurationMs": 90789,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 88666,
      "deployReadinessDurationMs": 2118,
      "deployedWorkerName": "os-preview-16",
      "deployedWorkerVersion": "1ca360e6-f7fc-410c-924a-65dea2687d78",
      "testDurationMs": 286933,
      "testRetries": "1 retried: an ephemeral event reaches a hosted processor that named its type (vitest x1) — Peer closed WebSocket: 1006",
      "workerSizeKib": 20988.89,
      "workerGzipKib": 5292.11,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5303.69
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-09-08T14:03:28.355Z",
      "deployedAt": "2026-09-08T13:40:10.765Z",
      "headSha": "c825a94e3394ebb04c8d1259da38229bf01aae8d",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-16.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/352129391959357",
      "shortSha": "c825a94",
      "cleanupDurationMs": 3633,
      "deployDurationMs": 34998,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 29179,
      "deployReadinessDurationMs": 5816,
      "deployedWorkerName": "docs-preview-16",
      "deployedWorkerVersion": "540a34d8-34a4-4dfb-944f-809d14241276",
      "testDurationMs": 2496,
      "testRetries": null,
      "workerSizeKib": 4136.05,
      "workerGzipKib": 975.57,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-09-08T14:03:29.749Z",
      "deployedAt": "2026-09-08T13:40:17.973Z",
      "headSha": "c825a94e3394ebb04c8d1259da38229bf01aae8d",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-16.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/352129391959357",
      "shortSha": "c825a94",
      "cleanupDurationMs": 5025,
      "deployDurationMs": 36804,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 36386,
      "deployReadinessDurationMs": 413,
      "deployedWorkerName": "auth-preview-16",
      "deployedWorkerVersion": "172d8426-4675-4287-b1a1-a4be7629a5a1",
      "testDurationMs": 18524,
      "testRetries": null,
      "workerSizeKib": 4178.28,
      "workerGzipKib": 855.11,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-09-08T14:03:30.198Z",
      "deployedAt": "2026-09-08T13:40:10.678Z",
      "headSha": "c825a94e3394ebb04c8d1259da38229bf01aae8d",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-16.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/352129391959357",
      "shortSha": "c825a94",
      "cleanupDurationMs": 5472,
      "deployDurationMs": 29598,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 29090,
      "deployReadinessDurationMs": 503,
      "deployedWorkerName": "streams-example-app-preview-16",
      "deployedWorkerVersion": "21ff51d5-cf07-42af-9524-83676ec1cd68",
      "testDurationMs": 60922,
      "testRetries": null,
      "workerSizeKib": 5665.33,
      "workerGzipKib": 1602.81,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-09-08T14:03:25.671Z",
      "deployedAt": "2026-09-08T13:39:51.385Z",
      "headSha": "c825a94e3394ebb04c8d1259da38229bf01aae8d",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-16.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/352129391959357",
      "shortSha": "c825a94",
      "cleanupDurationMs": 943,
      "deployDurationMs": 9991,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 9754,
      "deployReadinessDurationMs": 189,
      "deployedWorkerName": "dummy-petshop-preview-16",
      "deployedWorkerVersion": "325e3ca9-69e9-48a3-a4e7-b2cc0a542660",
      "testDurationMs": 12342,
      "testRetries": null,
      "workerSizeKib": 1331.5,
      "workerGzipKib": 232.81,
      "deployedFingerprint": "c321865fd82cf1ce04086fcbe3c487f157babc45+c5abf1055de73f3b4ffbc5e5b742dff1f0b5ee52",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `c825a94` | [https://auth.iterate-preview-16.com](https://auth.iterate-preview-16.com) | 855.1 KiB | 36.8s | 18.5s |  | 5.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/352129391959357) | 2026-09-08T14:03:29.749Z | Preview app released. |
| Docs | released | `c825a94` | [https://docs-preview-16.iterate-dev-preview.workers.dev](https://docs-preview-16.iterate-dev-preview.workers.dev) | 975.6 KiB | 35.0s | 2.5s |  | 3.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/352129391959357) | 2026-09-08T14:03:28.355Z | Preview app released. |
| Dummy Petshop | released | `c825a94` | [https://dummy-petshop.iterate-preview-16.com](https://dummy-petshop.iterate-preview-16.com) | 232.8 KiB | 10.0s | 12.3s |  | 943ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/352129391959357) | 2026-09-08T14:03:25.671Z | Preview app released. |
| OS | released | `c825a94` | [https://os.iterate-preview-16.com](https://os.iterate-preview-16.com) | 5.17 MiB (-11.6 KiB vs main) | 90.8s | 286.9s | 1 retried: an ephemeral event reaches a hosted processor that named its type (vitest x1) — Peer closed WebSocket: 1006 | 101.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/352129391959357) | 2026-09-08T14:05:06.086Z | Preview app released. |
| Streams Example App | released | `c825a94` | [https://streams.iterate-preview-16.com](https://streams.iterate-preview-16.com) | 1.57 MiB | 29.6s | 60.9s |  | 5.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/352129391959357) | 2026-09-08T14:03:30.198Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->