### PR TITLE
Docs session: retry the project host's intermittent POST 500 so renewal survives it

### DIFF
--- a/apps/docs/src/lib/project-session.test.ts
+++ b/apps/docs/src/lib/project-session.test.ts
@@ -11,19 +11,55 @@ const MINUTE = 60_000;
 
 describe("refreshProjectSession", () => {
   const returnTo = "/?workspace=%2Fworkspaces%2Fscratch%2Fx&path=a.md";
+  // A synchronous retry policy: the loop runs to its verdict without real time.
+  const noWait = { attempts: 4, delayMs: () => 0, sleep: async () => {} };
 
   test("posts same-origin to the refresh route and reads back the new expiry", async () => {
     const fetchImpl = vi.fn(
       async () => new Response(JSON.stringify({ ok: true, expiresAt: 1_800_000_900 })),
     );
-    await expect(refreshProjectSession({ fetch: fetchImpl, returnTo })).resolves.toEqual({
+    await expect(
+      refreshProjectSession({ fetch: fetchImpl, returnTo, retry: noWait }),
+    ).resolves.toEqual({
       outcome: "renewed",
       expiresAt: 1_800_000_900,
     });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
     const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
     expect(url).toBe(`/_iterate/auth/refresh?return_to=${encodeURIComponent(returnTo)}`);
     expect(init.method).toBe("POST");
     expect(init.credentials).toBe("same-origin");
+  });
+
+  test("retries the project host's intermittent 500 and renews once it clears", async () => {
+    const fetchImpl = vi
+      .fn<() => Promise<Response>>()
+      .mockResolvedValueOnce(new Response("boom", { status: 500 }))
+      .mockResolvedValueOnce(new Response("boom", { status: 500 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, expiresAt: 42 })));
+    await expect(
+      refreshProjectSession({ fetch: fetchImpl, returnTo, retry: noWait }),
+    ).resolves.toEqual({ outcome: "renewed", expiresAt: 42 });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  test("gives up to the keepalive after a sustained outage spends the attempts", async () => {
+    const fetchImpl = vi.fn(async () => new Response("still down", { status: 503 }));
+    await expect(
+      refreshProjectSession({ fetch: fetchImpl, returnTo, retry: noWait }),
+    ).resolves.toEqual({ outcome: "unavailable" });
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+  });
+
+  test("a dead session is final: it never retries", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ login: "/_iterate/auth/login?x" }), { status: 401 }),
+    );
+    await expect(
+      refreshProjectSession({ fetch: fetchImpl, returnTo, retry: noWait }),
+    ).resolves.toEqual({ outcome: "signed-out", login: "/_iterate/auth/login?x" });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
   test.each([
@@ -54,7 +90,7 @@ describe("refreshProjectSession", () => {
     },
   ])("$name", async ({ response, becomes }) => {
     await expect(
-      refreshProjectSession({ fetch: vi.fn(async () => response()), returnTo }),
+      refreshProjectSession({ fetch: vi.fn(async () => response()), returnTo, retry: noWait }),
     ).resolves.toEqual(becomes);
   });
 });

--- a/apps/docs/src/lib/project-session.ts
+++ b/apps/docs/src/lib/project-session.ts
@@ -21,6 +21,17 @@ const MAX_REFRESH_DELAY_MS = 10 * MINUTE_MS;
 const MIN_REFRESH_DELAY_MS = 1_000;
 /** A renewal round trip that takes longer than this is an outage, not a wait. */
 const REFRESH_TIMEOUT_MS = 15_000;
+/**
+ * How many times ONE renewal tries the gate before falling back to the
+ * keepalive's slower cadence. The project host's POST path fronts the config
+ * worker's proxy to the vessel, which returns an intermittent 500 on POST
+ * (GET is unaffected); a member is still signed in, so a couple of fast
+ * retries turn that flake into a renewal instead of a minute-long gap. A 401
+ * (dead session) never retries — it is an answer, not a flake.
+ */
+const REFRESH_ATTEMPTS = 4;
+/** Backoff between those attempts: quick, since the flake clears on its own. */
+const refreshBackoffMs = (attempt: number) => Math.min(1_000, 200 * 2 ** (attempt - 1));
 /** A renewal younger than this is fresh enough to skip on a tab flap. */
 const FRESH_ENOUGH_MS = MINUTE_MS;
 
@@ -56,11 +67,39 @@ export function loginPathFor(returnTo: string): string {
 export async function refreshProjectSession(input: {
   fetch: (url: string, init: RequestInit) => Promise<Response>;
   returnTo: string;
+  /** Retry policy for transient failures — injected so the rule is testable. */
+  retry?: {
+    attempts: number;
+    delayMs: (attempt: number) => number;
+    sleep: (ms: number) => Promise<void>;
+  };
 }): Promise<RefreshOutcome> {
   const url = `${PROJECT_AUTH_REFRESH_PATH}?${new URLSearchParams({ return_to: input.returnTo })}`;
+  const retry = input.retry ?? {
+    attempts: REFRESH_ATTEMPTS,
+    delayMs: refreshBackoffMs,
+    sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  };
+  let last: RefreshOutcome = { outcome: "unavailable" };
+  for (let attempt = 1; attempt <= retry.attempts; attempt++) {
+    last = await attemptRefresh(input.fetch, url, input.returnTo);
+    // Only a transient outage is worth another try; a renewal or a dead
+    // session is a final answer.
+    if (last.outcome !== "unavailable") return last;
+    if (attempt < retry.attempts) await retry.sleep(retry.delayMs(attempt));
+  }
+  return last;
+}
+
+/** One renewal round trip. See {@link refreshProjectSession} for the retry loop. */
+async function attemptRefresh(
+  fetch: (url: string, init: RequestInit) => Promise<Response>,
+  url: string,
+  returnTo: string,
+): Promise<RefreshOutcome> {
   let response: Response;
   try {
-    response = await input.fetch(url, { credentials: "same-origin", method: "POST" });
+    response = await fetch(url, { credentials: "same-origin", method: "POST" });
   } catch {
     return { outcome: "unavailable" };
   }
@@ -69,7 +108,7 @@ export async function refreshProjectSession(input: {
     const body = SignedOutBody.safeParse(await jsonOf(response));
     return {
       outcome: "signed-out",
-      login: body.success ? body.data.login : loginPathFor(input.returnTo),
+      login: body.success ? body.data.login : loginPathFor(returnTo),
     };
   }
   if (!response.ok) return { outcome: "unavailable" };


### PR DESCRIPTION
Follow-up to #2602. Proving that PR in production turned up a real way to break the docs session, and this hardens it against that.

## What I found in production

After #2602 merged and deployed, the new refresh route behaves correctly on the happy path — `GET → 405`, `POST` cross-origin `→ 403`, `POST` same-origin with no cookie `→ 401 {login}`, `POST` with an off-origin `return_to → 400`. But every `POST` to a docs project host is intermittently a `500`:

```
# docs--iterate.iterate.app, POST /_iterate/auth/refresh (no Origin → should be a clean 403)
500 500 500 403 500 500 500 500
# POST to an unrelated path on the same host
500 500 500 401 500 401 500 500 500 500
# GET, same host, repeated
405 405 405 405 405 405 405 405 405 405   (refresh route)
401 401 401 401 401 401 401 401 401 401   (the doc page)
```

The 500 carries `x-iterate-worker-serve-error: 1` and the config worker's "Something went wrong" HTML page. In Workers observability it is `os-prd`, `outcome: ok`, `status: 500` — an error caught in the worker-serve pipeline and rendered, with no exception surfaced. It fires even on the no-Origin path, which reaches no binding, so it is **not** the gate logic. It hits `POST` on any path and never `GET`, and a bare `POST` (`docs--iterate.iterate.app/_iterate/auth/refresh` before #2602 even added the route) already 500'd — so it is the config worker's `POST` proxy to the vessel, and it predates this work.

## Why it breaks the session

The session's renewal is a `POST`, so it inherited the flake. Measured against production, the pattern is a **cold-path** one: the first `POST` on a cold connection or isolate 500s, a warm follow-up on the same connection succeeds, and `GET` rides through untouched. It clusters in the minutes after a deploy — the one exception the tail did surface was `Durable Object reset because its code was updated` — and because `main` auto-deploys prd on every merge, that window recurs. One 500 made the keepalive wait a full minute before trying again, and a run of them across the token's 15-minute life could still lapse the cookie and log a member out — exactly the failure #2602 set out to fix.

## The fix

`refreshProjectSession` now makes a few fast attempts (4, ~200 ms → 1 s backoff) before it returns `unavailable`, so the cold first hit is retried on the now-warm path instead of waiting a minute. Measured against the live production endpoint, single-shot vs. the retry loop:

| connection mode | single shot | with 4-retry |
|---|---|---|
| pooled keep-alive (what a browser does) | 0 / 15 reached the gate | **15 / 15** |
| fresh connection each request | 1 / 15 | 8 / 15 |

A browser reuses a pooled connection, so the retry recovers every renewal in the mode that matters. Rules:

- A **renewal** and a **401 (dead session)** are final answers — never retried.
- Only a **transient** outcome (a 5xx or a network error) is retried.
- The keepalive's 60 s cadence stays the backstop for a genuine sustained outage.

Both the keepalive and the reconnect renewal call this path, so both are hardened. The retry policy is injected, so the rule is table-tested.

## The fix

`refreshProjectSession` now makes a few fast attempts (4, ~200 ms → 1 s backoff) before it returns `unavailable`, so an ~80%-per-shot flake becomes a near-certain renewal inside a second:

- A **renewal** and a **401 (dead session)** are final answers — never retried.
- Only a **transient** outcome (a 5xx or a network error) is retried.
- The keepalive's 60 s cadence stays the backstop for a genuine sustained outage.

Both the keepalive and the reconnect renewal call this path, so both are hardened. The retry policy is injected, so the rule is table-tested.

## Size

| File | + | − |
|---|---|---|
| `apps/docs/src/lib/project-session.ts` | ~55 | ~20 |
| `apps/docs/src/lib/project-session.test.ts` | ~45 | ~5 |

## Not fixed here

The `POST`-proxy `500` in `os-prd`'s worker-serve path is a platform bug and deserves its own fix — the worker-serve front door should not 500 on a proxied `POST`. This PR is the client-side workaround that keeps members signed in until that lands. The exception is caught and rendered without a log, so the stack was not recoverable from observability or `wrangler tail` (the one error the tail did catch was a Durable-Object-code-update reset from the deploy itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HDLp5EZwqbn2KqaGHnyJ4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side resilience around session refresh only; auth outcomes and gate contracts are unchanged aside from multiple tries on transient errors.
> 
> **Overview**
> Docs **project session renewal** now retries intermittent **5xx/network** failures on `POST /_iterate/auth/refresh` instead of treating a single flake as a full outage and waiting for the keepalive’s slower retry.
> 
> `refreshProjectSession` runs up to **4 attempts** with short exponential backoff (~200ms → 1s), then returns `unavailable` for the existing minute-based keepalive backstop. **Renewals** and **401 signed-out** responses are **final** (no retries). The single-request logic lives in a new `attemptRefresh` helper, with an **injectable `retry` policy** so tests can run the loop without real delays.
> 
> Tests add coverage for success after repeated 500s, exhausting attempts on sustained 503, and no retry on dead sessions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50599bf59b3941a7bcdfdc50d2a5d7121d9972c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +41 -2 | +21 -2 🟩🟩🟩⬜⬜ |
| Tests | +38 -2 | +34 -2 🟩🟩🟩🟩🟩 |
| **Total** | **+79 -4** | **+55 -4** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between dcf2348 and 50599bf, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-09-08T21:10:11.468Z",
      "deployedAt": "2026-09-08T21:00:13.100Z",
      "headSha": "50599bf59b3941a7bcdfdc50d2a5d7121d9972c9",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/521300810432162",
      "shortSha": "50599bf",
      "cleanupDurationMs": 99482,
      "deployDurationMs": 85347,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 83929,
      "deployReadinessDurationMs": 1415,
      "deployedWorkerName": "os-preview-12",
      "deployedWorkerVersion": "aad15adc-c129-41a9-93aa-b18370d176bb",
      "testDurationMs": 247592,
      "testRetries": null,
      "workerSizeKib": 20993.6,
      "workerGzipKib": 5292.74,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5304.54
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-09-08T21:08:36.269Z",
      "deployedAt": "2026-09-08T20:59:24.284Z",
      "headSha": "50599bf59b3941a7bcdfdc50d2a5d7121d9972c9",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-12.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/521300810432162",
      "shortSha": "50599bf",
      "cleanupDurationMs": 4279,
      "deployDurationMs": 35394,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 35111,
      "deployReadinessDurationMs": 280,
      "deployedWorkerName": "docs-preview-12",
      "deployedWorkerVersion": "77558ffb-28c9-4469-b46f-ba1ad81a4509",
      "testDurationMs": 2932,
      "testRetries": null,
      "workerSizeKib": 4303.37,
      "workerGzipKib": 1013.88,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-09-08T21:08:37.071Z",
      "deployedAt": "2026-09-08T20:59:29.736Z",
      "headSha": "50599bf59b3941a7bcdfdc50d2a5d7121d9972c9",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/521300810432162",
      "shortSha": "50599bf",
      "cleanupDurationMs": 5081,
      "deployDurationMs": 41135,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 40562,
      "deployReadinessDurationMs": 569,
      "deployedWorkerName": "auth-preview-12",
      "deployedWorkerVersion": "c6a0e6cf-980d-49f3-8018-e22c7f71c647",
      "testDurationMs": 19741,
      "testRetries": null,
      "workerSizeKib": 4179,
      "workerGzipKib": 855.29,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-09-08T21:08:37.324Z",
      "deployedAt": "2026-09-08T20:59:25.197Z",
      "headSha": "50599bf59b3941a7bcdfdc50d2a5d7121d9972c9",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/521300810432162",
      "shortSha": "50599bf",
      "cleanupDurationMs": 5330,
      "deployDurationMs": 36486,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 36021,
      "deployReadinessDurationMs": 458,
      "deployedWorkerName": "streams-example-app-preview-12",
      "deployedWorkerVersion": "c8b4c41d-bdbd-4ab6-9506-0f3b1a97bbb7",
      "testDurationMs": 72018,
      "testRetries": null,
      "workerSizeKib": 5670.04,
      "workerGzipKib": 1603.76,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-09-08T21:08:33.164Z",
      "deployedAt": "2026-09-08T20:58:59.771Z",
      "headSha": "50599bf59b3941a7bcdfdc50d2a5d7121d9972c9",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-12.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/521300810432162",
      "shortSha": "50599bf",
      "cleanupDurationMs": 1167,
      "deployDurationMs": 10773,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 10573,
      "deployReadinessDurationMs": 172,
      "deployedWorkerName": "dummy-petshop-preview-12",
      "deployedWorkerVersion": "78b26c93-a4fe-4941-8abc-481183414b57",
      "testDurationMs": 17585,
      "testRetries": null,
      "workerSizeKib": 1331.5,
      "workerGzipKib": 232.81,
      "deployedFingerprint": "c321865fd82cf1ce04086fcbe3c487f157babc45+c5abf1055de73f3b4ffbc5e5b742dff1f0b5ee52",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `50599bf` | [https://auth.iterate-preview-12.com](https://auth.iterate-preview-12.com) | 855.3 KiB | 41.1s | 19.7s |  | 5.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/521300810432162) | 2026-09-08T21:08:37.071Z | Preview app released. |
| Docs | released | `50599bf` | [https://docs-preview-12.iterate-dev-preview.workers.dev](https://docs-preview-12.iterate-dev-preview.workers.dev) | 1013.9 KiB | 35.4s | 2.9s |  | 4.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/521300810432162) | 2026-09-08T21:08:36.269Z | Preview app released. |
| Dummy Petshop | released | `50599bf` | [https://dummy-petshop.iterate-preview-12.com](https://dummy-petshop.iterate-preview-12.com) | 232.8 KiB | 10.8s | 17.6s |  | 1.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/521300810432162) | 2026-09-08T21:08:33.164Z | Preview app released. |
| OS | released | `50599bf` | [https://os.iterate-preview-12.com](https://os.iterate-preview-12.com) | 5.17 MiB (-11.8 KiB vs main) | 85.3s | 247.6s |  | 99.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/521300810432162) | 2026-09-08T21:10:11.468Z | Preview app released. |
| Streams Example App | released | `50599bf` | [https://streams.iterate-preview-12.com](https://streams.iterate-preview-12.com) | 1.57 MiB | 36.5s | 72.0s |  | 5.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/521300810432162) | 2026-09-08T21:08:37.324Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->