### PR TITLE
Collab pull loop reconnects for as long as the editor is open

### DIFF
--- a/packages/workspace-documents/src/collab-client.ts
+++ b/packages/workspace-documents/src/collab-client.ts
@@ -185,14 +185,6 @@ export class CollabConnection {
 
 const MAX_BACKOFF_MS = 10_000;
 const backoff = (attempt: number) => Math.min(500 * 2 ** attempt, MAX_BACKOFF_MS);
-/**
- * How many consecutive failed polls before the pull loop stops re-polling the
- * same version and re-opens the session from scratch. A short drop (a deploy,
- * a sleep) is ridden out by the next wait(); past this the session itself may
- * be gone server-side (idle-swept, evicted), and only a fresh open() recovers
- * it — re-polling a stale version would fail forever.
- */
-const REOPEN_AFTER_FAILURES = 3;
 
 /** The peer extension: collab state + the push/pull loops (official CM6
  * collab example shape, with capnweb long-poll as the transport). */
@@ -313,46 +305,20 @@ export function peerExtension(connection: CollabConnection, startVersion: number
             }
           } catch {
             if (this.done) break;
-            // Reconnect for as long as the editor is open. A multi-hour
-            // multiplayer session outlives deploys, evictions, and laptop
-            // sleeps; the pull long-poll rides every one of them out rather
-            // than declaring the session dead after a fixed count. A deleted
-            // or replaced file ("ended" above) and a signed-out re-dial (which
-            // navigates to sign-in) are the only terminals.
+            // Reconnect for as long as the editor is open, the same way the
+            // push loop already does. A multi-hour multiplayer session
+            // outlives deploys, evictions, and laptop sleeps; the pull
+            // long-poll rides every one of them out rather than declaring the
+            // session dead after a fixed count. Recovery needs no reopen here:
+            // a session reset or eviction rotates the epoch, so the very next
+            // wait() returns a "snapshot" (handled above, with correct acked-op
+            // slicing), and a deleted or replaced file returns "ended". Only a
+            // genuine transport outage lands here, and retrying it is right —
+            // when the network returns, wait() answers again. Backoff is
+            // capped, so a sustained outage settles into one quiet retry every
+            // MAX_BACKOFF_MS.
             this.failures++;
             connection.onStatus(`reconnecting (${this.failures})…`);
-            // Past a few failed polls the session may be gone server-side, so
-            // re-open it: a fresh snapshot recovers a swept session where
-            // re-polling the old version fails forever. Unsynced local edits
-            // cannot be rebased onto a snapshot that never saw them, so they
-            // are surfaced, never guessed into other people's document. A
-            // reopen that also fails is a real outage — fall through and keep
-            // retrying with capped backoff.
-            if (this.failures >= REOPEN_AFTER_FAILURES) {
-              try {
-                const reopened = await connection.open();
-                if (this.done) break;
-                let lost = "";
-                for (const update of sendableUpdates(this.view.state)) {
-                  update.changes.iterChanges((_fromA, _toA, _fromB, _toB, text) => {
-                    if (text.length > 0) lost += (lost === "" ? "" : "\n") + text.toString();
-                  });
-                }
-                this.done = true;
-                connection.onReseed(
-                  {
-                    ackedSeq: 0,
-                    content: reopened.content,
-                    epoch: connection.epoch,
-                    version: reopened.version,
-                  },
-                  lost || null,
-                );
-                return;
-              } catch {
-                // Reopen failed too — a real outage; keep retrying below.
-              }
-            }
             await sleep(backoff(this.failures));
           }
         }

--- a/packages/workspace-documents/src/collab-client.ts
+++ b/packages/workspace-documents/src/collab-client.ts
@@ -303,13 +303,15 @@ export function peerExtension(connection: CollabConnection, startVersion: number
             }
           } catch (error) {
             if (this.done) break;
+            // Reconnect for as long as the editor is open. A multi-hour
+            // multiplayer session outlives deploys, evictions, and laptop
+            // sleeps; the pull long-poll must ride every one of them out
+            // rather than declaring the session dead after a fixed count.
+            // The genuinely terminal cases end the loop elsewhere: a deleted
+            // or replaced file ("ended" above), and a signed-out re-dial,
+            // which navigates to sign-in. Backoff is capped, so a sustained
+            // outage settles into one quiet retry every MAX_BACKOFF_MS.
             this.failures++;
-            if (this.failures > 8) {
-              this.done = true;
-              connection.dead = true;
-              connection.onStatus(`disconnected: ${message(error)}`);
-              return;
-            }
             connection.onStatus(`reconnecting (${this.failures})…`);
             await sleep(backoff(this.failures));
           }

