### PR TITLE
Worker runner: replay an empty-body POST on clone-version skew, not only a null body

### DIFF
--- a/apps/os/src/domains/workers/worker-runner.test.ts
+++ b/apps/os/src/domains/workers/worker-runner.test.ts
@@ -674,9 +674,13 @@ it("recovers an empty-body POST (Content-Length: 0) after clone-version skew", a
   // body. That must still replay, or the POST 500s where the same GET recovers.
   const workerFetch = vi
     .fn()
-    .mockRejectedValueOnce(
-      new Error("Unable to deserialize cloned data due to invalid or unsupported version."),
-    )
+    // The first dispatch hands the empty stream to the isolate (consuming it)
+    // before the skew — a clone() of the used body would then throw, so the
+    // retry must rebuild the request instead.
+    .mockImplementationOnce(async (received: Request) => {
+      await received.text();
+      throw new Error("Unable to deserialize cloned data due to invalid or unsupported version.");
+    })
     .mockResolvedValueOnce(new Response("recovered"));
   h.resolveWorkerSource.mockResolvedValue({
     ok: true,

--- a/apps/os/src/domains/workers/worker-runner.test.ts
+++ b/apps/os/src/domains/workers/worker-runner.test.ts
@@ -668,6 +668,53 @@ it("gives up a bodyless POST after the attempt bound so the caller can reconnect
   expect(workerFetch).toHaveBeenCalledTimes(4);
 });
 
+it("recovers an empty-body POST (Content-Length: 0) after clone-version skew", async () => {
+  // A browser's bodyless fetch(url, { method: "POST" }) — the auth refresh —
+  // arrives with Content-Length: 0 and a non-null empty stream, not a null
+  // body. That must still replay, or the POST 500s where the same GET recovers.
+  const workerFetch = vi
+    .fn()
+    .mockRejectedValueOnce(
+      new Error("Unable to deserialize cloned data due to invalid or unsupported version."),
+    )
+    .mockResolvedValueOnce(new Response("recovered"));
+  h.resolveWorkerSource.mockResolvedValue({
+    ok: true,
+    source: {
+      assetConfig: undefined,
+      assetManifest: {},
+      assets: {},
+      cacheKey: "build-key",
+      commitOid: "commit-1",
+      mainModule: "worker.js",
+      modules: {},
+      wranglerConfig: undefined,
+    },
+  });
+  h.loadResolvedWorker.mockImplementation(() => ({
+    getEntrypoint: () => ({ fetch: workerFetch }),
+  }));
+  const runner = new DynamicWorkerRunner({
+    streamContext: { kind: "scope", scopePath: inlineRef.path },
+    exports: {} as ExecutionContext["exports"],
+    projectId: "prj_private",
+    scopePath: inlineRef.path,
+  });
+
+  const request = new Request("https://example.com/", {
+    method: "POST",
+    body: "",
+    headers: { "content-length": "0" },
+  });
+  // Guard the premise: an empty body is NOT null, so the body===null check
+  // alone would have skipped the retry.
+  expect(request.body).not.toBeNull();
+  const response = await runner.fetch({ ref: inlineRef, request });
+
+  expect(await response.text()).toBe("recovered");
+  expect(workerFetch).toHaveBeenCalledTimes(2);
+});
+
 it("recovers a WebSocket upgrade after clone-version skew (a reconnecting collab session)", async () => {
   // A WebSocket upgrade is a bodyless GET whose socket does not exist yet when
   // the dispatch throws, so a clone skew during a deploy is safe to replay —

--- a/apps/os/src/domains/workers/worker-runner.ts
+++ b/apps/os/src/domains/workers/worker-runner.ts
@@ -291,10 +291,15 @@ export class DynamicWorkerRunner {
           : undefined;
       // A clone-version skew is a loader-isolate deserialize failure BEFORE the
       // app runs (the shared isolate outlived its captured bindings), so any
-      // request with no body is safe to replay on a fresh isolate — a bodyless
-      // POST like the auth gate's refresh, and a WebSocket upgrade too, whose
-      // socket does not exist yet when the dispatch throws.
-      const cloneSkewReplayable = request.body === null;
+      // request with nothing to consume is safe to replay on a fresh isolate —
+      // and a WebSocket upgrade too, whose socket does not exist yet when the
+      // dispatch throws. "Nothing to consume" is a null body OR an explicitly
+      // empty one: a browser's bodyless `fetch(url, { method: "POST" })` — the
+      // auth gate's refresh — arrives with `Content-Length: 0` and a non-null
+      // empty stream, and it must replay too or that POST 500s where the same
+      // GET recovers.
+      const cloneSkewReplayable =
+        request.body === null || request.headers.get("content-length") === "0";
       let response: Response;
       try {
         response = await dispatch(request);

--- a/apps/os/src/domains/workers/worker-runner.ts
+++ b/apps/os/src/domains/workers/worker-runner.ts
@@ -371,10 +371,18 @@ export class DynamicWorkerRunner {
         traceRole,
       });
       try {
-        // Cloudflare's clone() widens the Request metadata generics even though
-        // the runtime value stays the same Fetch API request; the request is
-        // bodyless here, so the clone is a cheap header/URL copy.
-        return await dispatch(request.clone() as typeof request, crypto.randomUUID());
+        // Rebuild the request rather than clone() it: the caller only reaches
+        // here for a null- or empty-body request, and the first dispatch may
+        // already have handed that empty stream to the isolate — clone() on a
+        // used body throws, which would defeat the retry. A fresh request from
+        // the method, URL, and headers carries everything the gate needs (the
+        // body was empty) and never touches a stream.
+        const retryRequest = new Request(request.url, {
+          headers: request.headers,
+          method: request.method,
+          redirect: request.redirect,
+        }) as typeof request;
+        return await dispatch(retryRequest, crypto.randomUUID());
       } catch (error) {
         lastError = error;
         if (!isWorkerRpcCloneVersionError(error)) throw error;


### PR DESCRIPTION
Checking #2605/#2606 in production found my own fix was only half-working, and this closes the gap. "Never accept deviant behaviour" — so I root-caused the residual instead of writing it off as churn.

## The symptom

Hours after the last deploy, with no churn, a fresh-connection POST to the docs host still 500'd ~25-45%, while GET stayed at 0. A controlled `os-prd` tail told the real story:

| hammer | clone-skew retry logs | final 500s |
|---|---|---|
| GET × 40 | 12 | **0** |
| POST × 40 | 4 | **5** |

GET skewed 12 times and the retry recovered every one. POST had **fewer retry logs than final failures** — some POSTs were 500-ing *without the retry firing at all*.

## The cause

#2606 gated the clone-skew replay on `request.body === null`. But a browser's bodyless `fetch(url, { method: "POST" })` — which is exactly the auth gate's refresh — does not arrive with a null body. It arrives with `Content-Length: 0` and a non-null empty stream. So those POSTs failed the `body === null` check, skipped the retry, and 500'd where the identical GET recovered. A unit test guards the premise: an empty-string body is `!== null`.

## The fix

The replay gate now also treats an explicitly empty body (`Content-Length: 0`) as replayable. An empty body has nothing to consume, so replaying it is as safe as a null one, and a clone-version skew is still a pre-app loader failure (the app never ran, no side effect). Body-bearing requests are unchanged — never replayed — and the Durable-Object-reset branch is untouched.

## Tests

`apps/os/src/domains/workers/worker-runner.test.ts`: an empty-body POST (`Content-Length: 0`, non-null stream) that clone-skews is now retried and recovers; the existing null-body, WebSocket-upgrade, bounded-loop, and body-bearing-never-replayed cases still hold.

## Proof plan

After deploy I will re-run the `os-prd` GET-vs-POST comparison and the tail A/B, expecting the bodyless-POST final-500 rate to fall to GET's ~0 and the retry to fire on every POST skew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request replay logic on the dynamic worker fetch path (auth refresh POSTs); scope is narrow (empty-body only) but affects production ingress reliability after deploys.
> 
> **Overview**
> Fixes clone-version skew recovery for **bodyless POSTs** that browsers send with `Content-Length: 0` and a non-null empty body stream (e.g. auth refresh), which previously skipped replay because only `request.body === null` counted as safe.
> 
> **`DynamicWorkerRunner`** now treats null body **or** `Content-Length: 0` as replayable on stateless clone-skew retries; body-bearing POSTs are unchanged. Retries **rebuild** the `Request` from URL/method/headers instead of `clone()`, so a first dispatch that already read the empty stream does not break the retry.
> 
> Adds a unit test where the first dispatch consumes the empty body before skewing and the second attempt succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71fa283ee4c001be83d70f7518c8bc6ffefa7678. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +21 -8 | +8 -2 🟩⬜⬜⬜⬜ |
| Tests | +51 -0 | +40 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+72 -8** | **+48 -2** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between f527665 and 71fa283, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-09-09T04:24:24.632Z",
      "deployedAt": "2026-09-09T04:16:08.156Z",
      "headSha": "71fa283ee4c001be83d70f7518c8bc6ffefa7678",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/557777458340459",
      "shortSha": "71fa283",
      "cleanupDurationMs": 97691,
      "deployDurationMs": 46945,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 45850,
      "deployReadinessDurationMs": 1092,
      "deployedWorkerName": "os-preview-11",
      "deployedWorkerVersion": "53db21c0-4a6a-4af8-b867-aaece76fd931",
      "testDurationMs": 220093,
      "testRetries": null,
      "workerSizeKib": 20995.28,
      "workerGzipKib": 5293.08,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5304.72
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-09-09T04:22:50.784Z",
      "deployedAt": "2026-09-09T04:15:47.520Z",
      "headSha": "71fa283ee4c001be83d70f7518c8bc6ffefa7678",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-11.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/557777458340459",
      "shortSha": "71fa283",
      "cleanupDurationMs": 3839,
      "deployDurationMs": 25464,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 25212,
      "deployReadinessDurationMs": 247,
      "deployedWorkerName": "docs-preview-11",
      "deployedWorkerVersion": "1a37b54f-1dbc-4042-af95-e2317f7d4837",
      "testDurationMs": 2921,
      "testRetries": null,
      "workerSizeKib": 4662.08,
      "workerGzipKib": 1092.95,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-09-09T04:22:51.712Z",
      "deployedAt": "2026-09-09T04:15:54.531Z",
      "headSha": "71fa283ee4c001be83d70f7518c8bc6ffefa7678",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/557777458340459",
      "shortSha": "71fa283",
      "cleanupDurationMs": 4767,
      "deployDurationMs": 32500,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 32222,
      "deployReadinessDurationMs": 274,
      "deployedWorkerName": "auth-preview-11",
      "deployedWorkerVersion": "96de1bcb-ebc4-4887-bc05-932dc0a076db",
      "testDurationMs": 21827,
      "testRetries": null,
      "workerSizeKib": 4179,
      "workerGzipKib": 855.55,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-09-09T04:22:51.970Z",
      "deployedAt": "2026-09-09T04:15:42.758Z",
      "headSha": "71fa283ee4c001be83d70f7518c8bc6ffefa7678",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/557777458340459",
      "shortSha": "71fa283",
      "cleanupDurationMs": 5021,
      "deployDurationMs": 32963,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 20448,
      "deployReadinessDurationMs": 12510,
      "deployedWorkerName": "streams-example-app-preview-11",
      "deployedWorkerVersion": "b04f1e51-f3f5-4a07-8e4d-58ce023c8570",
      "testDurationMs": 91806,
      "testRetries": null,
      "workerSizeKib": 5671.72,
      "workerGzipKib": 1604.3,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-09-09T04:22:48.032Z",
      "deployedAt": "2026-09-09T04:03:20.317Z",
      "headSha": "71fa283ee4c001be83d70f7518c8bc6ffefa7678",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-11.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/557777458340459",
      "shortSha": "71fa283",
      "cleanupDurationMs": 1081,
      "deployDurationMs": 69,
      "deployConfigDurationMs": 5,
      "deployReuseProofDurationMs": 36,
      "deployedWorkerName": "dummy-petshop-preview-11",
      "deployedWorkerVersion": "6e50d81e-eaf9-44cb-a326-863bcefadf58",
      "testDurationMs": 6789,
      "testRetries": null,
      "workerSizeKib": 1331.5,
      "workerGzipKib": 232.81,
      "deployedFingerprint": "c321865fd82cf1ce04086fcbe3c487f157babc45+c5abf1055de73f3b4ffbc5e5b742dff1f0b5ee52",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `71fa283` | [https://auth.iterate-preview-11.com](https://auth.iterate-preview-11.com) | 855.5 KiB | 32.5s | 21.8s |  | 4.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/557777458340459) | 2026-09-09T04:22:51.712Z | Preview app released. |
| Docs | released | `71fa283` | [https://docs-preview-11.iterate-dev-preview.workers.dev](https://docs-preview-11.iterate-dev-preview.workers.dev) | 1.07 MiB | 25.5s | 2.9s |  | 3.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/557777458340459) | 2026-09-09T04:22:50.784Z | Preview app released. |
| Dummy Petshop | released | `71fa283` | [https://dummy-petshop.iterate-preview-11.com](https://dummy-petshop.iterate-preview-11.com) | 232.8 KiB | 69ms | 6.8s |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/557777458340459) | 2026-09-09T04:22:48.032Z | Preview app released. |
| OS | released | `71fa283` | [https://os.iterate-preview-11.com](https://os.iterate-preview-11.com) | 5.17 MiB (-11.6 KiB vs main) | 46.9s | 220.1s |  | 97.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/557777458340459) | 2026-09-09T04:24:24.632Z | Preview app released. |
| Streams Example App | released | `71fa283` | [https://streams.iterate-preview-11.com](https://streams.iterate-preview-11.com) | 1.57 MiB | 33.0s | 91.8s |  | 5.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/557777458340459) | 2026-09-09T04:22:51.970Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->