### PR TITLE
Keep paragraph comments within the native text selection

### DIFF
--- a/packages/ui/src/lib/document-projection.test.tsx
+++ b/packages/ui/src/lib/document-projection.test.tsx
@@ -39,6 +39,26 @@ describe("document source projection", () => {
     expect(markdown.slice(range!.start, range!.end)).toBe("Plain **bold middle");
   });
 
+  test.each(["Next paragraph.", "- Next list item."])(
+    "a paragraph selection ending at the start of %s excludes that block",
+    (following) => {
+      const markdown = `Selected paragraph.\n\n${following}\n`;
+      const root = mount(markdown);
+      const projection = buildDocumentProjection(root);
+      const start = pointAt(root, "Selected paragraph.");
+      const next = pointAt(root, "Next");
+      // Chromium's triple-click ends at offset zero of the following element.
+      const range = projection.domRangeToSource({
+        startContainer: start.node,
+        startOffset: 0,
+        endContainer: next.node.parentElement!,
+        endOffset: 0,
+      });
+
+      expect(markdown.slice(range!.start, range!.end).trim()).toBe("Selected paragraph.");
+    },
+  );
+
   test("maps fenced code to its body rather than an info string", () => {
     const markdown = "```python\npython\n```\n";
     const root = mount(markdown);

--- a/packages/ui/src/lib/document-projection.test.tsx
+++ b/packages/ui/src/lib/document-projection.test.tsx
@@ -39,7 +39,7 @@ describe("document source projection", () => {
     expect(markdown.slice(range!.start, range!.end)).toBe("Plain **bold middle");
   });
 
-  test.each(["Next paragraph.", "- Next list item."])(
+  test.each(["Next paragraph.", "- Next list item.", "- [ ] Next task."])(
     "a paragraph selection ending at the start of %s excludes that block",
     (following) => {
       const markdown = `Selected paragraph.\n\n${following}\n`;
@@ -47,15 +47,29 @@ describe("document source projection", () => {
       const projection = buildDocumentProjection(root);
       const start = pointAt(root, "Selected paragraph.");
       const next = pointAt(root, "Next");
-      // Chromium's triple-click ends at offset zero of the following element.
-      const range = projection.domRangeToSource({
-        startContainer: start.node,
-        startOffset: 0,
-        endContainer: next.node.parentElement!,
-        endOffset: 0,
-      });
-
-      expect(markdown.slice(range!.start, range!.end).trim()).toBe("Selected paragraph.");
+      // Native selections can end at the next text node or its wrapper.
+      for (const endContainer of [next.node, next.node.parentElement!]) {
+        expect(
+          projection.domRangeToSource({
+            startContainer: start.node,
+            startOffset: 0,
+            endContainer,
+            endOffset: 0,
+          }),
+        ).toEqual({ start: 0, end: 19 });
+      }
+      // Selecting up to a task's checkbox still includes none of its text.
+      const checkbox = root.querySelector("input");
+      if (checkbox) {
+        expect(
+          projection.domRangeToSource({
+            startContainer: start.node,
+            startOffset: 0,
+            endContainer: checkbox.parentElement!,
+            endOffset: 1,
+          }),
+        ).toEqual({ start: 0, end: 19 });
+      }
     },
   );
 

--- a/packages/ui/src/lib/document-projection.ts
+++ b/packages/ui/src/lib/document-projection.ts
@@ -98,19 +98,14 @@ export function buildDocumentProjection(root: HTMLElement): DocumentProjection {
     if (node.nodeType === Node.TEXT_NODE) {
       const segment = segmentForText(node);
       if (segment === undefined) return elementPointToSource(node.parentNode, affinity);
+      if (offset === 0 && affinity === "end")
+        return segments[segments.indexOf(segment) - 1]?.end ?? segment.start;
       if (!segment.atomic) return segment.start + Math.min(offset, segment.end - segment.start);
       if (offset <= 0) return segment.start;
       if (offset >= segment.text.data.length) return segment.end;
       return affinity === "start" ? segment.start : segment.end;
     }
     if (node.nodeType !== Node.ELEMENT_NODE) return null;
-
-    // A selection can end at offset zero of the next span. Use the previous
-    // text edge so neither that span nor its Markdown prefix is included.
-    if (offset === 0 && affinity === "end") {
-      const first = firstSegmentWithin(node);
-      if (first !== null) return segments[segments.indexOf(first) - 1]?.end ?? first.start;
-    }
 
     const children = Array.from(node.childNodes);
     if (affinity === "start") {
@@ -123,6 +118,9 @@ export function buildDocumentProjection(root: HTMLElement): DocumentProjection {
         const segment = lastSegmentWithin(child);
         if (segment !== null) return segment.end;
       }
+      // No preceding text is selected: exclude this block and its Markdown prefix.
+      const first = firstSegmentWithin(node);
+      if (first !== null) return segments[segments.indexOf(first) - 1]?.end ?? first.start;
     }
     return elementPointToSource(node, affinity);
   };

--- a/packages/ui/src/lib/document-projection.ts
+++ b/packages/ui/src/lib/document-projection.ts
@@ -120,7 +120,7 @@ export function buildDocumentProjection(root: HTMLElement): DocumentProjection {
       }
       // No preceding text is selected: exclude this block and its Markdown prefix.
       const first = firstSegmentWithin(node);
-      if (first !== null) return segments[segments.indexOf(first) - 1]?.end ?? first.start;
+      if (first) return segments[segments.indexOf(first) - 1]?.end ?? first.start;
     }
     return elementPointToSource(node, affinity);
   };

--- a/packages/ui/src/lib/document-projection.ts
+++ b/packages/ui/src/lib/document-projection.ts
@@ -105,6 +105,13 @@ export function buildDocumentProjection(root: HTMLElement): DocumentProjection {
     }
     if (node.nodeType !== Node.ELEMENT_NODE) return null;
 
+    // A selection can end at offset zero of the next span. Use the previous
+    // text edge so neither that span nor its Markdown prefix is included.
+    if (offset === 0 && affinity === "end") {
+      const first = firstSegmentWithin(node);
+      if (first !== null) return segments[segments.indexOf(first) - 1]?.end ?? first.start;
+    }
+
     const children = Array.from(node.childNodes);
     if (affinity === "start") {
       for (const child of children.slice(offset)) {

--- a/specs/seeded-apps.spec.ts
+++ b/specs/seeded-apps.spec.ts
@@ -336,11 +336,7 @@ test("review a workspace document in the seeded Docs app", async ({ baseURL, pag
   expect(review.threads.find((thread) => thread.anchor)?.comments[0]?.body).toBe(
     "Can we make this promise more concrete?",
   );
-  const anchor = review.threads.find((thread) => thread.anchor)?.anchor;
-  expect(anchor).not.toBeNull();
-  expect(review.projection.markdown.slice(anchor!.display.start, anchor!.display.end).trim()).toBe(
-    "Make review decisions directly in the workspace file.",
-  );
+  expect(saved).toContain("{==Make review decisions directly in the workspace file.==}");
   expect(saved).toContain("\ncomments:");
 
   await page.reload();

--- a/specs/seeded-apps.spec.ts
+++ b/specs/seeded-apps.spec.ts
@@ -312,8 +312,8 @@ test("review a workspace document in the seeded Docs app", async ({ baseURL, pag
   const reviewSentence = page
     .locator("div.cursor-text")
     .getByText("Make review decisions directly in the workspace file.", { exact: true });
-  await reviewSentence.selectText();
-  await reviewSentence.dispatchEvent("pointerup");
+  // Native paragraph selection can end at offset zero of the next block.
+  await reviewSentence.click({ clickCount: 3 });
   await page
     .getByPlaceholder("Comment on the selection…")
     .fill("Can we make this promise more concrete?");
@@ -336,7 +336,11 @@ test("review a workspace document in the seeded Docs app", async ({ baseURL, pag
   expect(review.threads.find((thread) => thread.anchor)?.comments[0]?.body).toBe(
     "Can we make this promise more concrete?",
   );
-  expect(saved).toContain("{==Make review decisions directly in the workspace file.==}");
+  const anchor = review.threads.find((thread) => thread.anchor)?.anchor;
+  expect(anchor).not.toBeNull();
+  expect(review.projection.markdown.slice(anchor!.display.start, anchor!.display.end).trim()).toBe(
+    "Make review decisions directly in the workspace file.",
+  );
   expect(saved).toContain("\ncomments:");
 
   await page.reload();


### PR DESCRIPTION
Triple-clicking a paragraph in Docs could attach its comment to the following paragraph or list item as well. Chromium ends that selection at offset zero of the next element; the projection fell back to that element's end.

Map this boundary to the previous text segment's end, excluding both the next text and its Markdown prefix. Five production lines, no new state or APIs. Found while verifying #2599 in production.

Validation: the new paragraph/list unit regressions failed before the fix and pass after it. The existing Docs browser walkthrough now uses a native triple-click and checks the exact persisted anchor. Claude Fable 5.1 reviewed the fix; its simplification and exact-assertion findings are addressed, including text-node and checkbox endpoints. Full local tests, typecheck, lint and formatting pass; preview CI exercises the combined flow.

## Risk map

Only selection ends that include none of the endpoint’s text change. Review the projection function first, then its regression examples. The saved RFM format and synchronization protocol are unchanged. No migration; existing comments keep their original anchors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Only selection-end mapping changes for empty-text boundaries; comment anchoring is user-visible but the change is narrow and heavily regression-tested.
> 
> **Overview**
> Fixes **Docs selection comments** that could include the next paragraph, list item, or task when Chromium ends a triple-click at **offset 0** of the following block.
> 
> **`domPointToSource`** now treats that boundary as the **previous segment’s end** (text node at offset 0 with `"end"` affinity, and element `"end"` when no preceding child text is selected), so the Markdown anchor stops at the selected paragraph and does not pull in the next block or its list/task prefix.
> 
> Adds **unit regressions** for paragraph → paragraph, list, and checkbox endpoints, and updates the **seeded Docs E2E** to triple-click like a real user and assert the persisted `{==…==}` anchor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0bd9253778aa139a3b77c0eb7e3482f96e2a20d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| UI components | +5 -0 | +4 -0 🟩⬜⬜⬜⬜ |
| Tests | +36 -2 | +32 -2 🟩🟩🟩🟩🟩 |
| **Total** | **+41 -2** | **+36 -2** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 2d3a0b2 and b0bd925, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-09-08T21:31:23.457Z",
      "deployedAt": "2026-09-08T21:22:33.896Z",
      "headSha": "b0bd9253778aa139a3b77c0eb7e3482f96e2a20d",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-15.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/259521205725495",
      "shortSha": "b0bd925",
      "cleanupDurationMs": 99312,
      "deployDurationMs": 84496,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 82456,
      "deployReadinessDurationMs": 2037,
      "deployedWorkerName": "os-preview-15",
      "deployedWorkerVersion": "1af5a1f8-d8ed-4390-862c-ecdb036965b2",
      "testDurationMs": 254780,
      "testRetries": "1 retried: Successful live capability replacement uses the new target (vitest x1) — stream-unavailable: Durable Object's isolate exceeded its memory limit and was reset.",
      "workerSizeKib": 20993.59,
      "workerGzipKib": 5292.78,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5304.54
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-09-08T21:29:48.177Z",
      "deployedAt": "2026-09-08T21:21:46.259Z",
      "headSha": "b0bd9253778aa139a3b77c0eb7e3482f96e2a20d",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-15.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/259521205725495",
      "shortSha": "b0bd925",
      "cleanupDurationMs": 4030,
      "deployDurationMs": 36358,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 34817,
      "deployReadinessDurationMs": 1537,
      "deployedWorkerName": "docs-preview-15",
      "deployedWorkerVersion": "d330d4a3-bc3e-4f42-8f95-41e2a4d6a4d6",
      "testDurationMs": 3106,
      "testRetries": null,
      "workerSizeKib": 4662.29,
      "workerGzipKib": 1092.97,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-09-08T21:29:45.369Z",
      "deployedAt": "2026-09-08T21:21:39.898Z",
      "headSha": "b0bd9253778aa139a3b77c0eb7e3482f96e2a20d",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-15.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/259521205725495",
      "shortSha": "b0bd925",
      "cleanupDurationMs": 1220,
      "deployDurationMs": 28665,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 28455,
      "deployReadinessDurationMs": 205,
      "deployedWorkerName": "semaphore-preview-15",
      "deployedWorkerVersion": "3591a0ec-233f-42b6-b9af-a50ed86dfa5c",
      "testDurationMs": 53355,
      "testRetries": null,
      "workerSizeKib": 1960.48,
      "workerGzipKib": 453.78,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-09-08T21:29:49.002Z",
      "deployedAt": "2026-09-08T21:21:46.194Z",
      "headSha": "b0bd9253778aa139a3b77c0eb7e3482f96e2a20d",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-15.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/259521205725495",
      "shortSha": "b0bd925",
      "cleanupDurationMs": 4850,
      "deployDurationMs": 35061,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 34750,
      "deployReadinessDurationMs": 305,
      "deployedWorkerName": "auth-preview-15",
      "deployedWorkerVersion": "aeecf5ff-b161-4953-bdf2-2c9562ea60d1",
      "testDurationMs": 18616,
      "testRetries": null,
      "workerSizeKib": 4179,
      "workerGzipKib": 855.62,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-09-08T21:29:49.049Z",
      "deployedAt": "2026-09-08T21:21:43.407Z",
      "headSha": "b0bd9253778aa139a3b77c0eb7e3482f96e2a20d",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-15.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/259521205725495",
      "shortSha": "b0bd925",
      "cleanupDurationMs": 4896,
      "deployDurationMs": 32434,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 31962,
      "deployReadinessDurationMs": 466,
      "deployedWorkerName": "streams-example-app-preview-15",
      "deployedWorkerVersion": "b24fb878-33bc-4e32-9251-196845632dfb",
      "testDurationMs": 66511,
      "testRetries": null,
      "workerSizeKib": 5670.03,
      "workerGzipKib": 1603.77,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-09-08T21:29:46.646Z",
      "deployedAt": "2026-09-08T21:21:46.147Z",
      "headSha": "b0bd9253778aa139a3b77c0eb7e3482f96e2a20d",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-15.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/259521205725495",
      "shortSha": "b0bd925",
      "cleanupDurationMs": 1277,
      "deployDurationMs": 6244,
      "deployConfigDurationMs": 1,
      "deployCommandDurationMs": 6039,
      "deployReadinessDurationMs": 201,
      "deployedWorkerName": "dummy-petshop-preview-15",
      "deployedWorkerVersion": "3e05ee50-b23f-42ed-ad96-9e90d4a18afc",
      "testDurationMs": 41631,
      "testRetries": null,
      "workerSizeKib": 1331.5,
      "workerGzipKib": 232.81,
      "deployedFingerprint": "c321865fd82cf1ce04086fcbe3c487f157babc45+c5abf1055de73f3b4ffbc5e5b742dff1f0b5ee52",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `b0bd925` | [https://auth.iterate-preview-15.com](https://auth.iterate-preview-15.com) | 855.6 KiB | 35.1s | 18.6s |  | 4.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/259521205725495) | 2026-09-08T21:29:49.002Z | Preview app released. |
| Docs | released | `b0bd925` | [https://docs-preview-15.iterate-dev-preview.workers.dev](https://docs-preview-15.iterate-dev-preview.workers.dev) | 1.07 MiB | 36.4s | 3.1s |  | 4.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/259521205725495) | 2026-09-08T21:29:48.177Z | Preview app released. |
| Dummy Petshop | released | `b0bd925` | [https://dummy-petshop.iterate-preview-15.com](https://dummy-petshop.iterate-preview-15.com) | 232.8 KiB | 6.2s | 41.6s |  | 1.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/259521205725495) | 2026-09-08T21:29:46.646Z | Preview app released. |
| OS | released | `b0bd925` | [https://os.iterate-preview-15.com](https://os.iterate-preview-15.com) | 5.17 MiB (-11.8 KiB vs main) | 84.5s | 254.8s | 1 retried: Successful live capability replacement uses the new target (vitest x1) — stream-unavailable: Durable Object's isolate exceeded its memory limit and was reset. | 99.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/259521205725495) | 2026-09-08T21:31:23.457Z | Preview app released. |
| Semaphore | released | `b0bd925` | [https://semaphore.iterate-preview-15.com](https://semaphore.iterate-preview-15.com) | 453.8 KiB | 28.7s | 53.4s |  | 1.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/259521205725495) | 2026-09-08T21:29:45.369Z | Preview app released. |
| Streams Example App | released | `b0bd925` | [https://streams.iterate-preview-15.com](https://streams.iterate-preview-15.com) | 1.57 MiB | 32.4s | 66.5s |  | 4.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/259521205725495) | 2026-09-08T21:29:49.049Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->
