### PR TITLE
Worker runner: replay a bodyless request on clone-version skew, not just GET/HEAD

### DIFF
--- a/apps/os/src/domains/workers/worker-runner.test.ts
+++ b/apps/os/src/domains/workers/worker-runner.test.ts
@@ -494,6 +494,94 @@ it("recovers a safe stateless fetch once with a fresh loader after clone-version
   });
 });
 
+it("recovers a BODYLESS POST after clone-version skew (the auth gate's refresh)", async () => {
+  // A clone-version skew is a loader-isolate deserialize failure before the
+  // app runs, so a request with no body — the gate's refresh POST — is safe
+  // to replay on a fresh loader, exactly like a GET. Regression for the
+  // production 500 that only hit POSTs to a project host after a deploy.
+  const workerFetch = vi
+    .fn()
+    .mockRejectedValueOnce(
+      new Error("Unable to deserialize cloned data due to invalid or unsupported version."),
+    )
+    .mockResolvedValueOnce(new Response("recovered"));
+  h.resolveWorkerSource.mockResolvedValue({
+    ok: true,
+    source: {
+      assetConfig: undefined,
+      assetManifest: {},
+      assets: {},
+      cacheKey: "build-key",
+      commitOid: "commit-1",
+      mainModule: "worker.js",
+      modules: {},
+      wranglerConfig: undefined,
+    },
+  });
+  h.loadResolvedWorker.mockImplementation(() => ({
+    getEntrypoint: () => ({ fetch: workerFetch }),
+  }));
+  const runner = new DynamicWorkerRunner({
+    streamContext: { kind: "scope", scopePath: inlineRef.path },
+    exports: {} as ExecutionContext["exports"],
+    projectId: "prj_private",
+    scopePath: inlineRef.path,
+  });
+
+  const response = await runner.fetch({
+    ref: inlineRef,
+    request: new Request("https://example.com/", { method: "POST" }),
+  });
+
+  expect(await response.text()).toBe("recovered");
+  expect(workerFetch).toHaveBeenCalledTimes(2);
+  const initialLoader = h.loadResolvedWorker.mock.calls[0]?.[0].loaderInstanceNonce;
+  const replacementLoader = h.loadResolvedWorker.mock.calls[1]?.[0].loaderInstanceNonce;
+  expect(replacementLoader).not.toBe(initialLoader);
+  expect(recordedSpans[0]?.attributes).toMatchObject({
+    "http.response.status_code": 200,
+    "iterate.worker.rpc_clone_version_retry": true,
+  });
+});
+
+it("never replays a BODY-BEARING POST on clone-version skew — the body cannot be consumed twice", async () => {
+  const workerFetch = vi
+    .fn()
+    .mockRejectedValueOnce(
+      new Error("Unable to deserialize cloned data due to invalid or unsupported version."),
+    );
+  h.resolveWorkerSource.mockResolvedValue({
+    ok: true,
+    source: {
+      assetConfig: undefined,
+      assetManifest: {},
+      assets: {},
+      cacheKey: "build-key",
+      commitOid: "commit-1",
+      mainModule: "worker.js",
+      modules: {},
+      wranglerConfig: undefined,
+    },
+  });
+  h.loadResolvedWorker.mockImplementation(() => ({
+    getEntrypoint: () => ({ fetch: workerFetch }),
+  }));
+  const runner = new DynamicWorkerRunner({
+    streamContext: { kind: "scope", scopePath: inlineRef.path },
+    exports: {} as ExecutionContext["exports"],
+    projectId: "prj_private",
+    scopePath: inlineRef.path,
+  });
+
+  await expect(
+    runner.fetch({
+      ref: inlineRef,
+      request: new Request("https://example.com/", { method: "POST", body: "payload" }),
+    }),
+  ).rejects.toThrow("Unable to deserialize cloned data");
+  expect(workerFetch).toHaveBeenCalledTimes(1);
+});
+
 it("replays one safe stateful fetch after its hosting Durable Object resets", async () => {
   const reset = Object.assign(new Error("Durable Object reset because its code was updated."), {
     durableObjectReset: true,

--- a/apps/os/src/domains/workers/worker-runner.ts
+++ b/apps/os/src/domains/workers/worker-runner.ts
@@ -270,18 +270,32 @@ export class DynamicWorkerRunner {
         return withWorkerCommit(await entrypoint.fetch(currentRequest), resolved.commitOid);
       };
 
-      const retryRequest =
+      // A request is byte-replayable when there is nothing to consume: GET and
+      // HEAD by spec, and any other method that carries no body (the auth
+      // gate's refresh POST is one). WebSocket upgrades are never replayed.
+      // Cloudflare's clone() widens the Request metadata generics even though
+      // the runtime value stays the same Fetch API request.
+      const replayableRequest =
         !isWebSocketUpgradeRequest(request) &&
-        (request.method === "GET" || request.method === "HEAD")
-          ? // Cloudflare's clone() widens the Request metadata generics even
-            // though the runtime value remains the same Fetch API request.
-            (request.clone() as typeof request)
+        (request.method === "GET" || request.method === "HEAD" || request.body === null)
+          ? (request.clone() as typeof request)
           : undefined;
+      // A Durable Object reset can land AFTER the app began handling the
+      // request, so only an idempotent method may replay that one; a
+      // clone-version skew is a loader-isolate deserialize failure BEFORE the
+      // app runs (the shared isolate outlived its captured bindings), so any
+      // byte-replayable request is safe to retry on a fresh isolate.
+      const isIdempotentMethod = request.method === "GET" || request.method === "HEAD";
       let response: Response;
       try {
         response = await dispatch(request);
       } catch (error) {
-        if (retryRequest && ref.type === "stateful" && isDurableObjectLifecycleError(error)) {
+        if (
+          replayableRequest &&
+          isIdempotentMethod &&
+          ref.type === "stateful" &&
+          isDurableObjectLifecycleError(error)
+        ) {
           span.setAttribute("iterate.worker.durable_object_availability_retry", true);
           console.info("Stateful worker fetch retrying after Durable Object unavailability", {
             error,
@@ -289,24 +303,23 @@ export class DynamicWorkerRunner {
             rayId: request.headers.get("cf-ray") ?? undefined,
             traceRole,
           });
-          // GET/HEAD are safe to replay. A deploy, eviction, or temporary
-          // platform fault may retire the hosting DO between dispatch and
-          // response; the second lookup reaches a fresh incarnation, and a
-          // second failure remains terminal.
-          response = await dispatch(retryRequest);
+          // A deploy, eviction, or temporary platform fault may retire the
+          // hosting DO between dispatch and response; the second lookup reaches
+          // a fresh incarnation, and a second failure remains terminal.
+          response = await dispatch(replayableRequest);
         } else if (
-          retryRequest &&
+          replayableRequest &&
           ref.type === "stateless" &&
-          error instanceof Error &&
-          error.message.includes(WORKERS_RPC_CLONE_VERSION_ERROR)
+          isWorkerRpcCloneVersionError(error)
         ) {
           span.setAttribute("iterate.worker.rpc_clone_version_retry", true);
           console.warn("Workers RPC clone-version skew; retrying stateless fetch once", {
+            method: request.method,
             projectId: this.#projectId,
             rayId: request.headers.get("cf-ray") ?? undefined,
             traceRole,
           });
-          response = await dispatch(retryRequest, crypto.randomUUID());
+          response = await dispatch(replayableRequest, crypto.randomUUID());
         } else {
           throw error;
         }


### PR DESCRIPTION
The clean root-cause fix behind #2602 / #2603. Proving those in production located the exact server-side reason a docs project host 500s.

## What actually breaks

Every `POST` to a docs project host (`docs--<project>.iterate.app`) intermittently returns the branded 500 page; `GET` is stable. Tailing `os-prd` while forcing the failure captured the cause 30 times out of 30:

```
["project serve failed", "Error: Unable to deserialize cloned data due to invalid or unsupported version."]
```

That is workerd's **clone-version skew** — a shared loader isolate outliving the bindings it captured — which clusters in the minutes after a deploy (new worker version, warm cached loader isolate). `DynamicWorkerRunner.fetch` already knows this failure and recovers it by retrying once on a fresh loader isolate (`iterate.worker.rpc_clone_version_retry`). But it only built a replay request for `GET`/`HEAD`:

```ts
const retryRequest =
  !isWebSocketUpgradeRequest(request) && (request.method === "GET" || request.method === "HEAD")
    ? (request.clone() as typeof request)
    : undefined;
```

So a `POST` hit the skew, `retryRequest` was `undefined`, the error was re-thrown, and `serveProjectResponse` turned it into the 500. The session's renewal (`/_iterate/auth/refresh`) is a bodyless `POST`, so it was landing in exactly this gap — and because `main` auto-deploys prd on every merge, the skew window recurs.

## Production proof of the diagnosis

Same host, same path, same fresh connections, same window — only the method differs:

| method | 500 rate over 40 fresh connections |
|---|---|
| `GET`  | **0 / 40** (all reached the gate → 405) |
| bodyless `POST` | **11 / 40** (29 reached the gate → 403) |

The only handling difference between the two is that `GET` already gets the fresh-nonce clone-version retry and the bodyless `POST` does not. During an active prd deploy the gap is total: a browser-pooled `POST` (which just re-hits the same stale shared loader isolate) recovered **0 / 15** even with the client's four-attempt retry, while `GET` stayed at 0 × 500 throughout — because its retry mints a *fresh* loader isolate carrying current code. This PR gives the bodyless `POST` that same fresh-isolate retry, so it should reach `GET`'s 0/40.

## The fix

A clone-version skew is a loader-isolate **deserialize failure before the app runs**, so any request with **no body** is just as safe to replay as a `GET`. The replay request is now built for any byte-replayable request — `GET`, `HEAD`, or a null body:

```ts
const replayableRequest =
  !isWebSocketUpgradeRequest(request) &&
  (request.method === "GET" || request.method === "HEAD" || request.body === null)
    ? (request.clone() as typeof request)
    : undefined;
```

Safety, kept deliberately narrow:

- The **stateful Durable-Object-reset** branch still replays only idempotent `GET`/`HEAD`. A reset can land *after* the app began handling the request, so replaying a `POST` there could double a side effect. A clone-version skew cannot — the app never ran.
- A **body-bearing** `POST` is still never replayed; its body cannot be consumed twice. No body buffering, no change to streaming or WebSocket transport.

## Tests

`apps/os/src/domains/workers/worker-runner.test.ts`:

- a bodyless `POST` that clone-skews once is retried on a fresh loader and succeeds (regression for this exact production 500);
- a body-bearing `POST` that clone-skews is **not** retried — the error propagates and the worker is invoked once.

## Relationship to #2602 / #2603

- #2602 (merged, live) added session renewal + reconnect.
- #2603 (merged, live) made the client's refresh retry the 500 — defense in depth at the app.
- This PR fixes the **root cause** in the platform, so the renewal `POST` (and every other bodyless request to a project host) recovers a post-deploy clone skew the same way a `GET` already does. The client retry stays as a second layer for network faults and anything past source resolution.

## Risk

Touches the shared project-host dispatch path, but the change is a narrow widening of an already-trusted retry (clone-version skew was already replayed for `GET`), gated to bodyless requests, with the riskier DO-reset branch left untouched. Worth a preview soak across a deploy with pooled and fresh connections before relying on it.

## Root cause, proven vs. assumed

The `os-prd` tail nails the throwing error to clone-version skew. A Codex review (xhigh) flagged that generic bodyless-`POST` replay would be unsafe for a *Durable Object reset* (which can execute before failing) — this PR deliberately does **not** widen that branch, only the clone-version-skew branch, where the app provably never ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HDLp5EZwqbn2KqaGHnyJ4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared project-host dispatch retry behavior on the critical path after deploys, but scope is limited to bodyless replay for an existing clone-skew recovery; DO-reset and body-bearing POST behavior stay unchanged.
> 
> **Overview**
> **Fixes intermittent project-host 500s** after deploy when a bodyless `POST` (e.g. auth refresh) hits Workers RPC clone-version skew. `DynamicWorkerRunner.fetch` already retried once on a fresh loader for `GET`/`HEAD`; it now treats any **byte-replayable** request the same for that path—`GET`, `HEAD`, or any method with `request.body === null`—while still excluding WebSocket upgrades.
> 
> **Retry rules are split on purpose.** Durable Object reset recovery still replays only idempotent `GET`/`HEAD` (side effects may have started). Clone-version skew retries any replayable request because the app never ran. **Body-bearing `POST`s are never replayed** (no double-read of the body).
> 
> Tests add regression coverage for bodyless `POST` recovery and for body-bearing `POST` failing without a second fetch. Clone-version detection in the fetch catch path uses `isWorkerRpcCloneVersionError` and logs the request method on retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6840626512209d9e556d126a7ec05fe40d6356d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +28 -15 | +15 -10 🟩🟥⬜⬜⬜ |
| Tests | +88 -0 | +79 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+116 -15** | **+94 -10** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 2d3a0b2 and 6840626, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-09-08T21:35:48.873Z",
      "deployedAt": "2026-09-08T21:24:09.536Z",
      "headSha": "6840626512209d9e556d126a7ec05fe40d6356d3",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/132661061683601",
      "shortSha": "6840626",
      "cleanupDurationMs": 98941,
      "deployDurationMs": 82115,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 80999,
      "deployReadinessDurationMs": 1113,
      "deployedWorkerName": "os-preview-6",
      "deployedWorkerVersion": "ce95e1fb-1c91-48d9-8aa5-a58454f5fb2d",
      "testDurationMs": 284235,
      "testRetries": "1 retried: mobile/approvals.spec.ts › approve and reject script bursts from inside the chat thread › mobile (playwright x1) — TimeoutError: locator.waitFor: Timeout 1000ms exceeded. Call log: \u001b[2m - waiting for getByRole('button', { name: 'Approve all 3 (Face ID)' }) to be visible\u001b[22m \u001b[33m Spinner was still visible after 30000ms (or a navigation was still in flight), the UI is likely stuck.\u001b[0m",
      "workerSizeKib": 20993.73,
      "workerGzipKib": 5292.98,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5304.54
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-09-08T21:34:13.338Z",
      "deployedAt": "2026-09-08T21:23:16.493Z",
      "headSha": "6840626512209d9e556d126a7ec05fe40d6356d3",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-6.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/132661061683601",
      "shortSha": "6840626",
      "cleanupDurationMs": 3404,
      "deployDurationMs": 28360,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 27954,
      "deployReadinessDurationMs": 403,
      "deployedWorkerName": "docs-preview-6",
      "deployedWorkerVersion": "c9624022-653d-45aa-a395-220821b66807",
      "testDurationMs": 4664,
      "testRetries": null,
      "workerSizeKib": 4662.05,
      "workerGzipKib": 1092.95,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-09-08T21:34:14.549Z",
      "deployedAt": "2026-09-08T21:23:22.078Z",
      "headSha": "6840626512209d9e556d126a7ec05fe40d6356d3",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/132661061683601",
      "shortSha": "6840626",
      "cleanupDurationMs": 4614,
      "deployDurationMs": 33855,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 33538,
      "deployReadinessDurationMs": 313,
      "deployedWorkerName": "auth-preview-6",
      "deployedWorkerVersion": "5bfb78f0-b2f1-4223-958c-3d864849734a",
      "testDurationMs": 21666,
      "testRetries": null,
      "workerSizeKib": 4179,
      "workerGzipKib": 855.52,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-09-08T21:34:14.419Z",
      "deployedAt": "2026-09-08T21:23:17.554Z",
      "headSha": "6840626512209d9e556d126a7ec05fe40d6356d3",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/132661061683601",
      "shortSha": "6840626",
      "cleanupDurationMs": 4481,
      "deployDurationMs": 29542,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 29013,
      "deployReadinessDurationMs": 524,
      "deployedWorkerName": "streams-example-app-preview-6",
      "deployedWorkerVersion": "15a3f1fe-3867-4390-8d70-f9bbd0bfda88",
      "testDurationMs": 64277,
      "testRetries": null,
      "workerSizeKib": 5670.17,
      "workerGzipKib": 1603.81,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-09-08T21:34:11.338Z",
      "deployedAt": "2026-09-08T21:22:57.191Z",
      "headSha": "6840626512209d9e556d126a7ec05fe40d6356d3",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-6.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/132661061683601",
      "shortSha": "6840626",
      "cleanupDurationMs": 1393,
      "deployDurationMs": 8919,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 8622,
      "deployReadinessDurationMs": 264,
      "deployedWorkerName": "dummy-petshop-preview-6",
      "deployedWorkerVersion": "a4b5c41d-b74d-405e-9299-a5dd6b32c3e4",
      "testDurationMs": 18874,
      "testRetries": null,
      "workerSizeKib": 1331.5,
      "workerGzipKib": 232.81,
      "deployedFingerprint": "c321865fd82cf1ce04086fcbe3c487f157babc45+c5abf1055de73f3b4ffbc5e5b742dff1f0b5ee52",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `6840626` | [https://auth.iterate-preview-6.com](https://auth.iterate-preview-6.com) | 855.5 KiB | 33.9s | 21.7s |  | 4.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/132661061683601) | 2026-09-08T21:34:14.549Z | Preview app released. |
| Docs | released | `6840626` | [https://docs-preview-6.iterate-dev-preview.workers.dev](https://docs-preview-6.iterate-dev-preview.workers.dev) | 1.07 MiB | 28.4s | 4.7s |  | 3.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/132661061683601) | 2026-09-08T21:34:13.338Z | Preview app released. |
| Dummy Petshop | released | `6840626` | [https://dummy-petshop.iterate-preview-6.com](https://dummy-petshop.iterate-preview-6.com) | 232.8 KiB | 8.9s | 18.9s |  | 1.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/132661061683601) | 2026-09-08T21:34:11.338Z | Preview app released. |
| OS | released | `6840626` | [https://os.iterate-preview-6.com](https://os.iterate-preview-6.com) | 5.17 MiB (-11.6 KiB vs main) | 82.1s | 284.2s | 1 retried: mobile/approvals.spec.ts › approve and reject script bursts from inside the chat thread › mobile (playwright x1) — TimeoutError: locator.waitFor: Timeout 1000ms exceeded. Call log: [2m - waiting for getByRole('button', { name: 'Approve all 3 (Face ID)' }) to be visible[22m [33m Spinner was still visible after 30000ms (or a navigation was still in flight), the UI is likely stuck.[0m | 98.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/132661061683601) | 2026-09-08T21:35:48.873Z | Preview app released. |
| Streams Example App | released | `6840626` | [https://streams.iterate-preview-6.com](https://streams.iterate-preview-6.com) | 1.57 MiB | 29.5s | 64.3s |  | 4.5s | [Workflow run](https://github.com/iterate/iterate/actions/runs/132661061683601) | 2026-09-08T21:34:14.419Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->