--- a/packages/workspace-documents/src/collab-client.ts
+++ b/packages/workspace-documents/src/collab-client.ts
@@ -185,6 +185,14 @@ export class CollabConnection {
 
 const MAX_BACKOFF_MS = 10_000;
 const backoff = (attempt: number) => Math.min(500 * 2 ** attempt, MAX_BACKOFF_MS);
+/**
+ * How many consecutive failed polls before the pull loop stops re-polling the
+ * same version and re-opens the session from scratch. A short drop (a deploy,
+ * a sleep) is ridden out by the next wait(); past this the session itself may
+ * be gone server-side (idle-swept, evicted), and only a fresh open() recovers
+ * it — re-polling a stale version would fail forever.
+ */
+const REOPEN_AFTER_FAILURES = 3;
 
 /** The peer extension: collab state + the push/pull loops (official CM6
  * collab example shape, with capnweb long-poll as the transport). */
@@ -235,7 +243,9 @@ export function peerExtension(connection: CollabConnection, startVersion: number
           }
         } catch (error) {
           this.failures++;
-          connection.onStatus(`push retry ${this.failures}: ${message(error)}`);
+          connection.onStatus(
+            `push retry ${this.failures}: ${error instanceof Error ? error.message : String(error)}`,
+          );
           await sleep(backoff(this.failures));
         }
         this.pushing = false;
@@ -301,18 +311,48 @@ export function peerExtension(connection: CollabConnection, startVersion: number
               this.recovering = false;
               void this.push();
             }
-          } catch (error) {
+          } catch {
             if (this.done) break;
             // Reconnect for as long as the editor is open. A multi-hour
             // multiplayer session outlives deploys, evictions, and laptop
-            // sleeps; the pull long-poll must ride every one of them out
-            // rather than declaring the session dead after a fixed count.
-            // The genuinely terminal cases end the loop elsewhere: a deleted
-            // or replaced file ("ended" above), and a signed-out re-dial,
-            // which navigates to sign-in. Backoff is capped, so a sustained
-            // outage settles into one quiet retry every MAX_BACKOFF_MS.
+            // sleeps; the pull long-poll rides every one of them out rather
+            // than declaring the session dead after a fixed count. A deleted
+            // or replaced file ("ended" above) and a signed-out re-dial (which
+            // navigates to sign-in) are the only terminals.
             this.failures++;
             connection.onStatus(`reconnecting (${this.failures})…`);
+            // Past a few failed polls the session may be gone server-side, so
+            // re-open it: a fresh snapshot recovers a swept session where
+            // re-polling the old version fails forever. Unsynced local edits
+            // cannot be rebased onto a snapshot that never saw them, so they
+            // are surfaced, never guessed into other people's document. A
+            // reopen that also fails is a real outage — fall through and keep
+            // retrying with capped backoff.
+            if (this.failures >= REOPEN_AFTER_FAILURES) {
+              try {
+                const reopened = await connection.open();
+                if (this.done) break;
+                let lost = "";
+                for (const update of sendableUpdates(this.view.state)) {
+                  update.changes.iterChanges((_fromA, _toA, _fromB, _toB, text) => {
+                    if (text.length > 0) lost += (lost === "" ? "" : "\n") + text.toString();
+                  });
+                }
+                this.done = true;
+                connection.onReseed(
+                  {
+                    ackedSeq: 0,
+                    content: reopened.content,
+                    epoch: connection.epoch,
+                    version: reopened.version,
+                  },
+                  lost === "" ? null : lost,
+                );
+                return;
+              } catch {
+                // Reopen failed too — a real outage; keep retrying below.
+              }
+            }
             await sleep(backoff(this.failures));
           }
         }
@@ -344,4 +384,3 @@ export function peerExtension(connection: CollabConnection, startVersion: number
 }
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-const message = (error: unknown) => (error instanceof Error ? error.message : String(error));

--- a/packages/workspace-documents/src/collab-client.ts
+++ b/packages/workspace-documents/src/collab-client.ts
@@ -346,7 +346,7 @@ export function peerExtension(connection: CollabConnection, startVersion: number
                     epoch: connection.epoch,
                     version: reopened.version,
                   },
