### PR TITLE
Worker runner: retry clone-version skew until it clears, and cover WebSocket upgrades

### DIFF
--- a/apps/os/src/domains/workers/worker-runner.test.ts
+++ b/apps/os/src/domains/workers/worker-runner.test.ts
@@ -582,6 +582,136 @@ it("never replays a BODY-BEARING POST on clone-version skew — the body cannot 
   expect(workerFetch).toHaveBeenCalledTimes(1);
 });
 
+it("keeps retrying a bodyless POST on a fresh isolate until the skew clears", async () => {
+  // One retry is not always enough: during a deploy the replacement isolate
+  // can be stale too, so the loop tries a fresh isolate up to the bound.
+  const workerFetch = vi
+    .fn()
+    .mockRejectedValueOnce(
+      new Error("Unable to deserialize cloned data due to invalid or unsupported version."),
+    )
+    .mockRejectedValueOnce(
+      new Error("Unable to deserialize cloned data due to invalid or unsupported version."),
+    )
+    .mockResolvedValueOnce(new Response("recovered on the third isolate"));
+  h.resolveWorkerSource.mockResolvedValue({
+    ok: true,
+    source: {
+      assetConfig: undefined,
+      assetManifest: {},
+      assets: {},
+      cacheKey: "build-key",
+      commitOid: "commit-1",
+      mainModule: "worker.js",
+      modules: {},
+      wranglerConfig: undefined,
+    },
+  });
+  h.loadResolvedWorker.mockImplementation(() => ({
+    getEntrypoint: () => ({ fetch: workerFetch }),
+  }));
+  const runner = new DynamicWorkerRunner({
+    streamContext: { kind: "scope", scopePath: inlineRef.path },
+    exports: {} as ExecutionContext["exports"],
+    projectId: "prj_private",
+    scopePath: inlineRef.path,
+  });
+
+  const response = await runner.fetch({
+    ref: inlineRef,
+    request: new Request("https://example.com/", { method: "POST" }),
+  });
+
+  expect(await response.text()).toBe("recovered on the third isolate");
+  expect(workerFetch).toHaveBeenCalledTimes(3);
+  const nonces = h.loadResolvedWorker.mock.calls.map((c) => c[0].loaderInstanceNonce);
+  // Each retry moved to a distinct fresh isolate.
+  expect(new Set(nonces.slice(1)).size).toBe(nonces.length - 1);
+});
+
+it("gives up a bodyless POST after the attempt bound so the caller can reconnect", async () => {
+  const workerFetch = vi
+    .fn()
+    .mockRejectedValue(
+      new Error("Unable to deserialize cloned data due to invalid or unsupported version."),
+    );
+  h.resolveWorkerSource.mockResolvedValue({
+    ok: true,
+    source: {
+      assetConfig: undefined,
+      assetManifest: {},
+      assets: {},
+      cacheKey: "build-key",
+      commitOid: "commit-1",
+      mainModule: "worker.js",
+      modules: {},
+      wranglerConfig: undefined,
+    },
+  });
+  h.loadResolvedWorker.mockImplementation(() => ({
+    getEntrypoint: () => ({ fetch: workerFetch }),
+  }));
+  const runner = new DynamicWorkerRunner({
+    streamContext: { kind: "scope", scopePath: inlineRef.path },
+    exports: {} as ExecutionContext["exports"],
+    projectId: "prj_private",
+    scopePath: inlineRef.path,
+  });
+
+  await expect(
+    runner.fetch({
+      ref: inlineRef,
+      request: new Request("https://example.com/", { method: "POST" }),
+    }),
+  ).rejects.toThrow("Unable to deserialize cloned data");
+  // First attempt plus CLONE_VERSION_MAX_ATTEMPTS - 1 retries = 4 dispatches.
+  expect(workerFetch).toHaveBeenCalledTimes(4);
+});
+
+it("recovers a WebSocket upgrade after clone-version skew (a reconnecting collab session)", async () => {
+  // A WebSocket upgrade is a bodyless GET whose socket does not exist yet when
+  // the dispatch throws, so a clone skew during a deploy is safe to replay —
+  // the collab session reconnects instead of failing.
+  const workerFetch = vi
+    .fn()
+    .mockRejectedValueOnce(
+      new Error("Unable to deserialize cloned data due to invalid or unsupported version."),
+    )
+    // 101 cannot be constructed as a Response in the test runtime; the point
+    // is that the upgrade request rode the clone-skew retry at all.
+    .mockResolvedValueOnce(new Response("connected"));
+  h.resolveWorkerSource.mockResolvedValue({
+    ok: true,
+    source: {
+      assetConfig: undefined,
+      assetManifest: {},
+      assets: {},
+      cacheKey: "build-key",
+      commitOid: "commit-1",
+      mainModule: "worker.js",
+      modules: {},
+      wranglerConfig: undefined,
+    },
+  });
+  h.loadResolvedWorker.mockImplementation(() => ({
+    getEntrypoint: () => ({ fetch: workerFetch }),
+  }));
+  const runner = new DynamicWorkerRunner({
+    streamContext: { kind: "scope", scopePath: inlineRef.path },
+    exports: {} as ExecutionContext["exports"],
+    projectId: "prj_private",
+    scopePath: inlineRef.path,
+  });
+
+  const response = await runner.fetch({
+    ref: inlineRef,
+    request: new Request("https://example.com/api", { headers: { Upgrade: "websocket" } }),
+  });
+
+  expect(await response.text()).toBe("connected");
+  expect(workerFetch).toHaveBeenCalledTimes(2);
+});
+
 it("replays one safe stateful fetch after its hosting Durable Object resets", async () => {
   const reset = Object.assign(new Error("Durable Object reset because its code was updated."), {
     durableObjectReset: true,

--- a/apps/os/src/domains/workers/worker-runner.ts
+++ b/apps/os/src/domains/workers/worker-runner.ts
@@ -366,6 +366,9 @@ export class DynamicWorkerRunner {
         traceRole,
       });
       try {
+        // Cloudflare's clone() widens the Request metadata generics even though
+        // the runtime value stays the same Fetch API request; the request is
+        // bodyless here, so the clone is a cheap header/URL copy.
         return await dispatch(request.clone() as typeof request, crypto.randomUUID());
       } catch (error) {
         lastError = error;

--- a/apps/os/src/domains/workers/worker-runner.ts
+++ b/apps/os/src/domains/workers/worker-runner.ts
@@ -32,6 +32,17 @@ export type DynamicWorkerTraceRole = "project_config" | "run_script" | "schedule
 const WORKERS_RPC_CLONE_VERSION_ERROR =
   "Unable to deserialize cloned data due to invalid or unsupported version.";
 
+/**
+ * How many times a replayable stateless request is dispatched through a
+ * clone-version skew before giving up (the first try plus its retries). One
+ * retry is not always enough: during a deploy the whole parent isolate is
+ * being replaced, so a fresh loader isolate can be stale too, and the first
+ * clean load is the one that pins the recovery nonce for every later request
+ * here. A small bound keeps a genuinely dying isolate from being hammered —
+ * past it the caller reconnects onto a different parent isolate.
+ */
+const CLONE_VERSION_MAX_ATTEMPTS = 4;
+
 /** True when an error is workerd's clone-version skew — a loader isolate
  * outliving the bindings it captured. The one error class where retiring the
  * shared isolate (a recovery nonce) and retrying is the correct response. */
@@ -270,32 +281,30 @@ export class DynamicWorkerRunner {
         return withWorkerCommit(await entrypoint.fetch(currentRequest), resolved.commitOid);
       };
 
-      // A request is byte-replayable when there is nothing to consume: GET and
-      // HEAD by spec, and any other method that carries no body (the auth
-      // gate's refresh POST is one). WebSocket upgrades are never replayed.
-      // Cloudflare's clone() widens the Request metadata generics even though
-      // the runtime value stays the same Fetch API request.
-      const replayableRequest =
+      // GET and HEAD are idempotent, so they may replay any transient dispatch
+      // failure. Cloudflare's clone() widens the Request metadata generics even
+      // though the runtime value stays the same Fetch API request.
+      const idempotentReplay =
         !isWebSocketUpgradeRequest(request) &&
-        (request.method === "GET" || request.method === "HEAD" || request.body === null)
+        (request.method === "GET" || request.method === "HEAD")
           ? (request.clone() as typeof request)
           : undefined;
-      // A Durable Object reset can land AFTER the app began handling the
-      // request, so only an idempotent method may replay that one; a
-      // clone-version skew is a loader-isolate deserialize failure BEFORE the
+      // A clone-version skew is a loader-isolate deserialize failure BEFORE the
       // app runs (the shared isolate outlived its captured bindings), so any
-      // byte-replayable request is safe to retry on a fresh isolate.
-      const isIdempotentMethod = request.method === "GET" || request.method === "HEAD";
+      // request with no body is safe to replay on a fresh isolate — a bodyless
+      // POST like the auth gate's refresh, and a WebSocket upgrade too, whose
+      // socket does not exist yet when the dispatch throws.
+      const cloneSkewReplayable = request.body === null;
       let response: Response;
       try {
         response = await dispatch(request);
       } catch (error) {
-        if (
-          replayableRequest &&
-          isIdempotentMethod &&
-          ref.type === "stateful" &&
-          isDurableObjectLifecycleError(error)
-        ) {
+        if (idempotentReplay && ref.type === "stateful" && isDurableObjectLifecycleError(error)) {
+          // A Durable Object reset can land AFTER the app began handling the
+          // request, so only an idempotent method replays it; a deploy,
+          // eviction, or temporary platform fault may retire the hosting DO
+          // between dispatch and response, and the second lookup reaches a
+          // fresh incarnation. A second failure remains terminal.
           span.setAttribute("iterate.worker.durable_object_availability_retry", true);
           console.info("Stateful worker fetch retrying after Durable Object unavailability", {
             error,
@@ -303,23 +312,20 @@ export class DynamicWorkerRunner {
             rayId: request.headers.get("cf-ray") ?? undefined,
             traceRole,
           });
-          // A deploy, eviction, or temporary platform fault may retire the
-          // hosting DO between dispatch and response; the second lookup reaches
-          // a fresh incarnation, and a second failure remains terminal.
-          response = await dispatch(replayableRequest);
+          response = await dispatch(idempotentReplay);
         } else if (
-          replayableRequest &&
+          cloneSkewReplayable &&
           ref.type === "stateless" &&
           isWorkerRpcCloneVersionError(error)
         ) {
           span.setAttribute("iterate.worker.rpc_clone_version_retry", true);
-          console.warn("Workers RPC clone-version skew; retrying stateless fetch once", {
-            method: request.method,
-            projectId: this.#projectId,
+          response = await this.#dispatchThroughCloneSkew({
+            dispatch,
+            request,
+            firstError: error,
             rayId: request.headers.get("cf-ray") ?? undefined,
             traceRole,
           });
-          response = await dispatch(replayableRequest, crypto.randomUUID());
         } else {
           throw error;
         }
@@ -327,6 +333,46 @@ export class DynamicWorkerRunner {
       span.setAttribute("http.response.status_code", response.status);
       return response;
     });
+  }
+
+  /**
+   * Replay a bodyless stateless dispatch through a clone-version skew on a
+   * fresh loader isolate, bounded by {@link CLONE_VERSION_MAX_ATTEMPTS}. Each
+   * retry mints a new isolate (a stale replacement during a deploy skews
+   * again); the first clean load pins the shared recovery nonce, so later
+   * requests on this parent isolate skip the skew. A non-skew error, or the
+   * bound running out, is terminal — the caller then reconnects elsewhere.
+   */
+  async #dispatchThroughCloneSkew({
+    dispatch,
+    request,
+    firstError,
+    rayId,
+    traceRole,
+  }: {
+    dispatch: (currentRequest: Request, freshInstanceNonce?: string) => Promise<Response>;
+    request: Request;
+    firstError: unknown;
+    rayId?: string;
+    traceRole?: DynamicWorkerTraceRole;
+  }): Promise<Response> {
+    let lastError = firstError;
+    for (let attempt = 2; attempt <= CLONE_VERSION_MAX_ATTEMPTS; attempt++) {
+      console.warn("Workers RPC clone-version skew; retrying stateless fetch on a fresh isolate", {
+        attempt,
+        method: request.method,
+        projectId: this.#projectId,
+        rayId,
+        traceRole,
+      });
+      try {
+        return await dispatch(request.clone() as typeof request, crypto.randomUUID());
+      } catch (error) {
+        lastError = error;
+        if (!isWorkerRpcCloneVersionError(error)) throw error;
+      }
+    }
+    throw lastError;
   }
 
   async invokeCapability({


### PR DESCRIPTION
Follow-up to #2605. Proving that fix in production showed one retry is not enough during a deploy, and hardens the path that a multi-hour multiplayer collab session depends on.

## Why one retry was not enough

#2605 gave a bodyless request a single clone-version-skew retry on a fresh loader isolate. Measured against prod right after its own deploy:

| connection | 500 rate |
|---|---|
| GET (edge-cacheable) | 0 / 40 |
| bodyless POST, fresh connection | 2–8 / 40 |
| bodyless POST, pooled + client retry | **0** (15 / 15 recovered) |

A pooled connection — what a real browser uses — recovered every time. But a fresh connection still 500'd 5–20% of the time in the deploy window, because during a deploy the whole parent isolate is being replaced, so the *fresh* isolate the single retry mints can be stale too. Tailing `os-prd` confirmed the residual was the same `Unable to deserialize cloned data due to invalid or unsupported version.` on both the first dispatch and the retry.

## The change

Both scoped to the clone-version-skew branch, where the error is a loader-isolate deserialize failure *before the app runs*, so replay is always safe:

- **Retry up to a small bound instead of once** (`CLONE_VERSION_MAX_ATTEMPTS = 4`). Each try mints a new isolate; the first clean load pins the shared recovery nonce, so every later request on that parent isolate skips the skew entirely. Past the bound the error is terminal and the caller reconnects onto a different parent isolate — a genuinely dying isolate is never hammered, and cost stays bounded because the recovery nonce makes concurrent requests converge instead of each minting isolates forever.
- **Cover WebSocket upgrades.** An upgrade is a bodyless GET whose socket does not exist yet when the dispatch throws, so a skew during a deploy is safe to replay. This is the one that matters for **multi-hour multiplayer**: those sessions span deploys and reconnect across them, and the reconnect's `/api` upgrade was previously excluded from the retry, so it could 500 in the churn window and cost the session its handshake.

Unchanged: the Durable-Object-reset branch still does one idempotent GET/HEAD retry (a reset can land after the app began), and a body-bearing request is still never replayed.

## Tests

`apps/os/src/domains/workers/worker-runner.test.ts`:

- a bodyless POST that skews twice recovers on the third isolate (distinct fresh nonces);
- a bodyless POST that skews every time gives up after the bound (4 dispatches) so the caller can reconnect;
- a WebSocket upgrade recovers after a skew (the reconnecting-collab case);
- the #2605 cases still hold (single skew recovers, body-bearing never replays).

## Proof plan

After this deploys I will re-run the fresh-connection GET-vs-POST comparison during the deploy's own churn window and expect the bodyless-POST 500 rate to fall to GET's ~0, closing the residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HDLp5EZwqbn2KqaGHnyJ4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core request dispatch and retry semantics on the worker runner path used for ingress and long-lived sessions; bounded retries limit blast radius but alter failure timing during deploy churn.
> 
> **Overview**
> **Hardens stateless `DynamicWorkerRunner.fetch` against workerd clone-version skew during deploys** by retrying on fresh loader isolates up to **4 attempts** instead of once, and by treating **any bodyless request** (including bodyless POST and WebSocket upgrades) as safe to replay for that error path.
> 
> Replay policy is split: **GET/HEAD** still get a single retry only for **Durable Object lifecycle** failures on stateful workers, while **clone-skew recovery** uses a new `#dispatchThroughCloneSkew` loop that clones the request and dispatches with a new `freshInstanceNonce` until success, a non-skew error, or the attempt bound—so collab reconnect upgrades and auth-style bodyless POSTs can survive multi-isolate staleness in a deploy window.
> 
> Tests cover double-skew recovery, terminal failure after four dispatches, and WebSocket upgrade recovery after one skew.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fbab81c54d707d4a1dd1c2d8a2ad2e8d597fb24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +76 -27 | +36 -15 🟩🟥⬜⬜⬜ |
| Tests | +130 -0 | +113 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+206 -27** | **+149 -15** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 33a488c and 0fbab81, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-09-08T22:11:51.784Z",
      "deployedAt": "2026-09-08T22:01:44.924Z",
      "headSha": "0fbab81c54d707d4a1dd1c2d8a2ad2e8d597fb24",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/219317368482665",
      "shortSha": "0fbab81",
      "cleanupDurationMs": 101942,
      "deployDurationMs": 70657,
      "deployConfigDurationMs": 1,
      "deployCommandDurationMs": 69490,
      "deployReadinessDurationMs": 1166,
      "deployedWorkerName": "os-preview-2",
      "deployedWorkerVersion": "fd7b9a0a-c7bb-475f-8a0e-da3fba5d09b1",
      "testDurationMs": 287712,
      "testRetries": "2 retried: first-party lane: client credential resolves from platform config, same strategy (vitest x1) — stream-unavailable: cannot access storage because object has moved to a different machine · an ITX-expression receiver isolates one repeatedly failing event, skips it, and continues (vitest x1) — Timed out waiting for the ITX receiver to isolate the failing event and acknowledge later events",
      "workerSizeKib": 20995.13,
      "workerGzipKib": 5293.04,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5304.77
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-09-08T22:10:13.839Z",
      "deployedAt": "2026-09-08T22:00:58.053Z",
      "headSha": "0fbab81c54d707d4a1dd1c2d8a2ad2e8d597fb24",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-2.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/219317368482665",
      "shortSha": "0fbab81",
      "cleanupDurationMs": 3994,
      "deployDurationMs": 22967,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 22615,
      "deployReadinessDurationMs": 346,
      "deployedWorkerName": "docs-preview-2",
      "deployedWorkerVersion": "3b6a02e0-0ac1-432e-8fbe-9d274bb6cd6e",
      "testDurationMs": 2850,
      "testRetries": null,
      "workerSizeKib": 4662.29,
      "workerGzipKib": 1092.97,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-09-08T22:10:14.840Z",
      "deployedAt": "2026-09-08T22:01:08.676Z",
      "headSha": "0fbab81c54d707d4a1dd1c2d8a2ad2e8d597fb24",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/219317368482665",
      "shortSha": "0fbab81",
      "cleanupDurationMs": 4993,
      "deployDurationMs": 33614,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 33238,
      "deployReadinessDurationMs": 371,
      "deployedWorkerName": "auth-preview-2",
      "deployedWorkerVersion": "59ddb9f1-abc3-4a30-bfcd-33ff28b1de4f",
      "testDurationMs": 19474,
      "testRetries": null,
      "workerSizeKib": 4179,
      "workerGzipKib": 855.28,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-09-08T22:10:14.937Z",
      "deployedAt": "2026-09-08T22:01:01.285Z",
      "headSha": "0fbab81c54d707d4a1dd1c2d8a2ad2e8d597fb24",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/219317368482665",
      "shortSha": "0fbab81",
      "cleanupDurationMs": 5089,
      "deployDurationMs": 26518,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 25846,
      "deployReadinessDurationMs": 666,
      "deployedWorkerName": "streams-example-app-preview-2",
      "deployedWorkerVersion": "0805b111-9389-4976-bb6d-0bffc078dac0",
      "testDurationMs": 74840,
      "testRetries": null,
      "workerSizeKib": 5671.57,
      "workerGzipKib": 1604.26,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-09-08T22:10:11.183Z",
      "deployedAt": "2026-09-08T21:50:17.172Z",
      "headSha": "0fbab81c54d707d4a1dd1c2d8a2ad2e8d597fb24",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-2.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/219317368482665",
      "shortSha": "0fbab81",
      "cleanupDurationMs": 1331,
      "deployDurationMs": 93,
      "deployConfigDurationMs": 7,
      "deployReuseProofDurationMs": 63,
      "deployedWorkerName": "dummy-petshop-preview-2",
      "deployedWorkerVersion": "57f4a1d5-b89a-40a0-8ac7-30550d680ecc",
      "testDurationMs": 7881,
      "testRetries": null,
      "workerSizeKib": 1331.5,
      "workerGzipKib": 232.81,
      "deployedFingerprint": "c321865fd82cf1ce04086fcbe3c487f157babc45+c5abf1055de73f3b4ffbc5e5b742dff1f0b5ee52",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `0fbab81` | [https://auth.iterate-preview-2.com](https://auth.iterate-preview-2.com) | 855.3 KiB | 33.6s | 19.5s |  | 5.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/219317368482665) | 2026-09-08T22:10:14.840Z | Preview app released. |
| Docs | released | `0fbab81` | [https://docs-preview-2.iterate-dev-preview.workers.dev](https://docs-preview-2.iterate-dev-preview.workers.dev) | 1.07 MiB | 23.0s | 2.9s |  | 4.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/219317368482665) | 2026-09-08T22:10:13.839Z | Preview app released. |
| Dummy Petshop | released | `0fbab81` | [https://dummy-petshop.iterate-preview-2.com](https://dummy-petshop.iterate-preview-2.com) | 232.8 KiB | 93ms | 7.9s |  | 1.3s | [Workflow run](https://github.com/iterate/iterate/actions/runs/219317368482665) | 2026-09-08T22:10:11.183Z | Preview app released. |
| OS | released | `0fbab81` | [https://os.iterate-preview-2.com](https://os.iterate-preview-2.com) | 5.17 MiB (-11.7 KiB vs main) | 70.7s | 287.7s | 2 retried: first-party lane: client credential resolves from platform config, same strategy (vitest x1) — stream-unavailable: cannot access storage because object has moved to a different machine · an ITX-expression receiver isolates one repeatedly failing event, skips it, and continues (vitest x1) — Timed out waiting for the ITX receiver to isolate the failing event and acknowledge later events | 101.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/219317368482665) | 2026-09-08T22:11:51.784Z | Preview app released. |
| Streams Example App | released | `0fbab81` | [https://streams.iterate-preview-2.com](https://streams.iterate-preview-2.com) | 1.57 MiB | 26.5s | 74.8s |  | 5.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/219317368482665) | 2026-09-08T22:10:14.937Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->