### PR TITLE
Project-host sessions renew and the Docs app reconnects instead of logging people out

### DIFF
--- a/apps/auth-contract/src/worker.ts
+++ b/apps/auth-contract/src/worker.ts
@@ -55,6 +55,10 @@ export type MintProjectAppSessionInput = {
   email?: string;
   /** Avatar URL, same display-only status as email/name. */
   image?: string;
+  /** When this member last signed in through the platform, in seconds. A
+   * renewal carries the original forward so a session's total age is
+   * bounded however often it renews; a fresh login leaves it unset. */
+  loginAt?: number;
   name?: string;
   projectId: string;
   userId: string;
@@ -66,9 +70,16 @@ export type ValidateProjectAppSessionInput = {
   token: string;
 };
 
-/** The actor proven by a project-app session after its live membership check. */
+/** The actor proven by a project-app session after its live membership check.
+ * The display identity rides along so a renewing gate can re-mint the same
+ * claims without decoding the token itself. */
 export type ValidatedProjectAppSession = {
+  email?: string;
   expiresAt: number;
+  image?: string;
+  /** The sign-in this session descends from, in seconds (see MintProjectAppSessionInput). */
+  loginAt: number;
+  name?: string;
   userId: string;
 };
 
@@ -108,7 +119,7 @@ export abstract class AuthWorker<Env = unknown> extends WorkerEntrypoint<Env> {
   }>;
   abstract mintProjectAppSession(
     input: MintProjectAppSessionInput,
-  ): Promise<{ token: string } | null>;
+  ): Promise<{ expiresAt: number; token: string } | null>;
   abstract validateProjectAppSession(
     input: ValidateProjectAppSessionInput,
   ): Promise<ValidatedProjectAppSession | null>;

--- a/apps/auth/src/server/project-app-session.test.ts
+++ b/apps/auth/src/server/project-app-session.test.ts
@@ -36,6 +36,55 @@ describe("project app sessions", () => {
     );
   });
 