-                  lost === "" ? null : lost,
+                  lost || null,
                 );
                 return;
               } catch {


### PR DESCRIPTION
Follow-up for multi-hour multiplayer collab: the client half of "no disconnects", alongside the platform fixes in #2605 / #2606.

## The gap

A multi-hour multiplayer edit session outlives deploys, isolate evictions, and laptop sleeps. The collab **pull** long-poll gave up after 8 consecutive failures (~45 s of capped backoff), set `connection.dead`, and showed a manual "disconnected" state — so any churn window longer than that disconnected everyone and made them reload. The **push** loop already retries indefinitely with the same capped backoff; only the pull loop had the cap.

## The change

The pull loop now reconnects for as long as the editor is open, matching the push loop:

- Transport failures reconnect forever with capped backoff (settling into one quiet retry every 10 s during a sustained outage).
- The genuinely terminal cases still end the loop: a deleted or replaced file (`ended`), an oversized edit, and a signed-out re-dial that navigates to sign-in.
- The `disconnected` state and its manual Reconnect button no longer appear, because the session recovers on its own.

## Why now

#2605 / #2606 stop the project-host clone-version skew from 500-ing a reconnect at the source. This is the client's matching guarantee: even across a long outage or several back-to-back deploys, the editor keeps trying instead of giving up. Together they're what a multi-hour session needs.

## Testing

Covered at the integration level by `specs/seeded-apps.spec.ts`, which cuts every live socket under the editor and asserts edits still sync through the replacement session. A unit test of the loop would need a DOM test environment for CodeMirror's `EditorView`, which this node-env package does not carry — the push loop's identical retry is untested for the same reason. The change is a removal of a give-up cap so the two loops match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HDLp5EZwqbn2KqaGHnyJ4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real-time sync recovery behavior for all workspace document editors; mis-handled infinite retry could mask permanent failures, though terminal paths and snapshot/ended handling are unchanged.
> 
> **Overview**
> **The collab pull long-poll no longer gives up after eight transport failures**, aligning with the push loop so long-lived multiplayer sessions can survive deploys, evictions, and sleeps without forcing a reload.
> 
> On pull errors the client keeps showing `reconnecting (n)…`, uses the same capped backoff (`MAX_BACKOFF_MS`), and clears back to `live · v…` when `wait()` succeeds again. It no longer sets `connection.dead` or a terminal `disconnected` message for transient outages; **ended** and **too-large** pushes still stop the session as before. Push retry status text inlines error formatting and drops the shared `message()` helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e481813c3868d4e96e3dd4cf914cb425b4e0f80e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +16 -9 | +4 -9 🟩🟩🟥🟥🟥 |
| **Total** | **+16 -9** | **+4 -9** 🟩🟩🟥🟥🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 33a488c and e481813, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-09-09T02:12:07.694Z",
      "deployedAt": "2026-09-09T02:03:13.391Z",
      "headSha": "e481813c3868d4e96e3dd4cf914cb425b4e0f80e",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/75448741574066",
      "shortSha": "e481813",
      "cleanupDurationMs": 99754,
      "deployDurationMs": 63985,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 62357,
      "deployReadinessDurationMs": 1625,
      "deployedWorkerName": "os-preview-8",
      "deployedWorkerVersion": "03982859-de18-48c3-8968-128a85323073",
      "testDurationMs": 257277,
      "testRetries": "1 retried: mobile/approvals.spec.ts › approve and reject script bursts from inside the chat thread › mobile (playwright x1) — TimeoutError: locator.click: Timeout 1000ms exceeded. Call log: \u001b[2m - waiting for getByPlaceholder('Message')\u001b[22m \u001b[2m - locator resolved to <textarea dir=\"auto\" autocorrect=\"on\" autocomplete=\"on\" spellcheck=\"true\" placeholder=\"Message\" autocapitalize=\"sentences\" virtualkeyboardpolicy=\"auto\" cl...",
      "workerSizeKib": 20993.73,
      "workerGzipKib": 5292.98,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5304.72
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-09-09T02:10:32.344Z",
      "deployedAt": "2026-09-09T02:02:39.067Z",
      "headSha": "e481813c3868d4e96e3dd4cf914cb425b4e0f80e",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-8.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/75448741574066",
      "shortSha": "e481813",
      "cleanupDurationMs": 4401,
      "deployDurationMs": 28411,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 28032,
      "deployReadinessDurationMs": 377,
      "deployedWorkerName": "docs-preview-8",
      "deployedWorkerVersion": "08bbbb1d-c4b2-4d53-92a9-132cecff55c7",
      "testDurationMs": 3032,
      "testRetries": null,
      "workerSizeKib": 4662.08,
      "workerGzipKib": 1092.95,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-09-09T02:10:33.133Z",
      "deployedAt": "2026-09-09T02:02:43.273Z",
      "headSha": "e481813c3868d4e96e3dd4cf914cb425b4e0f80e",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/75448741574066",
      "shortSha": "e481813",
      "cleanupDurationMs": 5188,
      "deployDurationMs": 32510,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 32236,
      "deployReadinessDurationMs": 270,
      "deployedWorkerName": "auth-preview-8",
      "deployedWorkerVersion": "7045f921-6652-4642-b237-e97b778e9cb1",
      "testDurationMs": 19713,
      "testRetries": null,
      "workerSizeKib": 4179,
      "workerGzipKib": 855.27,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-09-09T02:10:33.346Z",
      "deployedAt": "2026-09-09T02:02:29.635Z",
      "headSha": "e481813c3868d4e96e3dd4cf914cb425b4e0f80e",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/75448741574066",
      "shortSha": "e481813",
      "cleanupDurationMs": 5397,
      "deployDurationMs": 19144,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 18596,
      "deployReadinessDurationMs": 542,
      "deployedWorkerName": "streams-example-app-preview-8",
      "deployedWorkerVersion": "9562c0b3-d560-41f4-a7ad-f2c18fdc780f",
      "testDurationMs": 69129,
      "testRetries": null,
      "workerSizeKib": 5670.17,
      "workerGzipKib": 1603.81,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-09-09T02:10:28.910Z",
      "deployedAt": "2026-09-08T22:20:06.279Z",
      "headSha": "e481813c3868d4e96e3dd4cf914cb425b4e0f80e",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-8.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/75448741574066",
      "shortSha": "e481813",
      "cleanupDurationMs": 959,
      "deployDurationMs": 245,
      "deployConfigDurationMs": 6,
      "deployReuseProofDurationMs": 197,
      "deployedWorkerName": "dummy-petshop-preview-8",
      "deployedWorkerVersion": "caf14140-58ef-4ef9-b482-aed02c23dc41",
      "testDurationMs": 8255,
      "testRetries": null,
      "workerSizeKib": 1331.5,
      "workerGzipKib": 232.81,
      "deployedFingerprint": "c321865fd82cf1ce04086fcbe3c487f157babc45+c5abf1055de73f3b4ffbc5e5b742dff1f0b5ee52",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `e481813` | [https://auth.iterate-preview-8.com](https://auth.iterate-preview-8.com) | 855.3 KiB | 32.5s | 19.7s |  | 5.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/75448741574066) | 2026-09-09T02:10:33.133Z | Preview app released. |
| Docs | released | `e481813` | [https://docs-preview-8.iterate-dev-preview.workers.dev](https://docs-preview-8.iterate-dev-preview.workers.dev) | 1.07 MiB | 28.4s | 3.0s |  | 4.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/75448741574066) | 2026-09-09T02:10:32.344Z | Preview app released. |
| Dummy Petshop | released | `e481813` | [https://dummy-petshop.iterate-preview-8.com](https://dummy-petshop.iterate-preview-8.com) | 232.8 KiB | 245ms | 8.3s |  | 959ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/75448741574066) | 2026-09-09T02:10:28.910Z | Preview app released. |
| OS | released | `e481813` | [https://os.iterate-preview-8.com](https://os.iterate-preview-8.com) | 5.17 MiB (-11.7 KiB vs main) | 64.0s | 257.3s | 1 retried: mobile/approvals.spec.ts › approve and reject script bursts from inside the chat thread › mobile (playwright x1) — TimeoutError: locator.click: Timeout 1000ms exceeded. Call log: [2m - waiting for getByPlaceholder('Message')[22m [2m - locator resolved to <textarea dir="auto" autocorrect="on" autocomplete="on" spellcheck="true" placeholder="Message" autocapitalize="sentences" virtualkeyboardpolicy="auto" cl... | 99.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/75448741574066) | 2026-09-09T02:12:07.694Z | Preview app released. |
| Streams Example App | released | `e481813` | [https://streams.iterate-preview-8.com](https://streams.iterate-preview-8.com) | 1.57 MiB | 19.1s | 69.1s |  | 5.4s | [Workflow run](https://github.com/iterate/iterate/actions/runs/75448741574066) | 2026-09-09T02:10:33.346Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->