### PR TITLE
Docs: collaborative Markdown live editing with comments

### DIFF
--- a/apps/docs/src/components/workspace-document-page.tsx
+++ b/apps/docs/src/components/workspace-document-page.tsx
@@ -3,9 +3,9 @@ import {
   CheckIcon,
   Code2Icon,
   CopyIcon,
-  EyeIcon,
   FileTextIcon,
   MessageSquarePlusIcon,
+  PenLineIcon,
   SparklesIcon,
 } from "lucide-react";
 import { Button } from "@iterate-com/ui/components/button";
@@ -21,7 +21,6 @@ import {
 } from "@iterate-com/workspace-documents/html-annotations";
 import { authorColor, authorLabel } from "@iterate-com/workspace-documents/collab";
 import { commentIdentityFor } from "@iterate-com/workspace-documents/identity";
-import { DocumentPreview } from "@iterate-com/ui/components/document-preview";
 import { useDocumentReview } from "@iterate-com/workspace-documents/review";
 import { Drawer, DrawerContent, DrawerTitle } from "@iterate-com/ui/components/drawer";
 import type { WorkspaceDocumentTransport } from "@iterate-com/workspace-documents/types";
@@ -60,7 +59,7 @@ export function WorkspaceDocumentPage({
   // which would drop unsent edits on the floor.
   const [editorEpoch, setEditorEpoch] = useState(0);
   const [source, setSource] = useState("");
-  const [view, setView] = useState<"preview" | "source">("preview");
+  const [view, setView] = useState<"rich" | "source">("rich");
   const [status, setStatus] = useState("connecting…");
   const [showChanges, setShowChanges] = useState(false);
   const [commentsOpen, setCommentsOpen] = useState(false);
@@ -153,7 +152,7 @@ export function WorkspaceDocumentPage({
     source: reviewSource.source,
     identity: reviewSource.error ? null : identity,
     busy,
-    onTransform: onCommentTransform,
+    onTransform: editorApiRef.current?.isLive() ? onCommentTransform : undefined,
   });
   if (reviewSource.error)
     review.comments.notice = (
@@ -161,12 +160,14 @@ export function WorkspaceDocumentPage({
         {reviewSource.error}
       </p>
     );
-  const selectAnnotations = (ids: string[]) => {
-    review.preview.onSelectAnnotations?.(ids);
-    if (ids.length && window.matchMedia("(max-width: 1023px)").matches) {
+  const editorReview = {
+    ...review.editor,
+    onSelectThread: (id: string | null) => {
+      review.editor.onSelectThread(id);
+      if (!id || !window.matchMedia("(max-width: 1023px)").matches) return;
       focusMobileComposer.current = false;
       setCommentsOpen(true);
-    }
+    },
   };
 
   const copyLink = () => {
@@ -274,10 +275,7 @@ export function WorkspaceDocumentPage({
               size="icon-sm"
               aria-label="Track changes"
               aria-pressed={showChanges}
-              onClick={() => {
-                setShowChanges((value) => !value);
-                setView("source");
-              }}
+              onClick={() => setShowChanges((value) => !value)}
             >
               <SparklesIcon />
             </Button>
@@ -298,13 +296,13 @@ export function WorkspaceDocumentPage({
             </Button>
           </WithTooltip>
           <div className="flex rounded-lg border bg-muted/30 p-0.5">
-            <WithTooltip label="Preview">
+            <WithTooltip label="Rich editing">
               <ViewButton
-                active={view === "preview"}
-                label="Preview"
-                onClick={() => setView("preview")}
+                active={view === "rich"}
+                label="Rich editing"
+                onClick={() => setView("rich")}
               >
-                <EyeIcon aria-hidden className="size-3.5" />
+                <PenLineIcon aria-hidden className="size-3.5" />
               </ViewButton>
             </WithTooltip>
             <WithTooltip label={`Source (${loaded.snapshot.format})`}>
@@ -322,16 +320,16 @@ export function WorkspaceDocumentPage({
 
       <div className="grid min-h-0 flex-1 lg:grid-cols-[minmax(0,1fr)_23rem]">
         <section className="relative flex min-h-[60svh] min-w-0 flex-col bg-background lg:min-h-0">
-          <div className={view === "preview" ? "flex min-h-0 flex-1" : "hidden"}>
-            {loaded.snapshot.format === "markdown" ? (
-              <DocumentPreview {...review.preview} onSelectAnnotations={selectAnnotations} />
-            ) : (
+          {loaded.snapshot.format === "html" && view === "rich" ? (
+            <div className="flex min-h-0 flex-1">
               <HtmlDocumentPreview source={source} />
-            )}
-          </div>
+            </div>
+          ) : null}
           <div
             className={
-              view === "source" ? "flex min-h-0 flex-1 flex-col [&_.cm-editor]:h-full" : "hidden"
+              loaded.snapshot.format === "markdown" || view === "source"
+                ? "flex min-h-0 flex-1 flex-col [&_.cm-editor]:h-full"
+                : "hidden"
             }
           >
             <Suspense
@@ -349,6 +347,8 @@ export function WorkspaceDocumentPage({
                 displayName={displayName}
                 path={path}
                 mode={loaded.snapshot.format}
+                presentation={view}
+                review={loaded.snapshot.format === "markdown" ? editorReview : undefined}
                 redline={showChanges}
                 emptyPlaceholder={
                   loaded.snapshot.format === "html" ? "Write HTML…" : "Write in Markdown…"

--- a/apps/os/src/domains/live-state-pager.ts
+++ b/apps/os/src/domains/live-state-pager.ts
@@ -355,9 +355,8 @@ export async function dialLiveStatePager(
  * stay snapshot-per-read and dial nothing.
  *
  * When the Pager cannot be established, `pagerFailureDegrade` picks the
- * posture: `"reject"` makes `subscribe` throw so the call site can fall back
- * (the four DO hosts fall back to today's pinning subscribe — no liveness
- * regression, loudly logged); `"snapshot-only"` seeds the engine once from
+ * posture: `"reject"` makes `subscribe` throw for the caller's bounded,
+ * observable recovery; `"snapshot-only"` seeds the engine once from
  * `readSnapshot` and serves a live-shaped but push-less subscription (the
  * stream posture — stream subscriptions must never pin their DO).
  */

--- a/apps/os/src/domains/workspaces/collab-editor.test.tsx
+++ b/apps/os/src/domains/workspaces/collab-editor.test.tsx
@@ -164,3 +164,72 @@ test("a recovery snapshot updates the preview and cancels stale debounced text",
     vi.unstubAllGlobals();
   }
 });
+
+test("presentation changes preserve the live session and selection; an ended session refuses edits", async () => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+  const delivery = Promise.withResolvers<CollabWaitResult>();
+  const documentSession: WorkspaceDocumentLane = {
+    open: vi.fn(async () => ({ content: "# Shared", epoch: "first", version: 0 })),
+    wait: () => delivery.promise,
+    push: async () => ({ status: "accepted", version: 1 }),
+    present: async () => {},
+    changes: async () => ({
+      baseContent: "# Shared",
+      baseVersion: 0,
+      headVersion: 0,
+      inserted: [],
+      deleted: [],
+    }),
+  };
+  const transport: WorkspaceDocumentTransport = {
+    run: async (operation) => operation(documentSession),
+    runOnce: async (operation) => operation(documentSession),
+  };
+  const apiRef: { current: CollabEditorApi | null } = { current: null };
+  const extensions: Extension = [];
+  const rich = EditorView.editorAttributes.of({ class: "rich-presentation" });
+  const source: Extension = [];
+  function Editor({ presentation }: { presentation: Extension }) {
+    const { host } = useCollabEditor({
+      transport,
+      path: "/notes.md",
+      extensions,
+      presentation,
+      redline: false,
+      apiRef,
+    });
+    return <div ref={host} />;
+  }
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+  const root = createRoot(host);
+  try {
+    await act(async () => root.render(<Editor presentation={rich} />));
+    const view = EditorView.findFromDOM(host.querySelector(".cm-content")!)!;
+    await act(async () =>
+      view.dispatch({
+        changes: { from: 8, insert: " edit" },
+        selection: { anchor: 12 },
+        userEvent: "input.type",
+      }),
+    );
+    const selection = view.state.selection;
+    await act(async () => root.render(<Editor presentation={source} />));
+    expect(EditorView.findFromDOM(host.querySelector(".cm-content")!)).toBe(view);
+    expect(documentSession.open).toHaveBeenCalledTimes(1);
+    expect(view.state.selection).toBe(selection);
+    expect(view.state.doc.toString()).toBe("# Shared edit");
+    await act(async () => delivery.resolve({ status: "ended" }));
+    expect(view.state.readOnly).toBe(true);
+    expect(view.contentDOM.getAttribute("contenteditable")).toBe("false");
+    expect(apiRef.current?.isLive()).toBe(false);
+    expect(() => apiRef.current?.applyTransform((text) => text + " lost")).toThrow("Reconnect");
+    expect(view.state.doc.toString()).toBe("# Shared edit");
+  } finally {
+    await act(async () => root.unmount());
+    host.remove();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  }
+});

--- a/apps/os/src/domains/workspaces/collab-engine.test.ts
+++ b/apps/os/src/domains/workspaces/collab-engine.test.ts
@@ -357,6 +357,24 @@ describe("collab engine", () => {
     expect(engine.head(PATH)!.content).toBe(a.doc);
   });
 
+  test("minimalSplice preserves an unconfirmed edit between repeated replacements", async () => {
+    const source = "alpha middle alpha";
+    const { store } = fakeStore();
+    const engine = makeEngine(store);
+    const opened = await engine.open(PATH, async () => ({ content: source, epoch: EPOCH }));
+    const human = new Peer("human", opened.content, opened.version);
+    const middle = source.indexOf("middle") + "middle".length;
+    human.edit(middle, middle, " text");
+
+    await engine.applyExternal(PATH, (doc) =>
+      minimalSplice(doc, doc.toString().replaceAll("alpha", "beta")),
+    );
+    expect((await engine.push(human.sendable())).status).toBe("accepted");
+    await syncAll(engine, [human]);
+
+    expect(human.doc).toBe("beta middle text beta");
+  });
+
   test("dedupe identities are RETAINED for the session — idempotency is a guarantee", async () => {
     const { snapshots, store } = fakeStore();
     const engine = makeEngine(store);

--- a/apps/os/src/domains/workspaces/collab-engine.ts
+++ b/apps/os/src/domains/workspaces/collab-engine.ts
@@ -1,5 +1,6 @@
 import { ChangeSet, Text } from "@codemirror/state";
 import { rebaseUpdates, type Update } from "@codemirror/collab";
+import { textEdits } from "@iterate-com/workspace-documents/text-edits";
 
 /**
  * Server authority for per-file collaborative editing — the rebase model
@@ -97,24 +98,12 @@ export type CollabBroadcast = {
   toVersion: number;
 };
 
-/** Whole-content replacement as a common-prefix/suffix splice — preserves
- * concurrent edits outside the changed region (null when nothing changed). */
+/** Whole-content replacement as disjoint edits — preserves concurrent changes
+ * in unchanged regions (null when nothing changed). */
 export function minimalSplice(doc: Text, next: string): ChangeSet | null {
   const current = doc.toString();
   if (current === next) return null;
-  let start = 0;
-  const maxStart = Math.min(current.length, next.length);
-  while (start < maxStart && current[start] === next[start]) start++;
-  let endCurrent = current.length;
-  let endNext = next.length;
-  while (endCurrent > start && endNext > start && current[endCurrent - 1] === next[endNext - 1]) {
-    endCurrent--;
-    endNext--;
-  }
-  return ChangeSet.of(
-    { from: start, insert: next.slice(start, endNext), to: endCurrent },
-    current.length,
-  );
+  return ChangeSet.of(textEdits(current, next), current.length);
 }
 
 const SNAPSHOT_EVERY = 256;

--- a/apps/os/src/domains/workspaces/collab-review.test.ts
+++ b/apps/os/src/domains/workspaces/collab-review.test.ts
@@ -40,6 +40,14 @@ async function session(initial = source) {
         clientId,
         ops: [{ changes: changes.toJSON(), clientSeq: 0 }],
       }),
+    pushBatch: (changes: readonly ChangeSet[], clientId: string) =>
+      host.push({
+        path,
+        epoch: opened.epoch,
+        baseVersion: 0,
+        clientId,
+        ops: changes.map((change, clientSeq) => ({ changes: change.toJSON(), clientSeq })),
+      }),
   };
 }
 
@@ -156,6 +164,68 @@ fails("simultaneous first comments should share one valid endmatter", async () =
   expect(review.threads).toHaveLength(2);
   expect(review.projection.markdown.trimEnd()).toBe(source.trimEnd());
 });
+
+// Deliberately accepted for client-side RFM editing; see
+// tasks/roughdraft-concurrent-endmatter.md.
+const staleEndmatterFails = createFailing(test, /STALE ENDMATTER APPEND/);
+staleEndmatterFails(
+  "a stale EOF append remains document body while another client creates endmatter",
+  async () => {
+    const { host, push, pushBatch } = await session();
+    const comment = applyReviewOperation(source, {
+      type: "add-selected-comment",
+      expectedSource: source,
+      range: { start: 0, end: "First paragraph.\n".length },
+      body: "Check First.",
+      author: "alice",
+      createdAt: "2026-09-09T00:00:00.000Z",
+    });
+    if (!comment.ok) throw new Error(comment.message);
+    const bodyEnd = readReview(comment.source).body.range.end;
+    const localWithAppend =
+      comment.source.slice(0, bodyEnd) + "\n\nLOCAL_UNDONE" + comment.source.slice(bodyEnd);
+    expect(readReview(localWithAppend).diagnostics).toEqual([]);
+    const staleAppend = ChangeSet.of(
+      { from: source.length, insert: "\n\nREMOTE_KEPT" },
+      source.length,
+    );
+    expect(
+      (
+        await pushBatch(
+          [
+            ChangeSet.of(textEdits(source, comment.source), source.length),
+            ChangeSet.of(textEdits(comment.source, localWithAppend), comment.source.length),
+          ],
+          "alice",
+        )
+      ).status,
+    ).toBe("accepted");
+    expect((await push(staleAppend, "bob")).status).toBe("accepted");
+
+    const saved = (await host.readFile(path))!;
+    const review = readReview(saved);
+    const codes = review.diagnostics.map((diagnostic) => diagnostic.code);
+    const footerStart = saved.indexOf("\n---\ncomments:");
+    const remoteAppendIsAfterFooter =
+      footerStart >= 0 &&
+      footerStart < saved.lastIndexOf("REMOTE_KEPT") &&
+      saved.endsWith("REMOTE_KEPT");
+    if (
+      remoteAppendIsAfterFooter &&
+      codes.length === 2 &&
+      codes.includes("missing-endmatter-entry") &&
+      codes.includes("invalid-endmatter-yaml")
+    ) {
+      throw new Error(`STALE ENDMATTER APPEND: ${codes.join(", ")}`);
+    }
+    // Any different diagnostic must remain a real test failure rather than
+    // satisfying this narrow expected-failure pin.
+    expect(review.diagnostics).toEqual([]);
+    expect(review.projection.markdown).toContain("LOCAL_UNDONE");
+    expect(review.projection.markdown).toContain("REMOTE_KEPT");
+    expect(review.threads).toHaveLength(1);
+  },
+);
 
 const overlappingCommentsFail = createFailing(test, /CONCURRENT COMMENT OVERLAP/);
 for (const wordFirst of [true, false]) {

--- a/apps/os/src/domains/workspaces/collab-review.test.ts
+++ b/apps/os/src/domains/workspaces/collab-review.test.ts
@@ -79,6 +79,62 @@ for (const commentFirst of [true, false]) {
   });
 }
 
+test("an ordinary AI comment write keeps an unconfirmed human edit in its paragraph", async () => {
+  const { host, push } = await session();
+  const comment = applyReviewOperation(source, {
+    type: "add-selected-comment",
+    expectedSource: source,
+    range: { start: 0, end: "First".length },
+    body: "Check First.",
+    author: "agent",
+    createdAt: "2026-09-08T13:00:00.000Z",
+  });
+  if (!comment.ok) throw new Error(comment.message);
+  const human = ChangeSet.of(
+    {
+      from: source.indexOf("Second") + "Second".length,
+      insert: " collaboratively",
+    },
+    source.length,
+  );
+
+  // An agent read the source, produced a regular whole-file Markdown write,
+  // and a human still holds a local CodeMirror operation from that source.
+  expect(await host.writeFile(path, comment.source, "agent")).toBe(true);
+  expect((await push(human, "writer")).status).toBe("accepted");
+
+  const review = readReview((await host.readFile(path))!);
+  expect(review.diagnostics).toEqual([]);
+  expect(review.projection.markdown.trimEnd()).toBe(
+    "First paragraph.\n\nSecond collaboratively paragraph.",
+  );
+});
+
+test("a 100KiB AI comment write keeps an unconfirmed human edit in its paragraph", async () => {
+  const largeSource = `First paragraph.\n\n${"A filler paragraph. ".repeat(5_000)}\n\nSecond paragraph.\n`;
+  const { host, push } = await session(largeSource);
+  const comment = applyReviewOperation(largeSource, {
+    type: "add-selected-comment",
+    expectedSource: largeSource,
+    range: { start: 0, end: "First".length },
+    body: "Check First.",
+    author: "agent",
+    createdAt: "2026-09-08T13:00:00.000Z",
+  });
+  if (!comment.ok) throw new Error(comment.message);
+  const second = largeSource.lastIndexOf("Second") + "Second".length;
+  const human = ChangeSet.of({ from: second, insert: " collaboratively" }, largeSource.length);
+
+  expect(await host.writeFile(path, comment.source, "agent")).toBe(true);
+  expect((await push(human, "writer")).status).toBe("accepted");
+
+  const review = readReview((await host.readFile(path))!);
+  expect(review.diagnostics).toEqual([]);
+  expect(review.projection.markdown).toBe(
+    largeSource.replace("Second paragraph.", "Second collaboratively paragraph."),
+  );
+});
+
 // Deliberately accepted for client-side RFM editing; see tasks/roughdraft-concurrent-endmatter.md.
 const fails = createFailing(test, /FIRST COMMENT FOOTER RACE/);
 fails("simultaneous first comments should share one valid endmatter", async () => {

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -2152,7 +2152,13 @@ class AgentCollectionLiveStateRpcTarget
   async subscribe(
     onUpdate: (update: LiveUpdate<AgentCollectionProcessorState>) => unknown,
   ): Promise<LiveStateSubscriptionHandle> {
-    return await this.#bornThenRetry(() => this.#relay().subscribe(onUpdate));
+    // The Pager's upgrade is routed by the Stream DO's committed subscription
+    // catalog and therefore fails before the relay can inspect the facade's
+    // unconfigured-subscription refusal. Ensure this collection's idempotent
+    // birth batch first; get() supplies that narrow initialization and leaves
+    // no retained subscription.
+    await this.get();
+    return await this.#relay().subscribe(onUpdate);
   }
 }
 

--- a/apps/os/src/rpc-targets.ts
+++ b/apps/os/src/rpc-targets.ts
@@ -9001,10 +9001,9 @@ type LiveStateDurableObjectStub<State> = {
  * read must never leave a capability pinning the DO for the session's life.
  * `subscribe()` rides the client-given hibernatable Live State Pager
  * (domains/live-state-pager.ts) when the host declares the lane, so a
- * watched idle DO leaves memory; a host without the lane — and any socket
- * failure — falls back to forwarding the subscription into the DO, which
- * retains the callback there and pins it (exactly the pre-socket behavior,
- * loudly logged so pinning regressions are greppable).
+ * watched idle DO leaves memory. A Pager failure rejects the subscription;
+ * the browser hook reports it and performs its bounded re-subscribe, rather
+ * than retaining a callback that pins the Durable Object.
  */
 class LiveStateRelayRpcTarget<State extends object>
   extends IterateRpcRelay<"LiveStateRpc">
@@ -9081,14 +9080,7 @@ class LiveStateRelayRpcTarget<State extends object>
     onUpdate: (update: LiveUpdate<State>) => unknown,
   ): Promise<LiveStateSubscriptionHandle> {
     if (this.#relay !== undefined) {
-      try {
-        return new LiveStateSubscriptionRpcTarget(await this.#relay.subscribe(onUpdate));
-      } catch (error) {
-        console.warn(
-          "Live State Pager unavailable; subscription falls back to pinning the durable object",
-          { label: this.#label, error },
-        );
-      }
+      return new LiveStateSubscriptionRpcTarget(await this.#relay.subscribe(onUpdate));
     }
     return await (await (await this.#stub()).liveState).subscribe(onUpdate);
   }

--- a/apps/os/vitest.config.ts
+++ b/apps/os/vitest.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
         // Ships ESM with extensionless relative imports — fine for the vite
         // bundle, but Node's ESM resolver (vitest's default for deps) rejects
         // them; inlining lets vite resolve the package instead.
-        inline: ["codemirror-json-schema", /capnweb/],
+        inline: ["codemirror-json-schema", "@atomic-editor/editor", /capnweb/],
       },
     },
     // Route `/api2/test` is implemented as `api2.test.ts` — not a Vitest file.

--- a/docs/research/atomic-live-editing-validation.md
+++ b/docs/research/atomic-live-editing-validation.md
@@ -73,6 +73,12 @@ positions/staleness/trailing whitespace, unnecessary language replacement,
 Node test bundling, and invalid browser-test assumptions. The review also led
 to one shared operation/error path and removal of dead callback/test aliases.
 
+The first deployed walkthrough exposed a one-pixel remote-caret footprint that
+wrapped at the end of a full-width table row. Cancelling that footprint keeps
+the caret in the row (browser row height: 49.6 px → 31.4 px). The table test
+also now double-clicks the visible word rather than the empty center of its
+wide cell, and checks the native selection before replacing it.
+
 The deployed two-browser walkthrough and rendered multiplayer video are still
 pending. Local project app hosts incorrectly served OS's
 Vite graph for Docs's virtual client entry, before reaching the editor; the

--- a/docs/research/atomic-live-editing-validation.md
+++ b/docs/research/atomic-live-editing-validation.md
@@ -32,6 +32,11 @@ existing timeout inside both substring-search loops. The application asks for a
 30 seconds to about 51 ms. A normal comment operation produced three disjoint
 edits in about 0.3 ms. No document-size threshold forces whole-file replacement.
 
+The recording dependency is pinned to [Middlewright PR #44](https://github.com/iterate/middlewright/pull/44),
+which balances FFmpeg cursor expressions so long walkthroughs can render. Its
+77 video tests passed locally with subtitle-enabled FFmpeg. This changes test
+recording only.
+
 ## Browser timing
 
 Local Chromium, actual production rich-editor modules, one RFM comment and
@@ -77,19 +82,42 @@ The first deployed walkthrough exposed a one-pixel remote-caret footprint that
 wrapped at the end of a full-width table row. Cancelling that footprint keeps
 the caret in the row (browser row height: 49.6 px → 31.4 px). The table test
 also now double-clicks the visible word rather than the empty center of its
-wide cell, and checks the native selection before replacing it.
+wide cell, and checks the native selection before replacing it. Peer-caret
+labels are included in DOM text, so propagation checks scope to the cell and
+independently require the exact saved Markdown rows.
 
-The deployed two-browser walkthrough and rendered multiplayer video are still
-pending. Local project app hosts incorrectly served OS's
-Vite graph for Docs's virtual client entry, before reaching the editor; the
-spec therefore targets a deployed preview. Temporary proxy experiments were
-reverted.
+Both hosted Bugbot findings were checked against source and reproductions:
+multiline inline replacements are valid when supplied by a state field, and
+a partial parser request must retain its original source origin even if its
+first range is hidden. A new regression covers that hidden first range; a
+browser exercise confirmed a multiline comment stays hidden during native edits.
+
+The deployed two-browser walkthrough initially passed while its video exposed
+a missed native-caret defect: Chrome collapsed Select All → ArrowRight to the
+start of the last visible line when a hidden metadata block followed it. Later
+pastes consequently prepended and concatenated text. The footer now uses an inline replacement, keeping the browser caret at the
+visible body end. The saved-source assertion requires the tail
+paragraphs in order with their blank lines intact. The native Chromium
+reproduction passes; the deployed walkthrough tests this same EOF/paste path.
+
+Preview telemetry also exposed a legacy live-state subscription fallback that
+pinned its Durable Object after a Pager failure. That fallback is removed;
+subscription failures remain visible and use the existing ten-second retry timer
+for at most two retries. Success, manual refresh, or a new logical subscription
+resets the budget. Focused tests cover recovery, exhausted attempts, and changing
+subscriptions after exhaustion. Provider WebSocket lifecycle close records are
+classified separately from application errors; exact deployment evidence and
+the rendered two-client recording are attached to PR #2608.
 
 ## Known format limits
 
 RFM cannot represent crossing inline anchors. Existing exact expected-failure
 tests cover concurrent first-footer creation, overlapping anchors, and upstream
-metadata/endmatter behavior; see
+metadata/endmatter behavior. A new narrow expected failure reproduces a stale
+client appending at the old EOF while another creates the first comment footer:
+ordinary text rebasing preserves the append after the footer and invalidates
+its YAML. The browser undo walkthrough waits for the peer to receive that
+footer before proceeding; it does not claim to fix this race. See
 [the tracked task](../../tasks/roughdraft-concurrent-endmatter.md). This work does
 not claim semantic merging of arbitrary Markdown/YAML edits. A stale full-file
 write made after another edit was already confirmed still replaces that content.

--- a/docs/research/atomic-live-editing-validation.md
+++ b/docs/research/atomic-live-editing-validation.md
@@ -1,0 +1,89 @@
+# Atomic live Markdown editing: implementation and evidence
+
+2026-09-09. The editable document remains the original Markdown file, including
+Roughdraft Flavored Markdown comments and endmatter. Atomic supplies live preview
+on the existing CodeMirror editor. There is no rich document serializer, separate
+comment store, or new collaboration protocol.
+
+## Why these small extensions exist
+
+- RFM syntax is hidden while the anchored prose remains normal CodeMirror text.
+  A mapped Markdown syntax tree preserves headings, lists and tables when an
+  annotation wraps their Markdown markers.
+- The comment composer holds a mapped source selection while focus is elsewhere.
+  Submit transforms the current source into disjoint text changes, just like
+  typing. Drafts remain in React through popover unmounts and resyncs.
+- Native table cell decorations replace Atomic's serializing table widget. Cell
+  edits, selection and presence all use CodeMirror's original text DOM.
+- Rich/source switching reconfigures the same editor. Thread selection retains
+  the language, syntax tree and view plugins; attribution redlines work in rich
+  mode too.
+
+## Dependency patches
+
+[Atomic 0.6.2](https://github.com/kenforthewin/atomic-editor) is patched to decorate
+the viewport plus 160 lines on each side, rather than walking the whole document
+on every caret move. It also disables checkbox writes when CodeMirror is
+read-only. Its clean upstream typecheck/build and 97 product tests passed.
+
+[CodeMirror merge](https://github.com/codemirror/merge) is patched to observe its
+existing timeout inside both substring-search loops. The application asks for a
+50 ms diff budget. A pathological 1 MiB alternating rewrite changed from over
+30 seconds to about 51 ms. A normal comment operation produced three disjoint
+edits in about 0.3 ms. No document-size threshold forces whole-file replacement.
+
+## Browser timing
+
+Local Chromium, actual production rich-editor modules, one RFM comment and
+frontmatter/endmatter, twenty edits per fixture. Each sample times the synchronous
+CodeMirror state update plus view update, with a frame between samples. These are
+not end-to-end network timings or mobile measurements.
+
+| Markdown size | Initial update | Median edit | p95 edit |
+| ------------- | -------------: | ----------: | -------: |
+| 10 KiB        |          11 ms |      2.2 ms |   4.9 ms |
+| 100 KiB       |          24 ms |       10 ms |    11 ms |
+| 1 MiB         |         171 ms |       87 ms |    91 ms |
+
+At 1 MiB, about 80 ms of the median is state/parsing work. Large files remain a
+measurable limitation; they do not silently switch to source mode. The isolated
+Atomic decoration patch also reduced a 1 MiB caret-selection view update from
+about 80 ms to 1 ms. Browser dependency optimization was restarted before the
+final integrated timings above.
+
+## Correctness evidence
+
+- Three official CodeMirror collaboration clients perform 750 competing edits,
+  converge after each batch, retain a pending comment's passage, create the
+  comment, then undo it without removing remote text.
+- Server regression: an AI comment write around a 100 KiB document preserves an
+  unconfirmed human edit inside the unchanged body.
+- Native browser typing tests cover annotated passage boundaries, repeated
+  insertion, whole-document navigation around hidden endmatter, and CDP IME
+  composition at both edges and inside a passage. This is not proof of an actual
+  iOS/Android IME candidate window or kinetic scrolling.
+- Focused tests cover native tables, structural changes above tables, mapped
+  headings/lists/tables, partial parser requests, remote cursor ordering,
+  presentation identity, local undo, terminal read-only state, and composer
+  draft restoration.
+
+Claude Fable 5.1 reviewed both the design and the implementation through the
+Claude CLI. Confirmed findings were fixed: document-edge snapping, table line
+positions/staleness/trailing whitespace, unnecessary language replacement,
+Node test bundling, and invalid browser-test assumptions. The review also led
+to one shared operation/error path and removal of dead callback/test aliases.
+
+The deployed two-browser walkthrough and rendered multiplayer video are still
+pending. Local project app hosts incorrectly served OS's
+Vite graph for Docs's virtual client entry, before reaching the editor; the
+spec therefore targets a deployed preview. Temporary proxy experiments were
+reverted.
+
+## Known format limits
+
+RFM cannot represent crossing inline anchors. Existing exact expected-failure
+tests cover concurrent first-footer creation, overlapping anchors, and upstream
+metadata/endmatter behavior; see
+[the tracked task](../../tasks/roughdraft-concurrent-endmatter.md). This work does
+not claim semantic merging of arbitrary Markdown/YAML edits. A stale full-file
+write made after another edit was already confirmed still replaces that content.

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "json5": "^2.2.3",
     "knip": "^6.0.5",
     "lint-staged": "^16.2.7",
-    "middlewright": "https://pkg.pr.new/middlewright@c5feb42",
+    "middlewright": "https://pkg.pr.new/middlewright@08dd4f9",
     "oxfmt": "^0.35.0",
     "oxlint": "^1.50.0",
     "pkg-pr-new": "0.0.79",

--- a/packages/iterate/src/sdk/capnweb/react.test.tsx
+++ b/packages/iterate/src/sdk/capnweb/react.test.tsx
@@ -129,3 +129,84 @@ describe("generic Cap'n Web live state", () => {
     expect(unusedConnection).not.toHaveBeenCalled();
   });
 });
+
+test("retries a rejected subscription, then becomes live", async () => {
+  vi.useFakeTimers();
+  const connection = makeRoot();
+  const subscribe = vi
+    .spyOn(connection.root.liveState, "subscribe")
+    .mockRejectedValueOnce(new Error("Pager seed closed"));
+
+  function Harness() {
+    const { status } = useLiveState(
+      (root: typeof connection.root) => root.liveState,
+      (state) => state.name,
+    );
+    return createElement("output", { "data-status": status });
+  }
+
+  const container = document.body.appendChild(document.createElement("div"));
+  const reactRoot = createRoot(container);
+  await act(async () => {
+    reactRoot.render(
+      createElement(
+        CapnWebProvider,
+        { makeConnection: () => connection.root },
+        createElement(Harness),
+      ),
+    );
+  });
+  await act(async () => {});
+  expect(container.querySelector("output")?.getAttribute("data-status")).toBe("error");
+
+  await act(async () => vi.advanceTimersByTimeAsync(10_000));
+  expect(subscribe).toHaveBeenCalledTimes(2);
+  expect(container.querySelector("output")?.getAttribute("data-status")).toBe("live");
+
+  await act(async () => reactRoot.unmount());
+});
+
+test("bounds terminal retries per logical subscription", async () => {
+  vi.useFakeTimers();
+  const connection = makeRoot();
+  const subscribe = vi
+    .spyOn(connection.root.liveState, "subscribe")
+    .mockRejectedValue(new Error("permanent subscription failure"));
+
+  function Harness({ facet }: { facet: string }) {
+    const { status } = useLiveState(
+      (root: typeof connection.root) => root.liveState,
+      (state) => state.name,
+      [facet],
+    );
+    return createElement("output", { "data-status": status });
+  }
+
+  const container = document.body.appendChild(document.createElement("div"));
+  const reactRoot = createRoot(container);
+  const render = async (facet: string) => {
+    await act(async () => {
+      reactRoot.render(
+        createElement(
+          CapnWebProvider,
+          { makeConnection: () => connection.root },
+          createElement(Harness, { facet }),
+        ),
+      );
+    });
+  };
+  await render("agents");
+  await act(async () => vi.advanceTimersByTimeAsync(10_000));
+  await act(async () => vi.advanceTimersByTimeAsync(10_000));
+  expect(subscribe).toHaveBeenCalledTimes(3);
+  expect(container.querySelector("output")?.getAttribute("data-status")).toBe("error");
+
+  await render("tasks");
+  await act(async () => vi.advanceTimersByTimeAsync(10_000));
+  await act(async () => vi.advanceTimersByTimeAsync(10_000));
+  expect(subscribe).toHaveBeenCalledTimes(6);
+
+  await act(async () => vi.advanceTimersByTimeAsync(60_000));
+  expect(subscribe).toHaveBeenCalledTimes(6);
+  await act(async () => reactRoot.unmount());
+});

--- a/packages/iterate/src/sdk/capnweb/react.tsx
+++ b/packages/iterate/src/sdk/capnweb/react.tsx
@@ -36,6 +36,7 @@ const CapnWebContext = createContext<ConnectionSnapshot | undefined>(undefined);
 const CONNECTION_STABLE_MS = 30_000;
 const CONNECTION_RETRY_MAX_MS = 10_000;
 const SUBSCRIBE_RETRY_MS = 10_000;
+const MAX_SUBSCRIBE_RETRIES = 2;
 const SUBSCRIBE_TIMEOUT_MS = 15_000;
 const PING_INTERVAL_MS = 45_000;
 const PING_TIMEOUT_MS = 10_000;
@@ -237,7 +238,6 @@ export function useLiveState<Root extends CapnWebRoot, State, Selected = State>(
   const root = (hasRootOverride ? options.root : connection?.root) ?? undefined;
   const enabled = options?.enabled ?? true;
   const [epoch, setEpoch] = useState(0);
-  const refresh = useCallback(() => setEpoch((current) => current + 1), []);
   const liveRef = useRef(live);
   const selectorRef = useRef(selector);
   useEffect(() => {
@@ -255,6 +255,12 @@ export function useLiveState<Root extends CapnWebRoot, State, Selected = State>(
       : connection?.scope;
   // oxlint-disable-next-line react-hooks/exhaustive-deps -- this memo is intentionally keyed; deps complete the caller's logical-node identity
   const store = useMemo(() => createLiveStateStore<State>(), [logicalConnection, ...deps]);
+  // oxlint-disable-next-line react-hooks/exhaustive-deps -- store is the logical subscription identity; its replacement must reset the retry budget
+  const subscribeRetries = useMemo(() => ({ count: 0 }), [store]);
+  const refresh = useCallback(() => {
+    subscribeRetries.count = 0;
+    setEpoch((current) => current + 1);
+  }, [subscribeRetries]);
   const [subscriptionState, setSubscriptionState] = useState<{
     error?: string;
     epoch: number;
@@ -295,7 +301,10 @@ export function useLiveState<Root extends CapnWebRoot, State, Selected = State>(
           status: "error",
           store,
         });
-        if (shouldRetry) retry = setTimeout(refresh, SUBSCRIBE_RETRY_MS);
+        if (shouldRetry && subscribeRetries.count < MAX_SUBSCRIBE_RETRIES) {
+          subscribeRetries.count += 1;
+          retry = setTimeout(() => setEpoch((current) => current + 1), SUBSCRIBE_RETRY_MS);
+        }
       };
 
       // The context erases its root parameter; this hook's provider/factory/root
@@ -321,6 +330,7 @@ export function useLiveState<Root extends CapnWebRoot, State, Selected = State>(
               return;
             }
             handle = subscription;
+            subscribeRetries.count = 0;
             setSubscriptionState({
               epoch,
               generation: connection?.generation,
@@ -346,11 +356,11 @@ export function useLiveState<Root extends CapnWebRoot, State, Selected = State>(
           },
           (cause: unknown) => {
             clearTimeout(timeout);
-            report(cause);
+            report(cause, true);
           },
         );
       } catch (cause) {
-        report(cause);
+        report(cause, true);
       }
     }
 

--- a/packages/ui/src/components/document-comments.test.tsx
+++ b/packages/ui/src/components/document-comments.test.tsx
@@ -72,6 +72,10 @@ test("submission applies locally, retains a rejected draft, and never clears lat
   document.body.appendChild(host);
   const root = createRoot(host);
   let available = false;
+  let savedDraft = "";
+  const onDraftChange = (draft: string) => {
+    savedDraft = draft;
+  };
   const onSubmit = vi.fn(() => available);
   try {
     await act(async () => {
@@ -80,6 +84,7 @@ test("submission applies locally, retains a rejected draft, and never clears lat
           initialValue="First comment"
           placeholder="Comment"
           submitLabel="Send"
+          onDraftChange={onDraftChange}
           onSubmit={onSubmit}
         />,
       );
@@ -100,6 +105,19 @@ test("submission applies locally, retains a rejected draft, and never clears lat
     });
     expect(textarea.value).toBe("Next comment");
     expect(textarea.disabled).toBe(false);
+    await act(async () => root.render(null));
+    await act(async () =>
+      root.render(
+        <ReviewComposer
+          initialValue={savedDraft}
+          onDraftChange={onDraftChange}
+          placeholder="Comment"
+          submitLabel="Send"
+          onSubmit={onSubmit}
+        />,
+      ),
+    );
+    expect(host.querySelector("textarea")!.value).toBe("Next comment");
   } finally {
     await act(async () => root.unmount());
     host.remove();

--- a/packages/ui/src/components/document-comments.tsx
+++ b/packages/ui/src/components/document-comments.tsx
@@ -513,6 +513,7 @@ export function ReviewComposer({
   placeholder,
   submitLabel,
   textareaRef,
+  onDraftChange,
   onSubmit,
   onCancel,
 }: {
@@ -520,17 +521,23 @@ export function ReviewComposer({
   placeholder: string;
   submitLabel: string;
   textareaRef?: React.RefObject<HTMLTextAreaElement | null>;
+  /** Lets a temporary host retain its draft across unmounts. */
+  onDraftChange?: (draft: string) => void;
   /** Absent while unavailable: keep the draft editable and disable submission. */
   onSubmit?: (body: string) => boolean;
   onCancel?: () => void;
 }) {
   const [draft, setDraft] = React.useState(initialValue);
   const [error, setError] = React.useState<string | null>(null);
+  const updateDraft = (value: string) => {
+    setDraft(value);
+    onDraftChange?.(value);
+  };
   const submit = () => {
     if (!onSubmit || draft.trim() === "") return;
     setError(null);
     try {
-      if (onSubmit(draft)) setDraft("");
+      if (onSubmit(draft)) updateDraft("");
     } catch (error) {
       setError(error instanceof Error ? error.message : "The comment could not be saved.");
     }
@@ -547,7 +554,7 @@ export function ReviewComposer({
           <Textarea
             ref={textareaRef}
             value={draft}
-            onChange={(event) => setDraft(event.target.value)}
+            onChange={(event) => updateDraft(event.target.value)}
             onKeyDown={(event) => {
               if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
                 event.preventDefault();

--- a/packages/workspace-documents/README.md
+++ b/packages/workspace-documents/README.md
@@ -31,22 +31,43 @@ For Roughdraft Flavored Markdown, use `useDocumentReview`:
 ```tsx
 const review = useDocumentReview({ source, identity, busy, onTransform });
 
-<DocumentPreview {...review.preview} />
+// Add these props to the editor's existing transport/path configuration:
+<WorkspaceDocumentEditor {...editorProps} presentation="rich" review={review.editor} />
 <DocumentComments {...review.comments} />
+
+// A separate read-only Markdown preview is also available:
+<DocumentPreview {...review.preview} />
 ```
 
-The hook reads and writes RFM through `iterate/document-review`, maps display
-ranges back to source ranges, and checks the selection's display revision before
-it creates an anchored comment. `onTransform` receives a whole-file transform
+The hook reads and writes RFM through `iterate/document-review`. The rich editor
+holds a selected passage in CodeMirror source coordinates while the composer is
+focused, mapping it through local and remote edits. Submission uses that current
+range and the current file. The separate preview maps display ranges back to
+source and checks its revision. `onTransform` receives a whole-file transform
 and applies it to the current local editor with `applyTransform`. The editor uses
 CodeMirror's diff to dispatch separate text changes, preserving unchanged prose
 between a passage marker and its endmatter. Pending typing is included, and the
 normal collaboration protocol handles attribution, retries and redlines. An
-anchored comment still requires its preview selection to match the current local
+anchored comment from the separate preview requires its selection to match the current local
 source; otherwise the draft is retained for reselection. Explicit UI actions
 refresh the preview and discussion controls immediately; typing stays debounced.
 Snapshot recovery also refreshes consumers immediately and cancels stale pending
 reflections. Composers retain drafts when submit callbacks become unavailable.
+
+`presentation="rich"` uses Atomic's live Markdown decorations; `"source"` exposes
+the complete file for editing and repair. Switching reconfigures the same
+EditorView, preserving the collaboration session, selection, and undo history.
+Attribution redlines remain available in both modes. Tables use native CodeMirror
+text spans, so cell typing and Tab navigation do not serialize or replace a table.
+RFM syntax is hidden separately from editable prose. A projected syntax tree keeps
+Markdown headings, lists, and tables structured even when a comment wraps them;
+that tree is never serialized back into the file.
+
+The two dependency patches are deliberately local: Atomic decorates a buffered
+viewport instead of walking the whole file on every caret move, and disables
+checkbox writes in read-only sessions. CodeMirror's diff observes its configured
+deadline inside substring search. Ordinary file edits keep their disjoint changes
+at every document size; there is no size-based replacement or source-mode fallback.
 
 RFM cannot represent crossing inline review ranges; existing overlaps are
 rejected locally. Concurrent edits can still produce invalid markup: two clients

--- a/packages/workspace-documents/package.json
+++ b/packages/workspace-documents/package.json
@@ -20,21 +20,26 @@
     "test": "vitest run --reporter=default --reporter=../shared/src/test-support/e2e-policy/retry-telemetry-reporter.ts"
   },
   "dependencies": {
+    "@atomic-editor/editor": "0.6.2",
     "@codemirror/collab": "^6.1.1",
     "@codemirror/commands": "^6.10.4",
-    "@codemirror/merge": "^6.12.2",
     "@codemirror/lang-html": "^6.4.11",
     "@codemirror/lang-markdown": "^6.5.0",
+    "@codemirror/language": "^6.12.2",
+    "@codemirror/merge": "^6.12.2",
     "@codemirror/state": "^6.7.1",
     "@codemirror/view": "^6.43.6",
     "@iterate-com/ui": "workspace:*",
+    "@lezer/common": "^1.5.1",
     "capnweb": "npm:@iterate-com/capnweb@^0.10.0",
     "iterate": "workspace:*",
-    "react": "^19.2.7"
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "catalog:cloudflare",
     "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
     "typescript": "^5.9.3",
     "vite": "^8.0.16",
     "vitest": "^4.1.10"

--- a/packages/workspace-documents/src/collab-cursors.test.ts
+++ b/packages/workspace-documents/src/collab-cursors.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+import { cursorDecorations } from "./collab-cursors.ts";
+
+describe("remote cursor decorations", () => {
+  test("keeps an overlapping peer cursor after an earlier selection's head", () => {
+    const decorations = cursorDecorations(
+      [
+        { anchor: 0, at: 0, clientId: "u-alice-a1", head: 10 },
+        { anchor: 5, at: 0, clientId: "u-bob-b2", head: 5 },
+      ],
+      "u-mine-c3",
+      12,
+    );
+    const ranges: { from: number; to: number; widget: boolean }[] = [];
+    decorations.between(0, 12, (from, to, value) => {
+      ranges.push({ from, to, widget: value.spec.widget !== undefined });
+    });
+
+    expect(ranges.sort((left, right) => left.from - right.from || left.to - right.to)).toEqual([
+      { from: 0, to: 10, widget: false },
+      { from: 5, to: 5, widget: true },
+      { from: 10, to: 10, widget: true },
+    ]);
+  });
+});

--- a/packages/workspace-documents/src/collab-cursors.ts
+++ b/packages/workspace-documents/src/collab-cursors.ts
@@ -144,6 +144,7 @@ const theme = EditorView.baseTheme({
     display: "inline-block",
     height: "1.15em",
     marginLeft: "-1px",
+    marginRight: "-1px",
     position: "relative",
     verticalAlign: "text-bottom",
   },

--- a/packages/workspace-documents/src/collab-cursors.ts
+++ b/packages/workspace-documents/src/collab-cursors.ts
@@ -6,7 +6,7 @@ import {
   type DecorationSet,
   type ViewUpdate,
 } from "@codemirror/view";
-import { RangeSetBuilder } from "@codemirror/state";
+import type { Range } from "@codemirror/state";
 import type { CollabConnection } from "./collab-client.ts";
 import type { CollabPresence } from "./types.ts";
 import { authorColor, authorLabel } from "./collab-author.ts";
@@ -50,43 +50,30 @@ class CursorWidget extends WidgetType {
   }
 }
 
-function cursorDecorations(
+export function cursorDecorations(
   clients: CollabPresence["clients"],
   ownClientId: string,
   docLength: number,
 ): DecorationSet {
-  const builder = new RangeSetBuilder<Decoration>();
-  const remote: (CollabPresence["clients"][number] & { from: number; to: number })[] = [];
+  const ranges: Range<Decoration>[] = [];
   for (const client of clients) {
     if (client.clientId === ownClientId) continue;
-    remote.push({
-      ...client,
-      from: Math.min(Math.min(client.anchor, client.head), docLength),
-      to: Math.min(Math.max(client.anchor, client.head), docLength),
-    });
-  }
-  remote.sort(
-    (left, right) => left.from - right.from || left.clientId.localeCompare(right.clientId),
-  );
-  for (const client of remote) {
-    if (client.from < client.to) {
-      builder.add(
-        client.from,
-        client.to,
+    const from = Math.min(Math.min(client.anchor, client.head), docLength);
+    const to = Math.min(Math.max(client.anchor, client.head), docLength);
+    if (from < to) {
+      ranges.push(
         Decoration.mark({
           attributes: { style: `background: ${authorColor(client.clientId, 0.22)}` },
           class: "cm-remote-selection",
-        }),
+        }).range(from, to),
       );
     }
     const head = Math.min(client.head, docLength);
-    builder.add(
-      head,
-      head,
-      Decoration.widget({ side: 1, widget: new CursorWidget(client.clientId) }),
+    ranges.push(
+      Decoration.widget({ side: 1, widget: new CursorWidget(client.clientId) }).range(head),
     );
   }
-  return builder.finish();
+  return Decoration.set(ranges, true);
 }
 
 export function remoteCursorsExtension(connection: CollabConnection) {

--- a/packages/workspace-documents/src/collab-editor-api.ts
+++ b/packages/workspace-documents/src/collab-editor-api.ts
@@ -26,3 +26,14 @@ export interface CollabEditorApi {
   /** Transform the current local document into ordinary, disjoint text edits. */
   applyTransform(transform: (source: string) => string): void;
 }
+
+/**
+ * Review data supplied by a host to the Markdown editor. The editor keeps
+ * selection positions in CodeMirror; the host owns the comment rail and the
+ * plain-text review operation that persists a submitted comment.
+ */
+export type EditorReviewConfig = {
+  selectedThreadId: string | null;
+  onSelectThread: (id: string | null) => void;
+  onComment?: (range: { from: number; to: number }, body: string) => boolean;
+};

--- a/packages/workspace-documents/src/markdown-tables.test.ts
+++ b/packages/workspace-documents/src/markdown-tables.test.ts
@@ -1,0 +1,204 @@
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
+import { syntaxTree } from "@codemirror/language";
+import { applyReviewOperation } from "iterate/document-review";
+import { describe, expect, it, test } from "vitest";
+import { markdownTables, moveTableCell } from "./markdown-tables.ts";
+import { projectedMarkdown } from "./rfm-projected-markdown.ts";
+
+function createState(source: string): EditorState {
+  return EditorState.create({
+    doc: source,
+    extensions: [markdown({ base: markdownLanguage }), markdownTables()],
+  });
+}
+
+function tableNodes(state: EditorState, name: string): { from: number; to: number }[] {
+  const nodes: { from: number; to: number }[] = [];
+  syntaxTree(state).iterate({
+    enter(node) {
+      if (node.name === name) nodes.push({ from: node.from, to: node.to });
+    },
+  });
+  return nodes;
+}
+
+function decorationsAt(
+  state: EditorState,
+  position: number,
+): { attributes?: { class?: string; style?: string } }[] {
+  const decorations: { attributes?: { class?: string; style?: string } }[] = [];
+  for (const source of state.facet(EditorView.decorations)) {
+    const set = typeof source === "function" ? source({ state } as EditorView) : source;
+    set.between(position, position + 1, (from, _to, value) => {
+      if (from === position) decorations.push(value.spec);
+    });
+  }
+  return decorations;
+}
+
+function atomicRanges(state: EditorState): { from: number; to: number }[] {
+  const ranges: { from: number; to: number }[] = [];
+  for (const source of state.facet(EditorView.atomicRanges)) {
+    source({ state } as EditorView).between(0, state.doc.length, (from, to) => {
+      ranges.push({ from, to });
+    });
+  }
+  return ranges;
+}
+
+function commented(source: string, passage: string) {
+  const from = source.indexOf(passage);
+  const result = applyReviewOperation(source, {
+    type: "add-selected-comment",
+    expectedSource: source,
+    range: { start: from, end: from + passage.length },
+    author: "Ada",
+    body: "Please review | this.",
+    createdAt: "2026-09-09T02:00:00Z",
+  });
+  if (!result.ok) throw new Error(result.message);
+  return result.source;
+}
+
+function createProjectedState(source: string): EditorState {
+  return EditorState.create({ doc: source, extensions: [projectedMarkdown(), markdownTables()] });
+}
+
+describe("markdownTables", () => {
+  it("keeps the table as a normal Markdown source document", () => {
+    const source = `| Name | Owner |\n| --- | --- |\n| Alice | Ada |`;
+    const state = createState(source);
+    const from = source.indexOf("Alice");
+    const next = state.update({ changes: { from, to: from + 5, insert: "Alicia" } }).state;
+
+    expect(tableNodes(state, "Table")).toHaveLength(1);
+    expect(next.doc.toString()).toBe(source.replace("Alice", "Alicia"));
+    expect(tableNodes(next, "TableCell")).toHaveLength(4);
+  });
+
+  it("uses lezer's escape-aware cells and keeps an empty field", () => {
+    const source = `| A | B | C |\n| --- | --- | --- |\n| x\\|y || z |`;
+    const state = createState(source);
+
+    // `\\|` is a literal pipe. The empty middle field has no TableCell node.
+    expect(tableNodes(state, "TableCell")).toHaveLength(5);
+    expect(tableNodes(state, "TableDelimiter")).toHaveLength(9);
+  });
+
+  it("recognizes an even backslash run before a pipe as structural", () => {
+    const source = `| A | B | C |\n| --- | --- | --- |\n| x\\\\| y | z |`;
+    const state = createState(source);
+
+    expect(tableNodes(state, "TableCell")).toHaveLength(6);
+  });
+
+  it("supports GFM tables without outer pipes", () => {
+    const state = createState(`Name | Owner\n--- | ---\nAlice | Ada`);
+    expect(tableNodes(state, "TableCell")).toHaveLength(4);
+  });
+
+  it("moves Tab and Shift-Tab through native source positions", () => {
+    const source = `| Name | Owner |\n| --- | --- |\n| Alice | Ada |`;
+    let state = createState(source);
+    const alice = source.indexOf("Alice");
+    const ada = source.indexOf("Ada");
+    state = state.update({ selection: { anchor: alice + 2 } }).state;
+    const view = {
+      get state() {
+        return state;
+      },
+      dispatch(spec: Parameters<EditorState["update"]>[0]) {
+        state = state.update(spec).state;
+      },
+    };
+
+    // The command only needs CodeMirror's state/dispatch pair. This avoids a
+    // DOM harness while exercising the public keymap command's source offsets.
+    expect(moveTableCell(view as never, 1)).toBe(true);
+    expect(state.selection.main.head).toBe(ada);
+    expect(moveTableCell(view as never, -1)).toBe(true);
+    expect(state.selection.main.head).toBe(alice + "Alice".length);
+
+    state = state.update({ selection: { anchor: ada } }).state;
+    expect(moveTableCell(view as never, 1)).toBe(false);
+  });
+
+  it("removes the native table presentation when the divider is deleted", () => {
+    const source = `| Name | Owner |\n| --- | --- |\n| Alice | Ada |`;
+    const state = createState(source);
+    const marker = source.indexOf("---");
+    const next = state.update({ changes: { from: marker, to: marker + 3 } }).state;
+
+    expect(tableNodes(next, "Table")).toHaveLength(0);
+  });
+
+  it("registers the hidden divider as an atomic range for arrow navigation", () => {
+    const source = `| Name | Owner |\n| --- | --- |\n| Alice | Ada |`;
+    const state = createState(source);
+    const from = source.indexOf("| ---");
+    expect(atomicRanges(state)).toEqual([{ from, to: from + "| --- | --- |".length }]);
+  });
+
+  it("does not add a cell for whitespace after the final pipe", () => {
+    const source = `| A | B |\n| --- | --- |\n| x | y |  `;
+    const state = createState(source);
+    const rowStarts = [0, source.indexOf("| x")];
+
+    expect(tableNodes(state, "Table")).toHaveLength(1);
+
+    for (const rowStart of rowStarts) {
+      expect(decorationsAt(state, rowStart)).toContainEqual({
+        attributes: expect.objectContaining({ style: "--markdown-table-columns: 2" }),
+      });
+    }
+  });
+
+  it("drops table decorations when a fence opener changes the parse above it", () => {
+    const source = `\n| A | B |\n| --- | --- |\n| x | y |\n`;
+    const state = createState(source);
+    const next = state.update({ changes: { from: 0, insert: "```\n" } }).state;
+
+    expect(tableNodes(next, "Table")).toHaveLength(0);
+    expect(atomicRanges(next)).toEqual([]);
+  });
+
+  it("uses projected GFM delimiters when a hidden comment contains a pipe", () => {
+    const source = commented(`| Name | Owner |\n| --- | --- |\n| Alpha | Jonas |\n`, "Alpha");
+    const state = createProjectedState(source);
+    const alpha = source.indexOf("Alpha");
+    const jonas = source.indexOf("Jonas");
+    let selected = state.update({ selection: { anchor: alpha } }).state;
+    const view = {
+      get state() {
+        return selected;
+      },
+      dispatch(spec: Parameters<EditorState["update"]>[0]) {
+        selected = selected.update(spec).state;
+      },
+    };
+
+    expect(tableNodes(state, "TableCell")).toHaveLength(4);
+    expect(moveTableCell(view as never, 1)).toBe(true);
+    expect(selected.selection.main.head).toBe(jonas);
+  });
+
+  test.for(["| Alpha | Jonas |", "| Name | Owner |\n| --- | --- |\n| Alpha | Jonas |"])(
+    "keeps a projected whole-row or whole-table anchor structurally navigable",
+    (passage) => {
+      const source = commented(`| Name | Owner |\n| --- | --- |\n| Alpha | Jonas |\n`, passage);
+      const state = createProjectedState(source);
+
+      expect(tableNodes(state, "Table")).toHaveLength(1);
+      expect(tableNodes(state, "TableCell")).toHaveLength(4);
+      const rowStart = state.doc.lineAt(source.indexOf("Alpha")).from;
+      expect(decorationsAt(state, rowStart)).toContainEqual({
+        attributes: expect.objectContaining({
+          class: "cm-markdown-table-row",
+          style: "--markdown-table-columns: 2",
+        }),
+      });
+    },
+  );
+});

--- a/packages/workspace-documents/src/markdown-tables.ts
+++ b/packages/workspace-documents/src/markdown-tables.ts
@@ -1,0 +1,292 @@
+import { ensureSyntaxTree, syntaxTree } from "@codemirror/language";
+import {
+  Prec,
+  StateField,
+  type EditorState,
+  type Extension,
+  type Range,
+  type Transaction,
+} from "@codemirror/state";
+import { Decoration, EditorView, keymap, WidgetType, type DecorationSet } from "@codemirror/view";
+import type { SyntaxNode } from "@lezer/common";
+
+interface TableDecorations {
+  decorations: DecorationSet;
+  outer: DecorationSet;
+  atomic: DecorationSet;
+  ranges: { from: number; to: number }[];
+}
+
+class EmptyTableCell extends WidgetType {
+  override eq(): boolean {
+    return true;
+  }
+
+  override toDOM(): HTMLElement {
+    const cell = document.createElement("span");
+    cell.className = "cm-markdown-table-cell cm-markdown-table-empty-cell";
+    cell.setAttribute("aria-hidden", "true");
+    cell.textContent = "\u200b";
+    return cell;
+  }
+
+  override ignoreEvent(): boolean {
+    return false;
+  }
+}
+
+class HiddenTableDivider extends WidgetType {
+  override eq(): boolean {
+    return true;
+  }
+
+  override toDOM(): HTMLElement {
+    const divider = document.createElement("div");
+    divider.className = "cm-markdown-table-divider";
+    divider.setAttribute("aria-hidden", "true");
+    return divider;
+  }
+
+  override ignoreEvent(): boolean {
+    return true;
+  }
+}
+
+function directChildren(node: SyntaxNode, name: string): SyntaxNode[] {
+  const children: SyntaxNode[] = [];
+  for (let child = node.firstChild; child; child = child.nextSibling) {
+    if (child.name === name) children.push(child);
+  }
+  return children;
+}
+
+/** Fields are the source spans between GFM parser delimiters, not raw `|` scans. */
+function tableFields(state: EditorState, row: SyntaxNode): { from: number; to: number }[] {
+  const fields: { from: number; to: number }[] = [];
+  let start = row.from;
+  let end = row.to;
+  while (end > start && /\s/.test(state.doc.sliceString(end - 1, end))) end--;
+  let first = true;
+  for (const delimiter of directChildren(row, "TableDelimiter")) {
+    // The first outer pipe opens a field. Later adjacent pipes are empty fields.
+    if (!(first && start === delimiter.from)) fields.push({ from: start, to: delimiter.from });
+    start = delimiter.to;
+    first = false;
+  }
+  if (start < end) fields.push({ from: start, to: end });
+  return fields;
+}
+
+function editableFields(state: EditorState, row: SyntaxNode): { from: number; to: number }[] {
+  const cells = directChildren(row, "TableCell");
+  return tableFields(state, row).map((field) => {
+    const cell = cells.find(
+      (candidate) => candidate.from >= field.from && candidate.to <= field.to,
+    );
+    if (cell) return { from: cell.from, to: cell.to };
+
+    let from = field.from;
+    let to = field.to;
+    while (from < to && /\s/.test(state.doc.sliceString(from, from + 1))) from++;
+    while (to > from && /\s/.test(state.doc.sliceString(to - 1, to))) to--;
+    return { from, to };
+  });
+}
+
+function tableRows(table: SyntaxNode): SyntaxNode[] {
+  return [...directChildren(table, "TableHeader"), ...directChildren(table, "TableRow")];
+}
+
+function buildTables(state: EditorState): TableDecorations {
+  const regular: Range<Decoration>[] = [];
+  const outer: Range<Decoration>[] = [];
+  const atomic: Range<Decoration>[] = [];
+  const ranges: { from: number; to: number }[] = [];
+  const tree = ensureSyntaxTree(state, state.doc.length, 200) ?? syntaxTree(state);
+
+  tree.iterate({
+    enter(node) {
+      if (node.name !== "Table") return;
+      const table = node.node;
+      const rows = tableRows(table);
+      if (rows.length === 0) return false;
+      const columns = Math.max(1, ...rows.map((row) => tableFields(state, row).length));
+      ranges.push({ from: table.from, to: table.to });
+
+      for (const row of rows) {
+        regular.push(
+          Decoration.line({
+            attributes: {
+              class:
+                row.name === "TableHeader"
+                  ? "cm-markdown-table-row cm-markdown-table-header"
+                  : "cm-markdown-table-row",
+              style: `--markdown-table-columns: ${columns}`,
+            },
+          }).range(state.doc.lineAt(row.from).from),
+        );
+        for (const delimiter of directChildren(row, "TableDelimiter"))
+          regular.push(
+            Decoration.mark({ class: "cm-markdown-table-pipe" }).range(
+              delimiter.from,
+              delimiter.to,
+            ),
+          );
+        for (const field of tableFields(state, row)) {
+          if (field.from === field.to) {
+            outer.push(
+              Decoration.widget({ side: 1, widget: new EmptyTableCell() }).range(field.from),
+            );
+          } else {
+            outer.push(
+              Decoration.mark({ class: "cm-markdown-table-cell" }).range(field.from, field.to),
+            );
+          }
+        }
+      }
+
+      const divider = directChildren(table, "TableDelimiter")[0];
+      if (divider) {
+        const decoration = Decoration.replace({ block: true, widget: new HiddenTableDivider() });
+        regular.push(decoration.range(divider.from, divider.to));
+        atomic.push(decoration.range(divider.from, divider.to));
+      }
+      return false;
+    },
+  });
+
+  return {
+    decorations: Decoration.set(regular, true),
+    outer: Decoration.set(outer, true),
+    atomic: Decoration.set(atomic, true),
+    ranges,
+  };
+}
+
+function changesAffectTables(value: TableDecorations, transaction: Transaction): boolean {
+  let affected = false;
+  transaction.changes.iterChanges((fromA, toA, fromB, _toB, inserted) => {
+    if (affected) return;
+    if (value.ranges.some((range) => fromA <= range.to && toA >= range.from)) {
+      affected = true;
+      return;
+    }
+    const before = transaction.startState.doc.lineAt(
+      Math.min(fromA, transaction.startState.doc.length),
+    ).text;
+    const after = transaction.state.doc.lineAt(Math.min(fromB, transaction.state.doc.length)).text;
+    if (before.includes("|") || after.includes("|") || inserted.toString().includes("\n"))
+      affected = true;
+  });
+  return affected;
+}
+
+function rangesStillTables(state: EditorState, ranges: { from: number; to: number }[]): boolean {
+  const tree = syntaxTree(state);
+  return ranges.every((range) => {
+    for (
+      let node: SyntaxNode | null = tree.resolveInner(Math.min(range.from, state.doc.length), 1);
+      node;
+      node = node.parent
+    ) {
+      if (node.name === "Table") return true;
+    }
+    return false;
+  });
+}
+
+const tables = StateField.define<TableDecorations>({
+  create: buildTables,
+  update(value, transaction) {
+    if (!transaction.docChanged) {
+      return syntaxTree(transaction.state) === syntaxTree(transaction.startState)
+        ? value
+        : buildTables(transaction.state);
+    }
+    if (changesAffectTables(value, transaction)) return buildTables(transaction.state);
+    const mapped = {
+      decorations: value.decorations.map(transaction.changes),
+      outer: value.outer.map(transaction.changes),
+      atomic: value.atomic.map(transaction.changes),
+      ranges: value.ranges.map((range) => ({
+        from: transaction.changes.mapPos(range.from, 1),
+        to: transaction.changes.mapPos(range.to, -1),
+      })),
+    };
+    return rangesStillTables(transaction.state, mapped.ranges)
+      ? mapped
+      : buildTables(transaction.state);
+  },
+  provide(field) {
+    return [
+      EditorView.decorations.from(field, (value) => value.decorations),
+      EditorView.outerDecorations.from(field, (value) => value.outer),
+      EditorView.atomicRanges.of((view) => view.state.field(field).atomic),
+    ];
+  },
+});
+
+function tableCells(state: EditorState): { from: number; to: number }[] {
+  const cells: { from: number; to: number }[] = [];
+  syntaxTree(state).iterate({
+    enter(node) {
+      if (node.name !== "Table") return;
+      for (const row of tableRows(node.node)) cells.push(...editableFields(state, row));
+      return false;
+    },
+  });
+  return cells;
+}
+
+export function moveTableCell(view: EditorView, direction: 1 | -1): boolean {
+  const selection = view.state.selection.main;
+  if (!selection.empty) return false;
+  const cells = tableCells(view.state);
+  const index = cells.findIndex((cell) => cell.from <= selection.head && selection.head <= cell.to);
+  const target = cells[index + direction];
+  if (index < 0 || !target) return false;
+  view.dispatch({
+    selection: { anchor: direction === 1 ? target.from : target.to },
+    scrollIntoView: true,
+  });
+  return true;
+}
+
+/** Native GFM table presentation. The Markdown text remains CodeMirror's only buffer. */
+export function markdownTables(): Extension {
+  return [
+    tables,
+    Prec.high(
+      keymap.of([
+        { key: "Tab", run: (view) => moveTableCell(view, 1) },
+        { key: "Shift-Tab", run: (view) => moveTableCell(view, -1) },
+      ]),
+    ),
+    tableTheme,
+  ];
+}
+
+const tableTheme = EditorView.baseTheme({
+  ".cm-markdown-table-row": {
+    boxSizing: "border-box",
+    margin: "0",
+    maxWidth: "100%",
+    width: "min(100%, 56rem)",
+  },
+  ".cm-markdown-table-cell": {
+    border: "1px solid color-mix(in srgb, currentColor 18%, transparent)",
+    boxSizing: "border-box",
+    display: "inline-block",
+    maxWidth: "100%",
+    minWidth: "0",
+    padding: "0.35rem 0.6rem",
+    verticalAlign: "top",
+    width: "calc(100% / var(--markdown-table-columns))",
+  },
+  ".cm-markdown-table-header .cm-markdown-table-cell": {
+    background: "color-mix(in srgb, currentColor 7%, transparent)",
+    fontWeight: "650",
+  },
+  ".cm-markdown-table-divider": { height: "0", minHeight: "0", overflow: "hidden" },
+  ".cm-markdown-table-pipe": { display: "none" },
+});

--- a/packages/workspace-documents/src/rfm-controls.test.ts
+++ b/packages/workspace-documents/src/rfm-controls.test.ts
@@ -1,0 +1,253 @@
+import { Annotation, EditorState, StateEffect, StateField, Transaction } from "@codemirror/state";
+import { describe, expect, it } from "vitest";
+import { applyReviewOperation, readReview } from "iterate/document-review";
+import { rfmControlRanges, rfmInputFilter } from "./rfm-controls.ts";
+
+const source = [
+  "---",
+  "title: Review",
+  "---",
+  "",
+  'A {==one==}{>>root<<}{id="c1" by="Jonas" at="2026-09-08T10:00:00.000Z"}{>>reply<<}{id="c2" by="AI" at="2026-09-08T10:01:00.000Z" re="c1"} B {>>loose<<}{id="c3" by="AI" at="2026-09-08T10:02:00.000Z"}.',
+  "",
+  'A {++new++}{id="s1" by="AI" at="2026-09-08T10:03:00.000Z"}.',
+  "",
+  "---",
+  "comments:",
+  "  c1:",
+  "    by: Jonas",
+  '    at: "2026-09-08T10:00:00.000Z"',
+  "  c2:",
+  "    by: AI",
+  '    at: "2026-09-08T10:01:00.000Z"',
+  "    re: c1",
+  "  c3:",
+  "    by: AI",
+  '    at: "2026-09-08T10:02:00.000Z"',
+  "  s1:",
+  "    by: AI",
+  '    at: "2026-09-08T10:03:00.000Z"',
+  "",
+].join("\n");
+
+function range(kind: ReturnType<typeof rfmControlRanges>[number]["kind"]) {
+  const result = rfmControlRanges(readReview(source), source.length).find(
+    (candidate) => candidate.kind === kind,
+  );
+  if (!result) throw new Error(`Missing ${kind} control in fixture`);
+  return result;
+}
+
+describe("rfmControlRanges", () => {
+  it("covers every projected-away source range with absolute positions", () => {
+    const ranges = rfmControlRanges(readReview(source), source.length);
+
+    expect(ranges.map((range) => range.kind)).toEqual(
+      expect.arrayContaining(["frontmatter", "endmatter", "open", "suffix", "hidden", "atomic"]),
+    );
+    for (const [index, control] of ranges.entries()) {
+      expect(source.slice(control.from, control.to)).not.toBe("");
+      expect(control.from).toBeGreaterThanOrEqual(index === 0 ? 0 : ranges[index - 1]!.to);
+    }
+    expect(ranges.some((control) => source.slice(control.from, control.to).includes("loose"))).toBe(
+      true,
+    );
+    expect(ranges.some((control) => source.slice(control.from, control.to).includes("new"))).toBe(
+      true,
+    );
+  });
+
+  it("returns no controls for malformed review source", () => {
+    expect(rfmControlRanges(readReview("{==broken"), "{==broken".length)).toEqual([]);
+  });
+});
+
+describe("rfmInputFilter", () => {
+  const state = () => EditorState.create({ doc: source, extensions: rfmInputFilter() });
+
+  it("redirects atomic suffix Backspace to the preceding visible grapheme", () => {
+    const suffix = range("suffix");
+    const next = state().update({
+      changes: { from: suffix.from, to: suffix.to },
+      annotations: Transaction.userEvent.of("delete.backward"),
+    }).state;
+
+    expect(next.doc.toString()).toBe(source.replace("{==one==}", "{==on==}"));
+    expect(next.selection.main.head).toBe(suffix.from - 1);
+  });
+
+  it("preserves controls while replacing a selection that crosses them", () => {
+    const suffix = range("suffix");
+    const start = source.indexOf("one") + 1;
+    const next = state().update({ changes: { from: start, to: suffix.to + 2, insert: "X" } }).state;
+
+    expect(next.doc.toString()).toBe(source.replace("{==one==}", "{==oX==}").replace(" B ", " "));
+  });
+
+  it("keeps annotations and effects when it rewrites input", () => {
+    const suffix = range("suffix");
+    const marker = Annotation.define<string>();
+    const effect = StateEffect.define<string>();
+    const received = StateField.define({
+      create: () => "",
+      update: (value, transaction) =>
+        transaction.effects.find((candidate) => candidate.is(effect))?.value ?? value,
+    });
+    const next = EditorState.create({
+      doc: source,
+      extensions: [rfmInputFilter(), received],
+    }).update({
+      changes: { from: suffix.from, to: suffix.to },
+      annotations: [Transaction.userEvent.of("delete.backward"), marker.of("kept")],
+      effects: effect.of("kept"),
+      scrollIntoView: true,
+    });
+
+    expect(next.annotation(marker)).toBe("kept");
+    expect(next.state.field(received)).toBe("kept");
+    expect(next.scrollIntoView).toBe(true);
+  });
+
+  it("maps positional effects through the rewritten change", () => {
+    const suffix = range("suffix");
+    const position = StateEffect.define<number>({
+      map: (value, changes) => changes.mapPos(value),
+    });
+    const received = StateField.define({
+      create: () => -1,
+      update: (value, transaction) =>
+        transaction.effects.find((candidate) => candidate.is(position))?.value ?? value,
+    });
+    const next = EditorState.create({
+      doc: source,
+      extensions: [rfmInputFilter(), received],
+    }).update({
+      changes: { from: suffix.from, to: suffix.to },
+      annotations: Transaction.userEvent.of("delete.backward"),
+      effects: position.of(suffix.from),
+    }).state;
+
+    expect(next.field(received)).toBe(suffix.from - 1);
+  });
+
+  it("normalizes a programmatic caret inside hidden source", () => {
+    const suffix = range("suffix");
+    const next = state().update({ selection: { anchor: suffix.from + 1 } }).state;
+
+    expect(next.selection.main.head).toBe(suffix.from);
+  });
+
+  it("snaps an opening-control caret into anchor text for consecutive native input", () => {
+    const open = range("open");
+    let next = state().update({ selection: { anchor: open.from + 1 } }).state;
+
+    expect(next.selection.main.head).toBe(open.to);
+    for (const text of ["Z", "Q"]) {
+      const position = next.selection.main.head;
+      next = next.update({
+        changes: { from: position, insert: text },
+        selection: { anchor: position + text.length },
+        annotations: Transaction.userEvent.of("input.type"),
+      }).state;
+    }
+
+    expect(next.doc.toString()).toBe(source.replace("{==one==}", "{==ZQone==}"));
+  });
+
+  it("normalizes a rewritten caret against the changed document", () => {
+    const suffix = range("suffix");
+    const start = source.indexOf("one") + 1;
+    const inserted = "123456";
+    const next = state().update({
+      changes: { from: start, to: suffix.to + 2, insert: inserted },
+    }).state;
+
+    expect(next.selection.main.head).toBe(start + inserted.length);
+  });
+
+  it("keeps Ctrl+A then ArrowRight typing before endmatter", () => {
+    const footer = rfmControlRanges(readReview(source), source.length).find(
+      (control) => control.kind === "endmatter" && control.to === source.length,
+    );
+    if (!footer) throw new Error("Missing endmatter in fixture");
+    let next = state().update({ selection: { anchor: 0, head: source.length } }).state;
+    next = next.update({ selection: { anchor: source.length } }).state;
+
+    expect(next.selection.main.head).toBe(footer.from);
+    next = next.update({
+      changes: { from: next.selection.main.head, insert: "Typed\n" },
+      selection: { anchor: next.selection.main.head + 6 },
+      annotations: Transaction.userEvent.of("input.type"),
+    }).state;
+
+    expect(next.doc.toString()).toBe(
+      source.slice(0, footer.from) + "Typed\n" + source.slice(footer.from),
+    );
+  });
+
+  it("keeps empty-body document-comment typing before its endmatter", () => {
+    const applied = applyReviewOperation("", {
+      type: "add-document-comment",
+      body: "Review this document.",
+      author: "Jonas",
+    });
+    if (!applied.ok) throw new Error(applied.message);
+    const documentComment = applied.source;
+    const footer = rfmControlRanges(readReview(documentComment), documentComment.length).find(
+      (control) => control.kind === "endmatter" && control.to === documentComment.length,
+    );
+    if (!footer) throw new Error("Missing document-comment endmatter");
+    let next = EditorState.create({ doc: documentComment, extensions: rfmInputFilter() });
+    next = next.update({ selection: { anchor: documentComment.length } }).state;
+    next = next.update({
+      changes: { from: next.selection.main.head, insert: "Body\n" },
+      selection: { anchor: 5 },
+      annotations: Transaction.userEvent.of("input.type"),
+    }).state;
+
+    expect(next.doc.toString()).toBe(
+      documentComment.slice(0, footer.from) + "Body\n" + documentComment.slice(footer.from),
+    );
+    expect(readReview(next.doc.toString()).diagnostics).toEqual([]);
+  });
+
+  it("keeps frontmatter-only typing after the frontmatter", () => {
+    const frontmatterOnly = "---\nowner: Alice\n---\n";
+    let next = EditorState.create({ doc: frontmatterOnly, extensions: rfmInputFilter() });
+    next = next.update({ selection: { anchor: 0 } }).state;
+    next = next.update({
+      changes: { from: next.selection.main.head, insert: "B" },
+      selection: { anchor: frontmatterOnly.length + 1 },
+      annotations: Transaction.userEvent.of("input.type"),
+    }).state;
+
+    expect(next.doc.toString()).toBe(frontmatterOnly + "B");
+    expect(readReview(next.doc.toString()).diagnostics).toEqual([]);
+  });
+
+  it("does not block an authoritative source transform", () => {
+    const next = state().update({
+      changes: { from: 0, to: source.length, insert: "plain" },
+      filter: false,
+    }).state;
+
+    expect(next.doc.toString()).toBe("plain");
+  });
+
+  it("rewrites a normal multi-change transaction without throwing", () => {
+    const suffix = range("suffix");
+    const next = state().update({
+      changes: [
+        { from: 0, insert: "X" },
+        { from: suffix.from, to: suffix.to },
+      ],
+      annotations: Transaction.userEvent.of("delete.backward"),
+    }).state;
+
+    const bodyStart = readReview(source).body.range.start;
+    const expected = source.replace("{==one==}", "{==on==}");
+    expect(next.doc.toString()).toBe(
+      expected.slice(0, bodyStart) + "X" + expected.slice(bodyStart),
+    );
+  });
+});

--- a/packages/workspace-documents/src/rfm-controls.ts
+++ b/packages/workspace-documents/src/rfm-controls.ts
@@ -1,0 +1,307 @@
+import {
+  ChangeSet,
+  Annotation,
+  EditorSelection,
+  EditorState,
+  findClusterBreak,
+  RangeSet,
+  RangeValue,
+  StateEffect,
+  Transaction,
+  type Extension,
+} from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import type { DocumentReview } from "iterate/document-review";
+import { reviewForDocument } from "./rfm-document.ts";
+
+interface RfmControlRange {
+  from: number;
+  to: number;
+  kind: "open" | "suffix" | "hidden" | "atomic" | "frontmatter" | "endmatter";
+}
+
+class AtomicRange extends RangeValue {}
+
+const atomicRange = new AtomicRange();
+
+/**
+ * Source ranges that rich review projection does not expose as editable prose.
+ * Their positions are absolute CodeMirror document offsets.
+ */
+export function rfmControlRanges(
+  review: DocumentReview,
+  sourceLength: number,
+): readonly RfmControlRange[] {
+  if (review.diagnostics.some((diagnostic) => diagnostic.severity === "error")) return [];
+
+  const bodyStart = review.body.range.start;
+  const bodyEnd = review.body.range.end;
+  const anchors = new Set(
+    review.threads.flatMap((thread) =>
+      thread.anchor
+        ? [`${bodyStart + thread.anchor.source.start}:${bodyStart + thread.anchor.source.end}`]
+        : [],
+    ),
+  );
+  const ranges: RfmControlRange[] = [];
+  const add = (from: number, to: number, kind: RfmControlRange["kind"]) => {
+    if (from < to) ranges.push({ from, to, kind });
+  };
+
+  add(0, bodyStart, "frontmatter");
+  let cursor = bodyStart;
+  let previousWasAnchor = false;
+  for (let index = 0; index < review.projection.segments.length; index += 1) {
+    const segment = review.projection.segments[index]!;
+    const from = bodyStart + segment.source.start;
+    const to = bodyStart + segment.source.end;
+    const isAnchor = anchors.has(`${from}:${to}`);
+    if (cursor < from) {
+      const openStart =
+        isAnchor && review.body.source.slice(from - bodyStart - 3, from - bodyStart) === "{=="
+          ? from - 3
+          : from;
+      add(cursor, openStart, previousWasAnchor ? "suffix" : "hidden");
+      add(openStart, from, isAnchor ? "open" : "hidden");
+    }
+    if (segment.atomic) add(from, to, "atomic");
+    cursor = Math.max(cursor, to);
+    previousWasAnchor = isAnchor;
+  }
+  if (cursor < bodyEnd) add(cursor, bodyEnd, previousWasAnchor ? "suffix" : "hidden");
+  add(bodyEnd, sourceLength, "endmatter");
+
+  const normalized: RfmControlRange[] = [];
+  for (const range of ranges.sort((left, right) => left.from - right.from || left.to - right.to)) {
+    const previous = normalized.at(-1);
+    if (previous && range.from < previous.to) {
+      if (range.to > previous.to) previous.to = range.to;
+      continue;
+    }
+    normalized.push({ ...range });
+  }
+  return normalized;
+}
+
+function controlAt(ranges: readonly RfmControlRange[], position: number) {
+  const interior = ranges.find((range) => range.from < position && position < range.to);
+  if (interior) return interior;
+  return ranges.find(
+    (range) =>
+      (range.kind === "frontmatter" && position === range.from) ||
+      (range.kind === "endmatter" && position === range.to),
+  );
+}
+
+function visibleFragments(ranges: readonly RfmControlRange[], from: number, to: number) {
+  const fragments: { from: number; to: number }[] = [];
+  let cursor = from;
+  for (const range of ranges) {
+    if (range.from >= to) break;
+    if (range.to <= from) continue;
+    if (cursor < range.from) fragments.push({ from: cursor, to: range.from });
+    cursor = Math.max(cursor, range.to);
+  }
+  if (cursor < to) fragments.push({ from: cursor, to });
+  return fragments;
+}
+
+function previousEditable(source: string, ranges: readonly RfmControlRange[], position: number) {
+  let cursor = position;
+  while (cursor > 0) {
+    const range = ranges.find((candidate) => candidate.from < cursor && cursor <= candidate.to);
+    if (range) {
+      cursor = range.from;
+      continue;
+    }
+    const from = findClusterBreak(source, cursor, false);
+    if (!ranges.some((range) => range.from <= from && range.to >= cursor)) {
+      return { from, to: cursor };
+    }
+    cursor = from;
+  }
+  return null;
+}
+
+function nextEditable(source: string, ranges: readonly RfmControlRange[], position: number) {
+  let cursor = position;
+  while (cursor < source.length) {
+    const range = ranges.find((candidate) => candidate.from <= cursor && cursor < candidate.to);
+    if (range) {
+      cursor = range.to;
+      continue;
+    }
+    const to = findClusterBreak(source, cursor);
+    if (!ranges.some((range) => range.from <= cursor && range.to >= to)) {
+      return { from: cursor, to };
+    }
+    cursor = to;
+  }
+  return null;
+}
+
+function normalizePosition(ranges: readonly RfmControlRange[], position: number) {
+  const range = controlAt(ranges, position);
+  if (!range) return position;
+  if (range.kind === "frontmatter") return range.to;
+  if (range.kind === "endmatter") return range.from;
+  if (range.kind === "open") return range.to;
+  if (range.kind === "suffix") return range.from;
+  return position - range.from <= range.to - position ? range.from : range.to;
+}
+
+function normalizeSelection(ranges: readonly RfmControlRange[], selection: EditorSelection) {
+  let changed = false;
+  const normalized = selection.ranges.map((range) => {
+    const anchor = normalizePosition(ranges, range.anchor);
+    const head = normalizePosition(ranges, range.head);
+    if (anchor === range.anchor && head === range.head) return range;
+    changed = true;
+    return range.empty
+      ? EditorSelection.cursor(anchor, range.assoc)
+      : EditorSelection.range(anchor, head);
+  });
+  return changed ? EditorSelection.create(normalized, selection.mainIndex) : selection;
+}
+
+function transactionAnnotations(transaction: Transaction) {
+  // CodeMirror's public API exposes annotations by type, not as a collection.
+  // Replacing a transaction must retain custom annotations, which the runtime
+  // stores on this stable internal field.
+  return (
+    transaction as Transaction & {
+      annotations: readonly Annotation<unknown>[];
+    }
+  ).annotations;
+}
+
+interface RewrittenChange {
+  changes: { from: number; to: number; insert: string }[];
+  cursor: number | null;
+}
+
+function rewriteChange(
+  source: string,
+  ranges: readonly RfmControlRange[],
+  from: number,
+  to: number,
+  insert: string,
+  userEvent: string | undefined,
+): RewrittenChange | null {
+  const intersects = ranges.some((range) => range.from < to && range.to > from);
+  const insertionControl = from === to ? controlAt(ranges, from) : undefined;
+  if (!intersects && !insertionControl) return null;
+
+  let fragments = visibleFragments(ranges, from, to);
+  if (fragments.length === 0 && insert.length === 0) {
+    const adjacent =
+      userEvent === "delete.backward"
+        ? previousEditable(source, ranges, from)
+        : userEvent === "delete.forward"
+          ? nextEditable(source, ranges, to)
+          : null;
+    if (adjacent) fragments = [adjacent];
+  }
+  if (fragments.length === 0 && insert.length > 0 && insertionControl) {
+    const point = normalizePosition(ranges, from);
+    fragments = [{ from: point, to: point }];
+  }
+  if (fragments.length === 0) {
+    return { changes: [], cursor: normalizePosition(ranges, from) };
+  }
+
+  const changes = fragments.map((fragment, index) => ({
+    from: fragment.from,
+    to: fragment.to,
+    insert: index === 0 ? insert : "",
+  }));
+  const cursor =
+    insert.length > 0
+      ? fragments[0]!.from
+      : userEvent === "delete.forward"
+        ? normalizePosition(ranges, from)
+        : fragments[0]!.from;
+  return { changes, cursor };
+}
+
+/**
+ * Motion treats projected-away RFM source as atomic. Local non-composition
+ * edits that would alter it are rewritten to ordinary visible Markdown edits.
+ */
+export function rfmInputFilter(): Extension {
+  return [
+    EditorView.atomicRanges.of((view) => {
+      const ranges = rfmControlRanges(reviewForDocument(view.state.doc), view.state.doc.length);
+      return RangeSet.of(ranges.map((range) => atomicRange.range(range.from, range.to)));
+    }),
+    EditorState.transactionFilter.of((transaction) => {
+      const review = reviewForDocument(transaction.startState.doc);
+      const ranges = rfmControlRanges(review, transaction.startState.doc.length);
+      if (
+        transaction.annotation(Transaction.remote) ||
+        transaction.isUserEvent("undo") ||
+        transaction.isUserEvent("redo") ||
+        transaction.isUserEvent("input.type.compose") ||
+        ranges.length === 0
+      ) {
+        return transaction;
+      }
+      if (!transaction.docChanged) {
+        const originalSelection = transaction.selection ?? transaction.startState.selection;
+        const selection = normalizeSelection(ranges, originalSelection);
+        if (selection === originalSelection) return transaction;
+        return {
+          selection,
+          effects: transaction.effects,
+          annotations: transactionAnnotations(transaction),
+          scrollIntoView: transaction.scrollIntoView,
+        };
+      }
+
+      const source = transaction.startState.doc.toString();
+      const original: { from: number; to: number; insert: string }[] = [];
+      transaction.changes.iterChanges((from, to, _newFrom, _newTo, inserted) => {
+        original.push({ from, to, insert: inserted.toString() });
+      });
+      const rewritten = original.map((change) =>
+        rewriteChange(
+          source,
+          ranges,
+          change.from,
+          change.to,
+          change.insert,
+          transaction.annotation(Transaction.userEvent),
+        ),
+      );
+      if (rewritten.every((change) => change === null)) return transaction;
+
+      const changes = ChangeSet.of(
+        rewritten.flatMap((change, index) => change?.changes ?? [original[index]!]),
+        source.length,
+      );
+      const selection =
+        original.length === 1 && rewritten[0]?.cursor !== null
+          ? EditorSelection.create([
+              EditorSelection.cursor(
+                original[0]!.insert.length > 0
+                  ? changes.mapPos(rewritten[0]!.cursor!, -1) + original[0]!.insert.length
+                  : changes.mapPos(rewritten[0]!.cursor!, -1),
+              ),
+            ])
+          : transaction.startState.selection.map(changes);
+      const nextDocument = changes.apply(transaction.startState.doc);
+      const nextRanges = rfmControlRanges(reviewForDocument(nextDocument), nextDocument.length);
+      const effects = StateEffect.mapEffects(
+        StateEffect.mapEffects(transaction.effects, transaction.changes.invertedDesc),
+        changes,
+      );
+      return {
+        changes,
+        selection: normalizeSelection(nextRanges, selection),
+        effects,
+        annotations: transactionAnnotations(transaction),
+        scrollIntoView: transaction.scrollIntoView,
+      };
+    }),
+  ];
+}

--- a/packages/workspace-documents/src/rfm-document.ts
+++ b/packages/workspace-documents/src/rfm-document.ts
@@ -1,0 +1,14 @@
+import type { Text } from "@codemirror/state";
+import { readReview, type DocumentReview } from "iterate/document-review";
+
+const reviews = new WeakMap<Text, DocumentReview>();
+
+/** Share one review parse across syntax, decorations and editing for an immutable document. */
+export function reviewForDocument(doc: Text): DocumentReview {
+  let review = reviews.get(doc);
+  if (!review) {
+    review = readReview(doc.toString());
+    reviews.set(doc, review);
+  }
+  return review;
+}

--- a/packages/workspace-documents/src/rfm-multiplayer.test.ts
+++ b/packages/workspace-documents/src/rfm-multiplayer.test.ts
@@ -1,0 +1,123 @@
+import {
+  collab,
+  getSyncedVersion,
+  rebaseUpdates,
+  receiveUpdates,
+  sendableUpdates,
+  type Update,
+} from "@codemirror/collab";
+import { history, undo } from "@codemirror/commands";
+import { EditorSelection, EditorState, type Transaction } from "@codemirror/state";
+import { applyReviewOperation, readReview } from "iterate/document-review";
+import { expect, test } from "vitest";
+import {
+  pendingReviewPassage,
+  rfmReview,
+  setPendingReviewPassage,
+} from "./rfm-review-extension.ts";
+import { textEdits } from "./text-edits.ts";
+
+// This deliberately runs 750 edits and 750 rebases in one case, including RFM
+// parsing after each update; allow 10s under the monorepo's parallel CPU load.
+test(
+  "three peers preserve Markdown, a comment draft, and local undo through 750 competing edits",
+  { timeout: 10_000 },
+  () => {
+    const initial =
+      "# Shared review\n\nAlice writes here.\n\nBob writes here.\n\nCharlie writes here.\n\nDiscuss the launch copy.\n";
+    const seeded = applyReviewOperation(initial, {
+      type: "add-document-comment",
+      body: "Review together.",
+      author: "Alice",
+    });
+    if (!seeded.ok) throw new Error(seeded.message);
+    const callbacks = {
+      selectedThreadId: null,
+      onSelectThread: () => {},
+      onComment: () => true,
+      mountComposer: () => {},
+    };
+    const names = ["Alice", "Bob", "Charlie"];
+    const peers = names.map((clientID) =>
+      EditorState.create({
+        doc: seeded.source,
+        extensions: [history(), collab({ clientID }), rfmReview(callbacks)],
+      }),
+    );
+    const from = seeded.source.indexOf("launch copy");
+    peers[0] = peers[0]!.update({
+      effects: setPendingReviewPassage.of({
+        range: EditorSelection.range(from, from + "launch copy".length),
+        composing: true,
+      }),
+    }).state;
+    const accepted: Update[] = [];
+    function synchronize() {
+      for (const peer of peers) {
+        accepted.push(
+          ...rebaseUpdates(sendableUpdates(peer), accepted.slice(getSyncedVersion(peer))),
+        );
+        // Deliberately send all peers from the same old version, as simultaneous
+        // keyboard edits do. Each receives the full accepted batch afterwards.
+      }
+      for (let i = 0; i < peers.length; i++) {
+        peers[i] = peers[i]!.update(
+          receiveUpdates(peers[i]!, accepted.slice(getSyncedVersion(peers[i]!))),
+        ).state;
+      }
+    }
+    for (let round = 0; round < 250; round++) {
+      for (let i = 0; i < peers.length; i++) {
+        const state = peers[i]!;
+        const position =
+          state.doc.toString().indexOf(`${names[i]} writes here`) +
+          `${names[i]} writes here`.length;
+        peers[i] = state.update({
+          changes: { from: position, insert: `${i}` },
+          userEvent: "input.type",
+        }).state;
+      }
+      synchronize();
+      expect(new Set(peers.map((peer) => peer.doc.toString())).size).toBe(1);
+      expect(readReview(peers[0]!.doc.toString()).diagnostics).toEqual([]);
+      const passage = peers[0]!.field(pendingReviewPassage).range!;
+      expect(peers[0]!.sliceDoc(passage.from, passage.to)).toBe("launch copy");
+    }
+    const state = peers[0]!;
+    const range = state.field(pendingReviewPassage).range!;
+    const review = readReview(state.doc.toString());
+    const comment = applyReviewOperation(state.doc.toString(), {
+      type: "add-selected-comment",
+      expectedSource: state.doc.toString(),
+      range: {
+        start: range.from - review.body.range.start,
+        end: range.to - review.body.range.start,
+      },
+      body: "Make this concrete.",
+      author: "Alice",
+    });
+    if (!comment.ok) throw new Error(comment.message);
+    peers[0] = state.update({
+      changes: textEdits(state.doc.toString(), comment.source),
+      filter: false,
+      userEvent: "transform",
+    }).state;
+    synchronize();
+    expect(readReview(peers[2]!.doc.toString()).threads).toHaveLength(2);
+
+    undo({
+      state: peers[0],
+      dispatch: (transaction: Transaction) => {
+        peers[0] = transaction.state;
+      },
+    });
+    synchronize();
+    const saved = readReview(peers[2]!.doc.toString());
+    expect(saved.diagnostics).toEqual([]);
+    expect(saved.threads).toHaveLength(1);
+    for (let i = 0; i < names.length; i++)
+      expect(saved.projection.markdown).toContain(
+        `${names[i]} writes here${String(i).repeat(250)}.`,
+      );
+  },
+);

--- a/packages/workspace-documents/src/rfm-projected-markdown.test.ts
+++ b/packages/workspace-documents/src/rfm-projected-markdown.test.ts
@@ -1,7 +1,7 @@
 import { DocInput, ensureSyntaxTree, language, syntaxTree } from "@codemirror/language";
 import { Compartment, EditorState, Text } from "@codemirror/state";
 import { TreeFragment } from "@lezer/common";
-import { applyReviewOperation } from "iterate/document-review";
+import { applyReviewOperation, readReview } from "iterate/document-review";
 import { expect, test } from "vitest";
 import { projectedMarkdown } from "./rfm-projected-markdown.ts";
 import { richMarkdown } from "./rich-markdown.ts";
@@ -84,6 +84,28 @@ test("a parse requested after hidden controls keeps positions relative to its re
   const heading = tree.topNode.firstChild!;
   expect(heading.name).toBe("ATXHeading1");
   expect(source.slice(from + heading.from, from + heading.to)).toBe("# Second");
+});
+
+test("stopping inside a multi-line atomic suggestion returns a resumable source tree", () => {
+  const source =
+    'Before {++- item\n- next++}{id="s1" by="AI" at="2026-09-08T10:03:00.000Z"}.\n\nAfter.\n';
+  const review = readReview(source);
+  expect(review.diagnostics).toEqual([]);
+  const atomic = review.projection.segments.find((segment) => segment.atomic);
+  if (!atomic) throw new Error("Missing atomic suggestion");
+  const parser = projectedMarkdown().language.parser;
+  const partial = parser.startParse(source);
+  partial.stopAt(source.indexOf("- item") + 1);
+  let tree = partial.advance();
+  while (!tree) tree = partial.advance();
+
+  expect(tree.length).toBe(atomic.source.end + review.body.range.start);
+  expect(partial.parsedPos).toBe(tree.length);
+  const resumed = parser.parse(source, TreeFragment.addTree(tree, [], true));
+  expect(resumed.length).toBe(source.length);
+  expect(source.slice(resumed.topNode.lastChild!.from, resumed.topNode.lastChild!.to)).toBe(
+    "After.",
+  );
 });
 
 test("a fully hidden first requested range does not shift later projected Markdown", () => {

--- a/packages/workspace-documents/src/rfm-projected-markdown.test.ts
+++ b/packages/workspace-documents/src/rfm-projected-markdown.test.ts
@@ -1,0 +1,103 @@
+import { DocInput, ensureSyntaxTree, language, syntaxTree } from "@codemirror/language";
+import { Compartment, EditorState, Text } from "@codemirror/state";
+import { TreeFragment } from "@lezer/common";
+import { applyReviewOperation } from "iterate/document-review";
+import { expect, test } from "vitest";
+import { projectedMarkdown } from "./rfm-projected-markdown.ts";
+import { richMarkdown } from "./rich-markdown.ts";
+
+function commented(source: string, passage: string) {
+  const start = source.indexOf(passage);
+  const result = applyReviewOperation(source, {
+    type: "add-selected-comment",
+    expectedSource: source,
+    range: { start, end: start + passage.length },
+    author: "Alice",
+    body: "Please review | this.",
+    createdAt: "2026-09-09T02:00:00Z",
+  });
+  if (!result.ok) throw new Error(result.message);
+  return result.source;
+}
+
+test.for([
+  ["# Heading", "ATXHeading1"],
+  ["- First\n- Second", "BulletList"],
+  ["| Name | Owner |\n| --- | --- |\n| Alpha | Alice |", "Table"],
+])("a wrapped %s keeps Markdown syntax at source offsets", ([passage, nodeName]) => {
+  const source = commented(passage + "\n", passage);
+  const tree = projectedMarkdown().language.parser.parse(source);
+  const node = tree.topNode.firstChild!;
+  expect(node.name).toBe(nodeName);
+  expect(source.slice(node.from, node.to)).toBe(passage);
+  expect(tree.length).toBe(source.length);
+});
+
+test("a small edit reuses untouched syntax subtrees in an RFM document", () => {
+  const original = commented("# Heading\n\nFirst paragraph.\n\nLast **paragraph**.\n", "# Heading");
+  const parser = projectedMarkdown().language.parser;
+  const first = parser.parse(new DocInput(Text.of(original.split("\n"))));
+  const from = original.indexOf("First") + 5;
+  const next = original.slice(0, from) + " revised" + original.slice(from);
+  const fragments = TreeFragment.applyChanges(TreeFragment.addTree(first), [
+    { fromA: from, toA: from, fromB: from, toB: from + 8 },
+  ]);
+  const second = parser.parse(next, fragments);
+  expect(next.slice(second.topNode.lastChild!.from, second.topNode.lastChild!.to)).toBe(
+    "Last **paragraph**.",
+  );
+  expect(second.topNode.lastChild!.toTree()).toBe(first.topNode.lastChild!.toTree());
+});
+
+test("selecting a review thread keeps the existing rich language and parsed tree", () => {
+  const source = commented(
+    "# Heading\n\n" + "A **shared** paragraph.\n\n".repeat(1000),
+    "# Heading",
+  );
+  const layer = new Compartment();
+  const callbacks = { onSelectThread: () => {}, onComment: () => true, mountComposer: () => {} };
+  const state = EditorState.create({
+    doc: source,
+    extensions: layer.of(richMarkdown({ ...callbacks, selectedThreadId: null })),
+  });
+  const tree = ensureSyntaxTree(state, source.length, 200);
+  expect(tree?.length).toBe(source.length);
+  const next = state.update({
+    effects: layer.reconfigure(richMarkdown({ ...callbacks, selectedThreadId: "thread" })),
+  }).state;
+  expect(next.facet(language)).toBe(state.facet(language));
+  expect(syntaxTree(next)).toBe(tree);
+});
+
+test("an invalid review stays fully available to the Markdown source parser", () => {
+  const source = "# Heading\n\n{==broken\n\n---\ncomments: [\n";
+  const tree = projectedMarkdown().language.parser.parse(source);
+  expect(tree.length).toBe(source.length);
+  expect(tree.toString()).toContain("ATXHeading1");
+});
+
+test("a parse requested after hidden controls keeps positions relative to its requested start", () => {
+  const source = commented("# First\n\n# Second\n\n# Third\n", "# First");
+  const from = source.indexOf("# Second");
+  const tree = projectedMarkdown().language.parser.parse(source, [], [{ from, to: source.length }]);
+  expect(tree.length).toBe(source.length - from);
+  const heading = tree.topNode.firstChild!;
+  expect(heading.name).toBe("ATXHeading1");
+  expect(source.slice(from + heading.from, from + heading.to)).toBe("# Second");
+});
+
+test("an interrupted parse resumes through a large commented document", () => {
+  const source = commented("# First\n\n" + "Another **paragraph**.\n\n".repeat(500), "# First");
+  const parser = projectedMarkdown().language.parser;
+  const partial = parser.startParse(source);
+  const stop = source.indexOf("Another", 300);
+  partial.stopAt(stop);
+  let tree = partial.advance();
+  while (!tree) tree = partial.advance();
+  expect(tree.length).toBeLessThan(source.length);
+  const resumed = parser.parse(source, TreeFragment.addTree(tree, [], true));
+  expect(resumed.length).toBe(source.length);
+  expect(source.slice(resumed.topNode.lastChild!.from, resumed.topNode.lastChild!.to)).toBe(
+    "Another **paragraph**.",
+  );
+});

--- a/packages/workspace-documents/src/rfm-projected-markdown.test.ts
+++ b/packages/workspace-documents/src/rfm-projected-markdown.test.ts
@@ -86,6 +86,28 @@ test("a parse requested after hidden controls keeps positions relative to its re
   expect(source.slice(from + heading.from, from + heading.to)).toBe("# Second");
 });
 
+test("a fully hidden first requested range does not shift later projected Markdown", () => {
+  const source = commented("# Before\n\n# First\n\n# Second\n", "# First");
+  const hiddenControlStart = source.indexOf("{==");
+  const hiddenControlEnd = source.indexOf("# First");
+  const secondHeading = source.indexOf("# Second");
+  const tree = projectedMarkdown().language.parser.parse(
+    source,
+    [],
+    [
+      { from: hiddenControlStart, to: hiddenControlEnd },
+      { from: secondHeading, to: source.length },
+    ],
+  );
+  const heading = tree.topNode.firstChild!;
+
+  expect(tree.length).toBe(source.length - hiddenControlStart);
+  expect(heading.name).toBe("ATXHeading1");
+  expect(source.slice(hiddenControlStart + heading.from, hiddenControlStart + heading.to)).toBe(
+    "# Second",
+  );
+});
+
 test("an interrupted parse resumes through a large commented document", () => {
   const source = commented("# First\n\n" + "Another **paragraph**.\n\n".repeat(500), "# First");
   const parser = projectedMarkdown().language.parser;

--- a/packages/workspace-documents/src/rfm-projected-markdown.ts
+++ b/packages/workspace-documents/src/rfm-projected-markdown.ts
@@ -7,11 +7,16 @@ import { textEdits } from "./text-edits.ts";
 import { reviewForDocument } from "./rfm-document.ts";
 
 /** Map a rendered Markdown boundary into the sole editable source document. */
-function sourcePosition(review: DocumentReview, pos: number, side: -1 | 1) {
+function sourcePosition(review: DocumentReview, pos: number, side: -1 | 1, atomicBoundary = false) {
   for (const segment of review.projection.segments) {
     const { start, end } = segment.display;
     if (side > 0 ? start <= pos && pos < end : start < pos && pos <= end) {
-      if (segment.atomic && pos !== start && pos !== end) return null;
+      if (segment.atomic && pos !== start && pos !== end) {
+        if (!atomicBoundary) return null;
+        // A root/progress boundary cannot end inside opaque source markup.
+        // Its partial tree therefore owns the whole atomic source range.
+        return review.body.range.start + segment.source.end;
+      }
       return (
         review.body.range.start +
         segment.source.start +
@@ -91,6 +96,7 @@ export function projectedMarkdown() {
       const projectedStart = projectedRanges[0]?.from ?? 0;
       const sourceStart = ranges[0]?.from ?? 0;
       let stoppedAt: number | null = null;
+      let treeEnd: number | undefined;
 
       function mapNode(node: SyntaxNode, root = false): { tree: Tree; from: number } | null {
         const displayFrom = node.from + projectedStart;
@@ -99,7 +105,7 @@ export function projectedMarkdown() {
         const to =
           root && displayTo === projection.markdown.length
             ? input.length
-            : sourcePosition(review, displayTo, -1);
+            : sourcePosition(review, displayTo, -1, root);
         if (from === null || to === null || to < from) return null;
         // Most blocks live wholly within one unchanged source segment. Reusing
         // their actual trees preserves nested props and avoids walking every
@@ -129,9 +135,11 @@ export function projectedMarkdown() {
 
       return {
         get parsedPos() {
-          return base.parsedPos >= projection.markdown.length
-            ? input.length
-            : (sourcePosition(review, base.parsedPos, -1) ?? sourceStart);
+          const mapped =
+            base.parsedPos >= projection.markdown.length
+              ? input.length
+              : (sourcePosition(review, base.parsedPos, -1, true) ?? sourceStart);
+          return treeEnd === undefined ? mapped : Math.min(mapped, treeEnd);
         },
         get stoppedAt() {
           return stoppedAt;
@@ -144,6 +152,7 @@ export function projectedMarkdown() {
           const tree = base.advance();
           if (!tree) return null;
           const result = mapNode(tree.topNode, true)!.tree;
+          treeEnd = sourceStart + result.length;
           if (
             sourceStart === 0 &&
             projectedStart === 0 &&

--- a/packages/workspace-documents/src/rfm-projected-markdown.ts
+++ b/packages/workspace-documents/src/rfm-projected-markdown.ts
@@ -1,0 +1,163 @@
+import { DocInput, Language, LanguageSupport } from "@codemirror/language";
+import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
+import { highlightMarkdown } from "@atomic-editor/editor";
+import { Parser, Tree, TreeFragment, type Input, type SyntaxNode } from "@lezer/common";
+import { readReview, type DocumentReview } from "iterate/document-review";
+import { textEdits } from "./text-edits.ts";
+import { reviewForDocument } from "./rfm-document.ts";
+
+/** Map a rendered Markdown boundary into the sole editable source document. */
+function sourcePosition(review: DocumentReview, pos: number, side: -1 | 1) {
+  for (const segment of review.projection.segments) {
+    const { start, end } = segment.display;
+    if (side > 0 ? start <= pos && pos < end : start < pos && pos <= end) {
+      if (segment.atomic && pos !== start && pos !== end) return null;
+      return (
+        review.body.range.start +
+        segment.source.start +
+        (segment.atomic && pos === end ? segment.source.end - segment.source.start : pos - start)
+      );
+    }
+  }
+  return pos === 0 ? review.body.range.start : review.body.range.end;
+}
+
+/** Map source parser requests across hidden controls without making them editable. */
+function displayPosition(review: DocumentReview, pos: number) {
+  const bodyPos = pos - review.body.range.start;
+  for (const segment of review.projection.segments) {
+    const { source, display } = segment;
+    if (bodyPos <= source.start) return display.start;
+    if (bodyPos < source.end) {
+      return segment.atomic ? display.start : display.start + bodyPos - source.start;
+    }
+  }
+  return review.projection.markdown.length;
+}
+
+/** A projected parse retained only as long as CodeMirror retains its source syntax tree. */
+interface ProjectedParse {
+  markdown: string;
+  tree: Tree;
+}
+
+/** Parse display Markdown, but expose syntax nodes in original file coordinates. */
+export function projectedMarkdown() {
+  const support = markdown({ base: markdownLanguage, extensions: highlightMarkdown });
+  const previousParses = new WeakMap<Tree, ProjectedParse>();
+  class ReviewMarkdownParser extends Parser {
+    createParse(
+      input: Input,
+      fragments: readonly TreeFragment[],
+      ranges: readonly { from: number; to: number }[],
+    ) {
+      const source = input.read(0, input.length);
+      const review = input instanceof DocInput ? reviewForDocument(input.doc) : readReview(source);
+      const projection = review.projection;
+      if (
+        projection.markdown === source ||
+        review.diagnostics.some((d) => d.severity === "error")
+      ) {
+        return support.language.parser.startParse(
+          input,
+          fragments.filter((f) => !previousParses.has(f.tree)),
+          ranges,
+        );
+      }
+
+      // Reuse the underlying Markdown parse after diffing the immutable display
+      // strings. The document itself is never serialized from this syntax tree.
+      const previous = fragments.map((f) => previousParses.get(f.tree)).find(Boolean);
+      let reusable: readonly TreeFragment[] = [];
+      if (previous) {
+        let delta = 0;
+        const changed = textEdits(previous.markdown, projection.markdown).map((edit) => {
+          const fromB = edit.from + delta;
+          delta += edit.insert.length - (edit.to - edit.from);
+          return { fromA: edit.from, toA: edit.to, fromB, toB: fromB + edit.insert.length };
+        });
+        reusable = TreeFragment.applyChanges(TreeFragment.addTree(previous.tree), changed);
+      }
+      const projectedRanges = ranges.flatMap((range) => {
+        const from = displayPosition(review, range.from);
+        const to = displayPosition(review, range.to);
+        return from < to ? [{ from, to }] : [];
+      });
+      const base = support.language.parser.startParse(
+        projection.markdown,
+        reusable,
+        projectedRanges,
+      );
+      const projectedStart = projectedRanges[0]?.from ?? 0;
+      const sourceStart = ranges[0]?.from ?? 0;
+      let stoppedAt: number | null = null;
+
+      function mapNode(node: SyntaxNode, root = false): { tree: Tree; from: number } | null {
+        const displayFrom = node.from + projectedStart;
+        const displayTo = node.to + projectedStart;
+        const from = root ? sourceStart : sourcePosition(review, displayFrom, 1);
+        const to =
+          root && displayTo === projection.markdown.length
+            ? input.length
+            : sourcePosition(review, displayTo, -1);
+        if (from === null || to === null || to < from) return null;
+        // Most blocks live wholly within one unchanged source segment. Reusing
+        // their actual trees preserves nested props and avoids walking every
+        // inline token in a large document on every keystroke.
+        if (
+          !root &&
+          projection.segments.some(
+            (s) => !s.atomic && s.display.start <= displayFrom && s.display.end >= displayTo,
+          )
+        ) {
+          return { from, tree: node.toTree() };
+        }
+        const children: Tree[] = [];
+        const positions: number[] = [];
+        for (let child = node.firstChild; child; child = child.nextSibling) {
+          const mapped = mapNode(child);
+          if (mapped) {
+            children.push(mapped.tree);
+            positions.push(mapped.from - from);
+          }
+        }
+        return {
+          from,
+          tree: new Tree(node.type, children, positions, to - from, node.toTree().propValues),
+        };
+      }
+
+      return {
+        get parsedPos() {
+          return base.parsedPos >= projection.markdown.length
+            ? input.length
+            : (sourcePosition(review, base.parsedPos, -1) ?? sourceStart);
+        },
+        get stoppedAt() {
+          return stoppedAt;
+        },
+        stopAt(pos: number) {
+          stoppedAt = pos;
+          base.stopAt(displayPosition(review, pos));
+        },
+        advance() {
+          const tree = base.advance();
+          if (!tree) return null;
+          const result = mapNode(tree.topNode, true)!.tree;
+          if (
+            sourceStart === 0 &&
+            projectedStart === 0 &&
+            tree.length === projection.markdown.length
+          ) {
+            previousParses.set(result, { markdown: projection.markdown, tree });
+          }
+          return result;
+        },
+      };
+    }
+  }
+  return new LanguageSupport(
+    new Language(support.language.data, new ReviewMarkdownParser()),
+    support.support,
+  );
+}

--- a/packages/workspace-documents/src/rfm-review-extension.test.ts
+++ b/packages/workspace-documents/src/rfm-review-extension.test.ts
@@ -1,0 +1,98 @@
+import { EditorSelection, EditorState, Transaction } from "@codemirror/state";
+import { applyReviewOperation, readReview } from "iterate/document-review";
+import { expect, test } from "vitest";
+import {
+  pendingReviewPassage,
+  rfmReview,
+  setPendingReviewPassage,
+} from "./rfm-review-extension.ts";
+
+const callbacks = {
+  selectedThreadId: null,
+  onSelectThread: () => {},
+  onComment: () => true,
+  mountComposer: () => {},
+};
+
+test("a composing passage follows remote edits while the native selection moves elsewhere", () => {
+  const source = "---\nowner: Alice\n---\n\n# Launch\n\nReview this passage.\n";
+  const from = source.indexOf("this passage");
+  const range = EditorSelection.range(from, from + "this passage".length);
+  let state = EditorState.create({
+    doc: source,
+    selection: range,
+    extensions: rfmReview(callbacks),
+  });
+  state = state.update({ effects: setPendingReviewPassage.of({ range, composing: true }) }).state;
+  state = state.update({
+    changes: {
+      from: source.indexOf("Alice"),
+      to: source.indexOf("Alice") + 5,
+      insert: "Alice and Bob",
+    },
+    annotations: Transaction.remote.of(true),
+    filter: false,
+  }).state;
+  state = state.update({ selection: { anchor: state.doc.length } }).state;
+  const bookmark = state.field(pendingReviewPassage).range!;
+  expect(state.sliceDoc(bookmark.from, bookmark.to)).toBe("this passage");
+  expect(bookmark.from).toBe(from + 8);
+  const review = readReview(state.doc.toString());
+  const result = applyReviewOperation(state.doc.toString(), {
+    type: "add-selected-comment",
+    expectedSource: state.doc.toString(),
+    range: {
+      start: bookmark.from - review.body.range.start,
+      end: bookmark.to - review.body.range.start,
+    },
+    body: "Make this concrete.",
+    author: "Bob",
+  });
+  expect(result.ok).toBe(true);
+});
+
+test("authoritative review edits remove their controls through the ordinary transform path", () => {
+  const original = "Discuss this passage.\n";
+  const comment = applyReviewOperation(original, {
+    type: "add-selected-comment",
+    expectedSource: original,
+    range: { start: 8, end: 20 },
+    body: "Discuss",
+    author: "Alice",
+  });
+  if (!comment.ok) throw new Error(comment.message);
+  let state = EditorState.create({ doc: comment.source, extensions: rfmReview(callbacks) });
+  state = state.update({
+    changes: { from: 0, to: state.doc.length, insert: original },
+    filter: false,
+    userEvent: "transform",
+  }).state;
+  expect(state.doc.toString()).toBe(original);
+  expect(readReview(state.doc.toString()).threads).toEqual([]);
+});
+
+test("deleting a bookmarked passage preserves the composer so its draft can be recovered", () => {
+  const range = EditorSelection.range(0, 7);
+  let state = EditorState.create({
+    doc: "Passage.\n",
+    selection: range,
+    extensions: rfmReview(callbacks),
+  });
+  state = state.update({ effects: setPendingReviewPassage.of({ range, composing: true }) }).state;
+  state = state.update({
+    changes: { from: 0, to: 7 },
+    filter: false,
+    annotations: Transaction.remote.of(true),
+  }).state;
+  expect(state.field(pendingReviewPassage).composing).toBe(true);
+  expect(state.field(pendingReviewPassage).range?.empty).toBe(true);
+});
+
+test("malformed review markup does not open a selected-text composer", () => {
+  const state = EditorState.create({
+    doc: "{==broken",
+    selection: { anchor: 3, head: 9 },
+    extensions: rfmReview(callbacks),
+  });
+  expect(state.field(pendingReviewPassage).range).toBeNull();
+});

--- a/packages/workspace-documents/src/rfm-review-extension.ts
+++ b/packages/workspace-documents/src/rfm-review-extension.ts
@@ -1,0 +1,302 @@
+import {
+  EditorState,
+  Facet,
+  StateEffect,
+  StateField,
+  type SelectionRange,
+  type Range,
+} from "@codemirror/state";
+import {
+  Decoration,
+  EditorView,
+  keymap,
+  showTooltip,
+  WidgetType,
+  type TooltipView,
+} from "@codemirror/view";
+import type { ReviewSuggestion } from "iterate/document-review";
+import type { EditorReviewConfig } from "./collab-editor-api.ts";
+import { authorColor } from "./collab-author.ts";
+import { rfmControlRanges, rfmInputFilter } from "./rfm-controls.ts";
+import { reviewForDocument } from "./rfm-document.ts";
+
+/** A CodeMirror-positioned container whose draft is owned by the host's React composer. */
+export interface ReviewComposerMount {
+  element: HTMLElement;
+  submit(body: string): boolean;
+  cancel(): void;
+}
+
+/** Host callbacks plus the single portal mount required by the review tooltip. */
+export interface RfmReviewConfig extends EditorReviewConfig {
+  mountComposer(mount: ReviewComposerMount | null): void;
+}
+
+const config = Facet.define<RfmReviewConfig, RfmReviewConfig | undefined>({
+  combine: (values) => values[0],
+});
+
+/** A passage held in source coordinates while focus moves into a comment draft. */
+interface PendingPassage {
+  range: SelectionRange | null;
+  composing: boolean;
+}
+
+export const setPendingReviewPassage = StateEffect.define<PendingPassage>();
+
+function selectedPassage(state: EditorState): SelectionRange | null {
+  const range = state.selection.main;
+  if (range.empty || !state.facet(config)?.onComment || state.facet(EditorState.readOnly))
+    return null;
+  const review = reviewForDocument(state.doc);
+  if (review.diagnostics.some((d) => d.severity === "error")) return null;
+  if (
+    review.threads.some(
+      (thread) =>
+        thread.anchor &&
+        thread.anchor.source.start + review.body.range.start < range.to &&
+        thread.anchor.source.end + review.body.range.start > range.from,
+    )
+  )
+    return null;
+  if (
+    rfmControlRanges(review, state.doc.length).some(
+      (control) => control.from < range.to && control.to > range.from,
+    )
+  )
+    return null;
+  return range;
+}
+
+export const pendingReviewPassage = StateField.define<PendingPassage>({
+  create: (state) => ({ range: selectedPassage(state), composing: false }),
+  update(value, transaction) {
+    let next = value;
+    if (transaction.docChanged && value.range)
+      next = { ...value, range: value.range.map(transaction.changes) };
+    for (const effect of transaction.effects)
+      if (effect.is(setPendingReviewPassage)) return effect.value;
+    if (
+      !value.composing &&
+      (transaction.selection || transaction.docChanged || transaction.reconfigured)
+    ) {
+      return { range: selectedPassage(transaction.state), composing: false };
+    }
+    return next;
+  },
+  provide: (field) =>
+    showTooltip.from(field, (value) =>
+      value.range
+        ? {
+            pos: value.range.to,
+            above: true,
+            arrow: true,
+            create: createReviewTooltip,
+          }
+        : null,
+    ),
+});
+
+function createReviewTooltip(view: EditorView): TooltipView {
+  const dom = document.createElement("div");
+  let composing: boolean | null = null;
+  let unmount: (() => void) | null = null;
+  const cancel = () => {
+    view.dispatch({ effects: setPendingReviewPassage.of({ range: null, composing: false }) });
+    view.focus();
+  };
+  const update = () => {
+    const pending = view.state.field(pendingReviewPassage);
+    if (pending.composing === composing) return;
+    composing = pending.composing;
+    unmount?.();
+    unmount = null;
+    dom.replaceChildren();
+    dom.className = composing ? "cm-review-composer" : "cm-review-comment-action";
+    if (composing) {
+      const element = document.createElement("div");
+      dom.appendChild(element);
+      const mount = view.state.facet(config)?.mountComposer;
+      mount?.({
+        element,
+        submit(body) {
+          const range = view.state.field(pendingReviewPassage).range;
+          if (!range || range.empty)
+            throw new Error(
+              "The selected passage was deleted. Copy your draft and select another passage.",
+            );
+          const accepted =
+            view.state.facet(config)?.onComment?.({ from: range.from, to: range.to }, body) ??
+            false;
+          if (accepted) cancel();
+          return accepted;
+        },
+        cancel,
+      });
+      unmount = () => mount?.(null);
+    } else {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.textContent = "Comment";
+      button.setAttribute("aria-label", "Comment on selected text");
+      button.title = "Comment on selected text (Mod+Alt+M)";
+      button.addEventListener("mousedown", (event) => event.preventDefault());
+      button.addEventListener("click", () =>
+        view.dispatch({
+          effects: setPendingReviewPassage.of({
+            ...view.state.field(pendingReviewPassage),
+            composing: true,
+          }),
+        }),
+      );
+      dom.appendChild(button);
+    }
+  };
+  update();
+  return { dom, update, destroy: () => unmount?.() };
+}
+
+class SuggestionWidget extends WidgetType {
+  constructor(readonly suggestion: ReviewSuggestion) {
+    super();
+  }
+  override eq(other: SuggestionWidget) {
+    return JSON.stringify(this.suggestion) === JSON.stringify(other.suggestion);
+  }
+  toDOM() {
+    const span = document.createElement("span");
+    span.className = "cm-review-suggestion";
+    span.dataset.reviewThread = this.suggestion.id;
+    for (const [tag, text] of [
+      ["del", this.suggestion.originalText],
+      ["ins", this.suggestion.replacementText],
+    ]) {
+      if (!text) continue;
+      const part = document.createElement(tag);
+      part.textContent = text;
+      span.appendChild(part);
+    }
+    span.title = "Select to review this suggestion";
+    return span;
+  }
+  override ignoreEvent() {
+    return false;
+  }
+}
+
+function reviewDecorations(state: EditorState) {
+  const review = reviewForDocument(state.doc);
+  if (review.diagnostics.some((d) => d.severity === "error")) return Decoration.none;
+  const ranges: Range<Decoration>[] = [];
+  for (const control of rfmControlRanges(review, state.doc.length)) {
+    const suggestion =
+      control.kind === "atomic"
+        ? review.suggestions.find((s) => s.source.start + review.body.range.start === control.from)
+        : undefined;
+    ranges.push(
+      Decoration.replace({
+        block: control.kind === "frontmatter" || control.kind === "endmatter",
+        widget: suggestion ? new SuggestionWidget(suggestion) : undefined,
+      }).range(control.from, control.to),
+    );
+  }
+  for (const thread of review.threads) {
+    if (!thread.anchor || thread.anchor.source.start === thread.anchor.source.end) continue;
+    ranges.push(
+      Decoration.mark({
+        class:
+          "cm-review-anchor" +
+          (state.facet(config)?.selectedThreadId === thread.id ? " cm-review-anchor-selected" : ""),
+        attributes: {
+          "data-review-thread": thread.id,
+          style: `--review-color: ${authorColor(thread.comments[0]?.author ?? "someone", 1)}`,
+        },
+      }).range(
+        thread.anchor.source.start + review.body.range.start,
+        thread.anchor.source.end + review.body.range.start,
+      ),
+    );
+  }
+  const pending = state.field(pendingReviewPassage);
+  if (pending.composing && pending.range && !pending.range.empty) {
+    ranges.push(
+      Decoration.mark({ class: "cm-review-passage" }).range(pending.range.from, pending.range.to),
+    );
+  }
+  return Decoration.set(ranges, true);
+}
+
+const reviewField = StateField.define({
+  create: reviewDecorations,
+  update: (value, transaction) =>
+    transaction.docChanged ||
+    transaction.reconfigured ||
+    transaction.effects.some((e) => e.is(setPendingReviewPassage))
+      ? reviewDecorations(transaction.state)
+      : value,
+  provide: (field) => EditorView.decorations.from(field),
+});
+
+/** Review UI is derived from the current file; only the temporary passage lives outside it. */
+export function rfmReview(options: RfmReviewConfig) {
+  return [
+    config.of(options),
+    pendingReviewPassage,
+    reviewField,
+    rfmInputFilter(),
+    keymap.of([
+      {
+        key: "Mod-Alt-m",
+        run(view) {
+          const range = selectedPassage(view.state);
+          if (!range) return false;
+          view.dispatch({ effects: setPendingReviewPassage.of({ range, composing: true }) });
+          return true;
+        },
+      },
+    ]),
+    EditorView.domEventHandlers({
+      click(event, view) {
+        const target =
+          event.target instanceof Element
+            ? event.target.closest<HTMLElement>("[data-review-thread]")
+            : null;
+        if (target) view.state.facet(config)?.onSelectThread(target.dataset.reviewThread ?? null);
+        return false;
+      },
+    }),
+    EditorState.transactionExtender.of((transaction) => {
+      const id = transaction.state.facet(config)?.selectedThreadId;
+      if (!id || id === transaction.startState.facet(config)?.selectedThreadId) return null;
+      const review = reviewForDocument(transaction.newDoc);
+      const anchor = review.threads.find((thread) => thread.id === id)?.anchor;
+      if (!anchor) return null;
+      return {
+        effects: EditorView.scrollIntoView(anchor.source.start + review.body.range.start, {
+          y: "nearest",
+        }),
+      };
+    }),
+    EditorView.baseTheme({
+      ".cm-review-anchor": { boxShadow: "inset 0 -2px var(--review-color)", cursor: "text" },
+      ".cm-review-anchor-selected": {
+        backgroundColor: "color-mix(in srgb, var(--review-color) 16%, transparent)",
+      },
+      ".cm-review-passage": { backgroundColor: "var(--accent)" },
+      ".cm-review-comment-action button": {
+        padding: "5px 10px",
+        fontSize: "12px",
+        cursor: "pointer",
+      },
+      ".cm-review-composer": { padding: "12px", width: "min(320px, calc(100vw - 32px))" },
+      ".cm-review-suggestion del": {
+        backgroundColor: "color-mix(in srgb, #ef4444 15%, transparent)",
+        textDecoration: "line-through",
+      },
+      ".cm-review-suggestion ins": {
+        backgroundColor: "color-mix(in srgb, #22c55e 15%, transparent)",
+        textDecoration: "none",
+      },
+    }),
+  ];
+}

--- a/packages/workspace-documents/src/rfm-review-extension.ts
+++ b/packages/workspace-documents/src/rfm-review-extension.ts
@@ -195,7 +195,9 @@ function reviewDecorations(state: EditorState) {
         : undefined;
     ranges.push(
       Decoration.replace({
-        block: control.kind === "frontmatter" || control.kind === "endmatter",
+        // An inline footer leaves the browser a caret position after the last
+        // visible line; a terminal block replacement does not.
+        block: control.kind === "frontmatter",
         widget: suggestion ? new SuggestionWidget(suggestion) : undefined,
       }).range(control.from, control.to),
     );

--- a/packages/workspace-documents/src/rich-markdown.ts
+++ b/packages/workspace-documents/src/rich-markdown.ts
@@ -1,0 +1,47 @@
+import "@atomic-editor/editor/styles.css";
+import { Prec } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { atomicEditorTheme, atomicMarkdownSyntax, inlinePreview } from "@atomic-editor/editor";
+import { markdownTables } from "./markdown-tables.ts";
+import { projectedMarkdown } from "./rfm-projected-markdown.ts";
+import { rfmReview, type RfmReviewConfig } from "./rfm-review-extension.ts";
+
+// Keep the language and view plugins stable when only review selection changes.
+const presentation = [
+  Prec.high(projectedMarkdown()),
+  inlinePreview(),
+  atomicEditorTheme,
+  atomicMarkdownSyntax,
+  markdownTables(),
+  EditorView.editorAttributes.of({ class: "atomic-cm-editor" }),
+  Prec.high(
+    EditorView.theme({
+      "&": {
+        "--atomic-editor-fg": "var(--foreground)",
+        "--atomic-editor-fg-muted": "var(--muted-foreground)",
+        "--atomic-editor-bg": "var(--background)",
+        "--atomic-editor-bg-surface": "var(--popover)",
+        "--atomic-editor-bg-panel": "var(--muted)",
+        "--atomic-editor-border": "var(--border)",
+        "--atomic-editor-accent-bright": "var(--foreground)",
+        "--atomic-editor-selection-bg": "var(--accent)",
+        "--atomic-editor-font": "var(--font-sans, system-ui)",
+        fontSize: "15px",
+      },
+      ".cm-content": {
+        fontFamily: "var(--font-sans, system-ui)",
+        padding: "32px clamp(20px, 5vw, 56px) 30vh",
+        maxWidth: "900px",
+        margin: "0 auto",
+        boxSizing: "border-box",
+      },
+      ".cm-tooltip": { borderRadius: "10px", boxShadow: "0 4px 20px #0002", zIndex: "80" },
+      ".cm-line": { lineHeight: "1.7" },
+    }),
+  ),
+];
+
+/** A presentation over the existing Markdown buffer; no serializer or separate editor. */
+export function richMarkdown(review: RfmReviewConfig) {
+  return [presentation, rfmReview(review)];
+}

--- a/packages/workspace-documents/src/text-edits.test.ts
+++ b/packages/workspace-documents/src/text-edits.test.ts
@@ -1,0 +1,30 @@
+import { ChangeSet, Text } from "@codemirror/state";
+import { expect, test } from "vitest";
+import { textEdits } from "./text-edits.ts";
+
+test("keeps independent source ranges when adding a selected comment", () => {
+  const source = "First paragraph.\n\nSecond paragraph.\n";
+  const next =
+    "{==First==}{>>Check First.<<}{#c_1} paragraph.\n\nSecond paragraph.\n\n---\ncomments:\n  c_1:\n";
+  const edits = textEdits(source, next);
+
+  expect(edits).toHaveLength(3);
+  expect(
+    ChangeSet.of(edits, source.length)
+      .apply(Text.of(source.split("\n")))
+      .toString(),
+  ).toBe(next);
+});
+
+test("finishes a pathological one-megabyte rewrite with the requested text", () => {
+  const source = "ab".repeat(512 * 1024);
+  const next = "ba".repeat(512 * 1024);
+  const edits = textEdits(source, next);
+
+  expect(edits.length).toBeGreaterThan(0);
+  expect(
+    ChangeSet.of(edits, source.length)
+      .apply(Text.of(source.split("\n")))
+      .toString(),
+  ).toBe(next);
+});

--- a/packages/workspace-documents/src/text-edits.ts
+++ b/packages/workspace-documents/src/text-edits.ts
@@ -1,8 +1,10 @@
 import { diff } from "@codemirror/merge";
 
+const DIFF_CONFIG = { scanLimit: 10_000, timeout: 50 };
+
 /** Preserve unchanged text between edits so concurrent typing rebases in place. */
 export function textEdits(source: string, next: string) {
-  return diff(source, next).map(({ fromA, toA, fromB, toB }) => ({
+  return diff(source, next, DIFF_CONFIG).map(({ fromA, toA, fromB, toB }) => ({
     from: fromA,
     to: toA,
     insert: next.slice(fromB, toB),

--- a/packages/workspace-documents/src/use-collab-editor.ts
+++ b/packages/workspace-documents/src/use-collab-editor.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Compartment, EditorState, type Extension } from "@codemirror/state";
 import { getSyncedVersion, sendableUpdates } from "@codemirror/collab";
 import { EditorView } from "@codemirror/view";
+import { readOnlyExtension } from "@atomic-editor/editor";
 import { textEdits } from "./text-edits.ts";
 import { CollabConnection, peerExtension } from "./collab-client.ts";
 import { redlineExtension } from "./collab-redline.ts";
@@ -25,10 +26,13 @@ export function useCollabEditor(input: {
   displayName?: string;
   /** Host-facing document identifier used in callbacks and CollabEditorApi. */
   path: string;
-  /** Path sent to the workspace collab lane. Defaults to `path`. */
+  /** Path sent to the workspace collaboration session. Defaults to `path`. */
   workspacePath?: string;
   /** Extra extensions for the surface (keymaps, theme, listeners). */
   extensions: Extension;
+  /** The in-place document presentation. Reconfigured without remounting the
+   * collab session, history, selection, or remote cursor state. */
+  presentation?: Extension;
   /** Redline layers on at build time (kept in sync with toggle()). */
   redline: boolean;
   /** Place the caret on mount: select the `# headline` text (so typing
@@ -51,6 +55,8 @@ export function useCollabEditor(input: {
   const [recovery, setRecovery] = useState<string | null>(null);
   const redlineRef = useRef(input.redline);
   const toggleRef = useRef<((on: boolean) => void) | null>(null);
+  const presentationRef = useRef<Extension>(input.presentation ?? []);
+  const presentationToggleRef = useRef<((extension: Extension) => void) | null>(null);
   // Same ref discipline as redline: the session effect must NOT depend on
   // the callback's identity (an unstable prop would remount the editor),
   // but the adapter must still call the LATEST one.
@@ -74,6 +80,11 @@ export function useCollabEditor(input: {
   useEffect(() => {
     onPeersRef.current = input.onPeers;
   }, [input.onPeers]);
+  useEffect(() => {
+    const presentation = input.presentation ?? [];
+    presentationRef.current = presentation;
+    presentationToggleRef.current?.(presentation);
+  }, [input.presentation]);
   const setStatus = useCallback(
     (next: string) => {
       setStatusState(next);
@@ -89,7 +100,6 @@ export function useCollabEditor(input: {
     // while the new session is still seeding.
     setStatus("connecting…");
     const connection = new CollabConnection(transport, workspacePath, displayName);
-    connection.onStatus = setStatus;
     connection.onPeers = (clients) => {
       // Empty delivery = a dead session (the client fires [] on ended):
       // clear the strip rather than re-injecting a self that is not live.
@@ -104,6 +114,8 @@ export function useCollabEditor(input: {
       );
     };
     const redlineLayer = new Compartment();
+    const presentationLayer = new Compartment();
+    const editableLayer = new Compartment();
     let view: EditorView | null = null;
     let cancelled = false;
 
@@ -133,11 +145,21 @@ export function useCollabEditor(input: {
           // redline toggle is off.
           remoteCursorsExtension(connection),
           redlineLayer.of(redlines),
+          presentationLayer.of(presentationRef.current),
+          editableLayer.of(readOnlyExtension(connection.dead)),
         ],
       });
 
     toggleRef.current = (on: boolean) => {
       view?.dispatch({ effects: redlineLayer.reconfigure(redlines(on)) });
+    };
+    presentationToggleRef.current = (presentation: Extension) => {
+      view?.dispatch({ effects: presentationLayer.reconfigure(presentation) });
+    };
+
+    connection.onStatus = (next) => {
+      view?.dispatch({ effects: editableLayer.reconfigure(readOnlyExtension(connection.dead)) });
+      setStatus(next);
     };
 
     connection.onReseed = (snapshot, unsynced) => {
@@ -166,9 +188,14 @@ export function useCollabEditor(input: {
           const live = view;
           apiRef.current = {
             applyTransform: (transform) => {
+              if (connection.dead) throw new Error("Reconnect before editing this document.");
               const current = live.state.doc.toString();
               const next = transform(current);
-              live.dispatch({ changes: textEdits(current, next) });
+              live.dispatch({
+                changes: textEdits(current, next),
+                filter: false,
+                userEvent: "transform",
+              });
               // Explicit actions update their controls immediately, unlike continuous typing.
               if (reflectTimer) clearTimeout(reflectTimer);
               onLiveContent?.(path, live.state.doc.toString());
@@ -224,6 +251,7 @@ export function useCollabEditor(input: {
         }
       }
       toggleRef.current = null;
+      presentationToggleRef.current = null;
       if (apiRef !== undefined) apiRef.current = null;
       view?.destroy();
     };

--- a/packages/workspace-documents/src/use-document-review.tsx
+++ b/packages/workspace-documents/src/use-document-review.tsx
@@ -14,6 +14,7 @@ import {
   type ReviewOperation,
 } from "iterate/document-review";
 import { authorColor } from "./collab-author.ts";
+import type { EditorReviewConfig } from "./collab-editor-api.ts";
 import type { CommentIdentity } from "./types.ts";
 
 /** Connect RFM source to the format-independent preview and comments UI. */
@@ -26,21 +27,25 @@ export function useDocumentReview({
   source: string;
   identity: CommentIdentity | null;
   busy: boolean;
-  /** Apply to the current local source; false means the editor is unavailable. */
-  onTransform: (transform: (current: string) => string) => boolean;
+  /** Absent while unavailable; apply to the current source, preserving a failed draft. */
+  onTransform?: (transform: (current: string) => string) => boolean;
 }) {
   const review = useMemo(() => readReview(source), [source]);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const canWrite =
-    identity !== null && !busy && !review.diagnostics.some((d) => d.severity === "error");
+    identity !== null &&
+    !busy &&
+    !!onTransform &&
+    !review.diagnostics.some((d) => d.severity === "error");
 
-  const apply = (operation: ReviewOperation) => {
+  const apply = (operationFor: (current: string) => ReviewOperation) => {
     try {
-      const applied = onTransform((current) => {
-        const result = applyReviewOperation(current, operation);
-        if (!result.ok) throw new Error(result.message);
-        return result.source;
-      });
+      const applied =
+        onTransform?.((current) => {
+          const result = applyReviewOperation(current, operationFor(current));
+          if (!result.ok) throw new Error(result.message);
+          return result.source;
+        }) ?? false;
       if (!applied) {
         toast.error(
           "The document editor is unavailable. Your draft is saved here; reconnect to continue.",
@@ -57,23 +62,23 @@ export function useDocumentReview({
     if (!identity) return false;
     switch (action.kind) {
       case "add-document-comment":
-        return apply({ type: action.kind, body: action.body, author: identity.author });
+        return apply(() => ({ type: action.kind, body: action.body, author: identity.author }));
       case "reply":
-        return apply({
+        return apply(() => ({
           type: "reply",
           parentId: action.threadId,
           body: action.body,
           author: identity.author,
-        });
+        }));
       case "edit-comment":
-        return apply({ type: "edit", id: action.commentId, body: action.body });
+        return apply(() => ({ type: "edit", id: action.commentId, body: action.body }));
       case "delete-comment":
-        return apply({ type: "delete", id: action.commentId });
+        return apply(() => ({ type: "delete", id: action.commentId }));
       case "set-thread-status":
-        return apply({ type: "set-status", id: action.threadId, status: action.status });
+        return apply(() => ({ type: "set-status", id: action.threadId, status: action.status }));
       case "accept-suggestion":
       case "reject-suggestion":
-        return apply({ type: action.kind, id: action.threadId });
+        return apply(() => ({ type: action.kind, id: action.threadId }));
     }
   };
 
@@ -176,15 +181,34 @@ export function useDocumentReview({
             toast.error("This selection cannot be attached to the Markdown source.");
             return false;
           }
-          return apply({
+          return apply(() => ({
             type: "add-selected-comment",
             expectedSource: source,
             range: sourceRange,
             body,
             author: identity.author,
+          }));
+        }
+      : undefined,
+  };
+  const editor: EditorReviewConfig = {
+    selectedThreadId: selectedIds[0] ?? null,
+    onSelectThread: (id) => setSelectedIds(id ? [id] : []),
+    onComment: canWrite
+      ? (range, body) => {
+          if (!identity) return false;
+          return apply((current) => {
+            const bodyStart = readReview(current).body.range.start;
+            return {
+              type: "add-selected-comment",
+              expectedSource: current,
+              range: { start: range.from - bodyStart, end: range.to - bodyStart },
+              body,
+              author: identity.author,
+            };
           });
         }
       : undefined,
   };
-  return { preview, comments };
+  return { editor, preview, comments };
 }

--- a/packages/workspace-documents/src/workspace-document-editor.tsx
+++ b/packages/workspace-documents/src/workspace-document-editor.tsx
@@ -1,14 +1,19 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { EditorView, keymap, placeholder } from "@codemirror/view";
 import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 import { html } from "@codemirror/lang-html";
-import { markdown } from "@codemirror/lang-markdown";
+import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
+import { highlightMarkdown } from "@atomic-editor/editor";
+import { ReviewComposer } from "@iterate-com/ui/components/document-comments";
 import { useCollabEditor } from "./use-collab-editor.ts";
-import type { CollabEditorApi } from "./collab-editor-api.ts";
+import type { CollabEditorApi, EditorReviewConfig } from "./collab-editor-api.ts";
+import { richMarkdown } from "./rich-markdown.ts";
+import type { ReviewComposerMount } from "./rfm-review-extension.ts";
 import type { WorkspaceDocumentTransport } from "./types.ts";
 
 /**
- * Shared source editor: CodeMirror 6 over the workspace collab lane.
+ * Shared live Markdown editor: CodeMirror 6 over the workspace collaboration session.
  * Hosts keep it lazy so their document-list and shell bundles stay small.
  */
 export function WorkspaceDocumentEditor({
@@ -17,6 +22,8 @@ export function WorkspaceDocumentEditor({
   path,
   workspacePath,
   mode = "markdown",
+  presentation = "source",
+  review,
   redline,
   emptyPlaceholder = "Write in Markdown…",
   focusHeadline,
@@ -30,9 +37,11 @@ export function WorkspaceDocumentEditor({
   displayName?: string;
   /** Host-facing document identifier used in callbacks. */
   path: string;
-  /** Path sent to the workspace collab lane. Defaults to `path`. */
+  /** Path sent to the workspace collaboration session. Defaults to `path`. */
   workspacePath?: string;
   mode?: "html" | "markdown";
+  presentation?: "rich" | "source";
+  review?: EditorReviewConfig;
   redline: boolean;
   emptyPlaceholder?: string;
   focusHeadline?: "select" | "end" | { caret: number };
@@ -48,13 +57,25 @@ export function WorkspaceDocumentEditor({
   // Through a ref so the keymap (inside the deps-free extensions memo) always
   // sees the current handler without rebuilding the editor state.
   const requestCloseRef = useRef(onRequestClose);
+  const reviewRef = useRef(review);
+  const composerTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [composer, setComposer] = useState<ReviewComposerMount | null>(null);
+  const [commentDraft, setCommentDraft] = useState("");
   useEffect(() => {
     requestCloseRef.current = onRequestClose;
   }, [onRequestClose]);
+  useEffect(() => {
+    reviewRef.current = review;
+  }, [review]);
+  useEffect(() => {
+    composerTextareaRef.current?.focus();
+  }, [composer?.element]);
   const extensions = useMemo(
     () => [
       history(),
-      mode === "html" ? html() : markdown(),
+      mode === "html"
+        ? html()
+        : markdown({ base: markdownLanguage, extensions: highlightMarkdown }),
       keymap.of([
         {
           key: "Mod-Enter",
@@ -75,10 +96,26 @@ export function WorkspaceDocumentEditor({
     ],
     [emptyPlaceholder, mode],
   );
+  const canComment = review?.onComment !== undefined;
+  const richPresentation = useMemo(
+    () =>
+      mode === "markdown" && presentation === "rich"
+        ? richMarkdown({
+            selectedThreadId: review?.selectedThreadId ?? null,
+            onSelectThread: (id) => reviewRef.current?.onSelectThread(id),
+            onComment: canComment
+              ? (range, body) => reviewRef.current?.onComment?.(range, body) ?? false
+              : undefined,
+            mountComposer: setComposer,
+          })
+        : [],
+    [canComment, mode, presentation, review?.selectedThreadId],
+  );
   const editor = useCollabEditor({
     apiRef,
     displayName,
     extensions,
+    presentation: richPresentation,
     focusHeadline,
     onLiveContent,
     onPeers,
@@ -103,6 +140,28 @@ export function WorkspaceDocumentEditor({
         </div>
       )}
       <div ref={editor.host} className="min-h-0 flex-1 overflow-auto" />
+      {commentDraft && (!composer || presentation !== "rich") ? (
+        <p role="status" className="border-t px-4 py-2 text-xs text-muted-foreground">
+          Comment draft saved. Select text in rich mode to continue.
+        </p>
+      ) : null}
+      {presentation === "rich" && composer
+        ? createPortal(
+            <ReviewComposer
+              initialValue={commentDraft}
+              onDraftChange={setCommentDraft}
+              textareaRef={composerTextareaRef}
+              placeholder="Comment on selected text…"
+              submitLabel="Add comment"
+              onSubmit={canComment ? composer.submit : undefined}
+              onCancel={() => {
+                setCommentDraft("");
+                composer.cancel();
+              }}
+            />,
+            composer.element,
+          )
+        : null}
     </>
   );
 }

--- a/packages/workspace-documents/vitest.config.ts
+++ b/packages/workspace-documents/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // Atomic ships extensionless ESM imports; Vite resolves them as in the app.
+    server: { deps: { inline: ["@atomic-editor/editor"] } },
+  },
+});

--- a/patches/@atomic-editor__editor@0.6.2.patch
+++ b/patches/@atomic-editor__editor@0.6.2.patch
@@ -1,0 +1,203 @@
+diff --git a/dist/inline-preview.js b/dist/inline-preview.js
+index 67f18b3d3f9856530dd5cda94bb18d900657c8ca..bda55c39bcbf00931ae2dffbce14eed8cfbbb8d1 100644
+--- a/dist/inline-preview.js
++++ b/dist/inline-preview.js
+@@ -13,6 +13,16 @@ function defaultOnLinkClick(url) {
+     }
+ }
+ const FREEZE_TAIL_MS = 100;
++const PREVIEW_VIEWPORT_BUFFER_LINES = 160;
++function previewRange(view) {
++    const { doc } = view.state;
++    const firstVisible = doc.lineAt(view.viewport.from).number;
++    const lastVisible = doc.lineAt(view.viewport.to).number;
++    return {
++        from: doc.line(Math.max(1, firstVisible - PREVIEW_VIEWPORT_BUFFER_LINES)).from,
++        to: doc.line(Math.min(doc.lines, lastVisible + PREVIEW_VIEWPORT_BUFFER_LINES)).to,
++    };
++}
+ // ---- freeze plumbing -----------------------------------------------------
+ const setFrozen = StateEffect.define();
+ const previewFrozenField = StateField.define({
+@@ -237,7 +247,7 @@ class BulletWidget extends WidgetType {
+ }
+ const BULLET_WIDGET = new BulletWidget();
+ class TaskCheckboxWidget extends WidgetType {
+-    constructor(checked) {
++    constructor(checked, disabled) {
+         super();
+         Object.defineProperty(this, "checked", {
+             enumerable: true,
+@@ -245,9 +255,15 @@ class TaskCheckboxWidget extends WidgetType {
+             writable: true,
+             value: checked
+         });
++        Object.defineProperty(this, "disabled", {
++            enumerable: true,
++            configurable: true,
++            writable: true,
++            value: disabled
++        });
+     }
+     eq(other) {
+-        return other.checked === this.checked;
++        return other.checked === this.checked && other.disabled === this.disabled;
+     }
+     toDOM(view) {
+         // The `.cm-atomic-list-marker` class provides the uniform
+@@ -259,6 +275,7 @@ class TaskCheckboxWidget extends WidgetType {
+         const input = document.createElement('input');
+         input.type = 'checkbox';
+         input.checked = this.checked;
++        input.disabled = this.disabled;
+         input.className = 'cm-atomic-list-marker cm-atomic-task-checkbox';
+         input.setAttribute('contenteditable', 'false');
+         input.addEventListener('mousedown', (e) => {
+@@ -268,6 +285,8 @@ class TaskCheckboxWidget extends WidgetType {
+         input.addEventListener('click', (e) => {
+             e.preventDefault();
+             e.stopPropagation();
++            if (view.state.readOnly)
++                return;
+             const pos = view.posAtDOM(input);
+             if (pos < 0)
+                 return;
+@@ -337,7 +356,7 @@ function listItemDepth(item) {
+ function sameListItem(a, b) {
+     return a?.name === 'ListItem' && a.from === b.from && a.to === b.to;
+ }
+-function buildInlineDecorations(view) {
++function buildInlineDecorations(view, preview) {
+     const { state } = view;
+     const { doc } = state;
+     const ranges = [];
+@@ -355,24 +374,11 @@ function buildInlineDecorations(view) {
+                 activeLines.add(n);
+         }
+     }
+-    // Decorate the whole parsed tree — not the current viewport — so
+-    // that scrolling never needs to rebuild the decoration set. Prior
+-    // design walked viewport-only and rebuilt on every scroll, which
+-    // on iOS caused scroll-up momentum halts whenever new decorations
+-    // were applied to lines at the top of the viewport (anchor
+-    // conflict with the scroll animation). Cost: a one-shot whole-doc
+-    // walk on every doc / selection / focus change instead of a
+-    // smaller walk on every scroll.
+-    //
+-    // `ensureSyntaxTree(..., doc.length, ...)` guarantees the tree
+-    // actually covers the whole doc before we walk it. Without this,
+-    // for moderately long atoms the incremental parser's initial
+-    // pass falls short of the end, we'd walk only a prefix, and
+-    // content past that point renders as raw `##`/`**` forever —
+-    // decorations don't rebuild on scroll anymore. Subsequent calls
+-    // are near-free because ensureSyntaxTree short-circuits once the
+-    // tree reaches the target.
+-    const tree = ensureSyntaxTree(state, state.doc.length, 200) ?? syntaxTree(state);
++    // Decorate the drawn viewport plus a generous line buffer. Selection changes
++    // scale with what the user can see. Rebuild only after the real viewport
++    // leaves that buffer, avoiding fresh decorations on each mobile scroll
++    // update. The parser-progress effect revisits this slice as parsing advances.
++    const tree = ensureSyntaxTree(state, preview.to, 200) ?? syntaxTree(state);
+     // `from` positions of Link nodes whose range overlaps a selection.
+     // Link children (LinkMark/URL/LinkTitle) hide unless their parent
+     // Link's `from` is in this set — i.e. the cursor has entered the
+@@ -395,18 +401,16 @@ function buildInlineDecorations(view) {
+     // traversal — meaningful because this runs on every cursor move and
+     // its cost scales with document size.)
+     tree.iterate({
++        from: preview.from,
++        to: preview.to,
+         enter: (node) => {
+             if (node.name === 'FencedCode') {
+-                const firstLine = doc.lineAt(node.from).number;
+-                const lastLine = doc.lineAt(node.to).number;
+-                let anyActive = false;
+-                for (let n = firstLine; n <= lastLine; n++) {
+-                    if (activeLines.has(n)) {
+-                        anyActive = true;
+-                        break;
+-                    }
+-                }
+-                if (anyActive) {
++                const active = view.hasFocus &&
++                    !readOnly &&
++                    state.selection.ranges.some((range) => range.from <= node.to && range.to >= node.from);
++                if (active) {
++                    const firstLine = doc.lineAt(Math.max(node.from, preview.from)).number;
++                    const lastLine = doc.lineAt(Math.min(node.to, preview.to)).number;
+                     for (let n = firstLine; n <= lastLine; n++)
+                         activeLines.add(n);
+                 }
+@@ -537,8 +541,8 @@ function buildInlineDecorations(view) {
+                 if (listItem) {
+                     const depth = listItemDepth(listItem);
+                     const padding = LIST_BASE_EM + LIST_ALCOVE_EM + depth * LIST_LEVEL_EM;
+-                    const firstLine = doc.lineAt(listItem.from);
+-                    const lastLine = doc.lineAt(listItem.to);
++                    const firstLine = doc.lineAt(Math.max(listItem.from, preview.from));
++                    const lastLine = doc.lineAt(Math.min(listItem.to, preview.to));
+                     for (let number = firstLine.number; number <= lastLine.number; number++) {
+                         const ownedLine = doc.line(number);
+                         const contentOffset = ownedLine.text.search(/\S/);
+@@ -643,7 +647,7 @@ function buildInlineDecorations(view) {
+                     doc.sliceString(node.to, node.to + 1) === ' ';
+                 const replaceTo = hasTrailingSpace ? node.to + 1 : node.to;
+                 pushReplace(ranges, doc, node.from, replaceTo, {
+-                    widget: new TaskCheckboxWidget(checked),
++                    widget: new TaskCheckboxWidget(checked, readOnly),
+                 });
+                 if (checked) {
+                     const lineNum = doc.lineAt(node.from).number;
+@@ -767,7 +771,14 @@ const inlinePreviewPlugin = ViewPlugin.fromClass(class {
+             writable: true,
+             value: void 0
+         });
+-        this.decorations = buildInlineDecorations(view);
++        Object.defineProperty(this, "preview", {
++            enumerable: true,
++            configurable: true,
++            writable: true,
++            value: void 0
++        });
++        this.preview = previewRange(view);
++        this.decorations = buildInlineDecorations(view, this.preview);
+     }
+     update(update) {
+         const prevFrozen = update.startState.field(previewFrozenField);
+@@ -799,27 +810,26 @@ const inlinePreviewPlugin = ViewPlugin.fromClass(class {
+             if (treeGrew)
+                 break;
+         }
+-        // Note: `update.viewportChanged` is intentionally NOT in this
+-        // list. Scrolling alone must not rebuild decorations — doing
+-        // so on iOS halts momentum whenever the rebuild produces new
+-        // decorations for lines at the top of a scroll-up viewport
+-        // (CM6 anchor conflict with the scroll animation). Walking
+-        // the whole parsed tree on the remaining triggers means
+-        // scroll-time cost is zero; the tree walk itself is
+-        // single-digit ms for typical atoms.
++        // Scrolling only rebuilds after it leaves the buffered decoration slice.
++        // That keeps normal mobile momentum free of decoration replacement.
+         // A read-only toggle (compartment reconfigure) changes neither
+         // doc nor selection nor focus, so detect the facet flip directly
+         // — otherwise reading mode wouldn't repaint into / out of the
+         // fully-rendered state.
+         const readOnlyChanged = update.startState.facet(readOnlyFacet) !==
+             update.state.facet(readOnlyFacet);
++        const nextPreview = previewRange(update.view);
++        const viewportEscaped = update.viewportChanged &&
++            (update.view.viewport.from < this.preview.from || update.view.viewport.to > this.preview.to);
+         if (justUnfroze ||
+             update.docChanged ||
+             update.selectionSet ||
+             update.focusChanged ||
+             treeGrew ||
+-            readOnlyChanged) {
+-            this.decorations = buildInlineDecorations(update.view);
++            readOnlyChanged ||
++            viewportEscaped) {
++            this.preview = nextPreview;
++            this.decorations = buildInlineDecorations(update.view, this.preview);
+         }
+     }
+ }, {

--- a/patches/@codemirror__merge@6.12.2.patch
+++ b/patches/@codemirror__merge@6.12.2.patch
@@ -1,0 +1,44 @@
+diff --git a/dist/index.cjs b/dist/index.cjs
+index f3f9998639e0b29d8c6bfce1ff2f7914731b3b85..ba5b4016e57816b6d0d304deb56092cd81cb1505 100644
+--- a/dist/index.cjs
++++ b/dist/index.cjs
+@@ -242,6 +242,8 @@ function findMatch(a, fromA, toA, b, fromB, toB, size, divideTo) {
+         if (best || size < divideTo)
+             return best;
+         for (let start = fromA + size;;) {
++            if (timeout > 0 && Date.now() > timeout)
++                return best;
+             if (!validIndex(a, start))
+                 start++;
+             let end = start + size;
+@@ -252,6 +254,8 @@ function findMatch(a, fromA, toA, b, fromB, toB, size, divideTo) {
+             let seed = a.slice(start, end);
+             let found = -1;
+             while ((found = rangeB.indexOf(seed, found + 1)) != -1) {
++                if (timeout > 0 && Date.now() > timeout)
++                    return best;
+                 let prefixAfter = commonPrefix(a, end, toA, b, fromB + found + seed.length, toB);
+                 let suffixBefore = commonSuffix(a, fromA, start, b, fromB, fromB + found);
+                 let length = seed.length + prefixAfter + suffixBefore;
+diff --git a/dist/index.js b/dist/index.js
+index 8322cf9b1d463a8e6b4b0ccb4e36069e2de53bda..4866a5b8c93632776f6abc92834ed0d8e772fc21 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -240,6 +240,8 @@ function findMatch(a, fromA, toA, b, fromB, toB, size, divideTo) {
+         if (best || size < divideTo)
+             return best;
+         for (let start = fromA + size;;) {
++            if (timeout > 0 && Date.now() > timeout)
++                return best;
+             if (!validIndex(a, start))
+                 start++;
+             let end = start + size;
+@@ -250,6 +252,8 @@ function findMatch(a, fromA, toA, b, fromB, toB, size, divideTo) {
+             let seed = a.slice(start, end);
+             let found = -1;
+             while ((found = rangeB.indexOf(seed, found + 1)) != -1) {
++                if (timeout > 0 && Date.now() > timeout)
++                    return best;
+                 let prefixAfter = commonPrefix(a, end, toA, b, fromB + found + seed.length, toB);
+                 let suffixBefore = commonSuffix(a, fromA, start, b, fromB, fromB + found);
+                 let length = seed.length + prefixAfter + suffixBefore;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,8 +150,8 @@ importers:
         specifier: ^16.2.7
         version: 16.3.2
       middlewright:
-        specifier: https://pkg.pr.new/middlewright@c5feb42
-        version: https://pkg.pr.new/middlewright@c5feb42(@playwright/test@1.60.0)
+        specifier: https://pkg.pr.new/middlewright@08dd4f9
+        version: https://pkg.pr.new/middlewright@08dd4f9(@playwright/test@1.60.0)
       oxfmt:
         specifier: ^0.35.0
         version: 0.35.0
@@ -11104,8 +11104,8 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
-  middlewright@https://pkg.pr.new/middlewright@c5feb42:
-    resolution: {tarball: https://pkg.pr.new/middlewright@c5feb42}
+  middlewright@https://pkg.pr.new/middlewright@08dd4f9:
+    resolution: {tarball: https://pkg.pr.new/middlewright@08dd4f9}
     version: 0.1.0
     engines: {node: '>=20'}
     peerDependencies:
@@ -26231,7 +26231,7 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
-  middlewright@https://pkg.pr.new/middlewright@c5feb42(@playwright/test@1.60.0):
+  middlewright@https://pkg.pr.new/middlewright@08dd4f9(@playwright/test@1.60.0):
     dependencies:
       '@playwright/test': 1.60.0
       dedent: 1.7.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ packageExtensionsChecksum: sha256-EkBeg1CZMrkaUS7iAUQMaWo7TBKTiORkYxFouSMhx0U=
 pnpmfileChecksum: sha256-NYwZDqyYRb6nG9kuTlR90d09AzOclRDSF+lgvKeq0To=
 
 patchedDependencies:
+  '@atomic-editor/editor@0.6.2':
+    hash: de2cee03d872873f33c3d6c16aebacb577488abf0484fa7c6fc299d6af5cce38
+    path: patches/@atomic-editor__editor@0.6.2.patch
   '@better-auth/oauth-provider@1.6.9':
     hash: c0ff8564b3560e098f4088aecf42b4304ee36cd37e364108ee4a83031a314fca
     path: patches/@better-auth__oauth-provider@1.6.9.patch
@@ -62,6 +65,9 @@ patchedDependencies:
   '@cloudflare/workers-types@4.20260621.1':
     hash: ae8908e1d45f2ea02ffeabf1230701598cc2878240ef700403ff76df72677af2
     path: patches/@cloudflare__workers-types@4.20260621.1.patch
+  '@codemirror/merge@6.12.2':
+    hash: abd7a6151128bd71ee4e3b13e0acbcd8498e4c290990a300ad25687983b7d407
+    path: patches/@codemirror__merge@6.12.2.patch
   '@journeyapps/wa-sqlite@1.7.0':
     hash: 628f45a8b65f5811216d637fb5cc4584db8f69a125d1ae417c4e49bc38ebca83
     path: patches/@journeyapps__wa-sqlite@1.7.0.patch
@@ -834,7 +840,7 @@ importers:
         version: 6.9.5
       '@codemirror/merge':
         specifier: ^6.12.2
-        version: 6.12.2
+        version: 6.12.2(patch_hash=abd7a6151128bd71ee4e3b13e0acbcd8498e4c290990a300ad25687983b7d407)
       '@codemirror/state':
         specifier: ^6.7.1
         version: 6.7.1
@@ -1705,6 +1711,9 @@ importers:
 
   packages/workspace-documents:
     dependencies:
+      '@atomic-editor/editor':
+        specifier: 0.6.2
+        version: 0.6.2(patch_hash=de2cee03d872873f33c3d6c16aebacb577488abf0484fa7c6fc299d6af5cce38)(@codemirror/autocomplete@6.20.1)(@codemirror/commands@6.10.4)(@codemirror/lang-css@6.3.1)(@codemirror/lang-html@6.4.11)(@codemirror/lang-javascript@6.2.5)(@codemirror/lang-json@6.0.2)(@codemirror/lang-markdown@6.5.0)(@codemirror/lang-sql@6.10.0)(@codemirror/lang-yaml@6.1.2)(@codemirror/language@6.12.2)(@codemirror/search@6.6.0)(@codemirror/state@6.7.1)(@codemirror/view@6.43.6)(@lezer/common@1.5.1)(@lezer/highlight@1.2.3)(@lezer/markdown@1.6.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@codemirror/collab':
         specifier: ^6.1.1
         version: 6.1.1
@@ -1717,9 +1726,12 @@ importers:
       '@codemirror/lang-markdown':
         specifier: ^6.5.0
         version: 6.5.0
-      '@codemirror/merge':
+      '@codemirror/language':
         specifier: ^6.12.2
         version: 6.12.2
+      '@codemirror/merge':
+        specifier: ^6.12.2
+        version: 6.12.2(patch_hash=abd7a6151128bd71ee4e3b13e0acbcd8498e4c290990a300ad25687983b7d407)
       '@codemirror/state':
         specifier: ^6.7.1
         version: 6.7.1
@@ -1729,6 +1741,9 @@ importers:
       '@iterate-com/ui':
         specifier: workspace:*
         version: link:../ui
+      '@lezer/common':
+        specifier: ^1.5.1
+        version: 1.5.1
       capnweb:
         specifier: npm:@iterate-com/capnweb@0.10.0
         version: '@iterate-com/capnweb@0.10.0'
@@ -1738,6 +1753,9 @@ importers:
       react:
         specifier: ^19.2.7
         version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: catalog:cloudflare
@@ -1745,6 +1763,9 @@ importers:
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1865,6 +1886,67 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@atomic-editor/editor@0.6.2':
+    resolution: {integrity: sha512-b4cZRduNOoZ5sJ7ywaANcnLLKP3EJYfMUm5BgYK3Wb+9jI+KUs04RZHzFMVcdedNjvfqBDbzW6KYAmq5bAayxw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@codemirror/autocomplete': ^6.0.0
+      '@codemirror/commands': ^6.0.0
+      '@codemirror/lang-cpp': ^6.0.0
+      '@codemirror/lang-css': ^6.0.0
+      '@codemirror/lang-go': ^6.0.0
+      '@codemirror/lang-html': ^6.0.0
+      '@codemirror/lang-java': ^6.0.0
+      '@codemirror/lang-javascript': ^6.0.0
+      '@codemirror/lang-json': ^6.0.0
+      '@codemirror/lang-markdown': ^6.0.0
+      '@codemirror/lang-php': ^6.0.0
+      '@codemirror/lang-python': ^6.0.0
+      '@codemirror/lang-rust': ^6.0.0
+      '@codemirror/lang-sql': ^6.0.0
+      '@codemirror/lang-xml': ^6.0.0
+      '@codemirror/lang-yaml': ^6.0.0
+      '@codemirror/language': ^6.0.0
+      '@codemirror/legacy-modes': ^6.0.0
+      '@codemirror/search': ^6.0.0
+      '@codemirror/state': ^6.7.1
+      '@codemirror/view': ^6.43.6
+      '@lezer/common': ^1.0.0
+      '@lezer/highlight': ^1.0.0
+      '@lezer/markdown': ^1.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@codemirror/lang-cpp':
+        optional: true
+      '@codemirror/lang-css':
+        optional: true
+      '@codemirror/lang-go':
+        optional: true
+      '@codemirror/lang-html':
+        optional: true
+      '@codemirror/lang-java':
+        optional: true
+      '@codemirror/lang-javascript':
+        optional: true
+      '@codemirror/lang-json':
+        optional: true
+      '@codemirror/lang-php':
+        optional: true
+      '@codemirror/lang-python':
+        optional: true
+      '@codemirror/lang-rust':
+        optional: true
+      '@codemirror/lang-sql':
+        optional: true
+      '@codemirror/lang-xml':
+        optional: true
+      '@codemirror/lang-yaml':
+        optional: true
+      '@codemirror/legacy-modes':
+        optional: true
+
 
   '@babel/code-frame@7.10.4':
     resolution: {integrity: sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==}
@@ -14122,6 +14204,29 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
+  '@atomic-editor/editor@0.6.2(patch_hash=de2cee03d872873f33c3d6c16aebacb577488abf0484fa7c6fc299d6af5cce38)(@codemirror/autocomplete@6.20.1)(@codemirror/commands@6.10.4)(@codemirror/lang-css@6.3.1)(@codemirror/lang-html@6.4.11)(@codemirror/lang-javascript@6.2.5)(@codemirror/lang-json@6.0.2)(@codemirror/lang-markdown@6.5.0)(@codemirror/lang-sql@6.10.0)(@codemirror/lang-yaml@6.1.2)(@codemirror/language@6.12.2)(@codemirror/search@6.6.0)(@codemirror/state@6.7.1)(@codemirror/view@6.43.6)(@lezer/common@1.5.1)(@lezer/highlight@1.2.3)(@lezer/markdown@1.6.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/commands': 6.10.4
+      '@codemirror/lang-markdown': 6.5.0
+      '@codemirror/language': 6.12.2
+      '@codemirror/search': 6.6.0
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/markdown': 1.6.4
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/lang-json': 6.0.2
+      '@codemirror/lang-sql': 6.10.0
+      '@codemirror/lang-yaml': 6.1.2
+
+
   '@babel/code-frame@7.10.4':
     dependencies:
       '@babel/highlight': 7.25.9
@@ -15240,7 +15345,7 @@ snapshots:
       '@codemirror/view': 6.43.6
       crelt: 1.0.6
 
-  '@codemirror/merge@6.12.2':
+  '@codemirror/merge@6.12.2(patch_hash=abd7a6151128bd71ee4e3b13e0acbcd8498e4c290990a300ad25687983b7d407)':
     dependencies:
       '@codemirror/language': 6.12.2
       '@codemirror/state': 6.7.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -108,10 +108,12 @@ packageExtensions:
       '@types/react': '*'
 
 patchedDependencies:
+  '@atomic-editor/editor@0.6.2': patches/@atomic-editor__editor@0.6.2.patch
   '@better-auth/oauth-provider@1.6.9': patches/@better-auth__oauth-provider@1.6.9.patch
   # Remove once Cloudflare releases upstream fix 5fc1224cd73012d087b9438ff0ad931174e4bd86.
   '@cloudflare/sandbox@0.12.3': patches/@cloudflare__sandbox@0.12.3.patch
   '@cloudflare/worker-bundler@0.2.1': patches/@cloudflare__worker-bundler@0.2.1.patch
   '@cloudflare/workers-types@4.20260621.1': patches/@cloudflare__workers-types@4.20260621.1.patch
+  '@codemirror/merge@6.12.2': patches/@codemirror__merge@6.12.2.patch
   '@journeyapps/wa-sqlite@1.7.0': patches/@journeyapps__wa-sqlite@1.7.0.patch
   zod@4.5.4: patches/zod@4.5.4.patch

--- a/specs/seeded-apps.spec.ts
+++ b/specs/seeded-apps.spec.ts
@@ -178,6 +178,11 @@ test("review a workspace document in the seeded Docs app", async ({ baseURL, pag
       "- [ ] Review the launch copy",
       "- [ ] Confirm the rollout owner",
       "",
+      "| Area | Decision |",
+      "| --- | --- |",
+      "| Launch copy | Draft |",
+      "| Rollout | Pending |",
+      "",
       "## Review focus",
       "",
       "Make review decisions directly in the workspace file.",
@@ -226,42 +231,102 @@ test("review a workspace document in the seeded Docs app", async ({ baseURL, pag
   // provisioning and cold-start setup that this end-to-end proof also covers.
   page.videoMode?.setStartTime();
 
-  // A task-list checkbox is part of its list row, not a detached line above
-  // the copy. This geometric assertion protects the exact rendering failure
-  // that made the first Docs screenshots hard to scan.
-  const checklistItem = page.locator("li[data-task]").filter({ hasText: "Review the launch copy" });
-  const checkboxBox = await checklistItem.locator('input[type="checkbox"]').boundingBox();
-  const labelBox = await checklistItem
-    .getByText("Review the launch copy", { exact: true })
-    .boundingBox();
+  // Docs uses one shared browser context here, so these are two real
+  // concurrent clients for the same signed-in project member. A second
+  // identity would require project-member provisioning that is orthogonal to
+  // the editor protocol; distinct live sessions still exercise rebase,
+  // presence and every server ordering path.
+  const peer = await page.context().newPage();
+  await peer.goto(docsUrl.toString());
+  await peer.getByText(/^live · v\d+$/).waitFor({ timeout: 30_000 }); // timeout: second app-host load and collab attach have no spinnerWaiter-visible progress
+
+  const editor = page.locator(".cm-content");
+  const peerEditor = peer.locator(".cm-content");
+  await editor.waitFor();
+  await peerEditor.waitFor();
+
+  // A task-list checkbox remains aligned with its item in the live rich
+  // CodeMirror view — the raw source text is not a separate preview anymore.
+  const checklistItem = page
+    .locator(".cm-content")
+    .getByText("Review the launch copy", { exact: true });
+  const checkboxBox = await checklistItem.locator("xpath=preceding::input[1]").boundingBox();
+  const labelBox = await checklistItem.boundingBox();
   expect(checkboxBox).not.toBeNull();
   expect(labelBox).not.toBeNull();
   expect(
     Math.abs(checkboxBox!.y + checkboxBox!.height / 2 - (labelBox!.y + labelBox!.height / 2)),
   ).toBeLessThan(5);
 
+  // Source and rich editing are two presentations of the same CodeMirror
+  // state. Toggling cannot serialize or reseed the Markdown buffer.
+  const beforePresentationToggle = await workspace.readFile(documentPath);
   await page.getByRole("button", { name: "Source" }).click();
-  const editor = page.locator(".cm-content");
-  await editor.waitFor();
-  await editor.click();
-  // Select-all + ArrowRight parks the cursor at the end on macOS and Linux;
-  // Cmd/Ctrl+End is not a consistent CodeMirror binding across both.
-  await page.keyboard.press("ControlOrMeta+a");
-  await page.keyboard.press("ArrowRight");
-  await page.keyboard.type("\n\nReviewed in Docs.");
-  await editor.getByText("Reviewed in Docs.", { exact: true }).waitFor({ timeout: 10_000 }); // timeout: tight manual budget — CodeMirror keystroke echo has no loading UI for the spinner-waiter
-  await page.getByRole("button", { name: "Preview" }).click();
-  await page
-    .locator("div.cursor-text")
-    .getByText("Reviewed in Docs.", { exact: true })
-    .waitFor({ timeout: 10_000 }); // timeout: tight manual budget — the Preview repaint has no loading UI for the spinner-waiter
+  await page.getByRole("button", { name: "Rich editing" }).click();
+  await page.getByText("Docs review walkthrough", { exact: true }).waitFor();
+  expect(await workspace.readFile(documentPath)).toBe(beforePresentationToggle);
 
-  // Track changes is discoverable from Preview and opens the source redlines.
+  // Two independent rich editors concurrently change a body passage and two
+  // native table cells. The cells stay ordinary CodeMirror source ranges, so
+  // neither participant replaces a whole table widget.
+  await Promise.all([
+    (async () => {
+      await page.locator(".cm-markdown-table-cell", { hasText: "Draft" }).dblclick();
+      await page.keyboard.type("Approved");
+    })(),
+    (async () => {
+      await peer.locator(".cm-markdown-table-cell", { hasText: "Pending" }).dblclick();
+      await peer.keyboard.type("Scheduled");
+    })(),
+  ]);
+  await peer.getByText("Approved", { exact: true }).waitFor({ timeout: 10_000 }); // timeout: remote CodeMirror update is optimistic UI with no spinnerWaiter-visible progress
+  await page.getByText("Scheduled", { exact: true }).waitFor({ timeout: 10_000 }); // timeout: remote CodeMirror update is optimistic UI with no spinnerWaiter-visible progress
+  await Promise.all([
+    appendAtEnd(page, "\n\nPRIMARY_CONCURRENT_BODY"),
+    appendAtEnd(peer, "\n\nPEER_CONCURRENT_BODY"),
+  ]);
+  await page.getByText("PEER_CONCURRENT_BODY", { exact: true }).waitFor({ timeout: 10_000 }); // timeout: remote CodeMirror update has no spinnerWaiter-visible progress
+  await peer.getByText("PRIMARY_CONCURRENT_BODY", { exact: true }).waitFor({ timeout: 10_000 }); // timeout: remote CodeMirror update has no spinnerWaiter-visible progress
+
+  // The primary user keeps a native selection while the peer inserts text.
+  // Comment submission reads the mapped bookmark from the editor's live doc,
+  // not the React mirror that deliberately trails typing.
+  const reviewSentence = page
+    .locator(".cm-content")
+    .getByText("Make review decisions directly in the workspace file.", { exact: true });
+  await reviewSentence.click({ clickCount: 3 });
+  await appendAtEnd(peer, "\n\nPeer inserted while the passage was selected.");
+  await page.getByRole("button", { name: "Comment on selected text" }).click();
+  await page
+    .getByPlaceholder("Comment on selected text…")
+    .fill("Can we make this promise more concrete?");
+  await page.getByRole("button", { name: "Add comment" }).click();
+
+  // Undo only removes the local operation. A remote insertion that arrived
+  // between local typing and undo remains in both buffers and durable source.
+  await appendAtEnd(page, "\n\nLOCAL_UNDONE");
+  await appendAtEnd(peer, "\n\nREMOTE_KEPT");
+  await page.getByText("REMOTE_KEPT", { exact: true }).waitFor({ timeout: 10_000 }); // timeout: remote CodeMirror update has no spinnerWaiter-visible progress
+  await editor.click();
+  await page.keyboard.press("ControlOrMeta+z");
+  await expect
+    .poll(async () => String(await workspace.readFile(documentPath)), {
+      timeout: 30_000, // timeout: durability arrives through the live collab push, not spinnerWaiter-visible UI
+    })
+    .toContain("REMOTE_KEPT");
+  const afterUndo = (await workspace.readFile(documentPath))!;
+  expect(afterUndo).not.toContain("LOCAL_UNDONE");
+  expect(readReview(afterUndo)).toMatchObject({ diagnostics: [] });
+
+  // Rich end-of-document insertion belongs before the hidden endmatter.
+  await appendAtEnd(page, "\n\nReviewed in Docs.");
+  await page.getByText("Reviewed in Docs.", { exact: true }).waitFor({ timeout: 10_000 }); // timeout: tight manual budget — rich syntax projection has no spinnerWaiter-visible UI
+
+  // Track changes stays on the rich editor instead of forcing a source view.
   await page.getByRole("button", { name: "Track changes" }).click();
   await editor.locator(".cm-redline-ins").filter({ hasText: "Reviewed in Docs." }).waitFor();
   await page.getByRole("button", { name: "Track changes" }).click();
   expect(await editor.locator(".cm-redline-ins").count()).toBe(0);
-  await page.getByRole("button", { name: "Preview" }).click();
 
   // The 15-minute project session renews from the page itself (the request
   // the app's keepalive makes), through the config worker's gate, for the
@@ -284,11 +349,7 @@ test("review a workspace document in the seeded Docs app", async ({ baseURL, pag
       socket.close();
     }
   });
-  await page.getByRole("button", { name: "Source" }).click();
-  await editor.click();
-  await page.keyboard.press("ControlOrMeta+a");
-  await page.keyboard.press("ArrowRight");
-  await page.keyboard.type("\n\nStill here after the socket dropped.");
+  await appendAtEnd(page, "\n\nStill here after the socket dropped.");
   await page.getByText(/^live · v\d+$/).waitFor({ timeout: 30_000 }); // timeout: the pull loop's backoff before its re-dial — the a11y-only badge gives the spinner-waiter nothing to watch
   await expect
     .poll(async () => String(await workspace.readFile(documentPath)), {
@@ -296,7 +357,7 @@ test("review a workspace document in the seeded Docs app", async ({ baseURL, pag
     })
     .toContain("Still here after the socket dropped.");
 
-  await page.getByRole("button", { name: "Preview", exact: true }).click();
+  await page.getByRole("button", { name: "Rich editing", exact: true }).click();
 
   await page.getByRole("button", { name: "Comment on document" }).click();
   await page
@@ -309,15 +370,6 @@ test("review a workspace document in the seeded Docs app", async ({ baseURL, pag
     .waitFor();
   await commentsPanel.getByRole("heading", { name: "Whole document", exact: true }).waitFor();
 
-  const reviewSentence = page
-    .locator("div.cursor-text")
-    .getByText("Make review decisions directly in the workspace file.", { exact: true });
-  // Native paragraph selection can end at offset zero of the next block.
-  await reviewSentence.click({ clickCount: 3 });
-  await page
-    .getByPlaceholder("Comment on the selection…")
-    .fill("Can we make this promise more concrete?");
-  await page.getByRole("button", { name: "Comment", exact: true }).click();
   await commentsPanel
     .getByText("Can we make this promise more concrete?", { exact: true })
     .waitFor();
@@ -341,10 +393,7 @@ test("review a workspace document in the seeded Docs app", async ({ baseURL, pag
 
   await page.reload();
   await page.getByText(/^live · v\d+$/).waitFor();
-  const headingFontSize = await page
-    .getByRole("heading", { name: "Docs review walkthrough" })
-    .evaluate((element) => getComputedStyle(element).fontSize);
-  expect(headingFontSize).toBe("24px");
+  await page.getByText("Docs review walkthrough", { exact: true }).waitFor();
   await page.getByText("Can we make this promise more concrete?", { exact: true }).waitFor();
   await testInfo.attach("roughdraft-desktop", {
     body: await page.screenshot({ animations: "disabled" }),
@@ -360,7 +409,18 @@ test("review a workspace document in the seeded Docs app", async ({ baseURL, pag
     body: await page.screenshot({ animations: "disabled" }),
     contentType: "image/png",
   });
+  await peer.close();
 });
+
+async function appendAtEnd(page: import("@playwright/test").Page, text: string): Promise<void> {
+  const editor = page.locator(".cm-content");
+  await editor.click();
+  // Select-all + ArrowRight parks the cursor at the end on macOS and Linux;
+  // Cmd/Ctrl+End is not a consistent CodeMirror binding across both.
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.press("ArrowRight");
+  await page.keyboard.type(text);
+}
 
 /**
  * App hosts are `<app>--<project>.<base>`, one origin per app. Locally the

--- a/specs/seeded-apps.spec.ts
+++ b/specs/seeded-apps.spec.ts
@@ -271,12 +271,10 @@ test("review a workspace document in the seeded Docs app", async ({ baseURL, pag
   // neither participant replaces a whole table widget.
   await Promise.all([
     (async () => {
-      await page.locator(".cm-markdown-table-cell", { hasText: "Draft" }).dblclick();
-      await page.keyboard.type("Approved");
+      await replaceCellWord(page, "Draft", "Approved");
     })(),
     (async () => {
-      await peer.locator(".cm-markdown-table-cell", { hasText: "Pending" }).dblclick();
-      await peer.keyboard.type("Scheduled");
+      await replaceCellWord(peer, "Pending", "Scheduled");
     })(),
   ]);
   await peer.getByText("Approved", { exact: true }).waitFor({ timeout: 10_000 }); // timeout: remote CodeMirror update is optimistic UI with no spinnerWaiter-visible progress
@@ -420,6 +418,25 @@ async function appendAtEnd(page: import("@playwright/test").Page, text: string):
   await page.keyboard.press("ControlOrMeta+a");
   await page.keyboard.press("ArrowRight");
   await page.keyboard.type(text);
+}
+
+async function replaceCellWord(
+  page: import("@playwright/test").Page,
+  current: string,
+  replacement: string,
+): Promise<void> {
+  const cell = page.locator(".cm-markdown-table-cell", { hasText: current });
+  const bounds = await cell.boundingBox();
+  if (!bounds) throw new Error(`Table cell ${JSON.stringify(current)} is not visible.`);
+  // The cell is wider than its word. Double-click inside the visible text,
+  // not its whitespace, to exercise the browser's native word selection.
+  await cell.dblclick({ position: { x: Math.min(20, bounds.width / 2), y: bounds.height / 2 } });
+  await expect
+    .poll(() => cell.evaluate((element) => element.ownerDocument.getSelection()?.toString()), {
+      timeout: 1_000, // timeout: native selection is synchronous and has no spinnerWaiter-visible progress
+    })
+    .toBe(current);
+  await page.keyboard.type(replacement);
 }
 
 /**

--- a/specs/seeded-apps.spec.ts
+++ b/specs/seeded-apps.spec.ts
@@ -277,14 +277,45 @@ test("review a workspace document in the seeded Docs app", async ({ baseURL, pag
       await replaceCellWord(peer, "Pending", "Scheduled");
     })(),
   ]);
-  await peer.getByText("Approved", { exact: true }).waitFor({ timeout: 10_000 }); // timeout: remote CodeMirror update is optimistic UI with no spinnerWaiter-visible progress
-  await page.getByText("Scheduled", { exact: true }).waitFor({ timeout: 10_000 }); // timeout: remote CodeMirror update is optimistic UI with no spinnerWaiter-visible progress
+  // Peer carets are children of the native table cell, so exact text locators
+  // include their a11y label. Scope to the rendered cells instead.
+  await peer
+    .locator(".cm-markdown-table-cell")
+    .filter({ hasText: "Approved" })
+    .waitFor({ timeout: 10_000 }); // timeout: remote CodeMirror update is optimistic UI with no spinnerWaiter-visible progress
+  await page
+    .locator(".cm-markdown-table-cell")
+    .filter({ hasText: "Scheduled" })
+    .waitFor({ timeout: 10_000 }); // timeout: remote CodeMirror update is optimistic UI with no spinnerWaiter-visible progress
+  await expect
+    .poll(() => workspace.readFile(documentPath), {
+      timeout: 30_000, // timeout: source durability follows the live push, not spinnerWaiter-visible UI
+    })
+    .toContain("| Launch copy | Approved |");
+  await expect
+    .poll(() => workspace.readFile(documentPath), {
+      timeout: 30_000, // timeout: source durability follows the live push, not spinnerWaiter-visible UI
+    })
+    .toContain("| Rollout | Scheduled |");
   await Promise.all([
     appendAtEnd(page, "\n\nPRIMARY_CONCURRENT_BODY"),
     appendAtEnd(peer, "\n\nPEER_CONCURRENT_BODY"),
   ]);
-  await page.getByText("PEER_CONCURRENT_BODY", { exact: true }).waitFor({ timeout: 10_000 }); // timeout: remote CodeMirror update has no spinnerWaiter-visible progress
-  await peer.getByText("PRIMARY_CONCURRENT_BODY", { exact: true }).waitFor({ timeout: 10_000 }); // timeout: remote CodeMirror update has no spinnerWaiter-visible progress
+  // A peer-caret label is rendered beside remote text, so use the content
+  // projection for the visual assertion and verify both exact markers in the
+  // plain-text file below.
+  await editor.getByText("PEER_CONCURRENT_BODY").waitFor({ timeout: 10_000 }); // timeout: remote CodeMirror update has no spinnerWaiter-visible progress
+  await peerEditor.getByText("PRIMARY_CONCURRENT_BODY").waitFor({ timeout: 10_000 }); // timeout: remote CodeMirror update has no spinnerWaiter-visible progress
+  await expect
+    .poll(() => workspace.readFile(documentPath), {
+      timeout: 30_000, // timeout: source durability follows the live push, not spinnerWaiter-visible UI
+    })
+    .toContain("PRIMARY_CONCURRENT_BODY");
+  await expect
+    .poll(() => workspace.readFile(documentPath), {
+      timeout: 30_000, // timeout: source durability follows the live push, not spinnerWaiter-visible UI
+    })
+    .toContain("PEER_CONCURRENT_BODY");
 
   // The primary user keeps a native selection while the peer inserts text.
   // Comment submission reads the mapped bookmark from the editor's live doc,
@@ -293,18 +324,28 @@ test("review a workspace document in the seeded Docs app", async ({ baseURL, pag
     .locator(".cm-content")
     .getByText("Make review decisions directly in the workspace file.", { exact: true });
   await reviewSentence.click({ clickCount: 3 });
-  await appendAtEnd(peer, "\n\nPeer inserted while the passage was selected.");
+  await peerEditor.click();
+  await peer.keyboard.press("ControlOrMeta+a");
+  await peer.keyboard.press("ArrowLeft");
+  await peer.keyboard.insertText("Peer inserted before the selected passage.\n\n");
+  await editor.getByText("Peer inserted before the selected passage.").waitFor({ timeout: 10_000 }); // timeout: remote CodeMirror update has no spinnerWaiter-visible progress
   await page.getByRole("button", { name: "Comment on selected text" }).click();
   await page
     .getByPlaceholder("Comment on selected text…")
     .fill("Can we make this promise more concrete?");
   await page.getByRole("button", { name: "Add comment" }).click();
+  // The comment footer changes the canonical source length. Wait until the
+  // peer has the same RFM before it contributes its later independent edit.
+  await peer
+    .getByRole("complementary")
+    .getByText("Can we make this promise more concrete?", { exact: true })
+    .waitFor({ timeout: 10_000 }); // timeout: peer RFM parse follows a remote collab push, not spinnerWaiter-visible UI
 
   // Undo only removes the local operation. A remote insertion that arrived
   // between local typing and undo remains in both buffers and durable source.
   await appendAtEnd(page, "\n\nLOCAL_UNDONE");
   await appendAtEnd(peer, "\n\nREMOTE_KEPT");
-  await page.getByText("REMOTE_KEPT", { exact: true }).waitFor({ timeout: 10_000 }); // timeout: remote CodeMirror update has no spinnerWaiter-visible progress
+  await editor.getByText("REMOTE_KEPT").waitFor({ timeout: 10_000 }); // timeout: remote CodeMirror update has no spinnerWaiter-visible progress
   await editor.click();
   await page.keyboard.press("ControlOrMeta+z");
   await expect
@@ -318,7 +359,7 @@ test("review a workspace document in the seeded Docs app", async ({ baseURL, pag
 
   // Rich end-of-document insertion belongs before the hidden endmatter.
   await appendAtEnd(page, "\n\nReviewed in Docs.");
-  await page.getByText("Reviewed in Docs.", { exact: true }).waitFor({ timeout: 10_000 }); // timeout: tight manual budget — rich syntax projection has no spinnerWaiter-visible UI
+  await editor.getByText("Reviewed in Docs.").waitFor({ timeout: 10_000 }); // timeout: tight manual budget — rich syntax projection has no spinnerWaiter-visible UI
 
   // Track changes stays on the rich editor instead of forcing a source view.
   await page.getByRole("button", { name: "Track changes" }).click();
@@ -342,10 +383,19 @@ test("review a workspace document in the seeded Docs app", async ({ baseURL, pag
   // A live session that dies under the editor (a laptop waking, a colo
   // hiccup) comes back by itself, and edits made after it landed sync
   // through the replacement session.
-  await page.evaluate(() => {
-    for (const socket of (window as unknown as { __sockets: WebSocket[] }).__sockets) {
+  const socketClose = await page.evaluate(() => {
+    const sockets = (window as unknown as { __sockets: WebSocket[] }).__sockets;
+    const openSockets = sockets.filter((socket) => socket.readyState === WebSocket.OPEN).length;
+    const closedAt = new Date().toISOString();
+    for (const socket of sockets) {
       socket.close();
     }
+    return { closedAt, openSockets, sockets: sockets.length };
+  });
+  expect(socketClose.openSockets).toBeGreaterThan(0);
+  await testInfo.attach("intentional-websocket-close", {
+    body: JSON.stringify({ documentPath, projectSlug: slug, ...socketClose }, null, 2),
+    contentType: "application/json",
   });
   await appendAtEnd(page, "\n\nStill here after the socket dropped.");
   await page.getByText(/^live · v\d+$/).waitFor({ timeout: 30_000 }); // timeout: the pull loop's backoff before its re-dial — the a11y-only badge gives the spinner-waiter nothing to watch
@@ -354,6 +404,9 @@ test("review a workspace document in the seeded Docs app", async ({ baseURL, pag
       timeout: 30_000, // timeout: a workspace read over RPC — no loading UI for the spinner-waiter
     })
     .toContain("Still here after the socket dropped.");
+  expect(readReview((await workspace.readFile(documentPath))!).projection.markdown).toMatch(
+    /REMOTE_KEPT\n{2,}Reviewed in Docs\.\n{2,}Still here after the socket dropped\./,
+  );
 
   await page.getByRole("button", { name: "Rich editing", exact: true }).click();
 
@@ -386,7 +439,15 @@ test("review a workspace document in the seeded Docs app", async ({ baseURL, pag
   expect(review.threads.find((thread) => thread.anchor)?.comments[0]?.body).toBe(
     "Can we make this promise more concrete?",
   );
-  expect(saved).toContain("{==Make review decisions directly in the workspace file.==}");
+  // Browser paragraph selection includes its final line break; the RFM anchor
+  // preserves that live selection after the peer prepended source text.
+  expect(saved).toContain("{==Make review decisions directly in the workspace file.\n==}");
+  // Endmatter is hidden in rich mode. The real native EOF edits must retain
+  // their paragraph breaks and order immediately before it, not concatenate
+  // into the last visible line or spill into the YAML footer.
+  expect(saved).toMatch(
+    /\n{2,}REMOTE_KEPT\n{2,}Reviewed in Docs\.\n{2,}Still here after the socket dropped\.\n+---\ncomments:\n/,
+  );
   expect(saved).toContain("\ncomments:");
 
   await page.reload();
@@ -417,7 +478,10 @@ async function appendAtEnd(page: import("@playwright/test").Page, text: string):
   // Cmd/Ctrl+End is not a consistent CodeMirror binding across both.
   await page.keyboard.press("ControlOrMeta+a");
   await page.keyboard.press("ArrowRight");
-  await page.keyboard.type(text);
+  // One native input event keeps a concurrent end-of-file insertion atomic.
+  // Character-by-character concurrent typing is already exercised in the two
+  // distinct table cells above, without making this marker proof interleave.
+  await page.keyboard.insertText(text);
 }
 
 async function replaceCellWord(

--- a/tasks/roughdraft-concurrent-endmatter.md
+++ b/tasks/roughdraft-concurrent-endmatter.md
@@ -12,6 +12,12 @@ endmatter can each add a valid first comment. Rebasing preserves both insertions
 but creates two YAML footers; Roughdraft then reports a missing metadata entry.
 This limitation is explicitly accepted for the initial implementation.
 
+A related stale-client case is pinned as `STALE ENDMATTER APPEND`: one client
+creates its first comment and footer while another appends at the old EOF. Text
+OT preserves that stale append after the new footer, where it corrupts YAML.
+It cannot be fixed by relocating remote changes in one client, which would
+diverge from the shared document.
+
 The executable reproduction is
 `apps/os/src/domains/workspaces/collab-review.test.ts`, named
 “simultaneous first comments should share one valid endmatter”. It uses the real


### PR DESCRIPTION
Docs now opens Markdown in an editable live preview with comments, native table cells, and attribution redlines. Rich/source switching keeps the same CodeMirror collaboration session, selection, and undo history. Human typing, comment actions, and agent file edits all change the original Markdown file, including its RFM endmatter.

The reusable editor exposes presentation and review callbacks; the existing shared React composer can retain drafts across remounts:

```tsx
<WorkspaceDocumentEditor
  {...collaborationProps}
  presentation="rich"
  review={{ selectedThreadId, onSelectThread, onComment }}
/>
```

Atomic provides inline presentation. Small source-coordinate extensions preserve RFM-wrapped Markdown syntax, map comment selections through peer edits, and render tables without a second editor or serializer. External file writes now use disjoint text edits: adding an AI comment around a long document no longer moves an unconfirmed human body edit to EOF.

## Validation

Full repository typecheck, lint, knip, formatting, and tests pass. OS passed 3,124 tests; workspace-documents passed 70, including 750 competing edits across three official CodeMirror collaboration clients. Claude Fable 5.1 reviewed the design and code through the CLI; confirmed findings were fixed. Docs production build passes.

**CI is green on `52823a370`, including all six preview app lanes. All hosted review threads are addressed.** The final recorded two-client walkthrough passed against the restored preview, covering concurrent native table/body edits, mapped comment selections, local undo preserving peer text, rich/source switching, attribution redlines, explicit reconnect, durable valid RFM, and desktop/mobile comments.

https://github.com/user-attachments/assets/224f71f1-185c-456c-8461-43821b6a35a1

Recording: 2026-09-09 05:02:17–05:04:18 UTC, OS preview worker `f1480e4f-3be5-4809-ae62-6c36b1d313b0`. The test records closing one open WebSocket at `05:03:42.700Z`, then proves the subsequent edit is durable. Saved-source assertions require the tail paragraphs in order with their line breaks intact.

Telemetry audit (05:01:30–05:05:00 UTC): no owned application error or Pager/pinning-fallback event. Two native Cloudflare `Network connection lost` records occurred 2.064s and 4.540s after the recorded close; subsequent upgrades succeeded and the test proved durable recovery. This is evidence-backed attribution to the controlled WebSocket lifecycle, rather than socket-ID correlation: [first trace](https://dash.cloudflare.com/376ef7ed81b0573f93524de763666c15/observability/traces/f84c11222c8b6ff771b46f9212603bf3), [second trace](https://dash.cloudflare.com/376ef7ed81b0573f93524de763666c15/observability/traces/b13c000dde0a6b0d2c43618ad3a50df6).

Warning-level audit found one bounded clone-version retry (attempt 2 of at most 4), plus a [Cloudflare background-task cancellation](https://dash.cloudflare.com/376ef7ed81b0573f93524de763666c15/observability/traces/cf60814aca85686779bf246a30b45641) involving `StreamDurableObject.provideCapability`. The fixture’s client catalog subsequently showed `connected: false`, and document recovery passed. Baseline investigation found the same canceled capability-provision path in [pre-merge production](https://dash.cloudflare.com/04b3b57291ef2626c6a8daa9d47065a7/observability/traces/c4b5d244105d22557293cc59d207bb5b): `os-prd` version `cfe45d56-af66-4c9b-aebb-4b2d9ae1b36b`, 2026-09-08 22:13:42 UTC, with a later `capability provision dispose failed` error. This is a pre-existing platform lifecycle defect. Jonas explicitly authorized merging this green Docs change and investigating/fixing that defect in a separate PR; exact cancellation causality remains under investigation.

Preview testing also fixed an empty-agent Pager initialization defect and removed its legacy Durable Object pinning fallback. Failures are reported as an error state with at most two retries on the existing ten-second timer. CI's empty-catalog test passed after one retry on a snapshot equality assertion; mobile title propagation and the Docs walkthrough passed first try. The retry remains visible in CI, and no Pager 404 remained in that run.

**Known expected failures remain explicit:** this PR adds a narrowly matched reproduction for a stale client appending at the old EOF while another creates the first comment footer. Ordinary text rebasing puts that append after the footer and breaks YAML. Existing cases cover concurrent first-footer creation, overlapping anchors, and metadata/endmatter limitations; see [the tracked task](https://github.com/iterate/iterate/blob/jonas/docs-atomic-live-editing/tasks/roughdraft-concurrent-endmatter.md). The latest full OS run includes 18 expected failures and one existing skipped test; there is no broad quarantine.

## Risk map

- Review `rfm-controls.ts`, `rfm-projected-markdown.ts`, and `rfm-review-extension.ts` first: hidden source controls, projected syntax coordinates, mapped selections, and native deletion/composition are the most sensitive behavior. Malformed RFM remains visible for source repair. Real mobile IME candidate windows and kinetic scrolling are not proven by desktop CDP composition tests.
- Then review native tables, editor/composer integration, and server disjoint edits. Rich editing is the new Docs default; there is no storage migration, comment RPC, or additional synchronization protocol. Arbitrary stale full-file writes can still overwrite already-confirmed changes; crossing inline RFM anchors are not representable.
- Finally review dependency patches and tests. Atomic 0.6.2 limits decoration work to the viewport and respects read-only checkboxes. CodeMirror merge checks its existing timeout inside substring-search loops. No size threshold forces source mode or whole-file replacement.
- Local Chromium synchronous edit p95: 4.9 ms at 10 KiB, 11 ms at 100 KiB, 91 ms at 1 MiB. The 1 MiB parse cost is a known limitation, not a network/paint latency measurement. See the [validation report](https://github.com/iterate/iterate/blob/jonas/docs-atomic-live-editing/docs/research/atomic-live-editing-validation.md).

## Complexity

Production TypeScript: +1,364 / −113 (**net +1,251 LOC**). Tests/specs: +1,378 / −45. Dependency patches: 247 diff lines; dependency/configuration: +132 / −12; documentation: +155 / −5. Live editing adds code; the collaboration protocol remains unchanged. No separate document model, comment store, comment RPC, or semantic merge layer was added.

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +1,340 -88 | +1,144 -73 🟩🟩🟩🟩🟩 |
| UI components | +33 -26 | +31 -26 🟩⬜⬜⬜⬜ |
| Tests | +1,378 -45 | +1,209 -37 🟩🟩🟩🟩🟩 |
| Config | +10 -3 | +10 -3 🟩⬜⬜⬜⬜ |
| Docs | +155 -5 | +131 -5 🟩⬜⬜⬜⬜ |
| Other | +247 -0 | +247 -0 🟩⬜⬜⬜⬜ |
| Generated | +113 -8 | +109 -8 🟩⬜⬜⬜⬜ |
| **Total** | **+3,276 -175** | **+2,881 -152** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between d4240ea and 52823a3, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-09-09T07:38:57.445Z",
      "deployedAt": "2026-09-09T05:01:27.395Z",
      "headSha": "52823a3700d3c8438895c10d634cb710aa559d2e",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-14.com",
      "runUrl": "https://github.com/iterate/iterate/pull/2608",
      "shortSha": "52823a3",
      "cleanupDurationMs": 102816,
      "deployDurationMs": 72827,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 72760,
      "deployReadinessDurationMs": 60,
      "deployedWorkerName": "os-preview-14",
      "deployedWorkerVersion": "f1480e4f-3be5-4809-ae62-6c36b1d313b0",
      "workerSizeKib": 21058.84,
      "workerGzipKib": 5308.39,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5304.74
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-09-09T07:37:18.496Z",
      "deployedAt": "2026-09-09T05:00:35.054Z",
      "headSha": "52823a3700d3c8438895c10d634cb710aa559d2e",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-14.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/pull/2608",
      "shortSha": "52823a3",
      "cleanupDurationMs": 3863,
      "deployDurationMs": 20649,
      "deployConfigDurationMs": 7,
      "deployCommandDurationMs": 20417,
      "deployReadinessDurationMs": 225,
      "deployedWorkerName": "docs-preview-14",
      "deployedWorkerVersion": "352e6e0d-efab-49fd-9676-b91b013b2a14",
      "workerSizeKib": 4735.71,
      "workerGzipKib": 1109.97,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-09-09T07:37:15.468Z",
      "deployedAt": "2026-09-09T05:00:35.080Z",
      "headSha": "52823a3700d3c8438895c10d634cb710aa559d2e",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-14.com",
      "runUrl": "https://github.com/iterate/iterate/pull/2608",
      "shortSha": "52823a3",
      "cleanupDurationMs": 835,
      "deployDurationMs": 20608,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 20442,
      "deployReadinessDurationMs": 160,
      "deployedWorkerName": "semaphore-preview-14",
      "deployedWorkerVersion": "349d70fd-83f6-4ae3-ae84-4b2ad2b1ae01",
      "workerSizeKib": 1960.63,
      "workerGzipKib": 451.75,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-09-09T07:37:19.329Z",
      "deployedAt": "2026-09-09T05:00:40.355Z",
      "headSha": "52823a3700d3c8438895c10d634cb710aa559d2e",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-14.com",
      "runUrl": "https://github.com/iterate/iterate/pull/2608",
      "shortSha": "52823a3",
      "cleanupDurationMs": 4694,
      "deployDurationMs": 25963,
      "deployConfigDurationMs": 7,
      "deployCommandDurationMs": 25715,
      "deployReadinessDurationMs": 240,
      "deployedWorkerName": "auth-preview-14",
      "deployedWorkerVersion": "59787442-d474-4ed1-84ff-fa76dfa12a5d",
      "workerSizeKib": 4179.19,
      "workerGzipKib": 853.05,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-09-09T07:37:23.182Z",
      "deployedAt": "2026-09-09T05:00:38.731Z",
      "headSha": "52823a3700d3c8438895c10d634cb710aa559d2e",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-14.com",
      "runUrl": "https://github.com/iterate/iterate/pull/2608",
      "shortSha": "52823a3",
      "cleanupDurationMs": 8545,
      "deployDurationMs": 24155,
      "deployConfigDurationMs": 7,
      "deployCommandDurationMs": 24090,
      "deployReadinessDurationMs": 57,
      "deployedWorkerName": "streams-example-app-preview-14",
      "deployedWorkerVersion": "3694eaad-84c6-47c9-a015-5393c06d3780",
      "workerSizeKib": 5671.47,
      "workerGzipKib": 1602.7,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-09-09T07:37:16.681Z",
      "deployedAt": "2026-09-09T04:38:06.528Z",
      "headSha": "52823a3700d3c8438895c10d634cb710aa559d2e",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-14.com",
      "runUrl": "https://github.com/iterate/iterate/pull/2608",
      "shortSha": "52823a3",
      "cleanupDurationMs": 1213,
      "deployDurationMs": 206,
      "deployConfigDurationMs": 0,
      "deployReuseProofDurationMs": 186,
      "deployedWorkerName": "dummy-petshop-preview-14",
      "deployedWorkerVersion": "4a55e905-d17a-405e-be76-62b69a18c309",
      "workerSizeKib": 1331.5,
      "workerGzipKib": 232.81,
      "deployedFingerprint": "c321865fd82cf1ce04086fcbe3c487f157babc45+c5abf1055de73f3b4ffbc5e5b742dff1f0b5ee52",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `52823a3` | [https://auth.iterate-preview-14.com](https://auth.iterate-preview-14.com) | 853.0 KiB | 26.0s |  |  | 4.7s | [Workflow run](https://github.com/iterate/iterate/pull/2608) | 2026-09-09T07:37:19.329Z | Preview app released. |
| Docs | released | `52823a3` | [https://docs-preview-14.iterate-dev-preview.workers.dev](https://docs-preview-14.iterate-dev-preview.workers.dev) | 1.08 MiB | 20.6s |  |  | 3.9s | [Workflow run](https://github.com/iterate/iterate/pull/2608) | 2026-09-09T07:37:18.496Z | Preview app released. |
| Dummy Petshop | released | `52823a3` | [https://dummy-petshop.iterate-preview-14.com](https://dummy-petshop.iterate-preview-14.com) | 232.8 KiB | 206ms |  |  | 1.2s | [Workflow run](https://github.com/iterate/iterate/pull/2608) | 2026-09-09T07:37:16.681Z | Preview app released. |
| OS | released | `52823a3` | [https://os.iterate-preview-14.com](https://os.iterate-preview-14.com) | 5.18 MiB (+3.7 KiB vs main) | 72.8s |  |  | 102.8s | [Workflow run](https://github.com/iterate/iterate/pull/2608) | 2026-09-09T07:38:57.445Z | Preview app released. |
| Semaphore | released | `52823a3` | [https://semaphore.iterate-preview-14.com](https://semaphore.iterate-preview-14.com) | 451.8 KiB | 20.6s |  |  | 835ms | [Workflow run](https://github.com/iterate/iterate/pull/2608) | 2026-09-09T07:37:15.468Z | Preview app released. |
| Streams Example App | released | `52823a3` | [https://streams.iterate-preview-14.com](https://streams.iterate-preview-14.com) | 1.57 MiB | 24.2s |  |  | 8.5s | [Workflow run](https://github.com/iterate/iterate/pull/2608) | 2026-09-09T07:37:23.182Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->

The automated Cursor summary below cites an older preview Pager 404; the current-head initialization fix passed preview CI, and that finding was answered and resolved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large new editing/collab surface (RFM projection, rebasing, live-state subscription path) plus removal of the DO-pinning fallback; one preview e2e still fails on Pager 404 before subscribe.
> 
> **Overview**
> Docs Markdown moves from a read-only preview to **rich editing** in the same collaborative CodeMirror session: **rich/source** toggles reconfigure presentation without remounting collab, selection, or undo. RFM comments attach via new `presentation` / `review` props on `WorkspaceDocumentEditor`; track changes no longer forces source mode.
> 
> **workspace-documents** adds Atomic-based live Markdown with projected syntax over hidden RFM markup, native GFM table decorations, mapped comment selections/composer portals, and input filters for endmatter caret behavior. Server **`minimalSplice`** and client transforms use shared **`textEdits`** (patched `@codemirror/merge` timeout) so agent whole-file writes preserve concurrent human edits.
> 
> **Live state:** Pager subscription failures no longer fall back to pinning the DO; `useLiveState` retries rejected subscribes up to twice on a 10s timer, and agent collection **`subscribe`** runs **`get()`** first so the Stream catalog is born before the Pager upgrade.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52823a3700d3c8438895c10d634cb710aa559d2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->