+  it("carries the display identity through validation and reports the expiry it minted", async () => {
+    const userCanAccessProject = async () => true;
+    const before = Math.floor(Date.now() / 1000);
+    const issued = await mintProjectAppSession(
+      {
+        audience,
+        email: "one@example.com",
+        image: "https://img.example/one.png",
+        name: "One",
+        projectId,
+        userId: "usr_one",
+      },
+      { secret, userCanAccessProject },
+    );
+    assert.ok(issued);
+    // The mint result names its own expiry so a renewing gate can set the
+    // cookie's Max-Age without decoding the token.
+    assert.ok(issued.expiresAt >= before + 15 * 60 - 1 && issued.expiresAt <= before + 15 * 60 + 2);
+
+    const valid = await validateProjectAppSession(
+      { audience, projectId, token: issued.token },
+      { secret, userCanAccessProject },
+    );
+    assert.ok(valid);
+    // A fresh mint is its own sign-in: loginAt is stamped now.
+    assert.ok(valid.loginAt >= before && valid.loginAt <= before + 2);
+    assert.deepEqual(valid, {
+      email: "one@example.com",
+      expiresAt: issued.expiresAt,
+      image: "https://img.example/one.png",
+      loginAt: valid.loginAt,
+      name: "One",
+      userId: "usr_one",
+    });
+
+    // A renewal carries the ORIGINAL sign-in forward, so however often a
+    // session renews its total age stays bounded by that first login.
+    const renewed = await mintProjectAppSession(
+      { audience, loginAt: valid.loginAt - 3_600, projectId, userId: "usr_one" },
+      { secret, userCanAccessProject },
+    );
+    assert.ok(renewed);
+    const renewedClaims = await validateProjectAppSession(
+      { audience, projectId, token: renewed.token },
+      { secret, userCanAccessProject },
+    );
+    assert.equal(renewedClaims?.loginAt, valid.loginAt - 3_600);
+  });
+
   it("does not mint without project access", async () => {
     assert.equal(
       await mintProjectAppSession(

--- a/apps/auth/src/server/project-app-session.ts
+++ b/apps/auth/src/server/project-app-session.ts
@@ -1,6 +1,7 @@
 import { signJWT, verifyJWT } from "better-auth/crypto";
 import type {
   MintProjectAppSessionInput,
+  ValidatedProjectAppSession,
   ValidateProjectAppSessionInput,
 } from "@iterate-com/auth-contract/worker";
 import { z } from "zod";
@@ -17,6 +18,9 @@ const ProjectAppSessionClaims = z
     exp: z.number().int(),
     iat: z.number().int(),
     image: z.string().trim().min(1).max(2048).optional(),
+    // The sign-in this token descends from; renewals carry it forward.
+    // Optional: pre-rollout tokens read as signed in at issue.
+    loginAt: z.number().int().optional(),
     name: z.string().trim().min(1).max(256).optional(),
     projectId: z.string().trim().min(1).max(256),
     type: z.literal("project-app-session"),
@@ -33,7 +37,7 @@ type SessionDependencies = {
 export async function mintProjectAppSession(
   rawInput: MintProjectAppSessionInput,
   dependencies: SessionDependencies,
-): Promise<{ token: string } | null> {
+): Promise<{ expiresAt: number; token: string } | null> {
   const input = parseMintInput(rawInput);
   if (
     !(await dependencies.userCanAccessProject({
@@ -44,28 +48,37 @@ export async function mintProjectAppSession(
     return null;
   }
 
-  return {
-    token: await signJWT(
-      {
-        audience: input.audience,
-        ...(input.email === undefined ? {} : { email: input.email }),
-        ...(input.image === undefined ? {} : { image: input.image }),
-        ...(input.name === undefined ? {} : { name: input.name }),
-        projectId: input.projectId,
-        type: "project-app-session",
-        userId: input.userId,
-      },
-      dependencies.secret,
-      SESSION_TTL_SECONDS,
-    ),
-  };
+  const token = await signJWT(
+    {
+      audience: input.audience,
+      ...(input.email === undefined ? {} : { email: input.email }),
+      ...(input.image === undefined ? {} : { image: input.image }),
+      loginAt: input.loginAt ?? Math.floor(Date.now() / 1000),
+      ...(input.name === undefined ? {} : { name: input.name }),
+      projectId: input.projectId,
+      type: "project-app-session",
+      userId: input.userId,
+    },
+    dependencies.secret,
+    SESSION_TTL_SECONDS,
+  );
+  // The signer stamps `exp` itself; report exactly that so the gate's cookie
+  // Max-Age never drifts from the token it carries.
+  return { expiresAt: expiryOf(token), token };
+}
+
+/** The `exp` claim of a token this module just signed (payload only, no verification). */
+function expiryOf(token: string): number {
+  const payload = token.split(".")[1] ?? "";
+  const json = atob(payload.replaceAll("-", "+").replaceAll("_", "/"));
+  return z.object({ exp: z.number().int() }).parse(JSON.parse(json)).exp;
 }
 
 /** Verify signature and scope, then re-check access so revocation and admin demotion are live. */
 export async function validateProjectAppSession(
   rawInput: ValidateProjectAppSessionInput,
   dependencies: SessionDependencies,
-): Promise<{ expiresAt: number; userId: string } | null> {
+): Promise<ValidatedProjectAppSession | null> {
   let input: ReturnType<typeof parseValidateInput>;
   let rawClaims: unknown;
   try {
@@ -87,7 +100,15 @@ export async function validateProjectAppSession(
   ) {
     return null;
   }
-  return { expiresAt: claims.exp, userId: claims.userId };
+  return {
+    ...(claims.email === undefined ? {} : { email: claims.email }),
+    expiresAt: claims.exp,
+    ...(claims.image === undefined ? {} : { image: claims.image }),
+    // A pre-rollout token has no loginAt: it was signed in when issued.
+    loginAt: claims.loginAt ?? claims.iat,
+    ...(claims.name === undefined ? {} : { name: claims.name }),
+    userId: claims.userId,
+  };
 }
 
 function parseMintInput(input: MintProjectAppSessionInput) {
@@ -95,6 +116,7 @@ function parseMintInput(input: MintProjectAppSessionInput) {
     audience: parseAudience(input.audience),
     email: optionalDisplayField(input.email, 320),
     image: optionalDisplayField(input.image, 2048),
+    loginAt: z.number().int().nonnegative().optional().parse(input.loginAt),
     name: optionalDisplayField(input.name, 256),
     projectId: z.string().trim().min(1).max(256).parse(input.projectId),
     userId: z.string().trim().min(1).max(256).parse(input.userId),

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -68,9 +68,7 @@
     "vite": "^8.0.16",
     "vitest": "^4.1.10",
     "wrangler": "catalog:cloudflare",
-    "yaml": "^2.8.0"
-  },
-  "dependencies": {
+    "yaml": "^2.8.0",
     "zod": "4.5.4"
   }
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -69,5 +69,8 @@
     "vitest": "^4.1.10",
     "wrangler": "catalog:cloudflare",
     "yaml": "^2.8.0"
+  },
+  "dependencies": {
+    "zod": "4.5.4"
   }
 }

--- a/apps/docs/src/components/document-error.tsx
+++ b/apps/docs/src/components/document-error.tsx
@@ -1,13 +1,17 @@
+import { Button } from "@iterate-com/ui/components/button";
 import { SidebarTrigger } from "@iterate-com/ui/components/sidebar";
 
 export function DocumentError({
   workspacePath,
   path,
   message,
+  onRetry,
 }: {
   workspacePath: string;
   path: string;
   message: string;
+  /** Load the document again without leaving the page. */
+  onRetry?: () => void;
 }) {
   return (
     <div className="relative grid min-h-svh place-items-center bg-muted/20 px-6">
@@ -19,6 +23,11 @@ export function DocumentError({
         <h1 className="mt-2 break-all font-mono text-sm">{path}</h1>
         <p className="mt-1 break-all font-mono text-xs text-muted-foreground">{workspacePath}</p>
         <p className="mt-5 rounded-lg bg-destructive/5 p-3 text-sm text-destructive">{message}</p>
+        {onRetry === undefined ? null : (
+          <Button variant="outline" size="sm" className="mt-4" onClick={onRetry}>
+            Try again
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/apps/docs/src/components/workspace-document-page.tsx
+++ b/apps/docs/src/components/workspace-document-page.tsx
@@ -53,6 +53,10 @@ export function WorkspaceDocumentPage({
   const [loadError, setLoadError] = useState<string | null>(null);
   // Bumped by the error page's Try again: the load effect runs once more.
   const [loadAttempt, setLoadAttempt] = useState(0);
+  // Bumped by Reconnect: the editor remounts (its teardown flushes what it
+  // still holds; the new one reopens the session) — never a page reload,
+  // which would drop unsent edits on the floor.
+  const [editorEpoch, setEditorEpoch] = useState(0);
   const [source, setSource] = useState("");
   const [view, setView] = useState<"preview" | "source">("preview");
   const [status, setStatus] = useState("connecting…");
@@ -196,14 +200,18 @@ export function WorkspaceDocumentPage({
             {status}
           </span>
           {/* The editor could not open, or its sync loop gave up (a long
-              outage): the page is the unit of recovery — everything unsent
-              was flushed on the way down. */}
+              outage): remount it. Its teardown pushes whatever it still
+              holds over the shared session (which may have been re-dialed
+              since), and the fresh editor reopens from the server. */}
           {status.startsWith("disconnected") || status.startsWith("failed") ? (
             <Button
               size="sm"
               variant="outline"
               className="h-8 text-xs"
-              onClick={() => window.location.reload()}
+              onClick={() => {
+                setStatus("connecting…");
+                setEditorEpoch((epoch) => epoch + 1);
+              }}
             >
               Reconnect
             </Button>
@@ -299,6 +307,7 @@ export function WorkspaceDocumentPage({
               }
             >
               <WorkspaceDocumentEditor
+                key={editorEpoch}
                 transport={transport}
                 displayName={displayName}
                 path={path}

--- a/apps/docs/src/components/workspace-document-page.tsx
+++ b/apps/docs/src/components/workspace-document-page.tsx
@@ -23,7 +23,12 @@ import { authorColor, authorLabel } from "@iterate-com/workspace-documents/colla
 import { commentIdentityFor } from "@iterate-com/workspace-documents/identity";
 import { MarkdownDocumentPreview } from "@iterate-com/workspace-documents/preview";
 import type { WorkspaceDocumentTransport } from "@iterate-com/workspace-documents/types";
-import { withDocsProject, withDocsProjectOnce } from "../lib/docs-client.ts";
+import {
+  isSessionTransportError,
+  withDocsProject,
+  withDocsProjectOnce,
+} from "../lib/docs-client.ts";
+import { withRetries } from "../lib/retry.ts";
 import type { DocsUser, WorkspaceDocumentSnapshot } from "../lib/docs-api.ts";
 import { DocumentError } from "./document-error.tsx";
 import { HtmlDocumentPreview } from "./html-document-preview.tsx";
@@ -46,6 +51,8 @@ export function WorkspaceDocumentPage({
     user: DocsUser;
   } | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
+  // Bumped by the error page's Try again: the load effect runs once more.
+  const [loadAttempt, setLoadAttempt] = useState(0);
   const [source, setSource] = useState("");
   const [view, setView] = useState<"preview" | "source">("preview");
   const [status, setStatus] = useState("connecting…");
@@ -64,11 +71,19 @@ export function WorkspaceDocumentPage({
     setLoaded(null);
     setLoadError(null);
     setSelectedThreadId(null);
-    void withDocsProject(async (project) => {
-      const workspace = project.workspace(workspacePath);
-      const [snapshot, user] = await Promise.all([workspace.inspect(path), project.whoami()]);
-      return { snapshot, user };
-    })
+    // A transport failure here is a socket that died under us (a laptop
+    // waking, a colo hiccup): the shared client re-dials, and this waits
+    // out a network that is still coming back. An application error (no
+    // such document) is final at once.
+    void withRetries(
+      () =>
+        withDocsProject(async (project) => {
+          const workspace = project.workspace(workspacePath);
+          const [snapshot, user] = await Promise.all([workspace.inspect(path), project.whoami()]);
+          return { snapshot, user };
+        }),
+      { attempts: 3, delayMs: (attempt) => attempt * 1_500, shouldRetry: isSessionTransportError },
+    )
       .then((result) => {
         if (cancelled) return;
         setSource(result.snapshot.content);
@@ -82,7 +97,7 @@ export function WorkspaceDocumentPage({
     return () => {
       cancelled = true;
     };
-  }, [path, workspacePath]);
+  }, [path, workspacePath, loadAttempt]);
 
   const transport = useMemo<WorkspaceDocumentTransport>(
     () => ({
@@ -125,7 +140,14 @@ export function WorkspaceDocumentPage({
   };
 
   if (loadError !== null) {
-    return <DocumentError workspacePath={workspacePath} path={path} message={loadError} />;
+    return (
+      <DocumentError
+        workspacePath={workspacePath}
+        path={path}
+        message={loadError}
+        onRetry={() => setLoadAttempt((attempt) => attempt + 1)}
+      />
+    );
   }
   if (loaded === null) {
     return (
@@ -173,6 +195,19 @@ export function WorkspaceDocumentPage({
           >
             {status}
           </span>
+          {/* The editor could not open, or its sync loop gave up (a long
+              outage): the page is the unit of recovery — everything unsent
+              was flushed on the way down. */}
+          {status.startsWith("disconnected") || status.startsWith("failed") ? (
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-8 text-xs"
+              onClick={() => window.location.reload()}
+            >
+              Reconnect
+            </Button>
+          ) : null}
           <WithTooltip label="Comment on document">
             <Button
               size="sm"

--- a/apps/docs/src/lib/docs-client.test.ts
+++ b/apps/docs/src/lib/docs-client.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test, vi } from "vitest";
+import { createDocsClient, isSessionTransportError } from "./docs-client.ts";
+
+describe("isSessionTransportError", () => {
+  test.each([
+    { message: "RPC session was shut down by disposing the main stub", becomes: true },
+    { message: "Network connection lost.", becomes: true },
+    { message: "connection closed", becomes: true },
+    { message: "WebSocket is closed before the connection is established.", becomes: true },
+    { message: "os /api did not upgrade: 401", becomes: true },
+    // OS refusing the vessel's re-dial with the token this browser session
+    // was born with — a fresh browser handshake carries the renewed cookie.
+    { message: "missing or invalid auth", becomes: true },
+    { message: 'document "/repos/config/x.md" does not exist', becomes: false },
+    { message: "commit is the workspace owner's act", becomes: false },
+  ])("$message → $becomes", ({ message, becomes }) => {
+    expect(isSessionTransportError(new Error(message))).toBe(becomes);
+  });
+});
+
+/** A fake dial: each session is a number, operations decide by session. */
+function fakeClient(overrides: Partial<Parameters<typeof createDocsClient>[0]> = {}) {
+  let generation = 0;
+  const disposed: number[] = [];
+  const dial = vi.fn(() => {
+    const id = ++generation;
+    return {
+      project: id,
+      session: {
+        [Symbol.dispose]: () => {
+          disposed.push(id);
+        },
+      },
+    };
+  });
+  const refresh =
+    overrides.refresh ?? vi.fn(async () => ({ outcome: "renewed" as const, expiresAt: 0 }));
+  const signInAgain = overrides.signInAgain ?? vi.fn();
+  const client = createDocsClient({ ...overrides, dial, refresh, signInAgain });
+  return { client, dial, disposed, refresh, signInAgain };
+}
+
+const transportFailure = () => new Error("RPC session was shut down by disposing the main stub");
+
+describe("createDocsClient", () => {
+  test("an application error leaves the shared session alone", async () => {
+    const { client, dial, refresh } = fakeClient();
+    await expect(
+      client.withDocsProject(async () => {
+        throw new Error('document "x.md" does not exist');
+      }),
+    ).rejects.toThrow("does not exist");
+    expect(dial).toHaveBeenCalledTimes(1);
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  test("a transport error re-dials once and retries the operation", async () => {
+    const { client, dial, disposed } = fakeClient();
+    const result = await client.withDocsProject(async (project) => {
+      if (project === 1) throw transportFailure();
+      return `ok on ${project}`;
+    });
+    expect(result).toBe("ok on 2");
+    expect(dial).toHaveBeenCalledTimes(2);
+    expect(disposed).toEqual([1]);
+  });
+
+  test("concurrent callers share one re-dial", async () => {
+    const { client, dial } = fakeClient();
+    const operation = async (project: number) => {
+      if (project === 1) throw transportFailure();
+      return project;
+    };
+    const results = await Promise.all([
+      client.withDocsProject(operation),
+      client.withDocsProject(operation),
+      client.withDocsProject(operation),
+    ]);
+    expect(results).toEqual([2, 2, 2]);
+    expect(dial).toHaveBeenCalledTimes(2);
+  });
+
+  test("a caller whose session was already replaced retries without another re-dial", async () => {
+    const { client, dial } = fakeClient();
+    // Caller A fails on session 1 and re-dials to 2. Caller B, still holding
+    // session 1's failure, must ride session 2 instead of minting session 3.
+    const first = client.withDocsProject(async (project) => {
+      if (project === 1) throw transportFailure();
+      return project;
+    });
+    await first;
+    const second = await client.withDocsProject(async (project) => project);
+    expect(second).toBe(2);
+    expect(dial).toHaveBeenCalledTimes(2);
+  });
+
+  test("a failed re-dial renews the session and tries once more", async () => {
+    const { client, dial, refresh } = fakeClient();
+    const result = await client.withDocsProject(async (project) => {
+      if (project < 3) throw transportFailure();
+      return `ok on ${project}`;
+    });
+    expect(result).toBe("ok on 3");
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(dial).toHaveBeenCalledTimes(3);
+  });
+
+  test("a dead session hands off to sign-in instead of failing quietly", async () => {
+    const { client, refresh, signInAgain } = fakeClient({
+      refresh: vi.fn(async () => ({
+        outcome: "signed-out" as const,
+        login: "/_iterate/auth/login?return_to=%2Fx",
+      })),
+    });
+    await expect(
+      client.withDocsProject(async () => {
+        throw transportFailure();
+      }),
+    ).rejects.toThrow(/signing in again/i);
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(signInAgain).toHaveBeenCalledWith("/_iterate/auth/login?return_to=%2Fx");
+  });
+
+  test("withDocsProjectOnce never re-dials", async () => {
+    const { client, dial } = fakeClient();
+    await expect(
+      client.withDocsProjectOnce(async () => {
+        throw transportFailure();
+      }),
+    ).rejects.toThrow("shut down");
+    expect(dial).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/docs/src/lib/docs-client.test.ts
+++ b/apps/docs/src/lib/docs-client.test.ts
@@ -157,6 +157,48 @@ describe("createDocsClient", () => {
     expect(dial).toHaveBeenCalledTimes(4);
   });
 
+  test("a caller retired by another caller's renewal rides it instead of renewing again", async () => {
+    const renewals: Array<(outcome: RefreshOutcome) => void> = [];
+    const refresh = vi.fn(
+      () =>
+        new Promise<RefreshOutcome>((resolve) => {
+          renewals.push(resolve);
+        }),
+    );
+    const { client, dial, disposed } = fakeClient({ refresh });
+    // A loses 1 and its replacement 2, then waits on a renewal.
+    const a = client.withDocsProject(async (project) => {
+      if (project < 4) throw transportFailure();
+      return `a on ${project}`;
+    });
+    await settle();
+    expect(dial).toHaveBeenCalledTimes(2);
+    // B loses 2 too, dials 3 with the old cookie, and is mid-call on it.
+    let failB: (() => void) | null = null;
+    const b = client.withDocsProject((project) => {
+      if (project === 2) return Promise.reject(transportFailure());
+      if (project === 3) {
+        return new Promise<string>((_, reject) => {
+          failB = () => reject(transportFailure());
+        });
+      }
+      return Promise.resolve(`b on ${project}`);
+    });
+    await settle();
+    expect(dial).toHaveBeenCalledTimes(3);
+    // A's renewal lands: A retires 3 and dials 4 with the renewed cookie…
+    renewals[0]!({ outcome: "renewed", expiresAt: 0 });
+    await settle();
+    expect(dial).toHaveBeenCalledTimes(4);
+    expect(disposed).toContain(3);
+    // …which kills B's call on 3. B must ride 4, not renew again and retire it.
+    failB!();
+    await expect(b).resolves.toBe("b on 4");
+    await expect(a).resolves.toBe("a on 4");
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(disposed).not.toContain(4);
+  });
+
   test("concurrent callers share one renewal and one post-renewal dial", async () => {
     const refresh = vi.fn(async () => ({ outcome: "renewed" as const, expiresAt: 0 }));
     const { client, dial } = fakeClient({ refresh });

--- a/apps/docs/src/lib/docs-client.test.ts
+++ b/apps/docs/src/lib/docs-client.test.ts
@@ -199,6 +199,32 @@ describe("createDocsClient", () => {
     expect(disposed).not.toContain(4);
   });
 
+  test("a renewal that failed covers nobody: the next caller renews again", async () => {
+    const refresh = vi
+      .fn<() => Promise<RefreshOutcome>>()
+      .mockResolvedValueOnce({ outcome: "unavailable" })
+      .mockResolvedValue({ outcome: "renewed", expiresAt: 0 });
+    const { client, dial } = fakeClient({ refresh });
+    // A: 1 and 2 fail, the gate is briefly unavailable, A still tries 3 and succeeds.
+    await expect(
+      client.withDocsProject(async (project) => {
+        if (project < 3) throw transportFailure();
+        return `a on ${project}`;
+      }),
+    ).resolves.toBe("a on 3");
+    expect(refresh).toHaveBeenCalledTimes(1);
+    // B loses 3 and 4: the failed renewal must not count as coverage —
+    // B renews for real instead of retrying on the old cookie.
+    await expect(
+      client.withDocsProject(async (project) => {
+        if (project < 5) throw transportFailure();
+        return `b on ${project}`;
+      }),
+    ).resolves.toBe("b on 5");
+    expect(refresh).toHaveBeenCalledTimes(2);
+    expect(dial).toHaveBeenCalledTimes(5);
+  });
+
   test("concurrent callers share one renewal and one post-renewal dial", async () => {
     const refresh = vi.fn(async () => ({ outcome: "renewed" as const, expiresAt: 0 }));
     const { client, dial } = fakeClient({ refresh });

--- a/apps/docs/src/lib/docs-client.test.ts
+++ b/apps/docs/src/lib/docs-client.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, vi } from "vitest";
 import { createDocsClient, isSessionTransportError } from "./docs-client.ts";
+import type { RefreshOutcome } from "./project-session.ts";
 
 describe("isSessionTransportError", () => {
   test.each([
@@ -41,6 +42,11 @@ function fakeClient(overrides: Partial<Parameters<typeof createDocsClient>[0]> =
 }
 
 const transportFailure = () => new Error("RPC session was shut down by disposing the main stub");
+
+/** Let every pending microtask (a few awaits deep) run. */
+const settle = async () => {
+  for (let i = 0; i < 8; i++) await Promise.resolve();
+};
 
 describe("createDocsClient", () => {
   test("an application error leaves the shared session alone", async () => {
@@ -119,6 +125,53 @@ describe("createDocsClient", () => {
     ).rejects.toThrow(/signing in again/i);
     expect(refresh).toHaveBeenCalledTimes(1);
     expect(signInAgain).toHaveBeenCalledWith("/_iterate/auth/login?return_to=%2Fx");
+  });
+
+  test("a session dialed while the renewal was pending is not trusted after it", async () => {
+    let resolveRefresh: ((outcome: RefreshOutcome) => void) | null = null;
+    const { client, dial } = fakeClient({
+      refresh: vi.fn(
+        () =>
+          new Promise<RefreshOutcome>((resolve) => {
+            resolveRefresh = resolve;
+          }),
+      ),
+    });
+    // A loses session 1, then its replacement 2: it asks for a renewal and waits.
+    const a = client.withDocsProject(async (project) => {
+      if (project < 4) throw transportFailure();
+      return `a on ${project}`;
+    });
+    await settle();
+    expect(dial).toHaveBeenCalledTimes(2);
+    // Meanwhile B loses session 2 and dials 3 — with the OLD cookie.
+    const b = client.withDocsProject(async (project) => {
+      if (project < 3) throw transportFailure();
+      return `b on ${project}`;
+    });
+    await expect(b).resolves.toBe("b on 3");
+    expect(dial).toHaveBeenCalledTimes(3);
+    // The renewal lands: A must not ride 3, whose handshake predates it.
+    resolveRefresh!({ outcome: "renewed", expiresAt: 0 });
+    await expect(a).resolves.toBe("a on 4");
+    expect(dial).toHaveBeenCalledTimes(4);
+  });
+
+  test("concurrent callers share one renewal and one post-renewal dial", async () => {
+    const refresh = vi.fn(async () => ({ outcome: "renewed" as const, expiresAt: 0 }));
+    const { client, dial } = fakeClient({ refresh });
+    const operation = async (project: number) => {
+      if (project < 3) throw transportFailure();
+      return project;
+    };
+    const results = await Promise.all([
+      client.withDocsProject(operation),
+      client.withDocsProject(operation),
+      client.withDocsProject(operation),
+    ]);
+    expect(results).toEqual([3, 3, 3]);
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(dial).toHaveBeenCalledTimes(3);
   });
 
   test("withDocsProjectOnce never re-dials", async () => {

--- a/apps/docs/src/lib/docs-client.ts
+++ b/apps/docs/src/lib/docs-client.ts
@@ -16,7 +16,9 @@ import { refreshProjectSession, type RefreshOutcome } from "./project-session.ts
  *    ride the replacement instead of each minting their own.
  * 3. When the replacement itself cannot connect, the likeliest cause is a
  *    lapsed project session: renew it through the gate and try once more; a
- *    session the gate declares dead hands off to sign-in.
+ *    session the gate declares dead hands off to sign-in. One renewal is
+ *    shared by everyone waiting on it, and no session dialed before it
+ *    completed is trusted afterwards — its handshake carried the old cookie.
  */
 
 function dialDocsApi() {
@@ -49,6 +51,23 @@ export function createDocsClient<Project>(deps: {
   const isTransport = deps.isTransportError ?? isSessionTransportError;
   let live: { project: Project; session: unknown; generation: number } | null = null;
   let generation = 0;
+  let renewing: Promise<RefreshOutcome> | null = null;
+  /** The generation counter when the last renewal completed: every session
+   * dialed at or before it shook hands with the cookie that renewal replaced. */
+  let renewedAtGeneration = 0;
+
+  const renew = () => {
+    renewing ??= deps
+      .refresh()
+      .then((outcome) => {
+        renewedAtGeneration = generation;
+        return outcome;
+      })
+      .finally(() => {
+        renewing = null;
+      });
+    return renewing;
+  };
 
   const current = () => (live ??= { ...deps.dial(), generation: ++generation });
 
@@ -71,12 +90,12 @@ export function createDocsClient<Project>(deps: {
         return await operation(second.project);
       } catch (secondError) {
         if (!isTransport(secondError)) throw secondError;
-        const renewal = await deps.refresh();
+        const renewal = await renew();
         if (renewal.outcome === "signed-out") {
           deps.signInAgain(renewal.login);
           throw new Error("Your session expired — signing in again…");
         }
-        const third = replace(second.generation);
+        const third = replace(Math.max(second.generation, renewedAtGeneration));
         return await operation(third.project);
       }
     }

--- a/apps/docs/src/lib/docs-client.ts
+++ b/apps/docs/src/lib/docs-client.ts
@@ -60,6 +60,8 @@ export function createDocsClient<Project>(deps: {
   };
   let live: Session | null = null;
   let generation = 0;
+  /** Renewals that actually produced a fresh cookie — an outage or a dead
+   * session renews nothing, so neither counts as coverage for anyone. */
   let renewalsCompleted = 0;
   let renewing: Promise<RefreshOutcome> | null = null;
   /** The generation counter when the last renewal completed: every session
@@ -70,8 +72,10 @@ export function createDocsClient<Project>(deps: {
     renewing ??= deps
       .refresh()
       .then((outcome) => {
-        renewalsCompleted++;
-        renewedAtGeneration = generation;
+        if (outcome.outcome === "renewed") {
+          renewalsCompleted++;
+          renewedAtGeneration = generation;
+        }
         return outcome;
       })
       .finally(() => {

--- a/apps/docs/src/lib/docs-client.ts
+++ b/apps/docs/src/lib/docs-client.ts
@@ -1,5 +1,23 @@
 import { newWebSocketRpcSession } from "capnweb";
 import type { DocsApi } from "./docs-api.ts";
+import { refreshProjectSession, type RefreshOutcome } from "./project-session.ts";
+
+/**
+ * The app's ONE live Cap'n Web session to its vessel, shared by every caller
+ * (document page, comments, the file tree's poll, the board). A session dies
+ * with its socket — a laptop sleep, a colo hiccup, the gate refusing a
+ * handshake once the project cookie lapsed — and every call in flight on it
+ * fails. Recovery is the client's job and has three rules:
+ *
+ * 1. Only a TRANSPORT failure replaces the session. An application error
+ *    ("document does not exist", "not the owner") is an answer, and tearing
+ *    the shared socket down for it would fail every other caller.
+ * 2. One failure wave, one re-dial: callers that lost the same session all
+ *    ride the replacement instead of each minting their own.
+ * 3. When the replacement itself cannot connect, the likeliest cause is a
+ *    lapsed project session: renew it through the gate and try once more; a
+ *    session the gate declares dead hands off to sign-in.
+ */
 
 function dialDocsApi() {
   const url = new URL("/api", window.location.href);
@@ -8,39 +26,91 @@ function dialDocsApi() {
   return { project: session.authenticate(), session };
 }
 
-let liveApi: ReturnType<typeof dialDocsApi> | null = null;
-
-export async function withDocsProjectOnce<T>(
-  operation: (project: ReturnType<typeof dialDocsApi>["project"]) => PromiseLike<T>,
-): Promise<T> {
-  liveApi ??= dialDocsApi();
-  return operation(liveApi.project);
+/**
+ * Whether an error means the session's transport is gone, not that the call
+ * was refused. "missing or invalid auth" belongs here too: it is OS refusing
+ * the vessel's re-dial with the token this browser session was born with,
+ * so only a fresh browser handshake (which carries the renewed cookie) can
+ * bring the session back.
+ */
+export function isSessionTransportError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /shut down|network connection lost|connection closed|websocket|did not upgrade|socket hang up|failed to fetch|missing or invalid auth/i.test(
+    message,
+  );
 }
 
-export async function withDocsProject<T>(
-  operation: (project: ReturnType<typeof dialDocsApi>["project"]) => PromiseLike<T>,
-): Promise<T> {
-  liveApi ??= dialDocsApi();
-  try {
-    return await operation(liveApi.project);
-  } catch (firstError) {
-    dispose(liveApi.session);
-    liveApi = dialDocsApi();
+export function createDocsClient<Project>(deps: {
+  dial: () => { project: Project; session: unknown };
+  refresh: () => Promise<RefreshOutcome>;
+  signInAgain: (login: string) => void;
+  isTransportError?: (error: unknown) => boolean;
+}) {
+  const isTransport = deps.isTransportError ?? isSessionTransportError;
+  let live: { project: Project; session: unknown; generation: number } | null = null;
+  let generation = 0;
+
+  const current = () => (live ??= { ...deps.dial(), generation: ++generation });
+
+  /** Replace the session a caller lost — unless someone already did. */
+  const replace = (lost: number) => {
+    if (live !== null && live.generation > lost) return live;
+    dispose(live?.session);
+    live = { ...deps.dial(), generation: ++generation };
+    return live;
+  };
+
+  async function withDocsProject<T>(operation: (project: Project) => PromiseLike<T>): Promise<T> {
+    const first = current();
     try {
-      return await operation(liveApi.project);
-    } catch (secondError) {
-      liveApi = null;
-      throw secondError ?? firstError;
+      return await operation(first.project);
+    } catch (firstError) {
+      if (!isTransport(firstError)) throw firstError;
+      const second = replace(first.generation);
+      try {
+        return await operation(second.project);
+      } catch (secondError) {
+        if (!isTransport(secondError)) throw secondError;
+        const renewal = await deps.refresh();
+        if (renewal.outcome === "signed-out") {
+          deps.signInAgain(renewal.login);
+          throw new Error("Your session expired — signing in again…");
+        }
+        const third = replace(second.generation);
+        return await operation(third.project);
+      }
     }
   }
+
+  /** The live session, no recovery: for callers that must never tear it down. */
+  async function withDocsProjectOnce<T>(
+    operation: (project: Project) => PromiseLike<T>,
+  ): Promise<T> {
+    return await operation(current().project);
+  }
+
+  return { withDocsProject, withDocsProjectOnce };
 }
 
 function dispose(session: unknown): void {
   try {
     // Cap'n Web sessions are explicit-resource-management objects. The
     // runtime check keeps this safe in browsers without Symbol.dispose.
-    (session as { [Symbol.dispose]?: () => void })[Symbol.dispose]?.();
+    (session as { [Symbol.dispose]?: () => void } | undefined)?.[Symbol.dispose]?.();
   } catch {
     // A broken WebSocket session may already have disposed itself.
   }
 }
+
+const browserClient = createDocsClient<ReturnType<typeof dialDocsApi>["project"]>({
+  dial: dialDocsApi,
+  refresh: () =>
+    refreshProjectSession({
+      fetch: (url, init) => fetch(url, init),
+      returnTo: `${location.pathname}${location.search}`,
+    }),
+  signInAgain: (login) => location.assign(login),
+});
+
+export const withDocsProject = browserClient.withDocsProject;
+export const withDocsProjectOnce = browserClient.withDocsProjectOnce;

--- a/apps/docs/src/lib/docs-client.ts
+++ b/apps/docs/src/lib/docs-client.ts
@@ -17,8 +17,10 @@ import { refreshProjectSession, type RefreshOutcome } from "./project-session.ts
  * 3. When the replacement itself cannot connect, the likeliest cause is a
  *    lapsed project session: renew it through the gate and try once more; a
  *    session the gate declares dead hands off to sign-in. One renewal is
- *    shared by everyone waiting on it, and no session dialed before it
- *    completed is trusted afterwards — its handshake carried the old cookie.
+ *    shared by everyone waiting on it; no session dialed before it completed
+ *    is trusted afterwards (its handshake carried the old cookie); and a
+ *    caller whose session was retired that way rides the renewal instead
+ *    of starting another, which would retire the fresh session in turn.
  */
 
 function dialDocsApi() {
@@ -49,8 +51,16 @@ export function createDocsClient<Project>(deps: {
   isTransportError?: (error: unknown) => boolean;
 }) {
   const isTransport = deps.isTransportError ?? isSessionTransportError;
-  let live: { project: Project; session: unknown; generation: number } | null = null;
+  type Session = {
+    project: Project;
+    session: unknown;
+    generation: number;
+    /** How many renewals had completed when this session was dialed. */
+    renewalsAtDial: number;
+  };
+  let live: Session | null = null;
   let generation = 0;
+  let renewalsCompleted = 0;
   let renewing: Promise<RefreshOutcome> | null = null;
   /** The generation counter when the last renewal completed: every session
    * dialed at or before it shook hands with the cookie that renewal replaced. */
@@ -60,6 +70,7 @@ export function createDocsClient<Project>(deps: {
     renewing ??= deps
       .refresh()
       .then((outcome) => {
+        renewalsCompleted++;
         renewedAtGeneration = generation;
         return outcome;
       })
@@ -69,13 +80,19 @@ export function createDocsClient<Project>(deps: {
     return renewing;
   };
 
-  const current = () => (live ??= { ...deps.dial(), generation: ++generation });
+  const dial = (): Session => ({
+    ...deps.dial(),
+    generation: ++generation,
+    renewalsAtDial: renewalsCompleted,
+  });
+
+  const current = () => (live ??= dial());
 
   /** Replace the session a caller lost — unless someone already did. */
   const replace = (lost: number) => {
     if (live !== null && live.generation > lost) return live;
     dispose(live?.session);
-    live = { ...deps.dial(), generation: ++generation };
+    live = dial();
     return live;
   };
 
@@ -90,6 +107,14 @@ export function createDocsClient<Project>(deps: {
         return await operation(second.project);
       } catch (secondError) {
         if (!isTransport(secondError)) throw secondError;
+        if (second.renewalsAtDial < renewalsCompleted) {
+          // A renewal landed after this session was dialed — another
+          // caller's, which retired it under us. That renewal covers us
+          // too: ride what is live now (or dial) rather than renew again
+          // and retire the fresh session in turn.
+          const third = replace(second.generation);
+          return await operation(third.project);
+        }
         const renewal = await renew();
         if (renewal.outcome === "signed-out") {
           deps.signInAgain(renewal.login);

--- a/apps/docs/src/lib/project-session.test.ts
+++ b/apps/docs/src/lib/project-session.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  loginPathFor,
+  nextRefreshDelayMs,
+  refreshProjectSession,
+  startProjectSessionKeepalive,
+  type RefreshOutcome,
+} from "./project-session.ts";
+
+const MINUTE = 60_000;
+
+describe("refreshProjectSession", () => {
+  const returnTo = "/?workspace=%2Fworkspaces%2Fscratch%2Fx&path=a.md";
+
+  test("posts same-origin to the refresh route and reads back the new expiry", async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response(JSON.stringify({ ok: true, expiresAt: 1_800_000_900 })),
+    );
+    await expect(refreshProjectSession({ fetch: fetchImpl, returnTo })).resolves.toEqual({
+      outcome: "renewed",
+      expiresAt: 1_800_000_900,
+    });
+    const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe(`/_iterate/auth/refresh?return_to=${encodeURIComponent(returnTo)}`);
+    expect(init.method).toBe("POST");
+    expect(init.credentials).toBe("same-origin");
+  });
+
+  test.each([
+    {
+      name: "a 401 is a dead session, with the gate's login pointer",
+      response: () =>
+        new Response(JSON.stringify({ authenticated: false, login: "/_iterate/auth/login?x" }), {
+          status: 401,
+        }),
+      becomes: { outcome: "signed-out", login: "/_iterate/auth/login?x" },
+    },
+    {
+      name: "a 401 without a pointer still points at the login for this page",
+      response: () => new Response("nope", { status: 401 }),
+      becomes: { outcome: "signed-out", login: loginPathFor(returnTo) },
+    },
+    {
+      name: "a 503 is a transient outage",
+      response: () => new Response("later", { status: 503 }),
+      becomes: { outcome: "unavailable" },
+    },
+    {
+      name: "a network failure is a transient outage",
+      response: () => {
+        throw new TypeError("Failed to fetch");
+      },
+      becomes: { outcome: "unavailable" },
+    },
+  ])("$name", async ({ response, becomes }) => {
+    await expect(
+      refreshProjectSession({ fetch: vi.fn(async () => response()), returnTo }),
+    ).resolves.toEqual(becomes);
+  });
+});
+
+describe("nextRefreshDelayMs", () => {
+  test.each([
+    { remainingMin: 15, becomes: 7.5 * MINUTE },
+    { remainingMin: 4, becomes: 2 * MINUTE },
+    { remainingMin: 1, becomes: MINUTE / 2 },
+    // Never a floor that waits past expiry: a lapsed session renews at once.
+    { remainingMin: 0, becomes: 1_000 },
+    { remainingMin: -5, becomes: 1_000 },
+    { remainingMin: 60, becomes: 10 * MINUTE },
+  ])("$remainingMin min left → refresh in $becomes ms", ({ remainingMin, becomes }) => {
+    const now = 1_800_000_000_000;
+    expect(nextRefreshDelayMs(now / 1000 + remainingMin * 60, now)).toBe(becomes);
+  });
+});
+
+describe("startProjectSessionKeepalive", () => {
+  function harness(outcomes: RefreshOutcome[]) {
+    const timers = new Map<number, { fn: () => void; ms: number }>();
+    let nextId = 1;
+    let now = 1_800_000_000_000;
+    let visibleListener: (() => void) | null = null;
+    const refresh = vi.fn(async () => outcomes.shift() ?? { outcome: "unavailable" as const });
+    const onSignedOut = vi.fn();
+    const stop = startProjectSessionKeepalive({
+      refresh,
+      now: () => now,
+      timers: {
+        set: (fn, ms) => {
+          const id = nextId++;
+          timers.set(id, { fn, ms });
+          return id;
+        },
+        clear: (id) => void timers.delete(id as number),
+      },
+      onSignedOut,
+      visibility: {
+        isVisible: () => true,
+        onVisible: (fn) => {
+          visibleListener = fn;
+          return () => {
+            visibleListener = null;
+          };
+        },
+      },
+    });
+    const settle = async () => {
+      for (let i = 0; i < 6; i++) await Promise.resolve();
+    };
+    const fire = async () => {
+      const [id, timer] = [...timers.entries()][0] ?? [];
+      if (id === undefined || timer === undefined) throw new Error("no timer armed");
+      timers.delete(id);
+      now += timer.ms;
+      timer.fn();
+      await settle();
+    };
+    return {
+      refresh,
+      onSignedOut,
+      stop,
+      fire,
+      advance: (ms: number) => {
+        now += ms;
+      },
+      visible: async () => {
+        visibleListener?.();
+        await settle();
+      },
+      settle,
+      armed: () => [...timers.values()].map((t) => t.ms),
+    };
+  }
+
+  test("refreshes on start, then at half the remaining lifetime", async () => {
+    const h = harness([{ outcome: "renewed", expiresAt: 1_800_000_000 + 15 * 60 }]);
+    await h.settle();
+    expect(h.refresh).toHaveBeenCalledTimes(1);
+    expect(h.armed()).toEqual([7.5 * MINUTE]);
+  });
+
+  test("an outage retries in a minute; a dead session hands off once and stops", async () => {
+    const h = harness([
+      { outcome: "unavailable" },
+      { outcome: "signed-out", login: "/_iterate/auth/login?return_to=%2F" },
+    ]);
+    await h.settle();
+    expect(h.armed()).toEqual([MINUTE]);
+    await h.fire();
+    expect(h.onSignedOut).toHaveBeenCalledWith("/_iterate/auth/login?return_to=%2F");
+    expect(h.armed()).toEqual([]);
+  });
+
+  test("coming back to a tab refreshes at once when the last renewal is stale", async () => {
+    const h = harness([
+      { outcome: "renewed", expiresAt: 1_800_000_000 + 15 * 60 },
+      { outcome: "renewed", expiresAt: 1_800_000_000 + 20 * 60 },
+    ]);
+    await h.settle();
+    h.advance(2 * MINUTE);
+    await h.visible();
+    expect(h.refresh).toHaveBeenCalledTimes(2);
+    // The pending timer was replaced by the fresh schedule, not doubled.
+    expect(h.armed()).toHaveLength(1);
+    h.stop();
+    expect(h.armed()).toEqual([]);
+  });
+
+  test("a fresh renewal ignores a visibility flap", async () => {
+    const h = harness([{ outcome: "renewed", expiresAt: 1_800_000_000 + 15 * 60 }]);
+    await h.settle();
+    h.advance(10_000);
+    await h.visible();
+    expect(h.refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/docs/src/lib/project-session.test.ts
+++ b/apps/docs/src/lib/project-session.test.ts
@@ -91,7 +91,7 @@ describe("startProjectSessionKeepalive", () => {
           timers.set(id, { fn, ms });
           return id;
         },
-        clear: (id) => void timers.delete(id as number),
+        clear: (id) => void timers.delete(id),
       },
       onSignedOut,
       visibility: {

--- a/apps/docs/src/lib/project-session.ts
+++ b/apps/docs/src/lib/project-session.ts
@@ -1,0 +1,177 @@
+/**
+ * The project-host session the browser holds for this app: the
+ * `iterate-project-auth` cookie the platform gate mints for 15 minutes.
+ * Nothing in the browser can read it (HttpOnly), but it can ask the gate to
+ * renew it — the gate re-mints for the same user, project, and origin while
+ * the current token still proves a member. This module owns that renewal:
+ * the request, the schedule, and the hand-off to sign-in when the session
+ * is dead. Everything takes its clock, timers, and fetch as inputs so the
+ * rules are table-testable.
+ */
+
+const PROJECT_AUTH_LOGIN_PATH = "/_iterate/auth/login";
+const PROJECT_AUTH_REFRESH_PATH = "/_iterate/auth/refresh";
+
+const MINUTE_MS = 60_000;
+/** Never wait longer than this: a sliding renewal must keep pace with revocation. */
+const MAX_REFRESH_DELAY_MS = 10 * MINUTE_MS;
+/** A lapsed session renews at once (well, after a beat). */
+const MIN_REFRESH_DELAY_MS = 1_000;
+/** A renewal round trip that takes longer than this is an outage, not a wait. */
+const REFRESH_TIMEOUT_MS = 15_000;
+/** A renewal younger than this is fresh enough to skip on a tab flap. */
+const FRESH_ENOUGH_MS = MINUTE_MS;
+
+export type RefreshOutcome =
+  | { outcome: "renewed"; expiresAt: number }
+  | { outcome: "signed-out"; login: string }
+  | { outcome: "unavailable" };
+
+/** The gate's login start for one page (the same link its sign-in page carries). */
+export function loginPathFor(returnTo: string): string {
+  return `${PROJECT_AUTH_LOGIN_PATH}?${new URLSearchParams({ return_to: returnTo })}`;
+}
+
+/**
+ * One renewal round trip. A 401 is a dead session (the gate's body carries
+ * the login pointer); anything else that is not a renewal is an outage the
+ * caller should retry later.
+ */
+export async function refreshProjectSession(input: {
+  fetch: (url: string, init: RequestInit) => Promise<Response>;
+  returnTo: string;
+}): Promise<RefreshOutcome> {
+  const url = `${PROJECT_AUTH_REFRESH_PATH}?${new URLSearchParams({ return_to: input.returnTo })}`;
+  let response: Response;
+  try {
+    response = await input.fetch(url, { credentials: "same-origin", method: "POST" });
+  } catch {
+    return { outcome: "unavailable" };
+  }
+  if (response.status === 401) {
+    let login = loginPathFor(input.returnTo);
+    try {
+      const body: unknown = await response.json();
+      if (typeof body === "object" && body !== null && "login" in body) {
+        const pointer = (body as { login: unknown }).login;
+        if (typeof pointer === "string" && pointer.startsWith("/")) login = pointer;
+      }
+    } catch {
+      // A bare 401 still means signed out; the pointer is a courtesy.
+    }
+    return { outcome: "signed-out", login };
+  }
+  if (!response.ok) return { outcome: "unavailable" };
+  try {
+    const body: unknown = await response.json();
+    const expiresAt =
+      typeof body === "object" && body !== null && "expiresAt" in body
+        ? (body as { expiresAt: unknown }).expiresAt
+        : undefined;
+    if (typeof expiresAt !== "number") return { outcome: "unavailable" };
+    return { outcome: "renewed", expiresAt };
+  } catch {
+    return { outcome: "unavailable" };
+  }
+}
+
+/**
+ * Half the remaining lifetime, capped: soon enough to never lapse, rare enough
+ * to stay cheap. Halving is self-limiting (each renewal resets the clock), so
+ * a short remainder gets a short delay rather than a floor that would wait
+ * past expiry.
+ */
+export function nextRefreshDelayMs(expiresAt: number, now: number): number {
+  const remaining = expiresAt * 1000 - now;
+  return Math.min(MAX_REFRESH_DELAY_MS, Math.max(MIN_REFRESH_DELAY_MS, remaining / 2));
+}
+
+/**
+ * Keep the session alive while the page is open: renew on start, then at
+ * half the remaining lifetime; retry an outage in a minute; renew at once
+ * when a tab comes back to the foreground with a stale renewal; hand a dead
+ * session to sign-in exactly once and stop. Returns the stop function.
+ */
+export function startProjectSessionKeepalive(input: {
+  refresh: () => Promise<RefreshOutcome>;
+  now: () => number;
+  timers: { set: (fn: () => void, ms: number) => unknown; clear: (id: unknown) => void };
+  onSignedOut: (login: string) => void;
+  visibility?: { isVisible: () => boolean; onVisible: (fn: () => void) => () => void };
+}): () => void {
+  let timer: unknown = null;
+  let stopped = false;
+  let inFlight = false;
+  let lastRenewedAt = Number.NEGATIVE_INFINITY;
+
+  const arm = (ms: number) => {
+    if (timer !== null) input.timers.clear(timer);
+    timer = input.timers.set(() => {
+      timer = null;
+      void tick();
+    }, ms);
+  };
+
+  const tick = async () => {
+    if (stopped || inFlight) return;
+    inFlight = true;
+    let result: RefreshOutcome;
+    try {
+      result = await input.refresh();
+    } finally {
+      inFlight = false;
+    }
+    if (stopped) return;
+    if (result.outcome === "renewed") {
+      lastRenewedAt = input.now();
+      arm(nextRefreshDelayMs(result.expiresAt, input.now()));
+    } else if (result.outcome === "unavailable") {
+      arm(MINUTE_MS);
+    } else {
+      stop();
+      input.onSignedOut(result.login);
+    }
+  };
+
+  const unsubscribe = input.visibility?.onVisible(() => {
+    if (!stopped && input.now() - lastRenewedAt > FRESH_ENOUGH_MS) void tick();
+  });
+
+  const stop = () => {
+    stopped = true;
+    if (timer !== null) input.timers.clear(timer);
+    timer = null;
+    unsubscribe?.();
+  };
+
+  void tick();
+  return stop;
+}
+
+/** The browser wiring of the keepalive: real fetch, clock, timers, and navigation. */
+export function startBrowserProjectSessionKeepalive(): () => void {
+  return startProjectSessionKeepalive({
+    refresh: () =>
+      refreshProjectSession({
+        fetch: (url, init) =>
+          fetch(url, { ...init, signal: AbortSignal.timeout(REFRESH_TIMEOUT_MS) }),
+        returnTo: `${location.pathname}${location.search}`,
+      }),
+    now: () => Date.now(),
+    timers: {
+      set: (fn, ms) => window.setTimeout(fn, ms),
+      clear: (id) => window.clearTimeout(id as number),
+    },
+    onSignedOut: (login) => location.assign(login),
+    visibility: {
+      isVisible: () => document.visibilityState === "visible",
+      onVisible: (fn) => {
+        const handler = () => {
+          if (document.visibilityState === "visible") fn();
+        };
+        document.addEventListener("visibilitychange", handler);
+        return () => document.removeEventListener("visibilitychange", handler);
+      },
+    },
+  });
+}

--- a/apps/docs/src/lib/project-session.ts
+++ b/apps/docs/src/lib/project-session.ts
@@ -9,6 +9,8 @@
  * rules are table-testable.
  */
 
+import { z } from "zod";
+
 const PROJECT_AUTH_LOGIN_PATH = "/_iterate/auth/login";
 const PROJECT_AUTH_REFRESH_PATH = "/_iterate/auth/refresh";
 
@@ -26,6 +28,20 @@ export type RefreshOutcome =
   | { outcome: "renewed"; expiresAt: number }
   | { outcome: "signed-out"; login: string }
   | { outcome: "unavailable" };
+
+/** The gate's 200 body: the renewed token's expiry, in seconds. */
+const RenewedBody = z.object({ expiresAt: z.number() }).loose();
+/** The gate's 401 body: where to sign in again (an absolute path on this origin). */
+const SignedOutBody = z.object({ login: z.string().startsWith("/") }).loose();
+
+/** The response body as JSON, or null when there is none worth reading. */
+async function jsonOf(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
 
 /** The gate's login start for one page (the same link its sign-in page carries). */
 export function loginPathFor(returnTo: string): string {
@@ -49,30 +65,18 @@ export async function refreshProjectSession(input: {
     return { outcome: "unavailable" };
   }
   if (response.status === 401) {
-    let login = loginPathFor(input.returnTo);
-    try {
-      const body: unknown = await response.json();
-      if (typeof body === "object" && body !== null && "login" in body) {
-        const pointer = (body as { login: unknown }).login;
-        if (typeof pointer === "string" && pointer.startsWith("/")) login = pointer;
-      }
-    } catch {
-      // A bare 401 still means signed out; the pointer is a courtesy.
-    }
-    return { outcome: "signed-out", login };
+    // A bare 401 still means signed out; the login pointer is a courtesy.
+    const body = SignedOutBody.safeParse(await jsonOf(response));
+    return {
+      outcome: "signed-out",
+      login: body.success ? body.data.login : loginPathFor(input.returnTo),
+    };
   }
   if (!response.ok) return { outcome: "unavailable" };
-  try {
-    const body: unknown = await response.json();
-    const expiresAt =
-      typeof body === "object" && body !== null && "expiresAt" in body
-        ? (body as { expiresAt: unknown }).expiresAt
-        : undefined;
-    if (typeof expiresAt !== "number") return { outcome: "unavailable" };
-    return { outcome: "renewed", expiresAt };
-  } catch {
-    return { outcome: "unavailable" };
-  }
+  const body = RenewedBody.safeParse(await jsonOf(response));
+  return body.success
+    ? { outcome: "renewed", expiresAt: body.data.expiresAt }
+    : { outcome: "unavailable" };
 }
 
 /**
@@ -92,14 +96,14 @@ export function nextRefreshDelayMs(expiresAt: number, now: number): number {
  * when a tab comes back to the foreground with a stale renewal; hand a dead
  * session to sign-in exactly once and stop. Returns the stop function.
  */
-export function startProjectSessionKeepalive(input: {
+export function startProjectSessionKeepalive<TimerId>(input: {
   refresh: () => Promise<RefreshOutcome>;
   now: () => number;
-  timers: { set: (fn: () => void, ms: number) => unknown; clear: (id: unknown) => void };
+  timers: { set: (fn: () => void, ms: number) => TimerId; clear: (id: TimerId) => void };
   onSignedOut: (login: string) => void;
   visibility?: { isVisible: () => boolean; onVisible: (fn: () => void) => () => void };
 }): () => void {
-  let timer: unknown = null;
+  let timer: TimerId | null = null;
   let stopped = false;
   let inFlight = false;
   let lastRenewedAt = Number.NEGATIVE_INFINITY;
@@ -160,7 +164,7 @@ export function startBrowserProjectSessionKeepalive(): () => void {
     now: () => Date.now(),
     timers: {
       set: (fn, ms) => window.setTimeout(fn, ms),
-      clear: (id) => window.clearTimeout(id as number),
+      clear: (id) => window.clearTimeout(id),
     },
     onSignedOut: (login) => location.assign(login),
     visibility: {

--- a/apps/docs/src/lib/retry.test.ts
+++ b/apps/docs/src/lib/retry.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test, vi } from "vitest";
+import { withRetries } from "./retry.ts";
+
+describe("withRetries", () => {
+  test("succeeds on a later attempt, sleeping the given delays between tries", async () => {
+    let calls = 0;
+    const sleep = vi.fn(async (_ms: number) => {});
+    const result = await withRetries(
+      async () => {
+        calls++;
+        if (calls < 3) throw new Error(`not yet ${calls}`);
+        return "done";
+      },
+      { attempts: 3, delayMs: (attempt) => attempt * 1000, sleep },
+    );
+    expect(result).toBe("done");
+    expect(sleep.mock.calls.map(([ms]) => ms)).toEqual([1000, 2000]);
+  });
+
+  test("throws the last error once the attempts are spent", async () => {
+    let calls = 0;
+    await expect(
+      withRetries(
+        async () => {
+          calls++;
+          throw new Error(`fail ${calls}`);
+        },
+        { attempts: 2, delayMs: () => 0, sleep: async () => {} },
+      ),
+    ).rejects.toThrow("fail 2");
+  });
+
+  test("does not retry an error the caller says is final", async () => {
+    const run = vi.fn(async () => {
+      throw new Error("does not exist");
+    });
+    await expect(
+      withRetries(run, {
+        attempts: 3,
+        delayMs: () => 0,
+        shouldRetry: (error) => !(error instanceof Error && /exist/.test(error.message)),
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow("does not exist");
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/docs/src/lib/retry.ts
+++ b/apps/docs/src/lib/retry.ts
@@ -1,0 +1,28 @@
+/**
+ * Run an operation up to `attempts` times, sleeping `delayMs(attempt)` between
+ * tries, retrying only errors `shouldRetry` accepts. The last error is the
+ * one thrown. Clock injected so the rule is table-testable.
+ */
+export async function withRetries<T>(
+  run: () => Promise<T>,
+  options: {
+    attempts: number;
+    delayMs: (attempt: number) => number;
+    shouldRetry?: (error: unknown) => boolean;
+    sleep?: (ms: number) => Promise<void>;
+  },
+): Promise<T> {
+  const sleep = options.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  let attempt = 0;
+  for (;;) {
+    attempt++;
+    try {
+      return await run();
+    } catch (error) {
+      if (attempt >= options.attempts || (options.shouldRetry?.(error) ?? true) === false) {
+        throw error;
+      }
+      await sleep(options.delayMs(attempt));
+    }
+  }
+}

--- a/apps/docs/src/routes/__root.tsx
+++ b/apps/docs/src/routes/__root.tsx
@@ -1,8 +1,9 @@
-import type { ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 import { createRootRoute, HeadContent, Outlet, Scripts } from "@tanstack/react-router";
 import { SidebarInset, SidebarProvider } from "@iterate-com/ui/components/sidebar";
 import { TooltipProvider } from "@iterate-com/ui/components/tooltip";
 import appCss from "../styles.css?url";
+import { startBrowserProjectSessionKeepalive } from "../lib/project-session.ts";
 import { getAppShellContext } from "../lib/sidebar-state.ts";
 import { AppSidebar } from "../components/app-sidebar.tsx";
 
@@ -27,6 +28,9 @@ export const Route = createRootRoute({
 
 function RootComponent() {
   const { sidebarDefaultOpen } = Route.useLoaderData();
+  // The project-host session cookie lives 15 minutes; renewing it while
+  // the tab is open is what keeps the app signed in past that.
+  useEffect(() => startBrowserProjectSessionKeepalive(), []);
   return (
     <RootDocument>
       <TooltipProvider delay={0}>

--- a/apps/os/src/auth/project-app-session-token.test.ts
+++ b/apps/os/src/auth/project-app-session-token.test.ts
@@ -26,6 +26,36 @@ const CLAIMS = {
   userId: "usr_1",
 };
 
+describe("localProjectAppSessionValidator", () => {
+  it("carries the display identity claims alongside the actor", async () => {
+    const validate = localProjectAppSessionValidator(SECRET);
+    const token = await sign({ ...CLAIMS, email: "one@example.com", name: "One" });
+    expect(
+      await validate({ audience: CLAIMS.audience, projectId: "prj_one", token }),
+    ).toMatchObject({
+      email: "one@example.com",
+      name: "One",
+      userId: "usr_1",
+    });
+  });
+
+  it("reports the sign-in a token descends from, or its issue time for a pre-rollout token", async () => {
+    const validate = localProjectAppSessionValidator(SECRET);
+    const renewed = await sign({ ...CLAIMS, loginAt: 1_700_000_000 });
+    expect(
+      (await validate({ audience: CLAIMS.audience, projectId: "prj_one", token: renewed }))
+        ?.loginAt,
+    ).toBe(1_700_000_000);
+    const before = Math.floor(Date.now() / 1000);
+    const legacy = await validate({
+      audience: CLAIMS.audience,
+      projectId: "prj_one",
+      token: await sign(CLAIMS),
+    });
+    expect(legacy?.loginAt).toBeGreaterThanOrEqual(before);
+  });
+});
+
 describe("verifyProjectAppSessionToken", () => {
   it("answers the claims for a well-signed unexpired token", async () => {
     const token = await sign(CLAIMS);

--- a/apps/os/src/auth/project-app-session-token.ts
+++ b/apps/os/src/auth/project-app-session-token.ts
@@ -18,7 +18,15 @@ import { z } from "zod";
 const ProjectAppSessionClaims = z
   .object({
     audience: z.string(),
+    // Display identity (presence, authorship) — optional, no authority.
+    email: z.string().trim().min(1).max(320).optional(),
     exp: z.number().int(),
+    iat: z.number().int().optional(),
+    image: z.string().trim().min(1).max(2048).optional(),
+    // The sign-in this token descends from (renewals carry it forward);
+    // a pre-rollout token counts as signed in when it was issued.
+    loginAt: z.number().int().optional(),
+    name: z.string().trim().min(1).max(256).optional(),
     projectId: z.string().trim().min(1).max(256),
     type: z.literal("project-app-session"),
     userId: z.string().trim().min(1).max(256),
@@ -41,11 +49,25 @@ export function localProjectAppSessionValidator(secret: string) {
     audience: string;
     projectId: string;
     token: string;
-  }): Promise<{ expiresAt: number; userId: string } | null> => {
+  }): Promise<{
+    email?: string;
+    expiresAt: number;
+    image?: string;
+    loginAt: number;
+    name?: string;
+    userId: string;
+  } | null> => {
     const claims = await verifyProjectAppSessionToken(input.token, secret);
     if (claims === null) return null;
     if (claims.audience !== input.audience || claims.projectId !== input.projectId) return null;
-    return { expiresAt: claims.exp, userId: claims.userId };
+    return {
+      ...(claims.email === undefined ? {} : { email: claims.email }),
+      expiresAt: claims.exp,
+      loginAt: claims.loginAt ?? claims.iat ?? claims.exp,
+      ...(claims.image === undefined ? {} : { image: claims.image }),
+      ...(claims.name === undefined ? {} : { name: claims.name }),
+      userId: claims.userId,
+    };
   };
 }
 

--- a/apps/os/src/auth/project-auth.test.ts
+++ b/apps/os/src/auth/project-auth.test.ts
@@ -58,6 +58,7 @@ describe("project auth partial fetch", () => {
       }),
       vi.fn(async () => ({
         expiresAt: Math.floor(Date.now() / 1000) + 600,
+        loginAt: Math.floor(Date.now() / 1000) - 60,
         userId: "usr_one",
       })),
     );
@@ -71,6 +72,7 @@ describe("project auth partial fetch", () => {
   test("continues without consuming the request while the cookie remains valid", async () => {
     const validate = vi.fn(async () => ({
       expiresAt: Math.floor(Date.now() / 1000) + 600,
+      loginAt: Math.floor(Date.now() / 1000) - 60,
       userId: "usr_one",
     }));
     const request = new Request(`${appOrigin}/private`, {
@@ -88,14 +90,38 @@ describe("project auth partial fetch", () => {
       token: "signed-token",
     });
 
+    // A stale cookie on a navigation is a member who was here minutes ago:
+    // hand them straight back to the login start (silent while the OS
+    // session lives) instead of a sign-in page, and clear the dead cookie.
     const denied = await projectFetch(
-      new Request(`${appOrigin}/private`, {
+      new Request(`${appOrigin}/private?x=1`, {
         headers: { accept: "text/html", cookie: "iterate-project-auth=revoked" },
       }),
       vi.fn(async () => null),
     );
-    expect(denied?.status).toBe(200);
-    expect(denied?.headers.get("set-cookie")).toContain("Max-Age=0");
+    expect(denied?.status).toBe(302);
+    expect(denied?.headers.get("location")).toBe(
+      "/_iterate/auth/login?return_to=%2Fprivate%3Fx%3D1",
+    );
+    const cleared = denied?.headers.getSetCookie() ?? [];
+    expect(
+      cleared.some((c) => c.startsWith("iterate-project-auth=;") && c.includes("Max-Age=0")),
+    ).toBe(true);
+    expect(cleared.some((c) => c.startsWith("iterate-project-auth-retry=1;"))).toBe(true);
+
+    // The one-shot guard breaks a loop: bounced back with a still-dead
+    // cookie, the sign-in page renders as before.
+    const bounced = await projectFetch(
+      new Request(`${appOrigin}/private?x=1`, {
+        headers: {
+          accept: "text/html",
+          cookie: "iterate-project-auth=revoked; iterate-project-auth-retry=1",
+        },
+      }),
+      vi.fn(async () => null),
+    );
+    expect(bounced?.status).toBe(200);
+    expect(await bounced?.text()).toContain("Continue with iterate");
   });
 
   test("rejects cross-origin and oversized callback posts", async () => {
@@ -125,6 +151,137 @@ describe("project auth partial fetch", () => {
   });
 });
 
+describe("project auth session refresh", () => {
+  const refreshPath = `${appOrigin}/_iterate/auth/refresh?return_to=%2Fevents%3Fkind%3Droot`;
+  const soon = Math.floor(Date.now() / 1000) + 300;
+  const signedInAt = Math.floor(Date.now() / 1000) - 3_600;
+
+  test("re-mints a fresh cookie for a still-valid session", async () => {
+    const renewedExpiry = Math.floor(Date.now() / 1000) + 900;
+    const mintSession = vi.fn(async () => ({ expiresAt: renewedExpiry, token: "fresh-token" }));
+    const response = await projectFetch(
+      new Request(refreshPath, {
+        headers: { cookie: "iterate-project-auth=signed-token", origin: appOrigin },
+        method: "POST",
+      }),
+      vi.fn(async () => ({
+        email: "one@example.com",
+        expiresAt: soon,
+        image: "https://img.example/one.png",
+        loginAt: signedInAt,
+        name: "One",
+        userId: "usr_one",
+      })),
+      mintSession,
+    );
+    expect(response?.status).toBe(200);
+    // The renewed token is minted for the SAME user, project, and origin,
+    // carrying the display identity the app shows and the ORIGINAL sign-in
+    // (so renewals never extend a session past its absolute age) — never widened.
+    expect(mintSession).toHaveBeenCalledWith({
+      audience: appOrigin,
+      email: "one@example.com",
+      image: "https://img.example/one.png",
+      loginAt: signedInAt,
+      name: "One",
+      projectId,
+      userId: "usr_one",
+    });
+    const cookies = response?.headers.getSetCookie() ?? [];
+    // The cookie outlives the token (30 days): a lapsed token still present
+    // is what lets a later navigation re-mint silently instead of showing
+    // the sign-in page.
+    expect(cookies[0]).toMatch(
+      /^iterate-project-auth=fresh-token; Path=\/; HttpOnly; SameSite=Strict; Max-Age=2592000; Secure$/,
+    );
+    // A successful renewal also retires any loop guard from an earlier bounce.
+    expect(cookies.some((c) => c.startsWith("iterate-project-auth-retry=;"))).toBe(true);
+    expect(response?.headers.get("cache-control")).toContain("no-store");
+    await expect(response?.json()).resolves.toEqual({ ok: true, expiresAt: renewedExpiry });
+  });
+
+  test("a session past its absolute age is not renewed, however valid its token", async () => {
+    const mintSession = vi.fn(async () => ({ expiresAt: soon, token: "never" }));
+    const response = await projectFetch(
+      new Request(refreshPath, {
+        headers: { cookie: "iterate-project-auth=old-but-valid", origin: appOrigin },
+        method: "POST",
+      }),
+      vi.fn(async () => ({
+        expiresAt: soon,
+        loginAt: Math.floor(Date.now() / 1000) - 8 * 24 * 60 * 60,
+        userId: "usr_one",
+      })),
+      mintSession,
+    );
+    expect(response?.status).toBe(401);
+    expect(mintSession).not.toHaveBeenCalled();
+  });
+
+  test("a renewal without an Origin is refused: it is only ever the page's own fetch", async () => {
+    const mintSession = vi.fn(async () => ({ expiresAt: soon, token: "never" }));
+    const response = await projectFetch(
+      new Request(refreshPath, {
+        headers: { cookie: "iterate-project-auth=signed-token" },
+        method: "POST",
+      }),
+      vi.fn(async () => ({ expiresAt: soon, loginAt: signedInAt, userId: "usr_one" })),
+      mintSession,
+    );
+    expect(response?.status).toBe(403);
+    expect(mintSession).not.toHaveBeenCalled();
+  });
+
+  test("a dead session gets the login handoff, never a new token", async () => {
+    const mintSession = vi.fn(async () => ({ expiresAt: soon, token: "never" }));
+    const response = await projectFetch(
+      new Request(refreshPath, {
+        headers: { cookie: "iterate-project-auth=expired", origin: appOrigin },
+        method: "POST",
+      }),
+      vi.fn(async () => null),
+      mintSession,
+    );
+    expect(response?.status).toBe(401);
+    expect(mintSession).not.toHaveBeenCalled();
+    expect(response?.headers.get("set-cookie")).toContain("Max-Age=0");
+    await expect(response?.json()).resolves.toEqual({
+      authenticated: false,
+      login: "/_iterate/auth/login?return_to=%2Fevents%3Fkind%3Droot",
+    });
+  });
+
+  test("refuses to renew for anything but a same-origin browser POST", async () => {
+    const validate = vi.fn(async () => ({
+      expiresAt: soon,
+      loginAt: signedInAt,
+      userId: "usr_one",
+    }));
+    const crossOrigin = await projectFetch(
+      new Request(refreshPath, {
+        headers: { cookie: "iterate-project-auth=signed-token", origin: "https://evil.example" },
+        method: "POST",
+      }),
+      validate,
+    );
+    expect(crossOrigin?.status).toBe(403);
+    const wrongMethod = await projectFetch(
+      new Request(refreshPath, { headers: { cookie: "iterate-project-auth=signed-token" } }),
+      validate,
+    );
+    expect(wrongMethod?.status).toBe(405);
+    expect(validate).not.toHaveBeenCalled();
+  });
+
+  test("a missing cookie is a plain 401 with the login pointer", async () => {
+    const response = await projectFetch(
+      new Request(refreshPath, { headers: { origin: appOrigin }, method: "POST" }),
+    );
+    expect(response?.status).toBe(401);
+    await expect(response?.json()).resolves.toMatchObject({ authenticated: false });
+  });
+});
+
 describe("project auth actor exchange", () => {
   test("rejects malformed policy as a caller authentication outcome", () => {
     expect(() => parseProjectAuthPolicy({ policy: "other" } as never)).toThrow(
@@ -143,6 +300,7 @@ describe("project auth actor exchange", () => {
     });
     const validateSession = vi.fn(async () => ({
       expiresAt: Math.floor(Date.now() / 1000) + 600,
+      loginAt: Math.floor(Date.now() / 1000) - 60,
       userId: "usr_one",
     }));
 
@@ -163,7 +321,7 @@ describe("project auth actor exchange", () => {
   });
 
   test("rejects missing or invalid sessions and non-exact origins", async () => {
-    const validateSession = vi.fn(async () => ({ expiresAt: 1, userId: "usr_one" }));
+    const validateSession = vi.fn(async () => ({ expiresAt: 1, loginAt: 0, userId: "usr_one" }));
     const invalidHeaders: HeadersInit[] = [
       { origin: appOrigin },
       { cookie: "iterate-project-auth=signed-token" },
@@ -233,13 +391,25 @@ describe("project auth start", () => {
 
 function projectFetch(
   request: Request,
-  validateSession: (input: {
+  validateSession: (input: { audience: string; projectId: string; token: string }) => Promise<{
+    email?: string;
+    expiresAt: number;
+    image?: string;
+    loginAt: number;
+    name?: string;
+    userId: string;
+  } | null> = vi.fn(async () => null),
+  mintSession: (input: {
     audience: string;
+    email?: string;
+    image?: string;
+    name?: string;
     projectId: string;
-    token: string;
-  }) => Promise<{ expiresAt: number; userId: string } | null> = vi.fn(async () => null),
+    userId: string;
+  }) => Promise<{ expiresAt: number; token: string } | null> = vi.fn(async () => null),
 ): Promise<Response | null> {
   return handleProjectAuthFetch({
+    mintSession,
     osBaseUrl: osOrigin,
     projectId,
     request,

--- a/apps/os/src/auth/project-auth.ts
+++ b/apps/os/src/auth/project-auth.ts
@@ -20,14 +20,39 @@ export type ProjectAuthActor = Pick<ValidatedProjectAppSession, "userId">;
 type ProjectAuthRequest = Pick<Request, "body" | "headers" | "method" | "url">;
 
 const AUTH_COOKIE = "iterate-project-auth";
+/** One-shot marker set with the silent login handoff on a stale cookie: if
+ * the browser comes back still unauthenticated within its minute, the gate
+ * renders the sign-in page instead of bouncing again. */
+const RETRY_COOKIE = "iterate-project-auth-retry";
 const CALLBACK_PATH = "/_iterate/auth/callback";
 const LOGIN_PATH = "/_iterate/auth/login";
 const LOGOUT_PATH = "/_iterate/auth/logout";
+const REFRESH_PATH = "/_iterate/auth/refresh";
+/**
+ * How long the cookie jar keeps a session token: deliberately far longer
+ * than the token's own 15 minutes. A lapsed token still PRESENT is what lets
+ * a plain navigation re-mint silently; the moment the browser drops the
+ * cookie there is nothing to tell a returning member from a stranger, and
+ * the sign-in page becomes the only answer. Presence grants nothing — the
+ * token inside is verified on every request.
+ */
+const COOKIE_TTL_SECONDS = 30 * 24 * 60 * 60;
+/**
+ * The longest a session may live through renewals. Renewal proves a member
+ * with a valid token; it does not prove the platform sign-in that token
+ * descends from is still alive. Past this age the member signs in again.
+ */
+const MAX_SESSION_AGE_SECONDS = 7 * 24 * 60 * 60;
 const MAX_TOKEN_BYTES = 8192;
 
 type ValidateSession = (
   input: ValidateProjectAppSessionInput,
 ) => Promise<ValidatedProjectAppSession | null>;
+
+/** Re-mint a session for an actor validation already proved (the refresh route). */
+type MintSession = (
+  input: MintProjectAppSessionInput,
+) => Promise<{ expiresAt: number; token: string } | null>;
 
 /** Runtime-check policy values because project code crosses an RPC boundary. */
 export function parseProjectAuthPolicy(value: ProjectAuthPolicy): ProjectAuthPolicy {
@@ -85,12 +110,27 @@ export async function authenticateProjectRequest(input: {
  * path inspects metadata only and leaves the request body untouched.
  */
 export async function handleProjectAuthFetch(input: {
+  /** Absent only in callers that never serve the refresh route. */
+  mintSession?: MintSession;
   osBaseUrl: string | undefined;
   projectId: string;
   request: ProjectAuthRequest;
   validateSession: ValidateSession;
 }): Promise<Response | null> {
   const url = new URL(input.request.url);
+
+  if (url.pathname === REFRESH_PATH) {
+    if (input.request.method !== "POST") return methodNotAllowed("POST");
+    // A renewal is only ever the page's own fetch: an exact Origin, never a
+    // navigation or a request without one.
+    if (
+      input.request.headers.get("origin") === null ||
+      !isSameOriginBrowserRequest(input.request)
+    ) {
+      return forbiddenOrigin();
+    }
+    return await refreshSession(input, url);
+  }
 
   if (url.pathname === LOGIN_PATH) {
     if (input.request.method !== "GET") return methodNotAllowed("GET");
@@ -120,7 +160,8 @@ export async function handleProjectAuthFetch(input: {
     return new Response(null, { headers, status: 303 });
   }
 
-  const token = readCookie(input.request.headers.get("cookie"), AUTH_COOKIE);
+  const cookieHeader = input.request.headers.get("cookie");
+  const token = readCookie(cookieHeader, AUTH_COOKIE);
   if (token) {
     const validation = await validateOrDependencyResponse(input, token, url.origin);
     if (validation instanceof Response) return validation;
@@ -130,11 +171,89 @@ export async function handleProjectAuthFetch(input: {
   const login = `${LOGIN_PATH}?${new URLSearchParams({
     return_to: `${url.pathname}${url.search}`,
   })}`;
+  // A stale cookie on a navigation is a member who was here minutes ago:
+  // hand them straight back to the login start, which re-mints without a
+  // click while their OS session lives, instead of a sign-in page. The
+  // one-shot guard makes a second bounce render the page rather than loop.
+  if (
+    token &&
+    isHtmlNavigation(input.request) &&
+    input.osBaseUrl &&
+    readCookie(cookieHeader, RETRY_COOKIE) === null
+  ) {
+    const headers = noStoreHeaders();
+    headers.set("location", login);
+    headers.append("set-cookie", expiredCookie(url));
+    headers.append("set-cookie", retryGuardCookie(url));
+    return new Response(null, { headers, status: 302 });
+  }
   const response = isHtmlNavigation(input.request)
     ? loginPage(login)
     : Response.json({ authenticated: false, login }, { headers: noStoreHeaders(), status: 401 });
   if (token) response.headers.append("set-cookie", expiredCookie(url));
   return response;
+}
+
+/**
+ * Transparent renewal: while the cookie still proves a current member, mint a
+ * fresh token for the SAME user, project, and origin and set it back. The
+ * 15-minute token bounds revocation lag exactly as before — renewal needs a
+ * currently valid token, and both validation and the mint re-check access.
+ * A dead cookie answers like any other unauthenticated API call.
+ */
+async function refreshSession(
+  input: {
+    mintSession?: MintSession;
+    projectId: string;
+    request: ProjectAuthRequest;
+    validateSession: ValidateSession;
+  },
+  url: URL,
+): Promise<Response> {
+  let returnTo: string;
+  try {
+    returnTo = normalizeReturnPath(url.searchParams.get("return_to") ?? "/", url.origin);
+  } catch (error) {
+    return invalidRequest(error);
+  }
+  const login = `${LOGIN_PATH}?${new URLSearchParams({ return_to: returnTo })}`;
+  const signedOut = () => {
+    const headers = noStoreHeaders();
+    headers.append("set-cookie", expiredCookie(url));
+    return Response.json({ authenticated: false, login }, { headers, status: 401 });
+  };
+  const token = readCookie(input.request.headers.get("cookie"), AUTH_COOKIE);
+  if (!token) return signedOut();
+  const validation = await validateOrDependencyResponse(input, token, url.origin);
+  if (validation instanceof Response) return validation;
+  if (!validation) return signedOut();
+  if (validation.loginAt + MAX_SESSION_AGE_SECONDS <= Math.floor(Date.now() / 1000)) {
+    return signedOut();
+  }
+  if (input.mintSession === undefined) {
+    return unavailable("Project authentication is not configured.");
+  }
+  let issued: { expiresAt: number; token: string } | null;
+  try {
+    issued = await input.mintSession({
+      audience: url.origin,
+      ...(validation.email === undefined ? {} : { email: validation.email }),
+      ...(validation.image === undefined ? {} : { image: validation.image }),
+      loginAt: validation.loginAt,
+      ...(validation.name === undefined ? {} : { name: validation.name }),
+      projectId: input.projectId,
+      userId: validation.userId,
+    });
+  } catch (error) {
+    console.error("[project-auth] session renewal failed", error);
+    return unavailable("Project authentication is temporarily unavailable.");
+  }
+  // Access gone between validation and mint: no new token, same answer.
+  if (!issued) return signedOut();
+  const headers = noStoreHeaders();
+  headers.append("set-cookie", sessionCookie(issued.token, url));
+  headers.append("set-cookie", expiredRetryGuardCookie(url));
+  return Response.json({ ok: true, expiresAt: issued.expiresAt }, { headers });
 }
 
 export async function handleProjectAuthStart(input: {
@@ -224,7 +343,8 @@ async function redeemSession(input: {
   }
 
   const headers = noStoreHeaders();
-  headers.append("set-cookie", sessionCookie(token.trim(), validation.expiresAt, url));
+  headers.append("set-cookie", sessionCookie(token.trim(), url));
+  headers.append("set-cookie", expiredRetryGuardCookie(url));
   return Response.json({ ok: true, returnTo }, { headers });
 }
 
@@ -317,14 +437,13 @@ function readCookie(cookieHeader: string | null, name: string) {
   return null;
 }
 
-function sessionCookie(token: string, expiresAt: number, url: URL) {
-  const maxAge = Math.max(0, expiresAt - Math.floor(Date.now() / 1000));
+function sessionCookie(token: string, url: URL) {
   return [
     `${AUTH_COOKIE}=${token}`,
     "Path=/",
     "HttpOnly",
     "SameSite=Strict",
-    `Max-Age=${maxAge}`,
+    `Max-Age=${COOKIE_TTL_SECONDS}`,
     ...(url.protocol === "https:" ? ["Secure"] : []),
   ].join("; ");
 }
@@ -332,6 +451,28 @@ function sessionCookie(token: string, expiresAt: number, url: URL) {
 function expiredCookie(url: URL) {
   return [
     `${AUTH_COOKIE}=`,
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Strict",
+    "Max-Age=0",
+    ...(url.protocol === "https:" ? ["Secure"] : []),
+  ].join("; ");
+}
+
+function retryGuardCookie(url: URL) {
+  return [
+    `${RETRY_COOKIE}=1`,
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Strict",
+    "Max-Age=60",
+    ...(url.protocol === "https:" ? ["Secure"] : []),
+  ].join("; ");
+}
+
+function expiredRetryGuardCookie(url: URL) {
+  return [
+    `${RETRY_COOKIE}=`,
     "Path=/",
     "HttpOnly",
     "SameSite=Strict",

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -6531,6 +6531,9 @@ class ProjectAuthRpcTarget extends IterateRpcTarget<"ProjectAuth"> {
    */
   async fetch(request: Request): Promise<Response | null> {
     return await handleProjectAuthFetch({
+      // Renewal mints through the auth worker like login does; validation
+      // stays on the local lane.
+      mintSession: (input) => env.AUTH.mintProjectAppSession(input),
       osBaseUrl: parseConfig(env).baseUrl,
       projectId: this.props.projectId,
       request,

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -6532,7 +6532,8 @@ class ProjectAuthRpcTarget extends IterateRpcTarget<"ProjectAuth"> {
   async fetch(request: Request): Promise<Response | null> {
     return await handleProjectAuthFetch({
       // Renewal mints through the auth worker like login does; validation
-      // stays on the local lane.
+      // stays local (the HS256 check in project-app-session-token.ts, no
+      // auth-worker call).
       mintSession: (input) => env.AUTH.mintProjectAppSession(input),
       osBaseUrl: parseConfig(env).baseUrl,
       projectId: this.props.projectId,

--- a/docs/remote-apps.md
+++ b/docs/remote-apps.md
@@ -41,7 +41,13 @@ the vessel never sees an unauthenticated request.
 
 1. Read `x-itx-project-id` (stamped by platform ingress) and the
    `iterate-project-auth` cookie (the short-lived project-host session token
-   the auth worker minted at login — 15-minute TTL, refreshed transparently).
+   the auth worker minted at login — 15-minute TTL). Nothing renews it on
+   its own: a page that stays open longer than that must `POST
+/_iterate/auth/refresh` (same origin) before the token lapses, and the
+   gate re-mints it for the same member — `200 {expiresAt}`, or `401
+{login}` once the session is dead. A stale cookie on a plain navigation
+   is re-minted by a silent hop through the login route; only a member the
+   directory no longer knows sees the sign-in page.
 2. On each `/api` WebSocket connection, dial the platform back and present
    the token:
 

--- a/packages/workspace-documents/src/collab-client.ts
+++ b/packages/workspace-documents/src/collab-client.ts
@@ -254,7 +254,12 @@ export function peerExtension(connection: CollabConnection, startVersion: number
             // react-doctor-disable-next-line react-doctor/js-cache-property-access
             const result = await connection.wait(getSyncedVersion(this.view.state));
             if (this.done) break;
-            this.failures = 0;
+            if (this.failures > 0) {
+              // Back after "reconnecting (n)…": say so, or the badge would
+              // report a dead session that is in fact syncing again.
+              this.failures = 0;
+              connection.onStatus(`live · v${getSyncedVersion(this.view.state)}`);
+            }
             if (result.status === "ended") {
               // The file was deleted/replaced/reset: the session is gone for
               // everyone. Surface it and stop — reopening is a page decision.
@@ -315,8 +320,12 @@ export function peerExtension(connection: CollabConnection, startVersion: number
         // Best-effort final flush: unpushed edits still in the doc would die
         // with the view (the board may already show them via the live
         // reflector). Safe to fire even beside an in-flight push — the
-        // server dedupes by (clientId, clientSeq).
-        if (!this.done && !this.recovering) {
+        // server dedupes by (clientId, clientSeq). Deliberately also after
+        // the loops gave up (`done`): a Reconnect remount is exactly when
+        // those edits are worth one more try over the shared session, which
+        // may have been re-dialed since. Only a reseed in flight is skipped —
+        // its pending edits are positionally meaningless.
+        if (!this.recovering) {
           const pending = sendableUpdates(this.view.state);
           if (pending.length > 0) {
             // ONE quiet try on the live session: a failure here must never

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,6 +449,9 @@ importers:
       yaml:
         specifier: ^2.8.0
         version: 2.8.3
+      zod:
+        specifier: 4.5.4
+        version: 4.5.4(patch_hash=bf04bb1ec1f0b9f31a7416bf98f83d3451e5011852877ca0ac19c12fcb3129b5)
 
   apps/dummy-petshop:
     dependencies:

--- a/specs/mobile/notes.spec.ts
+++ b/specs/mobile/notes.spec.ts
@@ -8,80 +8,89 @@
 // derived title has landed yet.
 
 import { expect } from "@playwright/test";
+import { createFlake } from "@iterate-com/shared/test-support/flake-test";
 import { test } from "../test-support/test.ts";
 
-test("captures a note from the global composer and manages it on /notes", async ({
-  page,
-  helpers,
-}) => {
-  await using fixture = await helpers.createMobileFixture("mobile-notes");
+// Known flake (2026-09-08), quarantined per docs/testing.md: on preview CI the
+// 💬 hand-off's Message composer sometimes takes longer than the 1 s
+// inputValue() budget to appear — seen first-attempt on PR #2598 and on four
+// consecutive lane runs of PR #2602 (retry included), whose diff has no path
+// into this composer. The wrap keeps the test running and measured; unwrap
+// once the composer renders inside the budget again.
+const flake = createFlake(test, /locator\.inputValue: Timeout 1000ms exceeded/);
 
-  // The composer is already there on the chat-list screen — no navigation
-  // between "I opened the app" and "I captured the thought".
-  await page.getByText(`→ /notes in ${fixture.projectSlug}`).waitFor();
-  await page.getByPlaceholder("Capture a note").fill("Standing desk height: 76cm felt right");
-  await page.getByLabel("Save note").click();
+flake(
+  "captures a note from the global composer and manages it on /notes",
+  async ({ page, helpers }) => {
+    await using fixture = await helpers.createMobileFixture("mobile-notes");
 
-  await page.getByLabel("Collapse note composer").click();
-  await page.getByPlaceholder("Capture a note").waitFor({ state: "hidden" });
-  await page.getByLabel("Capture a note").click();
-  await page.getByPlaceholder("Capture a note").waitFor();
+    // The composer is already there on the chat-list screen — no navigation
+    // between "I opened the app" and "I captured the thought".
+    await page.getByText(`→ /notes in ${fixture.projectSlug}`).waitFor();
+    await page.getByPlaceholder("Capture a note").fill("Standing desk height: 76cm felt right");
+    await page.getByLabel("Save note").click();
 
-  // First-line title until the analysis settlement overlays it — either way
-  // the note's own text is on screen.
-  await page.getByText("view in /notes").click();
-  await page.getByPlaceholder("Search notes…").waitFor();
-  await page
-    .getByText(/76cm felt right/)
-    .first()
-    .waitFor();
+    await page.getByLabel("Collapse note composer").click();
+    await page.getByPlaceholder("Capture a note").waitFor({ state: "hidden" });
+    await page.getByLabel("Capture a note").click();
+    await page.getByPlaceholder("Capture a note").waitFor();
 
-  await page.getByPlaceholder("Search notes…").fill("standing desk");
-  await page
-    .getByText(/76cm felt right/)
-    .first()
-    .waitFor();
-  await page.getByPlaceholder("Search notes…").fill("zzz-no-match");
-  await page.getByText("No results").waitFor();
-  await page.getByPlaceholder("Search notes…").fill("");
+    // First-line title until the analysis settlement overlays it — either way
+    // the note's own text is on screen.
+    await page.getByText("view in /notes").click();
+    await page.getByPlaceholder("Search notes…").waitFor();
+    await page
+      .getByText(/76cm felt right/)
+      .first()
+      .waitFor();
 
-  await page
-    .getByText(/76cm felt right/)
-    .first()
-    .click();
-  await page.getByRole("button", { name: "✏️ Edit" }).click();
-  await page.getByLabel("Edit note text").fill("Standing desk height: 76cm — confirmed at home");
-  await page.getByRole("button", { name: "Save", exact: true }).click();
-  await page
-    .getByText(/confirmed at home/)
-    .first()
-    .waitFor();
+    await page.getByPlaceholder("Search notes…").fill("standing desk");
+    await page
+      .getByText(/76cm felt right/)
+      .first()
+      .waitFor();
+    await page.getByPlaceholder("Search notes…").fill("zzz-no-match");
+    await page.getByText("No results").waitFor();
+    await page.getByPlaceholder("Search notes…").fill("");
 
-  // 💬 pre-types a pointer to the note; the question under it is the human's
-  // to write, so nothing is sent on the way in.
-  await page.getByLabel("Chat about this note").click();
-  // inputValue() does the waiting; expect only checks the string it returned.
-  expect(await page.getByPlaceholder("Message").inputValue()).toMatch(
-    /About my note `\/repos\/notes\/.*\.md`:[\s\S]*confirmed at home/,
-  );
+    await page
+      .getByText(/76cm felt right/)
+      .first()
+      .click();
+    await page.getByRole("button", { name: "✏️ Edit" }).click();
+    await page.getByLabel("Edit note text").fill("Standing desk height: 76cm — confirmed at home");
+    await page.getByRole("button", { name: "Save", exact: true }).click();
+    await page
+      .getByText(/confirmed at home/)
+      .first()
+      .waitFor();
 
-  // Send it. This is the step that makes the platform PARSE the derived agent
-  // path (create() + message()), so a path it would reject — the note's
-  // filename stamp carries an uppercase T and Z — fails here instead of on a
-  // phone. Only the echo of our own message is asserted; whatever the agent
-  // says back is its own business.
-  await page.getByLabel("Send").click();
-  await page
-    .getByText(/About my note/)
-    .first()
-    .waitFor();
+    // 💬 pre-types a pointer to the note; the question under it is the human's
+    // to write, so nothing is sent on the way in.
+    await page.getByLabel("Chat about this note").click();
+    // inputValue() does the waiting; expect only checks the string it returned.
+    expect(await page.getByPlaceholder("Message").inputValue()).toMatch(
+      /About my note `\/repos\/notes\/.*\.md`:[\s\S]*confirmed at home/,
+    );
 
-  // The notes screen stayed mounted underneath the pushed chat — its row is
-  // still open.
-  await page.goBack();
+    // Send it. This is the step that makes the platform PARSE the derived agent
+    // path (create() + message()), so a path it would reject — the note's
+    // filename stamp carries an uppercase T and Z — fails here instead of on a
+    // phone. Only the echo of our own message is asserted; whatever the agent
+    // says back is its own business.
+    await page.getByLabel("Send").click();
+    await page
+      .getByText(/About my note/)
+      .first()
+      .waitFor();
 
-  // The delete tombstone empties the list over the live stream.
-  await page.getByRole("button", { name: "Delete…" }).click();
-  await page.getByRole("button", { name: "Yes, delete this note" }).click();
-  await page.getByText("Nothing here yet").waitFor();
-});
+    // The notes screen stayed mounted underneath the pushed chat — its row is
+    // still open.
+    await page.goBack();
+
+    // The delete tombstone empties the list over the live stream.
+    await page.getByRole("button", { name: "Delete…" }).click();
+    await page.getByRole("button", { name: "Yes, delete this note" }).click();
+    await page.getByText("Nothing here yet").waitFor();
+  },
+);

--- a/specs/mobile/notes.spec.ts
+++ b/specs/mobile/notes.spec.ts
@@ -16,8 +16,12 @@ import { test } from "../test-support/test.ts";
 // inputValue() budget to appear — seen first-attempt on PR #2598 and on four
 // consecutive lane runs of PR #2602 (retry included), whose diff has no path
 // into this composer. The wrap keeps the test running and measured; unwrap
-// once the composer renders inside the budget again.
-const flake = createFlake(test, /locator\.inputValue: Timeout 1000ms exceeded/);
+// once the composer renders inside the budget again. The wrapper deadline
+// sits well above a healthy run (~50s: signup fixture plus the whole flow)
+// and under the 240s spec timeout, so a hang goes red instead of green.
+const flake = createFlake(test, /locator\.inputValue: Timeout 1000ms exceeded/, {
+  timeoutMs: 120_000,
+});
 
 flake(
   "captures a note from the global composer and manages it on /notes",

--- a/specs/seeded-apps.spec.ts
+++ b/specs/seeded-apps.spec.ts
@@ -189,6 +189,19 @@ test("review a workspace document in the seeded Docs app", async ({ baseURL, pag
   const docsUrl = new URL(appUrl("docs", slug, baseURL!));
   docsUrl.searchParams.set("workspace", workspacePath);
   docsUrl.searchParams.set("path", documentPath);
+  // Every WebSocket the page opens is kept in reach so the test can cut the
+  // live session under the editor later and watch it come back.
+  await page.addInitScript(() => {
+    const sockets: WebSocket[] = [];
+    const Native = window.WebSocket;
+    window.WebSocket = class extends Native {
+      constructor(...args: ConstructorParameters<typeof WebSocket>) {
+        super(...args);
+        sockets.push(this);
+      }
+    } as typeof WebSocket;
+    (window as unknown as { __sockets: WebSocket[] }).__sockets = sockets;
+  });
   await page.goto(docsUrl.toString());
   // Same cold-build lane as the todo app above: the building page's spinner
   // carries the wait, ceiling raised to match.
@@ -270,6 +283,39 @@ test("review a workspace document in the seeded Docs app", async ({ baseURL, pag
     .getByText("Can we make this promise more concrete?", { exact: true })
     .waitFor();
   await commentsPanel.getByText("Selected text", { exact: true }).waitFor();
+
+  // The 15-minute project session renews from the page itself (the request
+  // the app's keepalive makes), through the config worker's gate, for the
+  // same member: a fresh expiry, no sign-in page.
+  const renewal = await page.evaluate(async () => {
+    const response = await fetch("/_iterate/auth/refresh?return_to=%2F", {
+      credentials: "same-origin",
+      method: "POST",
+    });
+    return { body: (await response.json()) as { expiresAt?: number }, status: response.status };
+  });
+  expect(renewal).toMatchObject({ status: 200 });
+  expect(renewal.body.expiresAt! * 1000).toBeGreaterThan(Date.now() + 14 * 60_000);
+
+  // A live session that dies under the editor (a laptop waking, a colo
+  // hiccup) comes back by itself, and edits made after it landed sync
+  // through the replacement session.
+  await page.evaluate(() => {
+    for (const socket of (window as unknown as { __sockets: WebSocket[] }).__sockets) {
+      socket.close();
+    }
+  });
+  await page.getByRole("button", { name: "Source" }).click();
+  await editor.click();
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.press("ArrowRight");
+  await page.keyboard.type("\n\nStill here after the socket dropped.");
+  await page.getByText(/^live · v\d+$/).waitFor({ timeout: 30_000 }); // timeout: the pull loop's backoff before its re-dial — the a11y-only badge gives the spinner-waiter nothing to watch
+  await expect
+    .poll(async () => String(await workspace.readFile(documentPath)), {
+      timeout: 30_000, // timeout: a workspace read over RPC — no loading UI for the spinner-waiter
+    })
+    .toContain("Still here after the socket dropped.");
 });
 
 /**


### PR DESCRIPTION
Using the Docs app on a production project host (`docs--iterate.iterate.app`) logged people out every fifteen minutes and turned every dropped socket into a permanent error. Three things were missing, and this PR adds them without changing any existing surface.

## What was happening

- The project-host session cookie (`iterate-project-auth`) is a 15-minute JWT. Nothing renewed it; `docs/remote-apps.md` claimed it was "refreshed transparently". After 15 minutes every navigation showed the gate's sign-in page and every `/api` WebSocket handshake got a 401.
- The vessel's dial to OS was authenticated with the token captured at the browser handshake, and re-dialed with that same token after any error. Once the token had lapsed, every re-dial was refused ("missing or invalid auth"). Production `/api` spans living 14 to 74 minutes ended in "Network connection lost."
- The browser held one shared Cap'n Web session and threw it away on *any* error (including "document does not exist"), and the document page turned any failure into a dead-end error screen.

## What this adds

**Platform (gate + auth worker)**

- `POST /_iterate/auth/refresh` on every project host: validates the current cookie, re-mints for the same member, project, and origin, and answers `200 {expiresAt}`. A dead session answers `401 {login}` with the cookie cleared; an auth outage answers 503 and leaves the cookie alone. Exact `Origin` required, `no-store`.
- A stale cookie on a plain HTML navigation now hops silently through the login route (the OS session is usually still alive) instead of rendering the sign-in page. A one-shot `iterate-project-auth-retry` cookie (60 s) stops a loop: if the hop lands back with the cookie still stale, the sign-in page renders as before.
- The cookie's `Max-Age` is now 30 days, decoupled from the token's 15 minutes. A lapsed token still *present* is what lets the silent hop tell a returning member from a stranger. Presence grants nothing: the token inside is verified on every request.
- Tokens carry `loginAt`, the platform sign-in they descend from. Renewal carries it forward and refuses a session older than seven days, so sliding renewal never becomes an unbounded bearer. Pre-rollout tokens read `iat` as their sign-in.
- `validateProjectAppSession` (auth worker and the OS local HS256 lane) reports the display claims and expiry, so the gate re-mints without decoding tokens itself.

**Docs app**

- A keepalive at the root renews the session on load, at half the remaining lifetime (capped at 10 min, floored at 1 s so it never waits past expiry), and when a tab returns to the foreground with a renewal older than a minute. An outage retries in a minute; a dead session hands off to sign-in exactly once with `return_to` set.
- The shared session is replaced only on a *transport* failure (socket shut down, connection lost, handshake refused, or OS refusing the vessel's stale re-dial). Application errors leave it alone. One re-dial per failure wave, shared by every concurrent caller; a re-dial that fails renews the session first and tries once more.
- The document page retries a transport failure while the network comes back, offers **Try again** on the error screen, and **Reconnect** when the editor could not open or its sync loop gave up.

## Size

| Area | Files | + | − |
|---|---|---|---|
| platform | 8 | 482 | 34 |
| docs app | 9 | 709 | 30 |
| e2e spec | 1 | 46 | 0 |
| docs | 1 | 7 | 1 |
| **total** | 19 | **1244** | **65** |

The two new client modules (`project-session.ts`, `docs-client.ts`) are the bulk of the app side; their tests are table-shaped rules.

## Pinned by tests

- `apps/os/src/auth/project-auth.test.ts`: renewal for a valid session (same claims, `loginAt` carried, 30-day cookie, retry-guard retired), dead session 401, over-age session 401, missing/foreign Origin 403, wrong method 405, missing cookie 401, stale-cookie navigation hops once then renders sign-in.
- `apps/auth/src/server/project-app-session.test.ts`: display claims and expiry survive validation; renewal preserves the original `loginAt`.
- `apps/os/src/auth/project-app-session-token.test.ts`: the local lane reports the same claims; `loginAt` falls back to `iat`.
- `apps/docs/src/lib/project-session.test.ts`: refresh outcomes (200/401/503/network), delay rule rows, keepalive scheduling, foreground refresh, single sign-in hand-off, stop.
- `apps/docs/src/lib/docs-client.test.ts`: transport-error table, one re-dial per wave, application errors leave the session, failed re-dial renews first, `withDocsProjectOnce` never re-dials.
- `apps/docs/src/lib/retry.test.ts`.
- `specs/seeded-apps.spec.ts` (Docs walkthrough, runs against the preview): renews through the deployed gate from the page and asserts a fresh expiry; then closes every WebSocket under the live editor, types, and asserts the text reaches the workspace through the replacement session.

## Risk map

- **Trust boundary: the refresh route.** It turns a valid cookie into a fresh one. It requires POST plus an exact same-origin `Origin`, validates before minting, mints for the audience of the request URL only, and refuses past the seven-day age. The cookie stays HttpOnly and SameSite=Strict, so a page cannot read it and a cross-site page cannot send it.
- **The silent login hop.** A stale cookie plus a missing retry guard redirects to the login route. The guard is set on the same response and cleared on redeem and on renewal. If the OS session is also dead the hop lands on the platform login page, same as today.
- **Retrying operations.** `withDocsProject` replays an operation after a transport failure, as it did before this PR (the old code replayed on *every* error). A mutation whose response was lost can run twice. The Docs mutations are idempotent or harmless twice (write same content, delete, revert, birth-if-needed); collab pushes carry their own sequence ids. Not changed here.
- **What this does not explain.** A short burst of Cloudflare "internal error" responses on `/api` seen in production telemetry is not attributed by this PR.

**On merge:** existing tokens keep working (all new claims optional to read). Existing cookies keep their old short `Max-Age` until they are next minted. Nothing to migrate.

**Suggested review order:** `apps/os/src/auth/project-auth.ts` (refresh handler, stale-cookie hop, cookie lifetime) → `apps/docs/src/lib/docs-client.ts` → `apps/docs/src/lib/project-session.ts` → auth worker + contract → document page and root wiring → spec → docs.

## Preview evidence

The seeded Docs spec (`specs/seeded-apps.spec.ts` › *review a workspace document in the seeded Docs app*) passed on the deployed preview in every lane run (six, across af9d8691c → 5e563a642). That is the end-to-end pin: the page renews its session through the config worker's gate and gets a fresh 15-minute expiry, then every WebSocket under the live editor is closed and the next edit still reaches the workspace through the replacement session.

**Lane status: green** on head 5e563a642 after slot preview-1 was erased and rebuilt (`pnpm erase-data --env preview_1`: Durable Objects tombstoned, auth D1 and directory KV wiped, 400 orphaned artifact repos deleted; then the lane rerun redeployed all five apps fresh — 6 suites passed, 0 failed). The first five runs were red on that slot on tests this PR does not touch, with the slot logging Durable Object memory resets and "overloaded":

- **`specs/mobile/notes.spec.ts` › captures a note from the global composer — QUARANTINED in this PR** (`createFlake`, per the protocol in `docs/testing.md`). At the 💬 hand-off the Message composer sometimes takes longer than `inputValue()`'s 1 s budget to appear (`locator.inputValue: Timeout 1000ms exceeded`). Seen first-attempt on PR #2598's lane and on runs 2, 3 and 4 here, retry included. No code path from this diff reaches that composer. The test keeps running and reporting; unwrap once it renders inside the budget again.
- **`apps/os/e2e/vitest/userspace-facet-source-version.e2e.test.ts`** — a `createFailing` pin whose bug did not reproduce (runs 1 and 4: "should have failed with /SAME-BOOT STALENESS/ but it succeeded") or whose own socket dropped (run 2, WS 1006). Its false-alarm history is in `tasks/platform-stall-repros.md`; the slot also logged `Internal error in Durable Object storage caused object to be reset` and a stale `streams-example-app` deployment ("the slot was likely erased since that deploy"), which is the coincidental-recycle shape that masks the pinned bug. Not touched here.

Also retried-and-passed on this slot across the runs: `agent-script-reuse`, `stream-resume-after-suspend`, `create-project`, `agent-fake-model-chat`, and the dynamic-worker build-version e2e (DO storage reset). On the green run, the first wave of web specs after the fresh deploy failed once on project bootstrap ("Failed to install iterate: Failed to fetch tarball", a cold-start effect of the rebuild) and all passed on retry; one `could not wipe stream … isolate exceeded its memory limit` line still appeared during the test-pool teardown, so the DO memory pressure is a platform property rather than stale slot data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HDLp5EZwqbn2KqaGHnyJ4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication session renewal, cookie lifetime, and silent re-login redirects on every project host; incorrect refresh or hop logic could extend sessions, loop redirects, or allow misuse of the refresh endpoint.
> 
> **Overview**
> Fixes **15-minute logouts** and **permanent errors after dropped WebSockets** on project-hosted apps (especially Docs) by adding transparent session renewal and client-side recovery.
> 
> **Platform gate and auth worker:** Adds **`POST /_iterate/auth/refresh`** (same-origin POST + exact `Origin`) to validate the current cookie and re-mint for the same member, project, and origin (`200 {expiresAt}`; dead session `401 {login}`). Session cookies now live **30 days** while JWTs stay **15 minutes**; tokens carry **`loginAt`** (renewals preserve it; **7-day** absolute cap). Stale cookies on HTML navigations get a **one-shot silent hop** through login (`iterate-project-auth-retry` guard). **`mintProjectAppSession`** returns **`expiresAt`**; validation returns **display claims** (`email`, `name`, `image`, `loginAt`) for gate re-mint without decoding.
> 
> **Docs app:** Root **keepalive** schedules refresh; **`createDocsClient`** replaces the shared Cap'n Web session only on **transport** failures, coordinates one re-dial per wave, and **renews** when re-dial fails. Document page **retries** transport errors on load, adds **Try again** / **Reconnect**, and remounts the editor on sync failure. Collab client reports **live** after reconnect and flushes edits on remount.
> 
> Also updates **remote-apps** docs, extends **seeded-apps** e2e for refresh + socket drop, and **quarantines** a flaky mobile notes Playwright step unrelated to this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e563a6422312a653b9237daf946ccc85d992424. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +592 -52 | +369 -43 🟩🟩🟩⬜⬜ |
| UI components | +61 -8 | +48 -8 🟩⬜⬜⬜⬜ |
| Tests | +858 -73 | +735 -56 🟩🟩🟩🟩🟩 |
| Config | +2 -1 | +2 -1 🟩⬜⬜⬜⬜ |
| Docs | +7 -1 | +7 -1 🟩⬜⬜⬜⬜ |
| Generated | +3 -0 | +3 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+1,523 -135** | **+1,164 -109** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between d3f1f4c and 5e563a6, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-09-08T20:42:31.686Z",
      "deployedAt": "2026-09-08T20:20:33.144Z",
      "headSha": "5e563a6422312a653b9237daf946ccc85d992424",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/414120398542042",
      "shortSha": "5e563a6",
      "cleanupDurationMs": 99972,
      "deployDurationMs": 56221,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 56169,
      "deployReadinessDurationMs": 49,
      "deployedWorkerName": "os-preview-1",
      "deployedWorkerVersion": "7742dc43-80c8-489b-a4d1-9fb24a520e3f",
      "testDurationMs": 272469,
      "testRetries": "14 retried: agent smoke > creates a project and receives an agent reply (agent smoke x1) — Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5e563a64223 · stream-resume-after-suspend.spec.ts › control: appended event is delivered to a live stream feed › preview-resilience (playwright x1) — Error: Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5... · stream-resume-after-suspend.spec.ts › feed resumes after the /api WebSocket dies (clean close) › preview-resilience (playwright x1) — Error: Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5... · stream-resume-after-suspend.spec.ts › feed resumes after page freeze + socket death (mobile suspend shape) › preview-resilience (playwright x1) — Error: Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5... · stream-resume-after-suspend.spec.ts › feed resumes after the /api WebSocket goes half-open (no close frame) › preview-resilience (playwright x1) — Error: Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5... · agent-fake-model-chat.spec.ts › a config file mention is materialized before the model sees the turn › web (playwright x1) — Error: Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5... · agent-fake-model-chat.spec.ts › multi-turn chat with a sarcastic agent served by the spec's own fake-model interceptor › web (playwright x1) — Error: Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5... · agent-script-reuse.spec.ts › a repeat request reuses the previous turn's journaled script instead of re-deriving it › web (playwright x1) — Error: Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5... · clients-os-app.spec.ts › two dashboard tabs are two clients; an itx caller navigates each independently › web (playwright x1) — Error: Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5... · collect-secret.spec.ts › a person provides a secret from a phone-sized sheet › web (playwright x1) — Error: Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5... · dashboard.spec.ts › can enter the dashboard with a forged session › web (playwright x1) — Error: Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5... · dashboard.spec.ts › loads project navigation only when it opens › web (playwright x1) — Error: Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5... · dashboard.spec.ts › opening OS returns to the most recently active project › web (playwright x1) — Error: Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5... · dashboard.spec.ts › project settings is available under /settings › web (playwright x1) — Error: Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5...",
      "workerSizeKib": 20993.6,
      "workerGzipKib": 5292.74,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5303.65
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-09-08T20:40:56.341Z",
      "deployedAt": "2026-09-08T20:20:11.108Z",
      "headSha": "5e563a6422312a653b9237daf946ccc85d992424",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-1.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/414120398542042",
      "shortSha": "5e563a6",
      "cleanupDurationMs": 4624,
      "deployDurationMs": 37652,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 34130,
      "deployReadinessDurationMs": 3518,
      "deployedWorkerName": "docs-preview-1",
      "deployedWorkerVersion": "f3b70faf-da3d-40a4-838b-3b6922127788",
      "testDurationMs": 4836,
      "testRetries": null,
      "workerSizeKib": 4302.17,
      "workerGzipKib": 1013.39,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-09-08T20:40:52.596Z",
      "deployedAt": "2026-09-08T20:01:24.616Z",
      "headSha": "7cf308695eca6e3c2ce1760b1e6d52e5e7bf4773",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/414120398542042",
      "shortSha": "7cf3086",
      "cleanupDurationMs": 876,
      "deployDurationMs": 28055,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 27819,
      "deployReadinessDurationMs": 231,
      "deployedWorkerName": "semaphore-preview-1",
      "deployedWorkerVersion": "c4068269-52d0-46a0-9bda-651a189543bd",
      "testDurationMs": 17295,
      "testRetries": null,
      "workerSizeKib": 1960.48,
      "workerGzipKib": 453.78,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-09-08T20:40:56.938Z",
      "deployedAt": "2026-09-08T20:20:17.784Z",
      "headSha": "5e563a6422312a653b9237daf946ccc85d992424",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/414120398542042",
      "shortSha": "5e563a6",
      "cleanupDurationMs": 5215,
      "deployDurationMs": 41256,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 40805,
      "deployReadinessDurationMs": 447,
      "deployedWorkerName": "auth-preview-1",
      "deployedWorkerVersion": "a25d4505-7390-4de4-a4ce-feca77a0aac1",
      "testDurationMs": 8482,
      "testRetries": null,
      "workerSizeKib": 4179,
      "workerGzipKib": 855.54,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-09-08T20:40:57.443Z",
      "deployedAt": "2026-09-08T20:20:01.624Z",
      "headSha": "5e563a6422312a653b9237daf946ccc85d992424",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/414120398542042",
      "shortSha": "5e563a6",
      "cleanupDurationMs": 5716,
      "deployDurationMs": 25159,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 24644,
      "deployReadinessDurationMs": 510,
      "deployedWorkerName": "streams-example-app-preview-1",
      "deployedWorkerVersion": "acafd1d8-ab39-4443-8d6b-17fc043fffdc",
      "testDurationMs": 93743,
      "testRetries": null,
      "workerSizeKib": 5670.04,
      "workerGzipKib": 1603.76,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-09-08T20:40:53.749Z",
      "deployedAt": "2026-09-08T20:19:44.858Z",
      "headSha": "5e563a6422312a653b9237daf946ccc85d992424",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-1.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/414120398542042",
      "shortSha": "5e563a6",
      "cleanupDurationMs": 1153,
      "deployDurationMs": 7945,
      "deployConfigDurationMs": 7,
      "deployCommandDurationMs": 7845,
      "deployReadinessDurationMs": 61,
      "deployedWorkerName": "dummy-petshop-preview-1",
      "deployedWorkerVersion": "ca573e46-3832-4659-886c-279036fd5e90",
      "testDurationMs": 47224,
      "testRetries": null,
      "workerSizeKib": 1331.5,
      "workerGzipKib": 232.81,
      "deployedFingerprint": "c321865fd82cf1ce04086fcbe3c487f157babc45+c5abf1055de73f3b4ffbc5e5b742dff1f0b5ee52",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `5e563a6` | [https://auth.iterate-preview-1.com](https://auth.iterate-preview-1.com) | 855.5 KiB | 41.3s | 8.5s |  | 5.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/414120398542042) | 2026-09-08T20:40:56.938Z | Preview app released. |
| Docs | released | `5e563a6` | [https://docs-preview-1.iterate-dev-preview.workers.dev](https://docs-preview-1.iterate-dev-preview.workers.dev) | 1013.4 KiB | 37.7s | 4.8s |  | 4.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/414120398542042) | 2026-09-08T20:40:56.341Z | Preview app released. |
| Dummy Petshop | released | `5e563a6` | [https://dummy-petshop.iterate-preview-1.com](https://dummy-petshop.iterate-preview-1.com) | 232.8 KiB | 7.9s | 47.2s |  | 1.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/414120398542042) | 2026-09-08T20:40:53.749Z | Preview app released. |
| OS | released | `5e563a6` | [https://os.iterate-preview-1.com](https://os.iterate-preview-1.com) | 5.17 MiB (-10.9 KiB vs main) | 56.2s | 272.5s | 14 retried: agent smoke > creates a project and receives an agent reply (agent smoke x1) — Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5e563a64223 · stream-resume-after-suspend.spec.ts › control: appended event is delivered to a live stream feed › preview-resilience (playwright x1) — Error: Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5... · stream-resume-after-suspend.spec.ts › feed resumes after the /api WebSocket dies (clean close) › preview-resilience (playwright x1) — Error: Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5... · stream-resume-after-suspend.spec.ts › feed resumes after page freeze + socket death (mobile suspend shape) › preview-resilience (playwright x1) — Error: Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5... · stream-resume-after-suspend.spec.ts › feed resumes after the /api WebSocket goes half-open (no close frame) › preview-resilience (playwright x1) — Error: Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5... · agent-fake-model-chat.spec.ts › a config file mention is materialized before the model sees the turn › web (playwright x1) — Error: Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5... · agent-fake-model-chat.spec.ts › multi-turn chat with a sarcastic agent served by the spec's own fake-model interceptor › web (playwright x1) — Error: Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5... · agent-script-reuse.spec.ts › a repeat request reuses the previous turn's journaled script instead of re-deriving it › web (playwright x1) — Error: Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5... · clients-os-app.spec.ts › two dashboard tabs are two clients; an itx caller navigates each independently › web (playwright x1) — Error: Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5... · collect-secret.spec.ts › a person provides a secret from a phone-sized sheet › web (playwright x1) — Error: Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5... · dashboard.spec.ts › can enter the dashboard with a forged session › web (playwright x1) — Error: Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5... · dashboard.spec.ts › loads project navigation only when it opens › web (playwright x1) — Error: Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5... · dashboard.spec.ts › opening OS returns to the most recently active project › web (playwright x1) — Error: Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5... · dashboard.spec.ts › project settings is available under /settings › web (playwright x1) — Error: Project could not be created: Default project worker bootstrap failed: Failed to install iterate: Failed to fetch tarball for iterate@https://pkg.pr.new/iterate/iterate/iterate@5e563a6422312a653b9237daf946ccc85d992424: 500 Internal Server Error (https://pkg.pr.new/iterate/iterate/iterate@5... | 100.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/414120398542042) | 2026-09-08T20:42:31.686Z | Preview app released. |
| Semaphore | released | `7cf3086` | [https://semaphore.iterate-preview-1.com](https://semaphore.iterate-preview-1.com) | 453.8 KiB | 28.1s | 17.3s |  | 876ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/414120398542042) | 2026-09-08T20:40:52.596Z | Preview app released. |
| Streams Example App | released | `5e563a6` | [https://streams.iterate-preview-1.com](https://streams.iterate-preview-1.com) | 1.57 MiB | 25.2s | 93.7s |  | 5.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/414120398542042) | 2026-09-08T20:40:57.443Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->