### PR TITLE
kit: one playout step for the board and the CLI, and no more jitter after a back-office turn

### DIFF
--- a/apps/kit/firmware/README.md
+++ b/apps/kit/firmware/README.md
@@ -56,6 +56,23 @@ ring ownership behind callbacks — a framework where the codebase wants two
 short rhyming implementations. If you change the grammar, change it in
 both files in the same commit.
 
+## The playout step is shared, and the transport is not, for the same reason
+
+`components/core/src/voice_playout.c` is the one speaker pass both the board
+(`components/voice/src/voice_loop.c`) and the Mac CLI
+(`targets/host_cli/main.c`) run — prime, take a frame, hole or end, skip or
+play, report — with only the ring and the sink injected as callbacks. That
+is the abstraction the transport refused, and it is right here because the
+ownership is different: playout is single-owner on both targets (one task on
+the board, the one loop on the host), so nothing inside the step is an
+atomic and no callback crosses a task. The two owners had drifted apart
+twice in one week before it was shared (2026-09-06 and 2026-09-09, both
+the answer timeline failing to restart, each on a path the other had
+fixed). What stays in each owner is exactly what is theirs: the queue's
+generations and reprime handshake, the codec's bounded wait, the room's
+lead — and the underrun promotion, which on the board is an app-task read
+of a playback-task stamp and so cannot live in a single-owner module.
+
 Run the fastest complete host check from `apps/kit`:
 
 ```bash

--- a/apps/kit/firmware/components/core/CMakeLists.txt
+++ b/apps/kit/firmware/components/core/CMakeLists.txt
@@ -14,6 +14,7 @@ set(ITERATE_KIT_CORE_SOURCES
   src/spsc_ring.c
   src/touch_tap.c
   src/voice_playback_clock.c
+  src/voice_playout.c
   src/voicelab_stream.c
   src/websocket_frame_reader.c
   src/websocket_frame_writer.c

--- a/apps/kit/firmware/components/core/include/iterate/kit/voice_playback_clock.h
+++ b/apps/kit/firmware/components/core/include/iterate/kit/voice_playback_clock.h
@@ -20,6 +20,21 @@ extern "C" {
  * frame to bound excessive backlog.  That question is about occupancy, which
  * is local to the consumer and knowable nowhere else.
  *
+ * IT ALSO OWNS THE ANSWER'S TIMELINE. Frame N of an answer belongs 20N ms
+ * after the first one played; the gap between that and the wall clock is how
+ * far behind realtime playback has fallen, and it is the only honest measure
+ * of "behind" — queue depth is not, because a whole answer legitimately
+ * arrives at once and a deep queue then means the sender was fast. Both the
+ * board and the host CLI used to keep that timeline themselves, beside this
+ * clock, and feed it in as a number. Each then had to remember, at every
+ * place an answer ends, to start the next one from zero — and each forgot a
+ * different place. The board forgot ordinary turns until 2026-09-06 (two
+ * boards played a fifth of every answer after the first for a week); the CLI
+ * forgot the live-audio dry path until 2026-09-09 (a back-office turn read as
+ * nine seconds late and four frames in five were discarded for the rest of
+ * it). The timeline is now reset HERE, in the same call that decides the ring
+ * is at the live edge, so there is no longer a caller who can forget.
+ *
  * There was a fifth answer, DROP_DEBT: one frame discarded per frame
  * concealed, so concealment could not permanently add its own duration to
  * playout lag.  Nothing ever incurred the debt — `drop_debt_frames` was only
@@ -36,6 +51,20 @@ struct iterate_kit_voice_playback_clock {
   bool answer_done;
   uint64_t last_write_ms;
   uint64_t starve_at_ms;
+  /**
+   * The current answer's playout timeline: when its first frame reached the
+   * speaker, and how many MILLISECONDS have been emitted since. Zero
+   * `answer_started_ms` means no answer is in flight, so nothing is late; the
+   * origin is then taken from the next frame that actually plays, which is
+   * correct however long the gap turns out to be.
+   *
+   * Needs no clock agreement with the server: both terms are local, and the
+   * answer's own first frame is the origin.
+   */
+  uint64_t answer_started_ms;
+  uint32_t answer_emitted_ms;
+  /** The worst lag any played frame was measured at; telemetry, never acted on. */
+  uint32_t lag_max_ms;
 };
 
 enum iterate_kit_voice_playback_action {
@@ -47,6 +76,12 @@ enum iterate_kit_voice_playback_action {
 
 void iterate_kit_voice_playback_clock_init(
     struct iterate_kit_voice_playback_clock *clock);
+
+/**
+ * The queue was thrown away — barge-in, a superseded answer, a new call or
+ * turn. Playback primes again, and the answer's timeline goes with its audio:
+ * a flush by definition leaves no answer in flight, so it leaves no timeline.
+ */
 void iterate_kit_voice_playback_clock_reprime(
     struct iterate_kit_voice_playback_clock *clock);
 void iterate_kit_voice_playback_clock_answer_done(
@@ -79,12 +114,24 @@ static inline uint32_t iterate_kit_voice_playout_lag_ms(
   return (uint32_t)(now_ms - due);
 }
 
+/** The clock's own answer, at `now_ms`, to the question above. */
+uint32_t iterate_kit_voice_playback_clock_lag_ms(
+    const struct iterate_kit_voice_playback_clock *clock, uint64_t now_ms);
+
 /** Whether the owner should remove a frame from the ring on this iteration. */
 bool iterate_kit_voice_playback_clock_ready(
     struct iterate_kit_voice_playback_clock *clock,
     uint32_t queued_bytes);
 
-/** Decide a dry sink tick after playback has left priming. */
+/**
+ * Decide a dry sink tick after playback has left priming.
+ *
+ * WAIT means the ring is empty because the answer is over — declared so, or
+ * silent past the conceal limit — and playback is AT THE LIVE EDGE. The
+ * answer's timeline is reset in the same breath: whatever lag it ended on is
+ * unrecoverable by definition, and carried forward it would only wait to be
+ * charged against the next answer.
+ */
 enum iterate_kit_voice_playback_action
 iterate_kit_voice_playback_clock_empty(
     struct iterate_kit_voice_playback_clock *clock, uint64_t now_ms);
@@ -92,18 +139,38 @@ iterate_kit_voice_playback_clock_empty(
 /**
  * Decide what to do with one whole frame removed from the ring.
  *
- * `lag_ms` is how far behind its own timeline this answer has fallen — frame
- * N belongs 20N ms after the first one played, and this is the gap between
- * that and now. It is the caller's to measure because only the caller knows
- * when a frame actually reached the speaker; it is the clock's to act on
- * because dropping a frame is a playout decision.
+ * `frame_ms` is how much audio the frame holds — the tail of an answer can be
+ * short. The clock measures the answer's lag against its own timeline; a
+ * frame it tells the owner to DISCARD has still spent its place in that
+ * timeline, and the clock advances it here. (Leave the counter alone and the
+ * computed lag never falls, so the loop keeps deciding it is late and skips
+ * again — it drains the whole backlog and the listener hears half the answer
+ * missing. Measured exactly that: 78 of 162 frames skipped.)
  */
 enum iterate_kit_voice_playback_action
 iterate_kit_voice_playback_clock_frame(
     struct iterate_kit_voice_playback_clock *clock,
     uint32_t queued_bytes,
-    uint32_t lag_ms,
+    uint32_t frame_ms,
     uint64_t now_ms);
+
+/**
+ * The owner played `played_ms` of a frame the clock said to PLAY.
+ *
+ * `played_at_ms` is when the frame was handed to the speaker, STAMPED BEFORE
+ * THE WRITE, NOT AFTER: codec admission may wait for bounded queue headroom,
+ * and stamping after that wait folds hardware pacing into the measurement, so
+ * a perfectly punctual loop reports itself progressively later and the
+ * catch-up rule then deletes speech to fix a delay that only existed in the
+ * metric. Measured that way: 1089 ms of "lag" while the ring held 1620 ms of
+ * audio, which is the signature of a consumer that is keeping up.
+ *
+ * The first frame played after a reset is the timeline's origin.
+ */
+void iterate_kit_voice_playback_clock_played(
+    struct iterate_kit_voice_playback_clock *clock,
+    uint64_t played_at_ms,
+    uint32_t played_ms);
 
 #ifdef __cplusplus
 }

--- a/apps/kit/firmware/components/core/include/iterate/kit/voice_playout.h
+++ b/apps/kit/firmware/components/core/include/iterate/kit/voice_playout.h
@@ -1,0 +1,155 @@
+#ifndef ITERATE_KIT_VOICE_PLAYOUT_H
+#define ITERATE_KIT_VOICE_PLAYOUT_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "iterate/kit/voice_playback_clock.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * ONE PLAYOUT STEP FOR THE BOARD AND THE HOST CLI.
+ *
+ * Both run the same sequence around the shared playback clock: is the ring
+ * primed; take one frame; a dry ring is either a hole in the answer or the
+ * end of it; a frame is skipped when the answer is behind with backlog to
+ * skip into, otherwise handed to the speaker; and what was handed over is
+ * reported so the answer's timeline advances. Each target used to write that
+ * sequence itself around its own ring and sink, and the two drifted apart
+ * twice in a week — the board forgot to restart the timeline on ordinary
+ * turns, the CLI forgot it on its live-audio dry path — because a rule
+ * written in two places is two rules.
+ *
+ * This is the sequence, once. What differs between targets is injected: the
+ * RING (a FreeRTOS queue with generations on the board; a byte ring on the
+ * host) and the SINK (a codec write that may wait for DMA headroom; a paced
+ * or unpaced CoreAudio/file converter), each a handful of callbacks. The
+ * counters both targets report are kept here too, so `spkPlayed` means the
+ * same thing in a board's health() as in the CLI's report.
+ *
+ * The step owns no thread and never blocks on its own account; the board's
+ * `read` blocks for its dry wait, the board's `write` for DMA headroom, and
+ * that is theirs. One owner mutates a playout; calls are allocation-free.
+ */
+
+/** What `ring.read` handed back. */
+enum iterate_kit_voice_playout_read {
+  /** Nothing queued: the live edge, or a hole. */
+  ITERATE_KIT_VOICE_PLAYOUT_READ_DRY = 0,
+  /** `*frame` holds `*length` bytes of PCM16, valid until the next read. */
+  ITERATE_KIT_VOICE_PLAYOUT_READ_FRAME,
+  /**
+   * A frame came out but belongs to an answer that has since been thrown
+   * away; the ring has dealt with it. Not dry — nothing is concealed — and
+   * not a frame — nothing is played.
+   */
+  ITERATE_KIT_VOICE_PLAYOUT_READ_ABANDONED,
+};
+
+/** What `sink.write` did with a frame the clock said to play. */
+enum iterate_kit_voice_playout_write {
+  ITERATE_KIT_VOICE_PLAYOUT_WRITE_OK = 0,
+  /** A replacement answer arrived while this frame waited; not a failure. */
+  ITERATE_KIT_VOICE_PLAYOUT_WRITE_ABANDONED,
+  /** The speaker did not admit it. */
+  ITERATE_KIT_VOICE_PLAYOUT_WRITE_FAILED,
+};
+
+struct iterate_kit_voice_playout_ring {
+  void *context;
+  /** Bytes queued and not yet handed to the sink. */
+  uint32_t (*queued_bytes)(void *context);
+  /** Removes at most one frame; may block for the ring's own dry wait. */
+  enum iterate_kit_voice_playout_read (*read)(
+      void *context, const uint8_t **frame, size_t *length);
+};
+
+struct iterate_kit_voice_playout_sink {
+  void *context;
+  /** The owner's monotonic clock, in milliseconds. */
+  uint64_t (*now_ms)(void *context);
+  /** Hands one frame to the speaker; may wait for bounded headroom. */
+  enum iterate_kit_voice_playout_write (*write)(
+      void *context, const uint8_t *frame, size_t length);
+  /**
+   * Emits one frame of silence for a hole the clock judged mid-answer. NULL
+   * where the hardware clocks out its own zeros and inserting more would
+   * only put the rest of the answer further behind — which is every board,
+   * and the host CLI whenever a real or modelled room is pulling.
+   */
+  bool (*conceal)(void *context);
+};
+
+/**
+ * What the step counted. Reported by both targets under the same names.
+ *
+ * `waits_priming` is the clock saying the ring is below prefill;
+ * `waits_dry` is the ring being empty. A stall in either used to be
+ * invisible — frames arriving with played AND conceal both frozen is exactly
+ * what these two look like from outside — which is why they are counted.
+ *
+ * `conceal_frames` is how often the source could not keep up mid-answer,
+ * whether or not the sink inserted anything for it: telemetry about the
+ * pipe, not about the listener's experience.
+ *
+ * `margin_min_ms` is how much audio was still queued behind the emptiest
+ * write: proving "no underruns" needs more than a count of holes, and a run
+ * with a healthy floor is evidence where a zero count alone proves nothing.
+ */
+struct iterate_kit_voice_playout_stats {
+  uint32_t waits_priming;
+  uint32_t waits_dry;
+  uint32_t frames_played;
+  uint32_t conceal_frames;
+  uint32_t catchup_frames;
+  uint32_t write_failures;
+  uint32_t writes;
+  uint32_t margin_min_ms;
+  uint32_t margin_max_ms;
+};
+
+struct iterate_kit_voice_playout {
+  struct iterate_kit_voice_playback_clock clock;
+  struct iterate_kit_voice_playout_stats stats;
+  /** When the sink was last handed a frame, whatever it did with it. */
+  uint64_t last_write_ms;
+};
+
+enum iterate_kit_voice_playout_outcome {
+  /** Below prefill; nothing was taken from the ring. */
+  ITERATE_KIT_VOICE_PLAYOUT_PRIMING = 0,
+  /** The ring handed back a frame of a flushed answer and dealt with it. */
+  ITERATE_KIT_VOICE_PLAYOUT_ABANDONED,
+  /** Dry mid-answer: a hole, concealed if the sink conceals. */
+  ITERATE_KIT_VOICE_PLAYOUT_STARVED,
+  /** Dry because the answer is over: back to priming, timeline forgotten. */
+  ITERATE_KIT_VOICE_PLAYOUT_SETTLED,
+  /** Behind with backlog to skip into: the frame was discarded to catch up. */
+  ITERATE_KIT_VOICE_PLAYOUT_SKIPPED,
+  ITERATE_KIT_VOICE_PLAYOUT_PLAYED,
+  /** The speaker let a replacement answer take the frame's place. */
+  ITERATE_KIT_VOICE_PLAYOUT_REPLACED,
+  /** The speaker refused the frame. */
+  ITERATE_KIT_VOICE_PLAYOUT_REFUSED,
+};
+
+void iterate_kit_voice_playout_init(struct iterate_kit_voice_playout *playout);
+
+/**
+ * One pass of the speaker. Call it from the one task that owns playback, as
+ * often as the sink wants feeding; it takes at most one frame.
+ */
+enum iterate_kit_voice_playout_outcome iterate_kit_voice_playout_step(
+    struct iterate_kit_voice_playout *playout,
+    const struct iterate_kit_voice_playout_ring *ring,
+    const struct iterate_kit_voice_playout_sink *sink);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ITERATE_KIT_VOICE_PLAYOUT_H */

--- a/apps/kit/firmware/components/core/src/voice_playback_clock.c
+++ b/apps/kit/firmware/components/core/src/voice_playback_clock.c
@@ -5,6 +5,16 @@
 #include <stddef.h>
 #include <string.h>
 
+/*
+ * Zero rather than `now`: the origin is then taken from the next frame that
+ * actually plays, which is correct however long the gap turns out to be.
+ */
+static void forget_answer_timeline(
+    struct iterate_kit_voice_playback_clock *clock) {
+  clock->answer_started_ms = 0U;
+  clock->answer_emitted_ms = 0U;
+}
+
 void iterate_kit_voice_playback_clock_init(
     struct iterate_kit_voice_playback_clock *clock) {
   if (clock == NULL) return;
@@ -17,6 +27,24 @@ void iterate_kit_voice_playback_clock_reprime(
   if (clock == NULL) return;
   clock->priming = true;
   clock->answer_done = false;
+  /*
+   * AND THE ANSWER'S CLOCK GOES WITH ITS AUDIO.
+   *
+   * The playout timeline is per-ANSWER — frame N belongs 20N ms after the
+   * first one played — so a flush, which by definition leaves no answer in
+   * flight, must leave no timeline either.
+   *
+   * This lived in the owners, beside their flush sites. On the board it was
+   * written at ONE of the four — the new-answer branch — and the other three
+   * were left resetting nothing: a new CALL emptied the ring and kept the last
+   * call's clock, so the first audio of the new one was measured against an
+   * answer minutes old and the catch-up rule deleted it. Measured on the
+   * StackChan: 34 frames skipped with `spkLagMaxMs` at 117,083. The board then
+   * moved it into its one abandon funnel; the host CLI's new-turn flush still
+   * reprimed without it. Here, every flush on every target resets it, because
+   * every flush reprimes.
+   */
+  forget_answer_timeline(clock);
 }
 
 void iterate_kit_voice_playback_clock_answer_done(
@@ -38,6 +66,13 @@ bool iterate_kit_voice_playback_clock_audio_arrived(
   }
   clock->answer_done = false;
   return underrun;
+}
+
+uint32_t iterate_kit_voice_playback_clock_lag_ms(
+    const struct iterate_kit_voice_playback_clock *clock, uint64_t now_ms) {
+  if (clock == NULL) return 0U;
+  return iterate_kit_voice_playout_lag_ms(
+      clock->answer_started_ms, clock->answer_emitted_ms, now_ms);
 }
 
 bool iterate_kit_voice_playback_clock_ready(
@@ -94,6 +129,32 @@ iterate_kit_voice_playback_clock_empty(
            ITERATE_KIT_VOICE_SPEAKER_CONCEAL_LIMIT_MS)) {
     clock->answer_done = false;
     clock->priming = true;
+    /*
+     * SETTLED BACK TO PRIMING, WHICH IS THE DEVICE'S OWN PROOF THAT NO
+     * ANSWER IS IN FLIGHT — and therefore that nothing is late.
+     *
+     * This is the only branch that returns WAIT: the answer was declared
+     * over, or nothing has been written for longer than the conceal limit.
+     * Either way the ring is empty and playback is AT THE LIVE EDGE, so
+     * whatever lag the last answer ended on is unrecoverable by definition —
+     * the catch-up rule already refuses to skip into an empty ring for that
+     * exact reason. Carrying the number forward does not measure anything; it
+     * only waits to be charged against the next answer.
+     *
+     * This is the reset that needs no cooperation from the sender. The
+     * reprime covers the answer that replaces a LIVE one; this covers every
+     * ordinary turn, including the ones where `drop` arrives a few chunks
+     * late — measured on the StackChan, where 800 ms of a new answer was
+     * delivered ahead of the clear that was supposed to precede it.
+     *
+     * IT IS DONE HERE, NOT BY THE CALLER. Both owners used to do it beside
+     * this call, and the host CLI had one dry path — live audio — that never
+     * made the call at all: after a back-office wait its next answer was
+     * measured against the previous one, read as nine seconds late, and lost
+     * four frames in five for the rest of the turn (prd, 2026-09-09). A reset
+     * that lives in the decision cannot be skipped by a path that skips it.
+     */
+    forget_answer_timeline(clock);
     return ITERATE_KIT_VOICE_PLAYBACK_WAIT;
   }
   /*
@@ -124,7 +185,7 @@ enum iterate_kit_voice_playback_action
 iterate_kit_voice_playback_clock_frame(
     struct iterate_kit_voice_playback_clock *clock,
     uint32_t queued_bytes,
-    uint32_t lag_ms,
+    uint32_t frame_ms,
     uint64_t now_ms) {
   const uint32_t queued_ms = queued_bytes / 32U;
   if (clock == NULL) return ITERATE_KIT_VOICE_PLAYBACK_WAIT;
@@ -177,10 +238,58 @@ iterate_kit_voice_playback_clock_frame(
    * mechanism. If the model does go that wrong, the honest signal is the same
    * one this function already trusts: lateness against the audio timeline.
    */
-  if (lag_ms > ITERATE_KIT_VOICE_SPEAKER_LAG_CATCHUP_MS &&
-      queued_ms > ITERATE_KIT_VOICE_FRAME_MS) {
+  /*
+   * AND ONLY WHILE AT LEAST THE THRESHOLD IS WAITING. Skipping recovers lag
+   * by playing less than has arrived, so the most it can ever recover is the
+   * backlog itself. A timeline that says seconds while the ring holds one
+   * chunk is not a stall in the audio — a stall banks the audio it withheld
+   * and the backlog shows it — it is a timeline that lost its footing: an
+   * answer ended, the silence after it went on counting, and a later answer
+   * is now measured against a clock it never started. Skipping into that
+   * chunk recovers 20 ms a frame against arrival at the same rate, so the
+   * lag never moves and every frame pays: measured on the host CLI, four in
+   * five frames of a 71-second answer discarded, the listener hearing one
+   * block of speech in every hundred milliseconds, for the whole answer.
+   * Requiring the backlog to carry the threshold makes "skip until level"
+   * mean what it says: level is reachable, in one cut, from what is queued.
+   */
+  if (iterate_kit_voice_playback_clock_lag_ms(clock, now_ms) >
+          ITERATE_KIT_VOICE_SPEAKER_LAG_CATCHUP_MS &&
+      queued_ms >= ITERATE_KIT_VOICE_SPEAKER_LAG_CATCHUP_MS) {
+    /*
+     * A SKIPPED FRAME STILL SPENT ITS PLACE IN THE TIMELINE.
+     *
+     * Skipping recovers lag only if the timeline advances as the frame is
+     * discarded. Leave the counter alone and the computed lag never falls,
+     * so the loop keeps deciding it is late and skips again — it drains the
+     * whole backlog and the listener hears half the answer missing.
+     * Measured exactly that: 78 of 162 frames skipped.
+     *
+     * Advancing here is what makes "skip until level" terminate at the point
+     * it is level, which is the entire safety of the mechanism.
+     */
+    clock->answer_emitted_ms += frame_ms;
     return ITERATE_KIT_VOICE_PLAYBACK_DROP_CATCHUP;
   }
   clock->last_write_ms = now_ms;
   return ITERATE_KIT_VOICE_PLAYBACK_PLAY;
+}
+
+void iterate_kit_voice_playback_clock_played(
+    struct iterate_kit_voice_playback_clock *clock,
+    uint64_t played_at_ms,
+    uint32_t played_ms) {
+  if (clock == NULL) return;
+  if (clock->answer_started_ms == 0U) {
+    clock->answer_started_ms = played_at_ms;
+    clock->answer_emitted_ms = 0U;
+  }
+  {
+    const uint32_t lag =
+        iterate_kit_voice_playback_clock_lag_ms(clock, played_at_ms);
+    if (lag > clock->lag_max_ms) clock->lag_max_ms = lag;
+  }
+  /* Milliseconds actually emitted, so a short read advances the timeline by
+   * what it played and not by a whole frame. */
+  clock->answer_emitted_ms += played_ms;
 }

--- a/apps/kit/firmware/components/core/src/voice_playout.c
+++ b/apps/kit/firmware/components/core/src/voice_playout.c
@@ -1,0 +1,130 @@
+#include "iterate/kit/voice_playout.h"
+
+#include "iterate/kit/voice_device_profile.h"
+
+#include <stddef.h>
+#include <string.h>
+
+enum {
+  BYTES_PER_MS = ITERATE_KIT_VOICE_FRAME_BYTES / ITERATE_KIT_VOICE_FRAME_MS,
+};
+
+void iterate_kit_voice_playout_init(struct iterate_kit_voice_playout *playout) {
+  if (playout == NULL) return;
+  memset(playout, 0, sizeof(*playout));
+  iterate_kit_voice_playback_clock_init(&playout->clock);
+}
+
+static void note_margin(
+    struct iterate_kit_voice_playout *playout,
+    const struct iterate_kit_voice_playout_ring *ring) {
+  const uint32_t margin_ms =
+      ring->queued_bytes(ring->context) / (uint32_t)BYTES_PER_MS;
+  ++playout->stats.writes;
+  if (playout->stats.writes == 1U || margin_ms < playout->stats.margin_min_ms) {
+    playout->stats.margin_min_ms = margin_ms;
+  }
+  if (margin_ms > playout->stats.margin_max_ms) {
+    playout->stats.margin_max_ms = margin_ms;
+  }
+}
+
+enum iterate_kit_voice_playout_outcome iterate_kit_voice_playout_step(
+    struct iterate_kit_voice_playout *playout,
+    const struct iterate_kit_voice_playout_ring *ring,
+    const struct iterate_kit_voice_playout_sink *sink) {
+  const uint8_t *frame = NULL;
+  size_t length = 0U;
+  uint32_t frame_ms;
+  uint64_t played_at_ms;
+  enum iterate_kit_voice_playout_outcome outcome;
+
+  if (playout == NULL || ring == NULL || sink == NULL) {
+    return ITERATE_KIT_VOICE_PLAYOUT_PRIMING;
+  }
+  if (!iterate_kit_voice_playback_clock_ready(
+          &playout->clock, ring->queued_bytes(ring->context))) {
+    /* Not feeding: nothing is playing, so nothing is written. */
+    ++playout->stats.waits_priming;
+    return ITERATE_KIT_VOICE_PLAYOUT_PRIMING;
+  }
+
+  switch (ring->read(ring->context, &frame, &length)) {
+  case ITERATE_KIT_VOICE_PLAYOUT_READ_ABANDONED:
+    return ITERATE_KIT_VOICE_PLAYOUT_ABANDONED;
+  case ITERATE_KIT_VOICE_PLAYOUT_READ_DRY:
+    /*
+     * DRY. The clock says whether that is a hole or the end.
+     *
+     * A hole is NOT filled with silence from here on a board: silence written
+     * into a DMA ring is indistinguishable from audio, occupies playout time,
+     * can never be taken back, and so permanently puts the rest of the answer
+     * 20 ms further behind — 149 times in one measured answer, three seconds
+     * of chopping. A board's ring already clocks out zeros when it is truly
+     * empty. A sink that has no such hardware behind it (the CLI's file
+     * model) supplies the silence so its recording keeps the timeline.
+     *
+     * The end resets the answer's timeline inside the clock, in this same
+     * call. THAT is the reset the two owners used to write themselves and
+     * each forgot on one path; asking the clock on EVERY dry read, from every
+     * path, is what this step guarantees.
+     */
+    ++playout->stats.waits_dry;
+    if (iterate_kit_voice_playback_clock_empty(
+            &playout->clock, sink->now_ms(sink->context)) ==
+        ITERATE_KIT_VOICE_PLAYBACK_CONCEAL) {
+      ++playout->stats.conceal_frames;
+      if (sink->conceal != NULL) (void)sink->conceal(sink->context);
+      return ITERATE_KIT_VOICE_PLAYOUT_STARVED;
+    }
+    return ITERATE_KIT_VOICE_PLAYOUT_SETTLED;
+  case ITERATE_KIT_VOICE_PLAYOUT_READ_FRAME:
+    break;
+  }
+  if (frame == NULL || length == 0U) return ITERATE_KIT_VOICE_PLAYOUT_ABANDONED;
+
+  /*
+   * Flooded: skip this frame to catch up.
+   *
+   * The sender paces off its own wall clock and the device consumes off its
+   * audio clock; the two are independent, so a stall accumulates as lag that
+   * nothing else ever pays back. Skipping one frame here, only while the
+   * answer is behind AND the backlog carries the threshold, is the same loss
+   * placed where it is least audible — see the clock for the two guards and
+   * what each one cost before it existed. The symmetric counterpart to
+   * concealment: conceal when starved, skip when flooded, count both.
+   */
+  frame_ms = (uint32_t)(length / BYTES_PER_MS);
+  if (iterate_kit_voice_playback_clock_frame(
+          &playout->clock,
+          ring->queued_bytes(ring->context),
+          frame_ms,
+          sink->now_ms(sink->context)) ==
+      ITERATE_KIT_VOICE_PLAYBACK_DROP_CATCHUP) {
+    ++playout->stats.catchup_frames;
+    return ITERATE_KIT_VOICE_PLAYOUT_SKIPPED;
+  }
+
+  /* Stamped BEFORE the write; the clock's `played` says why. */
+  played_at_ms = sink->now_ms(sink->context);
+  switch (sink->write(sink->context, frame, length)) {
+  case ITERATE_KIT_VOICE_PLAYOUT_WRITE_OK:
+    ++playout->stats.frames_played;
+    iterate_kit_voice_playback_clock_played(
+        &playout->clock, played_at_ms, frame_ms);
+    outcome = ITERATE_KIT_VOICE_PLAYOUT_PLAYED;
+    break;
+  case ITERATE_KIT_VOICE_PLAYOUT_WRITE_ABANDONED:
+    /* Intentional replacement, not a speaker failure. */
+    outcome = ITERATE_KIT_VOICE_PLAYOUT_REPLACED;
+    break;
+  case ITERATE_KIT_VOICE_PLAYOUT_WRITE_FAILED:
+  default:
+    ++playout->stats.write_failures;
+    outcome = ITERATE_KIT_VOICE_PLAYOUT_REFUSED;
+    break;
+  }
+  note_margin(playout, ring);
+  playout->last_write_ms = sink->now_ms(sink->context);
+  return outcome;
+}

--- a/apps/kit/firmware/components/voice/src/voice_loop.c
+++ b/apps/kit/firmware/components/voice/src/voice_loop.c
@@ -94,7 +94,7 @@ static uint32_t abandon_speaker_audio(void);
 #include "iterate/kit/voicelab_stream.h"
 #include "iterate/kit/voice_device_profile.h"
 #include "iterate/kit/voice/loop.h"
-#include "iterate/kit/voice_playback_clock.h"
+#include "iterate/kit/voice_playout.h"
 
 static const char tag[] = "iterate-voicelab";
 
@@ -552,12 +552,11 @@ EXT_RAM_BSS_ATTR static struct {
   atomic_uint speaker_generation;
   atomic_uint_fast64_t speaker_last_write_ms;
   /*
-   * The playback step's two persistent locals. They were locals of a `for(;;)`
-   * that never returned; a step returns every pass, so they live here with the
-   * rest of the speaker's state. Written only by the playback task.
+   * The playback step's persistent state — the shared playout clock, its
+   * counters and the last write — written only by the playback task. The
+   * step itself is shared with the host CLI: iterate/kit/voice_playout.h.
    */
-  struct iterate_kit_voice_playback_clock playout_clock;
-  uint64_t last_write_ms;
+  struct iterate_kit_voice_playout playout;
   uint32_t mic_frames_captured;
   uint32_t mic_frames_dropped;
   uint32_t mic_process_failures;
@@ -588,7 +587,6 @@ EXT_RAM_BSS_ATTR static struct {
   atomic_uint aec_sequence_discontinuities;
   atomic_uint aec_clock_regressions;
   atomic_uint aec_egress_copy_failures;
-  uint32_t speaker_frames_played;
   /* Written by both the app producer and playback consumer. */
   atomic_uint speaker_overflow_drops;
   /*
@@ -603,18 +601,6 @@ EXT_RAM_BSS_ATTR static struct {
   /* Queue-reset accounting is app-owned; in-flight rejection is playback-owned. */
   atomic_uint speaker_discarded_frames;
   /*
-   * The two ways the reader can decline to play WITHOUT touching any other
-   * counter, and therefore the only remaining blind spots in this loop.
-   *
-   * `speaker_waits_priming` is ready() saying no: the ring is below the
-   * prefill mark. `speaker_waits_dry` is the ring being empty and the clock
-   * choosing WAIT over CONCEAL. A stall in either is invisible today - the
-   * failing runs show frames arriving with played AND conceal both frozen,
-   * which is exactly what these two look like from outside.
-   */
-  uint32_t speaker_waits_priming;
-  uint32_t speaker_waits_dry;
-  /*
    * A starve is only a DEFECT if the stream had more to say. The buffer
    * legitimately empties at the end of every answer, and counting that as an
    * underrun made the metric read one per answer no matter how healthy the
@@ -623,19 +609,7 @@ EXT_RAM_BSS_ATTR static struct {
    * after it, meaning the answer was still in progress.
    */
   uint32_t speaker_underruns;
-  uint32_t speaker_conceal_frames;
-  uint32_t speaker_catchup_frames;
-  uint32_t speaker_write_failures;
-  uint32_t speaker_margin_max_ms;
   atomic_uint_fast64_t starve_at_ms;
-  /*
-   * Proving "no underruns" needs more than a count of holes: every write
-   * records how much audio was still queued behind it, so the minimum over a
-   * call says how close the pipe ever came to running dry. A run with a
-   * healthy floor is evidence; a zero count alone proves nothing.
-   */
-  uint32_t speaker_margin_min_ms;
-  uint32_t speaker_writes;
   uint32_t speaker_bad_frames;
   /* Connections replaced because nothing was being delivered on them. */
   uint32_t downlink_recycles;
@@ -699,23 +673,9 @@ EXT_RAM_BSS_ATTR static struct {
   /* Release pressed, but the capture queue is not yet on the wire. */
   bool flushing_turn;
   atomic_bool speaker_reprime;
-  /**
-   * When the current answer's playout began, and how much of it has played.
-   *
-   * Together these ARE the audio timeline: frame N of an answer should reach
-   * the speaker 20N ms after the first one did. The difference between that
-   * and the wall clock is how far behind realtime this device is, and it is
-   * the only honest measure of "behind" — queue depth is not, because a whole
-   * answer legitimately arrives at once and a deep queue then means the
-   * sender was fast, not that playback is late.
-   *
-   * Needs no clock agreement with the server: both terms are local, and the
-   * answer's own first frame is the origin.
-   */
-  atomic_uint_fast64_t answer_started_ms;
-  atomic_uint answer_emitted_ms;
-  /** When an RPC was last answered: the mount's own liveness, not the socket's. */
-  uint32_t speaker_lag_max_ms;
+  /* The answer's playout timeline — when it began, how much has played, the
+   * worst lag — is `playout.clock`'s, shared with the host CLI; see
+   * iterate/kit/voice_playback_clock.h. */
   atomic_bool speaker_answer_done;
   /*
    * The SENDER said this answer is complete, latched until the speaker actually
@@ -996,24 +956,15 @@ static uint32_t abandon_speaker_audio(void) {
   atomic_store_explicit(
       &runtime.speaker_reprime, true, memory_order_release);
   /*
-   * AND THE ANSWER'S CLOCK GOES WITH ITS AUDIO.
-   *
-   * The playout timeline is per-ANSWER — frame N belongs 20N ms after the
-   * first one played — so a flush, which by definition leaves no answer in
-   * flight, must leave no timeline either. Zero rather than `now`: the origin
-   * is then taken from the next frame that actually plays, which is correct
-   * however long the gap turns out to be.
-   *
-   * IN THE FUNNEL RATHER THAN AT THE FLUSH SITES, for the reason the funnel
-   * exists. It was written at ONE of the four — the new-answer branch — and
-   * the other three were left resetting nothing: a new CALL emptied the ring
-   * and kept the last call's clock, so the first audio of the new one was
-   * measured against an answer minutes old and the catch-up rule deleted it.
-   * Measured on the StackChan after this file's other fix: 34 frames skipped
-   * with `spkLagMaxMs` at 117,083.
+   * AND THE ANSWER'S CLOCK GOES WITH ITS AUDIO — carried by the reprime the
+   * playback task applies before its next frame: the playout clock owns the
+   * answer's timeline, and `iterate_kit_voice_playback_clock_reprime` starts
+   * it from zero. It used to be reset here by hand, in the funnel rather than
+   * at the flush sites, because it had first been written at ONE of the four
+   * and a new CALL then kept the last call's clock — 34 frames skipped with
+   * `spkLagMaxMs` at 117,083 on the StackChan. Now neither a site nor a
+   * funnel can forget it: whatever primes the clock resets the timeline.
    */
-  atomic_store_explicit(&runtime.answer_started_ms, 0U, memory_order_release);
-  atomic_store_explicit(&runtime.answer_emitted_ms, 0U, memory_order_release);
   /* And the part-frame waiting for audio that is never coming: spliced onto
    * the front of the next answer, it is a click once per barge-in. */
   speaker_partial_length = 0U;
@@ -1244,76 +1195,29 @@ static bool playback_apply_reprime(
 }
 
 /*
- * ONE PASS OF THE SPEAKER, so that it is a function rather than a `for(;;)`.
+ * THE BOARD'S RING AND SINK, AS THE SHARED PLAYOUT STEP SEES THEM.
  *
- * A step can be called, and therefore tested, and therefore driven by a host
- * that has one thread where a board has three. Nothing else about it changed:
- * every `continue` in the body below became a `return`, and the two locals
- * that had to survive an iteration — the playout clock and the last write —
- * moved into the runtime beside the state they already describe.
+ * The step — iterate/kit/voice_playout.h — is the sequence this board and the
+ * host CLI both run: prime, take one frame, treat a dry ring as a hole or the
+ * end, skip a late frame with backlog behind it, hand the rest to the
+ * speaker, report what was played. It used to be written here and again in
+ * the CLI, and the two drifted apart twice. What is below is only what is
+ * the board's alone: the FreeRTOS queue with its generations and reprime
+ * handshake, and the codec write with its bounded wait for DMA headroom.
  */
-void iterate_kit_voice_loop_playback_step(void) {
-  static struct speaker_frame frame;
-  /*
-   * The writer NEVER stops. That is the whole design.
-   *
-   * It used to stop on an empty read and wait to re-buy a cushion — and the
-   * cushion it waited for (40 ms) was SMALLER THAN THE DMA RING IT HAD JUST
-   * LET RUN DRY (90 ms). So every recovery under-filled the hardware and
-   * immediately starved again: one network hiccup produced a train of holes,
-   * which is why the rate never went to zero however large the buffers grew.
-   *
-   * The answer to that was to write silence on an empty read, and it was the
-   * wrong one: silence occupies playout time and cannot be taken back, so
-   * every frame of it puts the rest of the answer permanently further behind.
-   * The right answer, and the one three reference implementations use, is to
-   * wait long enough that a late frame is absorbed by the hardware cushion
-   * rather than concealed — see the read and the dry branch below.
-   */
-  size_t received;
 
-  /*
-   * FENCED OUT. While the microphone owns the shared pins — or the fence is
-   * moving in either direction — this step must not pull frames it can only
-   * fail to write. Frames stay queued; the fence drops within milliseconds of
-   * the turn committing, long before an answer.
-   */
-  if (runtime.board->playout_fenced_out != NULL &&
-      runtime.board->playout_fenced_out(runtime.board_context)) {
-    board_phase(ITERATE_KIT_VOICE_PHASE_WAITING);
-    DELAY_MS(5);
-    return;
-  }
+/* The frame in flight between the queue and the codec. File-scope so the
+ * write callback sees the generation the read callback received it with. */
+static struct speaker_frame playout_item;
 
-  (void)playback_apply_reprime(&runtime.playout_clock);
-  if (atomic_exchange_explicit(
-          &runtime.speaker_answer_done, false, memory_order_acq_rel)) {
-    iterate_kit_voice_playback_clock_answer_done(&runtime.playout_clock);
-  }
-  if (!iterate_kit_voice_playback_clock_ready(
-          &runtime.playout_clock, speaker_queued_bytes())) {
-    /*
-     * NOT FEEDING, SO NOT WATCHING.
-     *
-     * The watch means "we are handing the DAC audio right now". This branch
-     * decides not to, while the clock builds its prefill — and leaving the
-     * watch armed across it made the DAC's correct silence read as
-     * starvation at every boundary that re-primes: a cold first turn, a turn
-     * after idle, the refill after a barge-in, and teardown. That was the
-     * whole of the systematic DMA ledger deficits, and it is one missing disarm
-     * rather than four separate causes.
-     */
-    board_phase(ITERATE_KIT_VOICE_PHASE_WAITING);
-    ++runtime.speaker_waits_priming;
-    /* Idle, not starving: nothing is playing, so write nothing. */
-    if (runtime.last_write_ms != 0U &&
-        iterate_kit_voice_elapsed_ms(now_ms(NULL), runtime.last_write_ms) > SPEAKER_IDLE_POWERDOWN_MS) {
-      board_phase(ITERATE_KIT_VOICE_PHASE_QUIET);
-    }
-    DELAY_MS(5);
-    return;
-  }
+static uint32_t playout_ring_queued_bytes(void *context) {
+  (void)context;
+  return speaker_queued_bytes();
+}
 
+static enum iterate_kit_voice_playout_read playout_ring_read(
+    void *context, const uint8_t **frame, size_t *length) {
+  (void)context;
   /*
    * WAIT AS LONG AS THE HARDWARE CUSHION ALLOWS.
    *
@@ -1358,47 +1262,10 @@ void iterate_kit_voice_loop_playback_step(void) {
           &runtime.answer_declared_done, memory_order_acquire)) {
     board_phase(ITERATE_KIT_VOICE_PHASE_DRAINING);
   }
-  received = xQueueReceive(
-                 runtime.speaker_queue,
-                 &frame,
-                 pdMS_TO_TICKS(runtime.facts->speaker_dry_wait_ms)) ==
-                     pdTRUE
-      ? FRAME_BYTES
-      : 0U;
-
-  /*
-   * A REPRIME REQUESTED WHILE WE WERE BLOCKED STILL COUNTS.
-   *
-   * The receive above waits up to 60 ms, and a new answer's first frame
-   * routinely arrives inside that window — REPLACE sets speaker_reprime and
-   * pushes the frame, and this loop then wakes holding it. Checking the
-   * flag only at the top of the loop played that frame with priming already
-   * cancelled, so ~20 ms of the first phoneme escaped, the reprime was
-   * honoured on the NEXT iteration, and the rest of the answer waited out a
-   * full prefill behind it. That is the clipped first word.
-   */
-  if (received > 0U && playback_apply_reprime(&runtime.playout_clock)) {
-    /*
-     * A replacement can wake the blocked receive with its first frame. Put
-     * that whole tagged frame back at the head so opening prefill includes
-     * it. If another replacement raced this one, its generation is already
-     * stale and it must not be reintroduced after the newer queue reset.
-     */
-    if (frame.generation == atomic_load_explicit(
-                                &runtime.speaker_generation,
-                                memory_order_acquire)) {
-      if (xQueueSendToFront(runtime.speaker_queue, &frame, 0) != pdTRUE) {
-        (void)atomic_fetch_add_explicit(
-            &runtime.speaker_overflow_drops, 1U, memory_order_relaxed);
-      }
-    } else {
-      (void)atomic_fetch_add_explicit(
-          &runtime.speaker_discarded_frames, 1U, memory_order_relaxed);
-    }
-    return;
-  }
-
-  if (received == 0U) {
+  if (xQueueReceive(
+          runtime.speaker_queue,
+          &playout_item,
+          pdMS_TO_TICKS(runtime.facts->speaker_dry_wait_ms)) != pdTRUE) {
     /*
      * DRY. WRITE NOTHING AND COME BACK.
      *
@@ -1420,114 +1287,77 @@ void iterate_kit_voice_loop_playback_step(void) {
      *
      * This is what xiaozhi-esp32, ESPHome's speaker and esp-adf all do:
      * when the source is dry, stop calling write. None of them conceals.
+     * Hence no `conceal` on this board's sink: the step counts the hole and
+     * inserts nothing.
+     *
+     * "The answer has finished being HEARD" was once reported to the
+     * classifier from here; that distinction is now measured where the audio
+     * is actually thrown away (an abandon with bytes queued is a supersede,
+     * with an empty queue the gap between turns).
      */
-    /* Nothing to play: the zeros the DAC now sends are correct. */
     board_phase(ITERATE_KIT_VOICE_PHASE_WAITING);
-    /*
-     * "The answer has finished being HEARD" was reported to the classifier
-     * here, gated on the sender having declared it complete — the classifier
-     * needed it to tell a new answer following a finished one from a new
-     * answer cutting a live one off. That distinction is now measured where
-     * the audio is actually thrown away: an abandon with bytes still queued
-     * is a supersede, an abandon with an empty queue is the gap between
-     * turns. `answer_declared_done` still disarms the starvation watch above,
-     * which is the other thing it was ever for.
-     */
-    ++runtime.speaker_waits_dry;
-    if (iterate_kit_voice_playback_clock_empty(
-            &runtime.playout_clock, now_ms(NULL)) ==
-        ITERATE_KIT_VOICE_PLAYBACK_CONCEAL) {
-      /* Kept as telemetry: how often the source could not keep up. It no
-       * longer costs the listener anything. */
-      ++runtime.speaker_conceal_frames;
-      atomic_store_explicit(
-          &runtime.starve_at_ms, now_ms(NULL), memory_order_release);
-    } else {
-      /*
-       * SETTLED BACK TO PRIMING, WHICH IS THIS DEVICE'S OWN PROOF THAT NO
-       * ANSWER IS IN FLIGHT — and therefore that nothing is late.
-       *
-       * WAIT is returned by exactly one branch of the clock: the answer was
-       * declared over, or nothing has been written for longer than the conceal
-       * limit. Either way the ring is empty and playback is AT THE LIVE EDGE,
-       * so whatever lag the last answer ended on is unrecoverable by
-       * definition — the catch-up rule already refuses to skip into an empty
-       * ring for that exact reason. Carrying the number forward does not
-       * measure anything; it only waits to be charged against the next answer.
-       *
-       * This is the reset that needs no cooperation from the sender. `drop`
-       * covers the answer that replaces a LIVE one; this covers every ordinary
-       * turn, including the ones where `drop` arrives a few chunks late —
-       * measured on the StackChan, where 800 ms of a new answer was delivered
-       * ahead of the clear that was supposed to precede it.
-       */
-      atomic_store_explicit(
-          &runtime.answer_started_ms, 0U, memory_order_release);
-      atomic_store_explicit(
-          &runtime.answer_emitted_ms, 0U, memory_order_release);
-    }
-    return;
+    return ITERATE_KIT_VOICE_PLAYOUT_READ_DRY;
   }
 
-  if (frame.generation != atomic_load_explicit(
-                              &runtime.speaker_generation,
-                              memory_order_acquire)) {
+  /*
+   * A REPRIME REQUESTED WHILE WE WERE BLOCKED STILL COUNTS.
+   *
+   * The receive above waits up to 60 ms, and a new answer's first frame
+   * routinely arrives inside that window — REPLACE sets speaker_reprime and
+   * pushes the frame, and this loop then wakes holding it. Checking the
+   * flag only at the top of the loop played that frame with priming already
+   * cancelled, so ~20 ms of the first phoneme escaped, the reprime was
+   * honoured on the NEXT iteration, and the rest of the answer waited out a
+   * full prefill behind it. That is the clipped first word.
+   */
+  if (playback_apply_reprime(&runtime.playout.clock)) {
+    /*
+     * A replacement can wake the blocked receive with its first frame. Put
+     * that whole tagged frame back at the head so opening prefill includes
+     * it. If another replacement raced this one, its generation is already
+     * stale and it must not be reintroduced after the newer queue reset.
+     */
+    if (playout_item.generation == atomic_load_explicit(
+                                       &runtime.speaker_generation,
+                                       memory_order_acquire)) {
+      if (xQueueSendToFront(runtime.speaker_queue, &playout_item, 0) !=
+          pdTRUE) {
+        (void)atomic_fetch_add_explicit(
+            &runtime.speaker_overflow_drops, 1U, memory_order_relaxed);
+      }
+    } else {
+      (void)atomic_fetch_add_explicit(
+          &runtime.speaker_discarded_frames, 1U, memory_order_relaxed);
+    }
+    return ITERATE_KIT_VOICE_PLAYOUT_READ_ABANDONED;
+  }
+
+  if (playout_item.generation != atomic_load_explicit(
+                                     &runtime.speaker_generation,
+                                     memory_order_acquire)) {
     /* A replacement raced this frame after it left the synchronized queue. */
     (void)atomic_fetch_add_explicit(
         &runtime.speaker_discarded_frames, 1U, memory_order_relaxed);
     board_phase(ITERATE_KIT_VOICE_PHASE_WAITING);
-    return;
+    return ITERATE_KIT_VOICE_PLAYOUT_READ_ABANDONED;
   }
 
-  /*
-   * Flooded: skip this frame to catch up.
-   *
-   * The bridge paces off its own wall clock and the device consumes off
-   * the I2S clock; the two are independent, so a small rate difference
-   * accumulates without bound. Left alone the buffer fills and frames are
-   * discarded ON ARRIVAL — which punches a hole in the middle of speech.
-   * Dropping one 20ms frame here instead, only when there is most of a
-   * second of backlog, is the same total loss placed where it is least
-   * audible, and it bounds playout latency as a side effect.
-   *
-   * This is the symmetric counterpart to concealment: conceal when
-   * starved, skip when flooded, and count both honestly.
-   */
-  {
-    const enum iterate_kit_voice_playback_action action =
-        iterate_kit_voice_playback_clock_frame(
-            &runtime.playout_clock,
-            speaker_queued_bytes(),
-            iterate_kit_voice_playout_lag_ms(
-                atomic_load_explicit(
-                    &runtime.answer_started_ms, memory_order_acquire),
-                atomic_load_explicit(
-                    &runtime.answer_emitted_ms, memory_order_acquire),
-                now_ms(NULL)),
-            now_ms(NULL));
-    if (action == ITERATE_KIT_VOICE_PLAYBACK_DROP_CATCHUP) {
-      /*
-       * A SKIPPED FRAME STILL SPENT ITS PLACE IN THE TIMELINE.
-       *
-       * Skipping recovers lag only if the timeline advances as the frame is
-       * discarded. Leave the counter alone and the computed lag never
-       * falls, so the loop keeps deciding it is late and skips again — it
-       * drains the whole backlog and the listener hears half the answer
-       * missing. Measured exactly that: 78 of 162 frames skipped.
-       *
-       * Advancing here is what makes "skip until level" terminate at the
-       * point it is level, which is the entire safety of the mechanism.
-       */
-      ++runtime.speaker_catchup_frames;
-      (void)atomic_fetch_add_explicit(
-          &runtime.answer_emitted_ms,
-          (uint32_t)(received / (FRAME_BYTES / FRAME_MS)),
-          memory_order_acq_rel);
-      return;
-    }
-  }
+  *frame = (const uint8_t *)playout_item.samples;
+  *length = sizeof(playout_item.samples);
+  return ITERATE_KIT_VOICE_PLAYOUT_READ_FRAME;
+}
 
-  const uint64_t write_started_ms = now_ms(NULL);
+static uint64_t playout_sink_now_ms(void *context) {
+  (void)context;
+  return now_ms(NULL);
+}
+
+static enum iterate_kit_voice_playout_write playout_sink_write(
+    void *context, const uint8_t *frame, size_t length) {
+  enum iterate_kit_status write_status;
+  const uint64_t write_deadline_ms = now_ms(NULL) + 100U;
+  (void)context;
+  (void)frame; /* it is playout_item.samples; the generation rides with it */
   board_phase(ITERATE_KIT_VOICE_PHASE_FEEDING);
   /*
    * Admission is nonblocking. The hardware-owner task reserves the DMA
@@ -1535,20 +1365,18 @@ void iterate_kit_voice_loop_playback_step(void) {
    * five frame periods for bounded queue headroom and keeps running the
    * stream protocol independently of the codec driver's pacing.
    */
-  enum iterate_kit_status write_status;
-  const uint64_t write_deadline_ms = now_ms(NULL) + 100U;
   do {
     if (atomic_load_explicit(
             &runtime.speaker_reprime, memory_order_acquire) ||
-        frame.generation != atomic_load_explicit(
-                                &runtime.speaker_generation,
-                                memory_order_acquire)) {
+        playout_item.generation != atomic_load_explicit(
+                                       &runtime.speaker_generation,
+                                       memory_order_acquire)) {
       /* A replacement answer arrived while this stale frame waited. */
       write_status = ITERATE_KIT_UNAVAILABLE;
       break;
     }
     write_status = iterate_kit_audio_codec_write(
-        &runtime.codec, frame.samples, received / 2U);
+        &runtime.codec, playout_item.samples, length / 2U);
     if (write_status == ITERATE_KIT_BACKPRESSURE) {
       DELAY_MS(1);
     }
@@ -1556,94 +1384,142 @@ void iterate_kit_voice_loop_playback_step(void) {
            now_ms(NULL) < write_deadline_ms);
 
   if (write_status == ITERATE_KIT_OK) {
-    ++runtime.speaker_frames_played;
     /*
      * The mouth, from audio the DAC has accepted rather than audio that
      * arrived. This is the only place on the device where those two are the
      * same thing, which is why the tap is here and not on the receive path:
      * see waveshare_avatar.h for what the delay line does with it.
      */
-    board_playout(frame.samples, received / 2U);
-    /*
-     * HOW FAR BEHIND REALTIME THIS ANSWER HAS FALLEN.
-     *
-     * Frame N of an answer belongs 20N ms after the first one played. The
-     * gap between that and the wall clock is lag, and it only grows when
-     * playback stalls — never from the sender running ahead, which is why
-     * this is measured against the audio timeline rather than queue depth.
-     *
-     * Recorded rather than acted on. Paying it back means deleting speech,
-     * and this device has already shipped one mechanism that did exactly
-     * that; the number has to exist before anyone can argue about whether
-     * being late is worse than being clipped.
-     */
-    {
-      /*
-       * STAMPED BEFORE THE WRITE, NOT AFTER.
-       *
-       * codec admission may wait for bounded queue headroom. Stamping after
-       * that wait folds hardware pacing into the measurement,
-       * so a perfectly punctual loop reports itself progressively later and
-       * the catch-up rule then deletes speech to fix a delay that only
-       * existed in the metric. Measured that way: 1089 ms of "lag" while
-       * the ring held 1620 ms of audio, which is the signature of a
-       * consumer that is keeping up.
-       */
-      const uint64_t played_at = write_started_ms;
-      uint64_t answer_started = atomic_load_explicit(
-          &runtime.answer_started_ms, memory_order_acquire);
-      if (answer_started == 0U) {
-        atomic_store_explicit(
-            &runtime.answer_started_ms, played_at, memory_order_release);
-        atomic_store_explicit(
-            &runtime.answer_emitted_ms, 0U, memory_order_release);
-        answer_started = played_at;
-      }
-      {
-        const uint32_t lag = iterate_kit_voice_playout_lag_ms(
-            answer_started,
-            atomic_load_explicit(
-                &runtime.answer_emitted_ms, memory_order_acquire),
-            played_at);
-        if (lag > runtime.speaker_lag_max_ms) {
-          runtime.speaker_lag_max_ms = lag;
-        }
-      }
-      /* Milliseconds actually emitted, so a short read advances the
-       * timeline by what it played and not by a whole frame. */
-      (void)atomic_fetch_add_explicit(
-          &runtime.answer_emitted_ms,
-          (uint32_t)(received / (FRAME_BYTES / FRAME_MS)),
-          memory_order_acq_rel);
-    }
-  } else if (write_status == ITERATE_KIT_UNAVAILABLE &&
-             atomic_load_explicit(
-                 &runtime.speaker_reprime, memory_order_acquire)) {
+    board_playout(playout_item.samples, length / 2U);
+    return ITERATE_KIT_VOICE_PLAYOUT_WRITE_OK;
+  }
+  if (write_status == ITERATE_KIT_UNAVAILABLE &&
+      atomic_load_explicit(&runtime.speaker_reprime, memory_order_acquire)) {
     /* Intentional replacement, not a codec failure. */
     (void)atomic_fetch_add_explicit(
         &runtime.speaker_discarded_frames,
-        (uint32_t)(received / (FRAME_SAMPLES * sizeof(int16_t))),
+        (uint32_t)(length / (FRAME_SAMPLES * sizeof(int16_t))),
         memory_order_relaxed);
-  } else {
-    /* The bounded hardware path did not admit this frame. */
-    ++runtime.speaker_write_failures;
+    return ITERATE_KIT_VOICE_PLAYOUT_WRITE_ABANDONED;
+  }
+  /* The bounded hardware path did not admit this frame. */
+  return ITERATE_KIT_VOICE_PLAYOUT_WRITE_FAILED;
+}
+
+static const struct iterate_kit_voice_playout_ring playout_ring = {
+  .context = NULL,
+  .queued_bytes = playout_ring_queued_bytes,
+  .read = playout_ring_read,
+};
+
+static const struct iterate_kit_voice_playout_sink playout_sink = {
+  .context = NULL,
+  .now_ms = playout_sink_now_ms,
+  .write = playout_sink_write,
+  .conceal = NULL, /* the DAC clocks out its own zeros; see the dry read */
+};
+
+/*
+ * ONE PASS OF THE SPEAKER, so that it is a function rather than a `for(;;)`.
+ *
+ * A step can be called, and therefore tested, and therefore driven by a host
+ * that has one thread where a board has three. The pass itself is the shared
+ * step; what is here is the board's handshake around it and the board's
+ * response to what it decided.
+ */
+void iterate_kit_voice_loop_playback_step(void) {
+  /*
+   * The writer NEVER stops. That is the whole design.
+   *
+   * It used to stop on an empty read and wait to re-buy a cushion — and the
+   * cushion it waited for (40 ms) was SMALLER THAN THE DMA RING IT HAD JUST
+   * LET RUN DRY (90 ms). So every recovery under-filled the hardware and
+   * immediately starved again: one network hiccup produced a train of holes,
+   * which is why the rate never went to zero however large the buffers grew.
+   *
+   * The answer to that was to write silence on an empty read, and it was the
+   * wrong one: silence occupies playout time and cannot be taken back, so
+   * every frame of it puts the rest of the answer permanently further behind.
+   * The right answer, and the one three reference implementations use, is to
+   * wait long enough that a late frame is absorbed by the hardware cushion
+   * rather than concealed — see the read callback above.
+   */
+
+  /*
+   * FENCED OUT. While the microphone owns the shared pins — or the fence is
+   * moving in either direction — this step must not pull frames it can only
+   * fail to write. Frames stay queued; the fence drops within milliseconds of
+   * the turn committing, long before an answer.
+   */
+  if (runtime.board->playout_fenced_out != NULL &&
+      runtime.board->playout_fenced_out(runtime.board_context)) {
+    board_phase(ITERATE_KIT_VOICE_PHASE_WAITING);
+    DELAY_MS(5);
+    return;
   }
 
-  {
-    const uint32_t margin_ms = speaker_queued_bytes() / 32U;
-    ++runtime.speaker_writes;
-    if (runtime.speaker_writes == 1U ||
-        margin_ms < runtime.speaker_margin_min_ms) {
-      runtime.speaker_margin_min_ms = margin_ms;
-    }
-    if (margin_ms > runtime.speaker_margin_max_ms) {
-      runtime.speaker_margin_max_ms = margin_ms;
-    }
+  (void)playback_apply_reprime(&runtime.playout.clock);
+  if (atomic_exchange_explicit(
+          &runtime.speaker_answer_done, false, memory_order_acq_rel)) {
+    iterate_kit_voice_playback_clock_answer_done(&runtime.playout.clock);
   }
-  runtime.last_write_ms = now_ms(NULL);
-  atomic_store_explicit(
-    &runtime.speaker_last_write_ms, runtime.last_write_ms,
-    memory_order_release);
+
+  switch (iterate_kit_voice_playout_step(
+      &runtime.playout, &playout_ring, &playout_sink)) {
+  case ITERATE_KIT_VOICE_PLAYOUT_PRIMING:
+    /*
+     * NOT FEEDING, SO NOT WATCHING.
+     *
+     * The watch means "we are handing the DAC audio right now". This branch
+     * decides not to, while the clock builds its prefill — and leaving the
+     * watch armed across it made the DAC's correct silence read as
+     * starvation at every boundary that re-primes: a cold first turn, a turn
+     * after idle, the refill after a barge-in, and teardown. That was the
+     * whole of the systematic DMA ledger deficits, and it is one missing disarm
+     * rather than four separate causes.
+     */
+    board_phase(ITERATE_KIT_VOICE_PHASE_WAITING);
+    /* Idle, not starving: nothing is playing, so write nothing. */
+    if (runtime.playout.last_write_ms != 0U &&
+        iterate_kit_voice_elapsed_ms(now_ms(NULL), runtime.playout.last_write_ms) >
+            SPEAKER_IDLE_POWERDOWN_MS) {
+      board_phase(ITERATE_KIT_VOICE_PHASE_QUIET);
+    }
+    DELAY_MS(5);
+    return;
+  case ITERATE_KIT_VOICE_PLAYOUT_STARVED:
+    /*
+     * A hole mid-answer. The step counted it (`spkSoftDryTicks`: how often
+     * the source could not keep up; it no longer costs the listener anything)
+     * and this stamp lets the admit path promote it to an underrun if audio
+     * resumes within a second — a hole in an answer that was still going.
+     */
+    atomic_store_explicit(
+        &runtime.starve_at_ms, now_ms(NULL), memory_order_release);
+    return;
+  case ITERATE_KIT_VOICE_PLAYOUT_SETTLED:
+    /*
+     * SETTLED BACK TO PRIMING, which is this device's own proof that no
+     * answer is in flight — and the clock forgot the answer's timeline on
+     * that same WAIT, so nothing is late. That reset needs no cooperation
+     * from the sender: `drop` covers the answer that replaces a LIVE one;
+     * this covers every ordinary turn, including the ones where `drop`
+     * arrives a few chunks late — measured on the StackChan, where 800 ms of
+     * a new answer was delivered ahead of the clear that was supposed to
+     * precede it.
+     */
+    return;
+  case ITERATE_KIT_VOICE_PLAYOUT_ABANDONED:
+  case ITERATE_KIT_VOICE_PLAYOUT_SKIPPED:
+    return;
+  case ITERATE_KIT_VOICE_PLAYOUT_PLAYED:
+  case ITERATE_KIT_VOICE_PLAYOUT_REPLACED:
+  case ITERATE_KIT_VOICE_PLAYOUT_REFUSED:
+    atomic_store_explicit(
+        &runtime.speaker_last_write_ms, runtime.playout.last_write_ms,
+        memory_order_release);
+    return;
+  }
 }
 
 /* --- microphone path ------------------------------------------------------ */
@@ -2279,7 +2155,7 @@ static size_t health_json(char *out, size_t capacity) {
     {"micPeakMax",
      atomic_load_explicit(&runtime.mic_peak_max, memory_order_relaxed)},
     {"spkFrames", runtime.voicelab.spk_frames_received},
-    {"spkPlayed", runtime.speaker_frames_played},
+    {"spkPlayed", runtime.playout.stats.frames_played},
     {"spkOverflow",
      atomic_load_explicit(
          &runtime.speaker_overflow_drops, memory_order_relaxed)},
@@ -2292,13 +2168,13 @@ static size_t health_json(char *out, size_t capacity) {
      * and the listener: on the turns that moved it, spkStarvedMs was 0 and every
      * frame received was played. spkStarvedMs is the audible-failure gate.
      */
-    {"spkSoftDryTicks", runtime.speaker_conceal_frames},
-    {"spkCatchup", runtime.speaker_catchup_frames},
-    {"spkWriteFailures", runtime.speaker_write_failures},
-    {"spkMarginMaxMs", runtime.speaker_margin_max_ms},
-    {"spkLagMaxMs", runtime.speaker_lag_max_ms},
-    {"spkMarginMinMs", runtime.speaker_margin_min_ms},
-    {"spkWrites", runtime.speaker_writes},
+    {"spkSoftDryTicks", runtime.playout.stats.conceal_frames},
+    {"spkCatchup", runtime.playout.stats.catchup_frames},
+    {"spkWriteFailures", runtime.playout.stats.write_failures},
+    {"spkMarginMaxMs", runtime.playout.stats.margin_max_ms},
+    {"spkLagMaxMs", runtime.playout.clock.lag_max_ms},
+    {"spkMarginMinMs", runtime.playout.stats.margin_min_ms},
+    {"spkWrites", runtime.playout.stats.writes},
     {"spkBadFrames", runtime.speaker_bad_frames},
     /*
      * A CHUNK THE DEVICE COULD NOT DECODE, which is now the only way audio
@@ -2333,8 +2209,8 @@ static size_t health_json(char *out, size_t capacity) {
      * a clock that owes nothing to the event lane. */
     {"spkDrops", runtime.speaker_drops},
     {"spkLastDropUptimeMs", runtime.last_drop_uptime_ms},
-    {"spkWaitPriming", runtime.speaker_waits_priming},
-    {"spkAnswerDrains", runtime.speaker_waits_dry},
+    {"spkWaitPriming", runtime.playout.stats.waits_priming},
+    {"spkAnswerDrains", runtime.playout.stats.waits_dry},
     /*
      * THE FACE LANE, AND WHICH HALF OF IT IS DARK.
      *
@@ -2732,7 +2608,7 @@ bool iterate_kit_voice_loop_init(
   (void)snprintf(
       stream_path, sizeof(stream_path), "%s", facts->stream_path);
   turn_policy = facts->turns;
-  iterate_kit_voice_playback_clock_init(&runtime.playout_clock);
+  iterate_kit_voice_playout_init(&runtime.playout);
   /*
    * The app task is the sole consumer of the control inbox and therefore the
    * producer of every speaker frame: it parses the delivery batch, base64
@@ -3725,8 +3601,8 @@ void iterate_kit_voice_loop_step(uint64_t now_ms_value) {
       }
       if (runtime.voicelab.call_active &&
           runtime.voicelab.call_active != call_active_shown) {
-        runtime.speaker_margin_min_ms = 0U;
-        runtime.speaker_writes = 0U;
+        runtime.playout.stats.margin_min_ms = 0U;
+        runtime.playout.stats.writes = 0U;
       }
       if (runtime.voicelab.call_active != call_active_shown) {
         /*
@@ -4176,8 +4052,8 @@ void iterate_kit_voice_loop_step(uint64_t now_ms_value) {
               runtime.voicelab.batches_on_connection,
               runtime.voicelab.spk_frames_received,
               runtime.voicelab.spk_decode_failures,
-              runtime.speaker_frames_played,
-              runtime.speaker_conceal_frames,
+              runtime.playout.stats.frames_played,
+              runtime.playout.stats.conceal_frames,
               runtime.speaker_underruns,
               (unsigned int)(speaker_queued_bytes() / 32U));
         }

--- a/apps/kit/firmware/targets/host_cli/cli_capabilities.c
+++ b/apps/kit/firmware/targets/host_cli/cli_capabilities.c
@@ -245,7 +245,7 @@ static void cli_capabilities_write_health_start(
       runtime->stats_sequence++, cli_runtime_now_ms(NULL),
       runtime->voicelab.frames_sent, runtime->voicelab.frame_send_failures,
       runtime->mic_frames_captured, mic_dropped, runtime->mic_frames_gated,
-      runtime->voicelab.spk_frames_received, runtime->speaker_frames_played,
+      runtime->voicelab.spk_frames_received, runtime->playout.stats.frames_played,
       runtime->speaker_overflow_drops);
 }
 
@@ -272,9 +272,9 @@ static void cli_capabilities_write_health_audio(
       "\"connGeneration\":%u,"
       "\"bridgeAgeMs\":%u,\"downlinkRecycles\":%u,\"batchAgeMs\":%u,"
       "\"uptimeMs\":%" PRIu64,
-      runtime->speaker_underruns, runtime->speaker_conceal_frames,
-      runtime->speaker_catchup_frames,
-      runtime->speaker_write_failures, runtime->speaker_margin_max_ms,
+      runtime->speaker_underruns, runtime->playout.stats.conceal_frames,
+      runtime->playout.stats.catchup_frames,
+      runtime->playout.stats.write_failures, runtime->playout.stats.margin_max_ms,
       runtime->speaker_bad_frames,
       runtime->voicelab.spk_decode_failures, runtime->barge_in_flushes,
       runtime->voicelab.batches_on_connection,
@@ -318,7 +318,7 @@ static void cli_capabilities_write_health_end(
       writer,
       ",\"spkMarginMinMs\":%u,\"spkMarginP10Ms\":%u,\"spkWrites\":%u,"
       "\"outboxUsed\":%u,\"outboxSlots\":%u}",
-      runtime->speaker_margin_min_ms, 0U, runtime->speaker_writes,
+      runtime->playout.stats.margin_min_ms, 0U, runtime->playout.stats.writes,
       outbox->current_slots, ITERATE_KIT_VOICE_CONTROL_OUTBOX_SLOTS);
 }
 

--- a/apps/kit/firmware/targets/host_cli/cli_runtime.h
+++ b/apps/kit/firmware/targets/host_cli/cli_runtime.h
@@ -54,7 +54,7 @@
 #include "iterate/kit/platforms/darwin_audio_codec.h"
 #include "iterate/kit/platforms/posix_itx_transport.h"
 #include "iterate/kit/spsc_ring.h"
-#include "iterate/kit/voice_playback_clock.h"
+#include "iterate/kit/voice_playout.h"
 #include "iterate/kit/voicelab_stream.h"
 
 struct cli_runtime {
@@ -91,7 +91,13 @@ struct cli_runtime {
   uint32_t frame_sequence;
   struct cli_microphone microphone;
   struct cli_speaker speaker;
-  struct iterate_kit_voice_playback_clock playback_clock;
+  /*
+   * The playout step shared with the board — the clock, the answer's
+   * timeline and every counter the report calls spk* — and the frame in
+   * flight between the ring and the room. See iterate/kit/voice_playout.h.
+   */
+  struct iterate_kit_voice_playout playout;
+  uint8_t playout_frame[ITERATE_KIT_VOICE_FRAME_BYTES];
   struct cli_wav_source source;
   struct cli_wav_sink sink;
   /* What the microphone captured; opened only when --mic-record was given. */
@@ -163,14 +169,6 @@ struct cli_runtime {
   uint32_t turn_room_completed_start_bytes;
   /** Bytes this scripted turn successfully submitted to the room boundary. */
   uint32_t turn_room_submitted_bytes;
-  /**
-   * The current answer's playout timeline: when its first frame reached the
-   * speaker, and how many MILLISECONDS have been emitted since. See iterate_kit_voice_playout_lag_ms —
-   * both targets measure lateness the same way, from the same helper.
-   */
-  uint64_t answer_started_ms;
-  uint32_t answer_emitted_ms;
-  uint32_t speaker_lag_max_ms;
   uint64_t next_mic_at_ms;
   uint64_t next_playback_at_ms;
   uint64_t next_stats_at_ms;
@@ -184,18 +182,11 @@ struct cli_runtime {
   uint32_t mic_frames_captured;
   uint32_t mic_frames_dropped;
   uint32_t mic_frames_gated;
-  uint32_t speaker_frames_played;
   uint32_t speaker_overflow_drops;
   uint32_t speaker_underruns;
-  uint32_t speaker_conceal_frames;
-  uint32_t speaker_catchup_frames;
-  uint32_t speaker_write_failures;
   uint32_t mic_write_failures;
   /* Frames the room never got because the speaker ring was full. */
   uint32_t speaker_room_drops;
-  uint32_t speaker_margin_min_ms;
-  uint32_t speaker_margin_max_ms;
-  uint32_t speaker_writes;
   uint32_t speaker_bad_frames;
   uint32_t barge_in_flushes;
   uint32_t liveness_restarts;

--- a/apps/kit/firmware/targets/host_cli/main.c
+++ b/apps/kit/firmware/targets/host_cli/main.c
@@ -142,20 +142,20 @@ static bool cli_main_write_playback(
     struct cli_runtime *runtime, const uint8_t *pcm);
 
 /* Feeds the converter until it stops asking; unpaced, exactly one frame. */
-static void cli_main_feed_playback(
-    struct cli_runtime *runtime, uint64_t now_ms);
+static void cli_main_feed_playback(struct cli_runtime *runtime);
 
 /* Completes an answered or overdue turn before consuming another frame. */
 static void cli_main_finish_answer_if_ready(
     struct cli_runtime *runtime, uint64_t now_ms);
 
-/* Produces one concealment frame when the playback clock requires it. */
-static void cli_main_conceal_if_needed(
-    struct cli_runtime *runtime, uint64_t now_ms);
-
-/* Applies the playback clock's decision to one dequeued frame. */
-static void cli_main_play_frame(
-    struct cli_runtime *runtime, const uint8_t *frame, uint64_t now_ms);
+/* The speaker ring and the room, as the shared playout step sees them. */
+static uint32_t cli_main_ring_queued_bytes(void *context);
+static enum iterate_kit_voice_playout_read cli_main_ring_read(
+    void *context, const uint8_t **frame, size_t *length);
+static uint64_t cli_main_sink_now_ms(void *context);
+static enum iterate_kit_voice_playout_write cli_main_sink_write(
+    void *context, const uint8_t *frame, size_t length);
+static bool cli_main_sink_conceal(void *context);
 
 /* Advances the real-time playback clock by at most one frame. */
 static void cli_main_poll_playback(
@@ -760,7 +760,7 @@ static bool cli_main_init_runtime(struct cli_runtime *runtime)
   if (!cli_main_init_keyboard(runtime)) return false;
   cli_speaker_clear(&runtime->speaker);
   cli_microphone_clear(&runtime->microphone);
-  iterate_kit_voice_playback_clock_init(&runtime->playback_clock);
+  iterate_kit_voice_playout_init(&runtime->playout);
   cli_runtime_log(
       "info", "iterate-kit-cli ready client=%s stream=%s staticBytes=%zu outbox=%u",
       runtime->client_path, runtime->options.stream_path, sizeof(*runtime),
@@ -874,7 +874,7 @@ static void cli_main_accept_speaker_frame(
     return;
   }
   if (iterate_kit_voice_playback_clock_audio_arrived(
-          &runtime->playback_clock, cli_runtime_now_ms(NULL))) {
+          &runtime->playout.clock, cli_runtime_now_ms(NULL))) {
     ++runtime->speaker_underruns;
     if (runtime->conversation.current_turn != NULL) {
       ++runtime->conversation.current_turn->underruns;
@@ -976,10 +976,8 @@ static void cli_main_on_control(
      */
     iterate_kit_darwin_audio_codec_set_playback_expected(&runtime->audio_codec, false);
     cli_speaker_clear(&runtime->speaker);
-    iterate_kit_voice_playback_clock_reprime(&runtime->playback_clock);
-    /* A new answer is a new timeline: lag does not carry across answers. */
-    runtime->answer_started_ms = 0U;
-    runtime->answer_emitted_ms = 0U;
+    /* A new answer is a new timeline: the reprime forgets the old one. */
+    iterate_kit_voice_playback_clock_reprime(&runtime->playout.clock);
     ++runtime->barge_in_flushes;
   } else if (control == ITERATE_KIT_VOICELAB_CONTROL_RESPONSE_DONE) {
     /*
@@ -988,7 +986,7 @@ static void cli_main_on_control(
      * handed over. Only the clock is told; nothing is thrown away.
      */
     runtime->answer_done = true;
-    iterate_kit_voice_playback_clock_answer_done(&runtime->playback_clock);
+    iterate_kit_voice_playback_clock_answer_done(&runtime->playout.clock);
   } else if (control == ITERATE_KIT_VOICELAB_CONTROL_CALL_ACCEPTED) {
     cli_runtime_log("info", "call accepted");
   } else if (control == ITERATE_KIT_VOICELAB_CONTROL_CALL_ENDED) {
@@ -1020,7 +1018,6 @@ static bool cli_main_record_frame(
   assert(runtime != NULL && pcm != NULL);
   if (cli_wav_sink_write(
           &runtime->sink, pcm, ITERATE_KIT_VOICE_FRAME_BYTES) != CLI_WAV_OK) {
-    ++runtime->speaker_write_failures;
     runtime->stop_requested = true;
     return false;
   }
@@ -1161,72 +1158,73 @@ static void cli_main_finish_answer_if_ready(
   }
 }
 
-static void cli_main_conceal_if_needed(
-    struct cli_runtime *runtime, uint64_t now_ms)
+static uint32_t cli_main_ring_queued_bytes(void *context)
 {
+  const struct cli_runtime *runtime = context;
   assert(runtime != NULL);
-  const enum iterate_kit_voice_playback_action action =
-      iterate_kit_voice_playback_clock_empty(&runtime->playback_clock, now_ms);
-  if (action != ITERATE_KIT_VOICE_PLAYBACK_CONCEAL) return;
+  return (uint32_t)runtime->speaker.used;
+}
+
+static enum iterate_kit_voice_playout_read cli_main_ring_read(
+    void *context, const uint8_t **frame, size_t *length)
+{
+  struct cli_runtime *runtime = context;
+  assert(runtime != NULL && frame != NULL && length != NULL);
+  if (cli_speaker_read(
+          &runtime->speaker, runtime->playout_frame,
+          sizeof(runtime->playout_frame)) != CLI_SPEAKER_OK) {
+    return ITERATE_KIT_VOICE_PLAYOUT_READ_DRY;
+  }
+  *frame = runtime->playout_frame;
+  *length = sizeof(runtime->playout_frame);
+  return ITERATE_KIT_VOICE_PLAYOUT_READ_FRAME;
+}
+
+static uint64_t cli_main_sink_now_ms(void *context)
+{
+  (void)context;
+  return cli_runtime_now_ms(NULL);
+}
+
+static enum iterate_kit_voice_playout_write cli_main_sink_write(
+    void *context, const uint8_t *frame, size_t length)
+{
+  struct cli_runtime *runtime = context;
+  assert(runtime != NULL && frame != NULL);
+  assert(length == (size_t)ITERATE_KIT_VOICE_FRAME_BYTES);
+  (void)length;
+  if (!cli_main_write_playback(runtime, frame)) {
+    return ITERATE_KIT_VOICE_PLAYOUT_WRITE_FAILED;
+  }
+  /*
+   * The turn's own ledger, from audio the room actually took: what the
+   * report calls occupancy and played, the progress the turn watchdog
+   * measures instead of elapsed time, and when the answer was first heard.
+   */
+  {
+    const uint64_t now_ms = cli_runtime_now_ms(NULL);
+    struct cli_report_turn *turn = runtime->conversation.current_turn;
+    if (turn != NULL) {
+      cli_report_observe_occupancy(
+          turn, cli_speaker_queued_ms(&runtime->speaker));
+      ++turn->frames_played;
+      runtime->turn_progress_ms = now_ms;
+      if (turn->first_audio_ms == 0U) turn->first_audio_ms = now_ms;
+    }
+  }
+  return ITERATE_KIT_VOICE_PLAYOUT_WRITE_OK;
+}
+
+static bool cli_main_sink_conceal(void *context)
+{
+  struct cli_runtime *runtime = context;
   static const uint8_t silence[ITERATE_KIT_VOICE_FRAME_BYTES] = {0};
-  if (!cli_main_write_playback(runtime, silence)) return;
-  ++runtime->speaker_conceal_frames;
+  assert(runtime != NULL);
+  if (!cli_main_write_playback(runtime, silence)) return false;
   if (runtime->conversation.current_turn != NULL) {
     ++runtime->conversation.current_turn->frames_concealed;
   }
-}
-
-static void cli_main_play_frame(
-    struct cli_runtime *runtime, const uint8_t *frame, uint64_t now_ms)
-{
-  assert(runtime != NULL && frame != NULL);
-  const enum iterate_kit_voice_playback_action action =
-      iterate_kit_voice_playback_clock_frame(
-          &runtime->playback_clock, (uint32_t)runtime->speaker.used,
-          iterate_kit_voice_playout_lag_ms(
-              runtime->answer_started_ms, runtime->answer_emitted_ms,
-              now_ms),
-          now_ms);
-  if (action == ITERATE_KIT_VOICE_PLAYBACK_DROP_CATCHUP) {
-    /* The skipped frame still spent its place in the timeline; see the
-     * device's copy of this branch for why leaving it makes skipping run
-     * away and delete half an answer. */
-    ++runtime->speaker_catchup_frames;
-    runtime->answer_emitted_ms += ITERATE_KIT_VOICE_FRAME_MS;
-    return;
-  }
-  if (action != ITERATE_KIT_VOICE_PLAYBACK_PLAY) return;
-  if (!cli_main_write_playback(runtime, frame)) return;
-  ++runtime->speaker_frames_played;
-  ++runtime->speaker_writes;
-  {
-    if (runtime->answer_started_ms == 0U) {
-      runtime->answer_started_ms = now_ms;
-      runtime->answer_emitted_ms = 0U;
-    }
-    {
-      const uint32_t lag = iterate_kit_voice_playout_lag_ms(
-          runtime->answer_started_ms, runtime->answer_emitted_ms, now_ms);
-      if (lag > runtime->speaker_lag_max_ms) {
-        runtime->speaker_lag_max_ms = lag;
-      }
-    }
-    runtime->answer_emitted_ms += ITERATE_KIT_VOICE_FRAME_MS;
-  }
-  const uint32_t margin = cli_speaker_queued_ms(&runtime->speaker);
-  if (runtime->speaker_writes == 1U ||
-      margin < runtime->speaker_margin_min_ms) {
-    runtime->speaker_margin_min_ms = margin;
-  }
-  if (margin > runtime->speaker_margin_max_ms) {
-    runtime->speaker_margin_max_ms = margin;
-  }
-  struct cli_report_turn *turn = runtime->conversation.current_turn;
-  if (turn == NULL) return;
-  cli_report_observe_occupancy(turn, margin);
-  ++turn->frames_played;
-  runtime->turn_progress_ms = now_ms;
-  if (turn->first_audio_ms == 0U) turn->first_audio_ms = now_ms;
+  return true;
 }
 
 static void cli_main_poll_playback(
@@ -1257,7 +1255,7 @@ static void cli_main_poll_playback(
      * reuse a completed buffer.
      */
     cli_main_finish_answer_if_ready(runtime, now_ms);
-    cli_main_feed_playback(runtime, now_ms);
+    cli_main_feed_playback(runtime);
     return;
   }
   if (runtime->next_playback_at_ms == 0U) {
@@ -1272,11 +1270,10 @@ static void cli_main_poll_playback(
     runtime->next_playback_at_ms = now_ms + ITERATE_KIT_VOICE_FRAME_MS;
   }
   cli_main_finish_answer_if_ready(runtime, now_ms);
-  cli_main_feed_playback(runtime, now_ms);
+  cli_main_feed_playback(runtime);
 }
 
-static void cli_main_feed_playback(
-    struct cli_runtime *runtime, uint64_t now_ms)
+static void cli_main_feed_playback(struct cli_runtime *runtime)
 {
   assert(runtime != NULL);
   const bool room_pulls = runtime->options.live_audio ||
@@ -1300,25 +1297,41 @@ static void cli_main_feed_playback(
    * without a count a discard policy would drain the whole thirty-second ring
    * in one iteration while the converter went on asking.
    */
+  const struct iterate_kit_voice_playout_ring ring = {
+    .context = runtime,
+    .queued_bytes = cli_main_ring_queued_bytes,
+    .read = cli_main_ring_read,
+  };
+  /*
+   * WHO CONCEALS. The hardware puller is the exact authority for missing
+   * room audio: feeding software-generated concealment on this loop's 5 ms
+   * poll would fill a 20 ms hardware queue four times too fast and hide the
+   * callback's own starvation evidence. The unpaced/file-only model has no
+   * such authority, so it supplies the silence itself. Everything else —
+   * including asking the clock on EVERY dry read, which this loop once
+   * skipped for a live room and paid for with a back-office turn played one
+   * block in five (prd, 2026-09-09) — is the step's, shared with the board.
+   */
+  const struct iterate_kit_voice_playout_sink sink = {
+    .context = runtime,
+    .now_ms = cli_main_sink_now_ms,
+    .write = cli_main_sink_write,
+    .conceal = room_pulls ? NULL : cli_main_sink_conceal,
+  };
   uint32_t fed = 0U;
   do {
-    if (!iterate_kit_voice_playback_clock_ready(
-            &runtime->playback_clock, (uint32_t)runtime->speaker.used)) return;
-    uint8_t frame[ITERATE_KIT_VOICE_FRAME_BYTES] = {0};
-    if (cli_speaker_read(&runtime->speaker, frame, sizeof(frame)) !=
-        CLI_SPEAKER_OK) {
-      /*
-       * The hardware puller is the exact authority for missing room audio.
-       * Feeding software-generated concealment on this loop's 5 ms poll
-       * would fill a 20 ms hardware queue four times too fast and hide the
-       * callback's own starvation evidence. The unpaced/file-only model has
-       * no such authority, so it retains the core concealment decision.
-       */
-      if (room_pulls) return;
-      cli_main_conceal_if_needed(runtime, now_ms);
+    switch (iterate_kit_voice_playout_step(&runtime->playout, &ring, &sink)) {
+    case ITERATE_KIT_VOICE_PLAYOUT_PRIMING:
+    case ITERATE_KIT_VOICE_PLAYOUT_ABANDONED:
+    case ITERATE_KIT_VOICE_PLAYOUT_STARVED:
+    case ITERATE_KIT_VOICE_PLAYOUT_SETTLED:
       return;
+    case ITERATE_KIT_VOICE_PLAYOUT_SKIPPED:
+    case ITERATE_KIT_VOICE_PLAYOUT_PLAYED:
+    case ITERATE_KIT_VOICE_PLAYOUT_REPLACED:
+    case ITERATE_KIT_VOICE_PLAYOUT_REFUSED:
+      break;
     }
-    cli_main_play_frame(runtime, frame, now_ms);
     ++fed;
   } while (fed < CLI_PACED_SINK_MAX_DEPTH_FRAMES &&
            (cli_paced_sink_ready(&runtime->paced_sink) ||
@@ -1532,7 +1545,7 @@ static void cli_main_start_talk(
   runtime->frame_sequence = 0U;
   cli_microphone_clear(&runtime->microphone);
   cli_speaker_clear(&runtime->speaker);
-  iterate_kit_voice_playback_clock_reprime(&runtime->playback_clock);
+  iterate_kit_voice_playback_clock_reprime(&runtime->playout.clock);
   /*
    * A LOST ptt-start IS A LOST BARGE-IN: the server's answer-drop triggers on
    * this exact event, so a press that captures audio but fails to say
@@ -1765,13 +1778,13 @@ static void cli_main_draw_screen(struct cli_runtime *runtime, uint64_t now_ms)
     .mic_sent = runtime->voicelab.frames_sent,
     .mic_lost = audio.capture_frames_dropped,
     .spk_received = runtime->voicelab.spk_frames_received,
-    .spk_played = runtime->speaker_frames_played,
+    .spk_played = runtime->playout.stats.frames_played,
     .spk_ring_ms = cli_speaker_queued_ms(&runtime->speaker),
-    .spk_conceal = runtime->speaker_conceal_frames,
+    .spk_conceal = runtime->playout.stats.conceal_frames,
     .spk_underruns = runtime->speaker_underruns,
     .spk_dropped = runtime->speaker_room_drops + runtime->speaker_overflow_drops,
     .spk_starved = audio.playback_starved_buffers,
-    .spk_catchup = runtime->speaker_catchup_frames,
+    .spk_catchup = runtime->playout.stats.catchup_frames,
     .turn_release_to_commit_ms = runtime->turn_release_to_commit_ms,
     .turn_commit_to_audio_ms = runtime->turn_commit_to_audio_ms,
     .outbox_used = (uint32_t)outbox.current_slots,
@@ -1894,7 +1907,7 @@ static void cli_main_pulse(
       runtime->transport.control_sender.messages_sent,
       runtime->voicelab.frames_sent, runtime->voicelab.batches_on_connection,
       runtime->voicelab.spk_frames_received,
-      runtime->speaker_frames_played, runtime->speaker_conceal_frames,
+      runtime->playout.stats.frames_played, runtime->playout.stats.conceal_frames,
       runtime->speaker_underruns, cli_speaker_queued_ms(&runtime->speaker),
       /*
        * A live microphone that macOS refused looks exactly like a quiet room

--- a/apps/kit/firmware/tests/CMakeLists.txt
+++ b/apps/kit/firmware/tests/CMakeLists.txt
@@ -74,6 +74,9 @@ iterate_kit_add_core_test(iterate-kit-spsc-ring-test spsc_ring_test.c)
 iterate_kit_add_core_test(iterate-kit-touch-tap-test touch_tap_test.c)
 iterate_kit_add_core_test(
   iterate-kit-voice-playback-clock-test voice_playback_clock_test.c)
+# THE STEP BOTH TARGETS RUN, against a ring that is an array and a sink that
+# counts: every branch the board's and the CLI's playback share, asserted once.
+iterate_kit_add_core_test(iterate-kit-voice-playout-test voice_playout_test.c)
 iterate_kit_add_core_test(iterate-kit-voicelab-stream-test voicelab_stream_test.c)
 iterate_kit_add_core_test(
   iterate-kit-websocket-frame-writer-test websocket_frame_writer_test.c)

--- a/apps/kit/firmware/tests/cli_paced_sink_test.c
+++ b/apps/kit/firmware/tests/cli_paced_sink_test.c
@@ -2,7 +2,7 @@
 
 #include "cli_speaker.h"
 #include "iterate/kit/voice_device_profile.h"
-#include "iterate/kit/voice_playback_clock.h"
+#include "iterate/kit/voice_playout.h"
 
 #include <assert.h>
 #include <stdio.h>
@@ -69,7 +69,8 @@ struct rig_result {
 
 struct rig {
   struct cli_paced_sink sink;
-  struct iterate_kit_voice_playback_clock clock;
+  struct iterate_kit_voice_playout playout;
+  uint64_t now_ms;
   uint64_t next_due_ms;
   struct rig_result result;
 };
@@ -336,34 +337,75 @@ static void rig_deliver_answer(uint32_t frames)
   }
 }
 
-static bool rig_feed_once(struct rig *rig, uint64_t now_ms)
+static uint32_t rig_ring_queued_bytes(void *context)
 {
-  assert(rig != NULL);
-  if (!iterate_kit_voice_playback_clock_ready(
-          &rig->clock, (uint32_t)rig_speaker.used)) {
-    ++rig->result.dry_ticks;
-    return false;
-  }
+  (void)context;
+  return (uint32_t)rig_speaker.used;
+}
+
+static enum iterate_kit_voice_playout_read rig_ring_read(
+    void *context, const uint8_t **frame, size_t *length)
+{
+  (void)context;
   if (cli_speaker_read(&rig_speaker, rig_frame, sizeof(rig_frame)) !=
       CLI_SPEAKER_OK) {
-    ++rig->result.dry_ticks;
-    if (iterate_kit_voice_playback_clock_empty(&rig->clock, now_ms) ==
-        ITERATE_KIT_VOICE_PLAYBACK_CONCEAL) {
-      ++rig->result.conceal_frames;
-      rig_record(rig, 1U);
-      (void)cli_paced_sink_offer(&rig->sink);
-    }
-    return false;
+    return ITERATE_KIT_VOICE_PLAYOUT_READ_DRY;
   }
-  if (iterate_kit_voice_playback_clock_frame(
-          &rig->clock, (uint32_t)rig_speaker.used,
-          0U, now_ms) != ITERATE_KIT_VOICE_PLAYBACK_PLAY) {
-    return false;
-  }
-  ++rig->result.frames_played;
+  *frame = rig_frame;
+  *length = sizeof(rig_frame);
+  return ITERATE_KIT_VOICE_PLAYOUT_READ_FRAME;
+}
+
+static uint64_t rig_sink_now_ms(void *context)
+{
+  const struct rig *rig = context;
+  assert(rig != NULL);
+  return rig->now_ms;
+}
+
+static enum iterate_kit_voice_playout_write rig_sink_write(
+    void *context, const uint8_t *frame, size_t length)
+{
+  struct rig *rig = context;
+  assert(rig != NULL && frame != NULL);
+  assert(length == sizeof(rig_frame));
+  (void)length;
+  rig_record(rig, 1U);
+  (void)cli_paced_sink_offer(&rig->sink);
+  return ITERATE_KIT_VOICE_PLAYOUT_WRITE_OK;
+}
+
+static bool rig_sink_conceal(void *context)
+{
+  struct rig *rig = context;
+  assert(rig != NULL);
   rig_record(rig, 1U);
   (void)cli_paced_sink_offer(&rig->sink);
   return true;
+}
+
+/*
+ * The CLI's own ring and converter, driven by the SHARED playout step — the
+ * one the board runs too — so this rig witnesses the step against real CLI
+ * modules rather than re-implementing the sequence beside it.
+ */
+static bool rig_feed_once(struct rig *rig, uint64_t now_ms)
+{
+  assert(rig != NULL);
+  const struct iterate_kit_voice_playout_ring ring = {
+    .context = rig,
+    .queued_bytes = rig_ring_queued_bytes,
+    .read = rig_ring_read,
+  };
+  const struct iterate_kit_voice_playout_sink sink = {
+    .context = rig,
+    .now_ms = rig_sink_now_ms,
+    .write = rig_sink_write,
+    .conceal = rig_sink_conceal,
+  };
+  rig->now_ms = now_ms;
+  return iterate_kit_voice_playout_step(&rig->playout, &ring, &sink) ==
+      ITERATE_KIT_VOICE_PLAYOUT_PLAYED;
 }
 
 static void rig_poll_playback(struct rig *rig, uint64_t now_ms)
@@ -402,7 +444,7 @@ static void rig_run(const struct rig_plan *plan, struct rig_result *out)
   assert(plan != NULL && out != NULL);
   memset(&rig_state, 0, sizeof(rig_state));
   cli_speaker_clear(&rig_speaker);
-  iterate_kit_voice_playback_clock_init(&rig_state.clock);
+  iterate_kit_voice_playout_init(&rig_state.playout);
   const struct cli_paced_sink_config config = {
     .frames_per_second = plan->pace_fps,
     .depth_frames = 0U,
@@ -418,6 +460,10 @@ static void rig_run(const struct rig_plan *plan, struct rig_result *out)
     rig_poll_playback(&rig_state, now_ms);
     now_ms += rig_step_ms(plan, now_ms);
   }
+  rig_state.result.frames_played = rig_state.playout.stats.frames_played;
+  rig_state.result.conceal_frames = rig_state.playout.stats.conceal_frames;
+  rig_state.result.dry_ticks = rig_state.playout.stats.waits_priming +
+      rig_state.playout.stats.waits_dry;
   rig_state.result.converter_underruns = rig_state.sink.underrun_frames;
   rig_state.result.converter_refusals = rig_state.sink.refused_frames;
   rig_state.result.converter_emitted =

--- a/apps/kit/firmware/tests/voice_playback_clock_test.c
+++ b/apps/kit/firmware/tests/voice_playback_clock_test.c
@@ -3,6 +3,33 @@
 
 #include <assert.h>
 
+enum {
+  FRAME_MS = ITERATE_KIT_VOICE_FRAME_MS,
+  BYTES_PER_MS = 32,
+  ONE_CHUNK_BYTES = 100 * BYTES_PER_MS, /* the sender's 100 ms chunk */
+  CATCHUP_MS = ITERATE_KIT_VOICE_SPEAKER_LAG_CATCHUP_MS,
+};
+
+/* Leaves priming the way an owner does: with the prefill in the ring. */
+static void leave_priming(struct iterate_kit_voice_playback_clock *clock) {
+  assert(iterate_kit_voice_playback_clock_ready(
+      clock, ITERATE_KIT_VOICE_SPEAKER_PREFILL_BYTES));
+}
+
+/*
+ * Plays one frame at `at_ms` from a ring holding `queued_bytes` behind it,
+ * the way both owners do: the decision, then the report of what was played.
+ */
+static void play_frame(
+    struct iterate_kit_voice_playback_clock *clock,
+    uint32_t queued_bytes,
+    uint64_t at_ms) {
+  assert(iterate_kit_voice_playback_clock_frame(
+             clock, queued_bytes, FRAME_MS, at_ms) ==
+      ITERATE_KIT_VOICE_PLAYBACK_PLAY);
+  iterate_kit_voice_playback_clock_played(clock, at_ms, FRAME_MS);
+}
+
 /*
  * The opening bridge burst is useful only if playback waits for the device's
  * real prefill.  Starting one byte early recreates the zero-margin opening
@@ -38,8 +65,7 @@ static void concealment_never_costs_a_real_frame(void) {
   struct iterate_kit_voice_playback_clock clock;
   uint32_t index;
   iterate_kit_voice_playback_clock_init(&clock);
-  assert(iterate_kit_voice_playback_clock_ready(
-      &clock, ITERATE_KIT_VOICE_SPEAKER_PREFILL_BYTES));
+  leave_priming(&clock);
   /* Ten dry ticks: ten frames of inserted silence. */
   for (index = 0U; index < 10U; ++index) {
     assert(iterate_kit_voice_playback_clock_empty(&clock, 1000U + index * 20U) ==
@@ -48,12 +74,9 @@ static void concealment_never_costs_a_real_frame(void) {
   assert(iterate_kit_voice_playback_clock_audio_arrived(&clock, 1200U));
   /* Every frame that arrives after them is PLAYED. None pays for anything. */
   for (index = 0U; index < 10U; ++index) {
-    assert(iterate_kit_voice_playback_clock_frame(
-               &clock, 0U, 0U, 1200U + index * 20U) ==
-        ITERATE_KIT_VOICE_PLAYBACK_PLAY);
+    play_frame(&clock, 0U, 1200U + index * 20U);
   }
 }
-
 
 /*
  * response.done turns an empty ring into normal answer completion, never an
@@ -63,8 +86,7 @@ static void concealment_never_costs_a_real_frame(void) {
 static void completed_answer_returns_to_priming_without_silence(void) {
   struct iterate_kit_voice_playback_clock clock;
   iterate_kit_voice_playback_clock_init(&clock);
-  assert(iterate_kit_voice_playback_clock_ready(
-      &clock, ITERATE_KIT_VOICE_SPEAKER_PREFILL_BYTES));
+  leave_priming(&clock);
   iterate_kit_voice_playback_clock_answer_done(&clock);
   assert(iterate_kit_voice_playback_clock_empty(&clock, 1000U) ==
       ITERATE_KIT_VOICE_PLAYBACK_WAIT);
@@ -82,41 +104,173 @@ static void completed_answer_returns_to_priming_without_silence(void) {
  * The old rule keyed on queue DEPTH, which cannot see this: a deep queue
  * means the sender was fast, not that playback is late, so the threshold had
  * to be set just under the ring and consequently never fired.
+ *
+ * AND A SKIPPED FRAME SPENDS ITS PLACE IN THE TIMELINE, which is what makes
+ * "skip until level" terminate: 900 ms late with a second queued is exactly
+ * twenty skips, then the next frame plays. Leave the timeline alone on a skip
+ * and it would skip the whole second — measured, 78 of 162 frames.
  */
 static void falling_behind_its_timeline_is_recovered(void)
 {
   struct iterate_kit_voice_playback_clock clock;
-  const uint32_t late = ITERATE_KIT_VOICE_SPEAKER_LAG_CATCHUP_MS + 1U;
-  const uint32_t level = ITERATE_KIT_VOICE_SPEAKER_LAG_CATCHUP_MS;
-  const uint32_t backlog = 500U * 32U; /* half a second waiting to be played */
+  const uint32_t backlog = 1000U * BYTES_PER_MS; /* a second waiting */
+  const uint32_t late_by = 900U;
+  uint64_t now;
   uint32_t index;
 
   iterate_kit_voice_playback_clock_init(&clock);
+  leave_priming(&clock);
+  play_frame(&clock, backlog, 1000U); /* the timeline's origin */
+  now = 1000U + FRAME_MS + late_by; /* the next frame is due; we are late */
+  assert(iterate_kit_voice_playback_clock_lag_ms(&clock, now) == late_by);
   /*
    * Late WITH A BACKLOG, which is the only case worth skipping: it keeps
    * skipping until level, rather than trimming one frame in fifty — measured,
    * that recovered 60 ms against 3.1 s of lag, so the answer ended long
    * before the device was level and it simply stayed behind.
    */
-  for (index = 0U; index < 20U; ++index) {
+  for (index = 0U; index < (late_by - CATCHUP_MS) / FRAME_MS; ++index) {
     assert(
         iterate_kit_voice_playback_clock_frame(
-            &clock, backlog, late, 1000U + index * 20U) ==
+            &clock, backlog, FRAME_MS, now) ==
         ITERATE_KIT_VOICE_PLAYBACK_DROP_CATCHUP);
   }
   /* Level again: skipping stops at once, so the cut is bounded by the lag. */
-  assert(
-      iterate_kit_voice_playback_clock_frame(
-          &clock, backlog, level, 1400U) ==
-      ITERATE_KIT_VOICE_PLAYBACK_PLAY);
+  assert(iterate_kit_voice_playback_clock_lag_ms(&clock, now) == CATCHUP_MS);
+  play_frame(&clock, backlog, now);
   /*
    * And late with NOTHING QUEUED plays: the next frame is the live edge, so
    * discarding it would delete speech and recover nothing. Unguarded, this
    * ate the opening of every answer — lag peaks exactly when one starts.
    */
+  play_frame(&clock, 0U, now + 3000U);
+}
+
+/*
+ * A TIMELINE THAT LOST ITS FOOTING IS NOT A STALL. The back-office turn of
+ * 2026-09-09: an answer ends, the ring runs dry for nine seconds while the
+ * colleague works, and the follow-up answers arrive at exactly playback rate.
+ * Measured against the first answer's clock the device is "nine seconds
+ * late", the ring never holds more than the chunk that just landed, and the
+ * old rule skipped four frames in five of a 71-second answer without the lag
+ * ever moving. With one chunk queued there is nothing to catch up INTO: the
+ * frame is played. Half a second waiting is a stall's signature and is still
+ * skipped.
+ *
+ * The lag here is manufactured — the timeline is started and then abandoned
+ * for nine seconds without the dry tick that would forget it — because the
+ * guard has to hold even when the timeline is wrong.
+ */
+static void seconds_of_lag_with_only_a_chunk_queued_is_played(void)
+{
+  struct iterate_kit_voice_playback_clock clock;
+  const uint32_t half_a_second = CATCHUP_MS * BYTES_PER_MS;
+  uint64_t now = 1000U;
+  uint32_t index;
+  iterate_kit_voice_playback_clock_init(&clock);
+  leave_priming(&clock);
+  play_frame(&clock, ONE_CHUNK_BYTES, now);
+  now += 9000U;
+  assert(iterate_kit_voice_playback_clock_lag_ms(&clock, now) > 8000U);
+  for (index = 0U; index < 50U; ++index, now += FRAME_MS) {
+    play_frame(&clock, ONE_CHUNK_BYTES, now);
+  }
   assert(
-      iterate_kit_voice_playback_clock_frame(&clock, 0U, late, 1500U) ==
-      ITERATE_KIT_VOICE_PLAYBACK_PLAY);
+      iterate_kit_voice_playback_clock_frame(
+          &clock, half_a_second, FRAME_MS, now) ==
+      ITERATE_KIT_VOICE_PLAYBACK_DROP_CATCHUP);
+}
+
+/*
+ * AN ANSWER THAT ENDED DOES NOT MAKE THE NEXT ONE LATE.
+ *
+ * This is the reset both owners used to carry themselves, and each forgot on
+ * one path: the board on ordinary turns (a fifth of every answer after the
+ * first, for a week), the host CLI on its live-audio dry path (nine seconds
+ * of "lag" after a back-office wait, four frames in five discarded). The
+ * clock forgets the timeline in the same call that decides the ring is at the
+ * live edge, so a caller can no longer skip the reset by skipping a branch.
+ */
+static void an_answer_that_ended_does_not_make_the_next_one_late(void)
+{
+  struct iterate_kit_voice_playback_clock clock;
+  uint64_t now = 1000U;
+  uint32_t index;
+  iterate_kit_voice_playback_clock_init(&clock);
+  leave_priming(&clock);
+  for (index = 0U; index < 10U; ++index, now += FRAME_MS) {
+    play_frame(&clock, ONE_CHUNK_BYTES, now);
+  }
+  /* The sender said it was over; the ring runs dry; playback settles. */
+  iterate_kit_voice_playback_clock_answer_done(&clock);
+  assert(iterate_kit_voice_playback_clock_empty(&clock, now) ==
+      ITERATE_KIT_VOICE_PLAYBACK_WAIT);
+  /* Nine seconds of the colleague working. */
+  now += 9000U;
+  assert(iterate_kit_voice_playback_clock_lag_ms(&clock, now) == 0U);
+  /* The follow-up answer, at playback rate, with the sender's 4 s lead. */
+  leave_priming(&clock);
+  for (index = 0U; index < 100U; ++index, now += FRAME_MS) {
+    play_frame(&clock, 4000U * BYTES_PER_MS, now);
+    assert(iterate_kit_voice_playback_clock_lag_ms(&clock, now) == 0U);
+  }
+}
+
+/*
+ * AND SO DOES ONE THAT STALLED WITHOUT BEING DECLARED OVER: silence past the
+ * conceal limit is the clock giving the answer up, and the timeline goes with
+ * it — a stall the source never recovered from is not a debt the next answer
+ * owes.
+ */
+static void a_given_up_answer_is_forgotten_too(void)
+{
+  struct iterate_kit_voice_playback_clock clock;
+  uint64_t now = 1000U;
+  iterate_kit_voice_playback_clock_init(&clock);
+  leave_priming(&clock);
+  play_frame(&clock, 0U, now);
+  now += ITERATE_KIT_VOICE_SPEAKER_CONCEAL_LIMIT_MS; /* still within it */
+  assert(iterate_kit_voice_playback_clock_empty(&clock, now) ==
+      ITERATE_KIT_VOICE_PLAYBACK_CONCEAL);
+  assert(iterate_kit_voice_playback_clock_lag_ms(&clock, now) > 0U);
+  now += 1U; /* and now past it */
+  assert(iterate_kit_voice_playback_clock_empty(&clock, now) ==
+      ITERATE_KIT_VOICE_PLAYBACK_WAIT);
+  assert(iterate_kit_voice_playback_clock_lag_ms(&clock, now + 60000U) == 0U);
+}
+
+/*
+ * A FLUSH FORGETS THE ANSWER'S TIMELINE. A new call, a barge-in, a new turn:
+ * all reprime, and none of them may keep the last answer's clock — a new
+ * CALL once did, on the board, and its first audio was measured against an
+ * answer minutes old (34 frames skipped, `spkLagMaxMs` 117,083).
+ */
+static void a_flush_forgets_the_answers_timeline(void)
+{
+  struct iterate_kit_voice_playback_clock clock;
+  iterate_kit_voice_playback_clock_init(&clock);
+  leave_priming(&clock);
+  play_frame(&clock, 0U, 1000U);
+  iterate_kit_voice_playback_clock_reprime(&clock);
+  assert(iterate_kit_voice_playback_clock_lag_ms(&clock, 120000U) == 0U);
+  leave_priming(&clock);
+  play_frame(&clock, 1000U * BYTES_PER_MS, 120000U);
+}
+
+/*
+ * THE WORST LAG IS REMEMBERED, from the moment the frame was handed over —
+ * telemetry, so a run can prove "never late" with a number and not a count of
+ * holes.
+ */
+static void the_worst_lag_is_remembered(void)
+{
+  struct iterate_kit_voice_playback_clock clock;
+  iterate_kit_voice_playback_clock_init(&clock);
+  leave_priming(&clock);
+  play_frame(&clock, 0U, 1000U);
+  play_frame(&clock, 0U, 1320U); /* 300 ms late, nothing to skip into */
+  play_frame(&clock, 0U, 1340U); /* and back on time relative to that */
+  assert(clock.lag_max_ms == 300U);
 }
 
 /*
@@ -133,16 +287,15 @@ static void falling_behind_its_timeline_is_recovered(void)
 static void a_deep_queue_on_time_loses_nothing(void)
 {
   struct iterate_kit_voice_playback_clock clock;
-  const uint32_t deep = 8000U * 32U; /* twice the sender's budget */
+  const uint32_t deep = 8000U * BYTES_PER_MS; /* twice the sender's budget */
   uint32_t index;
 
   iterate_kit_voice_playback_clock_init(&clock);
+  leave_priming(&clock);
   for (index = 0U; index < 200U; ++index) {
-    assert(
-        iterate_kit_voice_playback_clock_frame(
-            &clock, deep, 0U, 1000U + index * 20U) ==
-        ITERATE_KIT_VOICE_PLAYBACK_PLAY);
+    play_frame(&clock, deep, 1000U + index * 20U);
   }
+  assert(clock.lag_max_ms == 0U);
 }
 
 int main(void) {
@@ -150,6 +303,11 @@ int main(void) {
   concealment_never_costs_a_real_frame();
   completed_answer_returns_to_priming_without_silence();
   falling_behind_its_timeline_is_recovered();
+  seconds_of_lag_with_only_a_chunk_queued_is_played();
+  an_answer_that_ended_does_not_make_the_next_one_late();
+  a_given_up_answer_is_forgotten_too();
+  a_flush_forgets_the_answers_timeline();
+  the_worst_lag_is_remembered();
   a_deep_queue_on_time_loses_nothing();
   return 0;
 }

--- a/apps/kit/firmware/tests/voice_playout_test.c
+++ b/apps/kit/firmware/tests/voice_playout_test.c
@@ -1,0 +1,356 @@
+/*
+ * THE SHARED PLAYOUT STEP, DRIVEN BY A SCRIPTED RING AND SINK.
+ *
+ * The board's answer-clock test proves the step through a real queue and a
+ * fake codec; the CLI's paced-sink test proves it through the CLI's ring and
+ * converter. This file proves the step ITSELF: every branch, with the ring
+ * and the sink reduced to arrays and counters, so a rule that both targets
+ * depend on is asserted once where both can see it.
+ */
+#include "iterate/kit/voice_device_profile.h"
+#include "iterate/kit/voice_playout.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <string.h>
+
+enum {
+  FRAME_BYTES = ITERATE_KIT_VOICE_FRAME_BYTES,
+  FRAME_MS = ITERATE_KIT_VOICE_FRAME_MS,
+  BYTES_PER_MS = FRAME_BYTES / FRAME_MS,
+  /** Enough frames for the clock to leave priming, whatever the prefill is. */
+  PREFILL_FRAMES = ITERATE_KIT_VOICE_SPEAKER_PREFILL_BYTES / FRAME_BYTES + 1,
+  RING_FRAMES = 1024,
+};
+
+/* --- a ring that is an array ---------------------------------------------- */
+
+static struct {
+  uint8_t frames[RING_FRAMES][FRAME_BYTES];
+  uint32_t head;
+  uint32_t tail;
+  bool abandon_next;
+  uint8_t out[FRAME_BYTES];
+} ring_state;
+
+static void ring_deliver(uint32_t frames) {
+  while (frames-- > 0U) {
+    memset(
+        ring_state.frames[ring_state.tail % RING_FRAMES],
+        (int)(ring_state.tail + 1U),
+        FRAME_BYTES);
+    ++ring_state.tail;
+  }
+}
+
+static uint32_t ring_queued_bytes(void *context) {
+  (void)context;
+  return (ring_state.tail - ring_state.head) * (uint32_t)FRAME_BYTES;
+}
+
+static enum iterate_kit_voice_playout_read ring_read(
+    void *context, const uint8_t **frame, size_t *length) {
+  (void)context;
+  if (ring_state.abandon_next) {
+    ring_state.abandon_next = false;
+    if (ring_state.tail > ring_state.head) ++ring_state.head;
+    return ITERATE_KIT_VOICE_PLAYOUT_READ_ABANDONED;
+  }
+  if (ring_state.tail == ring_state.head) {
+    return ITERATE_KIT_VOICE_PLAYOUT_READ_DRY;
+  }
+  memcpy(
+      ring_state.out,
+      ring_state.frames[ring_state.head % RING_FRAMES],
+      FRAME_BYTES);
+  ++ring_state.head;
+  *frame = ring_state.out;
+  *length = FRAME_BYTES;
+  return ITERATE_KIT_VOICE_PLAYOUT_READ_FRAME;
+}
+
+static const struct iterate_kit_voice_playout_ring ring = {
+  .context = NULL,
+  .queued_bytes = ring_queued_bytes,
+  .read = ring_read,
+};
+
+/* --- a sink that counts, with a clock it owns ------------------------------ */
+
+static struct {
+  uint64_t now_ms;
+  /** How long the speaker makes a write wait for headroom. */
+  uint32_t admission_wait_ms;
+  enum iterate_kit_voice_playout_write next_write;
+  uint32_t written;
+  uint32_t concealed;
+  uint8_t last_written;
+} sink_state;
+
+static uint64_t sink_now_ms(void *context) {
+  (void)context;
+  return sink_state.now_ms;
+}
+
+static enum iterate_kit_voice_playout_write sink_write(
+    void *context, const uint8_t *frame, size_t length) {
+  (void)context;
+  assert(length == (size_t)FRAME_BYTES);
+  sink_state.now_ms += sink_state.admission_wait_ms;
+  if (sink_state.next_write == ITERATE_KIT_VOICE_PLAYOUT_WRITE_OK) {
+    ++sink_state.written;
+    sink_state.last_written = frame[0];
+  }
+  return sink_state.next_write;
+}
+
+static bool sink_conceal(void *context) {
+  (void)context;
+  ++sink_state.concealed;
+  return true;
+}
+
+static const struct iterate_kit_voice_playout_sink concealing_sink = {
+  .context = NULL,
+  .now_ms = sink_now_ms,
+  .write = sink_write,
+  .conceal = sink_conceal,
+};
+
+/* A board: the DAC clocks out its own zeros, so nothing is inserted. */
+static const struct iterate_kit_voice_playout_sink hardware_sink = {
+  .context = NULL,
+  .now_ms = sink_now_ms,
+  .write = sink_write,
+  .conceal = NULL,
+};
+
+static struct iterate_kit_voice_playout playout;
+
+static void reset(uint64_t now_ms) {
+  memset(&ring_state, 0, sizeof(ring_state));
+  memset(&sink_state, 0, sizeof(sink_state));
+  sink_state.now_ms = now_ms;
+  iterate_kit_voice_playout_init(&playout);
+}
+
+static enum iterate_kit_voice_playout_outcome step(
+    const struct iterate_kit_voice_playout_sink *sink) {
+  return iterate_kit_voice_playout_step(&playout, &ring, sink);
+}
+
+/** One on-time tick: the step, then the frame period passes. */
+static enum iterate_kit_voice_playout_outcome tick(
+    const struct iterate_kit_voice_playout_sink *sink) {
+  const enum iterate_kit_voice_playout_outcome outcome = step(sink);
+  sink_state.now_ms += FRAME_MS;
+  return outcome;
+}
+
+/* --- the tests ------------------------------------------------------------ */
+
+static void nothing_plays_before_prefill(void) {
+  reset(1000U);
+  ring_deliver(1U);
+  assert(step(&hardware_sink) == ITERATE_KIT_VOICE_PLAYOUT_PRIMING);
+  assert(playout.stats.waits_priming == 1U);
+  assert(sink_state.written == 0U && ring_queued_bytes(NULL) == FRAME_BYTES);
+  ring_deliver(PREFILL_FRAMES);
+  assert(step(&hardware_sink) == ITERATE_KIT_VOICE_PLAYOUT_PLAYED);
+  assert(sink_state.last_written == 1U); /* in order, from the first */
+}
+
+/*
+ * A whole answer plays, and the dry ring after it is the END, not a hole:
+ * nothing is concealed, and the timeline is forgotten so that nothing is
+ * late afterwards however long the silence.
+ */
+static void an_answer_plays_whole_then_settles(void) {
+  uint32_t index;
+  reset(1000U);
+  ring_deliver(50U);
+  iterate_kit_voice_playback_clock_answer_done(&playout.clock);
+  for (index = 0U; index < 50U; ++index) {
+    assert(tick(&concealing_sink) == ITERATE_KIT_VOICE_PLAYOUT_PLAYED);
+  }
+  assert(sink_state.written == 50U && playout.stats.frames_played == 50U);
+  assert(playout.stats.writes == 50U);
+  assert(playout.stats.margin_max_ms == 49U * FRAME_MS);
+  assert(playout.stats.margin_min_ms == 0U);
+  assert(playout.clock.lag_max_ms == 0U);
+  assert(tick(&concealing_sink) == ITERATE_KIT_VOICE_PLAYOUT_SETTLED);
+  assert(playout.stats.waits_dry == 1U && sink_state.concealed == 0U);
+  assert(playout.stats.conceal_frames == 0U);
+  assert(iterate_kit_voice_playback_clock_lag_ms(
+             &playout.clock, sink_state.now_ms + 60000U) == 0U);
+  /* And the ring is priming again: a lone frame waits for company. */
+  ring_deliver(1U);
+  assert(step(&concealing_sink) == ITERATE_KIT_VOICE_PLAYOUT_PRIMING);
+}
+
+/*
+ * A dry ring MID-ANSWER is a hole. It is counted on every target — that is
+ * telemetry about the pipe — and filled only by a sink that has nothing
+ * behind it clocking out zeros already. And the answer resumes played, not
+ * skipped: a hole is not a backlog.
+ */
+static void a_hole_mid_answer_is_concealed_only_by_a_sink_that_can(void) {
+  uint32_t index;
+  reset(1000U);
+  ring_deliver((uint32_t)PREFILL_FRAMES);
+  for (index = 0U; index < (uint32_t)PREFILL_FRAMES; ++index) {
+    assert(tick(&concealing_sink) == ITERATE_KIT_VOICE_PLAYOUT_PLAYED);
+  }
+  assert(tick(&concealing_sink) == ITERATE_KIT_VOICE_PLAYOUT_STARVED);
+  assert(sink_state.concealed == 1U && playout.stats.conceal_frames == 1U);
+  assert(tick(&hardware_sink) == ITERATE_KIT_VOICE_PLAYOUT_STARVED);
+  assert(sink_state.concealed == 1U && playout.stats.conceal_frames == 2U);
+  assert(playout.stats.waits_dry == 2U);
+  ring_deliver(1U);
+  assert(tick(&hardware_sink) == ITERATE_KIT_VOICE_PLAYOUT_PLAYED);
+  assert(playout.stats.catchup_frames == 0U);
+}
+
+/*
+ * THE BACK-OFFICE TURN OF 2026-09-09, AT THE STEP. An answer ends; the
+ * colleague works for nine seconds; the follow-up arrives with the sender's
+ * four-second lead and then at playback rate. Measured against the first
+ * answer's clock that is nine seconds of lag with four seconds queued — the
+ * catch-up rule's exact trigger — and the host CLI discarded four frames in
+ * five for the rest of the turn. The step forgets the timeline when the
+ * first answer settles, on whichever path found the ring dry.
+ */
+static void an_answer_after_a_long_silence_is_on_time(void) {
+  uint32_t index;
+  reset(1000U);
+  ring_deliver(20U);
+  iterate_kit_voice_playback_clock_answer_done(&playout.clock);
+  for (index = 0U; index < 20U; ++index) {
+    assert(tick(&hardware_sink) == ITERATE_KIT_VOICE_PLAYOUT_PLAYED);
+  }
+  assert(tick(&hardware_sink) == ITERATE_KIT_VOICE_PLAYOUT_SETTLED);
+  sink_state.now_ms += 9000U;
+  ring_deliver(200U); /* the lead: four seconds, all at once */
+  for (index = 0U; index < 300U; ++index) {
+    assert(tick(&hardware_sink) == ITERATE_KIT_VOICE_PLAYOUT_PLAYED);
+    if (index % 5U == 4U) ring_deliver(5U); /* then 100 ms per 100 ms */
+  }
+  assert(playout.stats.catchup_frames == 0U);
+  assert(playout.stats.frames_played == 320U);
+  assert(playout.clock.lag_max_ms == 0U);
+}
+
+/*
+ * And an answer that merely STALLED — never declared over — is given up on
+ * past the conceal limit, timeline included; the next one is on time too.
+ */
+static void a_stalled_answer_is_given_up_and_the_next_is_on_time(void) {
+  uint32_t index;
+  reset(1000U);
+  ring_deliver(20U);
+  for (index = 0U; index < 20U; ++index) {
+    assert(tick(&hardware_sink) == ITERATE_KIT_VOICE_PLAYOUT_PLAYED);
+  }
+  assert(tick(&hardware_sink) == ITERATE_KIT_VOICE_PLAYOUT_STARVED);
+  sink_state.now_ms += ITERATE_KIT_VOICE_SPEAKER_CONCEAL_LIMIT_MS;
+  assert(tick(&hardware_sink) == ITERATE_KIT_VOICE_PLAYOUT_SETTLED);
+  sink_state.now_ms += 30000U;
+  ring_deliver(200U);
+  for (index = 0U; index < 200U; ++index) {
+    assert(tick(&hardware_sink) == ITERATE_KIT_VOICE_PLAYOUT_PLAYED);
+  }
+  assert(playout.stats.catchup_frames == 0U);
+}
+
+/*
+ * BEHIND WITH A BACKLOG, the step skips until level and then plays: 900 ms
+ * late with two seconds queued is exactly twenty skipped frames, because
+ * every skip spends its place in the timeline.
+ */
+static void a_late_answer_with_backlog_is_skipped_until_level(void) {
+  uint32_t index;
+  reset(1000U);
+  ring_deliver(100U);
+  assert(step(&hardware_sink) == ITERATE_KIT_VOICE_PLAYOUT_PLAYED);
+  sink_state.now_ms += FRAME_MS + 900U;
+  for (index = 0U;
+       index < (900U - ITERATE_KIT_VOICE_SPEAKER_LAG_CATCHUP_MS) / FRAME_MS;
+       ++index) {
+    assert(step(&hardware_sink) == ITERATE_KIT_VOICE_PLAYOUT_SKIPPED);
+  }
+  assert(playout.stats.catchup_frames == 20U);
+  assert(sink_state.written == 1U);
+  assert(tick(&hardware_sink) == ITERATE_KIT_VOICE_PLAYOUT_PLAYED);
+  assert(sink_state.last_written == 22U); /* frames 2..21 were the cut */
+  for (index = 0U; index < 20U; ++index) {
+    assert(tick(&hardware_sink) == ITERATE_KIT_VOICE_PLAYOUT_PLAYED);
+  }
+  assert(playout.stats.catchup_frames == 20U);
+}
+
+/* A frame of a flushed answer is nobody's: not played, not a hole. */
+static void an_abandoned_frame_is_neither_played_nor_a_hole(void) {
+  reset(1000U);
+  ring_deliver((uint32_t)PREFILL_FRAMES + 1U);
+  ring_state.abandon_next = true;
+  assert(step(&hardware_sink) == ITERATE_KIT_VOICE_PLAYOUT_ABANDONED);
+  assert(sink_state.written == 0U && playout.stats.frames_played == 0U);
+  assert(playout.stats.waits_dry == 0U && playout.stats.conceal_frames == 0U);
+  assert(playout.stats.catchup_frames == 0U && playout.stats.writes == 0U);
+  assert(step(&hardware_sink) == ITERATE_KIT_VOICE_PLAYOUT_PLAYED);
+  assert(sink_state.last_written == 2U);
+}
+
+/*
+ * A write the speaker refuses is a failure and is counted; one abandoned
+ * for a replacement is not. Neither starts the answer's timeline — only
+ * audio the speaker actually took can be late.
+ */
+static void a_refused_write_is_counted_and_an_abandoned_one_is_not(void) {
+  reset(1000U);
+  ring_deliver((uint32_t)PREFILL_FRAMES + 2U);
+  sink_state.next_write = ITERATE_KIT_VOICE_PLAYOUT_WRITE_FAILED;
+  assert(tick(&hardware_sink) == ITERATE_KIT_VOICE_PLAYOUT_REFUSED);
+  assert(playout.stats.write_failures == 1U && playout.stats.writes == 1U);
+  assert(playout.clock.answer_started_ms == 0U);
+  sink_state.next_write = ITERATE_KIT_VOICE_PLAYOUT_WRITE_ABANDONED;
+  assert(tick(&hardware_sink) == ITERATE_KIT_VOICE_PLAYOUT_REPLACED);
+  assert(playout.stats.write_failures == 1U && playout.stats.writes == 2U);
+  assert(playout.clock.answer_started_ms == 0U);
+  sink_state.next_write = ITERATE_KIT_VOICE_PLAYOUT_WRITE_OK;
+  assert(tick(&hardware_sink) == ITERATE_KIT_VOICE_PLAYOUT_PLAYED);
+  assert(playout.stats.frames_played == 1U && playout.stats.writes == 3U);
+  assert(playout.clock.answer_started_ms != 0U);
+}
+
+/*
+ * THE STAMP IS TAKEN BEFORE THE WRITE. A speaker that makes every write wait
+ * for headroom must not make a punctual loop look late: the origin of the
+ * timeline is when the frame was handed over, not when the DAC took it.
+ */
+static void the_stamp_is_taken_before_the_write(void) {
+  uint32_t index;
+  reset(1000U);
+  sink_state.admission_wait_ms = 15U;
+  ring_deliver(50U);
+  for (index = 0U; index < 50U; ++index) {
+    assert(step(&hardware_sink) == ITERATE_KIT_VOICE_PLAYOUT_PLAYED);
+    sink_state.now_ms = 1000U + (index + 1U) * FRAME_MS; /* punctual */
+  }
+  assert(playout.clock.answer_started_ms == 1000U);
+  assert(playout.clock.lag_max_ms == 0U);
+  assert(playout.stats.catchup_frames == 0U);
+}
+
+int main(void) {
+  nothing_plays_before_prefill();
+  an_answer_plays_whole_then_settles();
+  a_hole_mid_answer_is_concealed_only_by_a_sink_that_can();
+  an_answer_after_a_long_silence_is_on_time();
+  a_stalled_answer_is_given_up_and_the_next_is_on_time();
+  a_late_answer_with_backlog_is_skipped_until_level();
+  an_abandoned_frame_is_neither_played_nor_a_hole();
+  a_refused_write_is_counted_and_an_abandoned_one_is_not();
+  the_stamp_is_taken_before_the_write();
+  return 0;
+}

--- a/apps/os/scripts/voicelab/index.ts
+++ b/apps/os/scripts/voicelab/index.ts
@@ -11,6 +11,7 @@ export { matrix } from "./matrix.ts";
 export { reveal } from "./reveal.ts";
 export { reliability } from "./reliability.ts";
 export { talk } from "./talk.ts";
+export { tap } from "./tap.ts";
 export { interjectRecall } from "./interject-recall.ts";
 export { vadDuplex } from "./vad-duplex.ts";
 export { timeline } from "./timeline.ts";

--- a/apps/os/scripts/voicelab/probe-audio.ts
+++ b/apps/os/scripts/voicelab/probe-audio.ts
@@ -71,7 +71,7 @@ export interface StreamHandle {
     connectionKey: string;
     eventTypes: string[];
     processEventBatch: (batch: { events?: { type: string; payload?: unknown }[] }) => void;
-  }): Promise<unknown>;
+  }): Promise<{ close(): void }>;
   append(
     ...events: { type: string; ephemeral?: true; payload: Record<string, unknown> }[]
   ): Promise<unknown>;

--- a/apps/os/scripts/voicelab/tap.ts
+++ b/apps/os/scripts/voicelab/tap.ts
@@ -75,10 +75,14 @@ export async function tap(options: TapOptions): Promise<void> {
   const file = fs.openSync(options.out, "w");
   const openedAt = Date.now();
   let rows = 0;
-  await stream.openConnection({
+  let closed = false;
+  const connection = await stream.openConnection({
     connectionKey: `tap-${openedAt}`,
     eventTypes: LIVE_TYPES,
     processEventBatch: (batch) => {
+      /* A batch already in flight can land after the window ends; the file is
+       * gone by then, so it is dropped rather than written to a dead descriptor. */
+      if (closed) return;
       const atTapMs = Date.now() - openedAt;
       for (const event of batch.events ?? []) {
         /* Rows are what the payload says it is; the shapes below are the
@@ -113,7 +117,14 @@ export async function tap(options: TapOptions): Promise<void> {
     },
   });
   console.log(`tapping ${options.path} for ${minutes} min → ${options.out}`);
-  await new Promise((resolve) => setTimeout(resolve, minutes * 60_000));
-  fs.closeSync(file);
+  try {
+    await new Promise((resolve) => setTimeout(resolve, minutes * 60_000));
+  } finally {
+    /* The subscription closes BEFORE the file: batches keep arriving until the
+     * live stream hears the close, and a write after closeSync would throw. */
+    closed = true;
+    connection.close();
+    fs.closeSync(file);
+  }
   console.log(`${rows} rows`);
 }

--- a/apps/os/scripts/voicelab/tap.ts
+++ b/apps/os/scripts/voicelab/tap.ts
@@ -1,0 +1,119 @@
+// Record a voice stream's LIVE side — the ephemeral events a later read can
+// never show — with the facet's own clocks, so a call's timing can be judged
+// after the fact from the server's point of view.
+//
+//   doppler run --config prd -- pnpm cli voicelab tap --project iterate \
+//     --path /agents/voice/2609090928 --out /tmp/tap.jsonl --minutes 3
+//
+// WHY THIS EXISTS. The host CLI's report says what the DEVICE saw: frames
+// received, ring occupancy, starvation. When playback starves while every
+// frame still arrives (the back-office consultation of 2026-09-09), that
+// report cannot say whether the provider delivered late or the facet
+// released late. The facet stamps both: every mirrored provider event and
+// client control carries `receivedAtFacetMs`, every spk-frame carries
+// `sentAtFacetMs`, and the durable colleague events say when the back office
+// spoke. This tap writes them all as one JSONL, one row per event, with the
+// tap's own arrival clock beside the facet's — the whole timeline of a call
+// in a file `voicelab tap-report` can judge.
+import fs from "node:fs";
+import { openStream } from "./probe-audio.ts";
+import type { VoicelabConnectOptions } from "./connect.ts";
+
+/** Options for `pnpm cli voicelab tap`. */
+export interface TapOptions extends VoicelabConnectOptions {
+  /** The voice stream to watch. */
+  path: string;
+  /** JSONL file to write, one row per event. */
+  out: string;
+  /** How long to listen. */
+  minutes?: number;
+}
+
+/** One row of the tap: the tap's arrival clock, the event, and its facet stamps. */
+export interface TapRow {
+  /** Milliseconds since the tap opened, on the tap's clock. */
+  atTapMs: number;
+  type: string;
+  /** Facet clock at the moment the facet stamped the event, when it did. */
+  receivedAtFacetMs?: number;
+  sentAtFacetMs?: number;
+  /** spk-frame: sequence and base64 length (bytes = length * 3 / 4). */
+  deviceSpeakerFrameSeq?: number;
+  pcmB64Length?: number;
+  lastFrameOfAnswer?: boolean;
+  clearSpeakerBufferBeforeFrame?: boolean;
+  /** grok-event: the provider event's own type and, for audio deltas, its byte count. */
+  providerType?: string;
+  deltaBytes?: number;
+  /** Everything else the event carried, minus audio bytes. */
+  payload?: Record<string, unknown>;
+}
+
+const LIVE_TYPES = [
+  "events.iterate.com/voice-agent/spk-frame",
+  "events.iterate.com/voice-agent/grok-event",
+  "events.iterate.com/voice-agent/mic-frame",
+  "events.iterate.com/voice-agent/ptt-start",
+  "events.iterate.com/voice-agent/ptt-end",
+  "events.iterate.com/voice-agent/call-started",
+  "events.iterate.com/voice-agent/conversation-accepted",
+  "events.iterate.com/voice-agent/conversation-end-requested",
+  "events.iterate.com/voice-agent/conversation-ended",
+  "events.iterate.com/voice-agent/utterance-transcript",
+  "events.iterate.com/voice-agent/answer-transcript",
+  "events.iterate.com/voice-agent/colleague-status",
+  "events.iterate.com/voice-agent/colleague-note",
+  "events.iterate.com/voice-agent/provider-error",
+];
+
+export async function tap(options: TapOptions): Promise<void> {
+  if (!options.path.startsWith("/")) {
+    throw new Error(`--path must be absolute; received ${JSON.stringify(options.path)}`);
+  }
+  const minutes = options.minutes ?? 3;
+  const stream = await openStream({ ...options, streamPath: options.path });
+  const file = fs.openSync(options.out, "w");
+  const openedAt = Date.now();
+  let rows = 0;
+  await stream.openConnection({
+    connectionKey: `tap-${openedAt}`,
+    eventTypes: LIVE_TYPES,
+    processEventBatch: (batch) => {
+      const atTapMs = Date.now() - openedAt;
+      for (const event of batch.events ?? []) {
+        /* Rows are what the payload says it is; the shapes below are the
+         * contract's own field names, read loosely because a tap must never
+         * refuse a row it did not expect. */
+        const payload = (event.payload ?? {}) as Record<string, unknown>;
+        const type = event.type.replace("events.iterate.com/voice-agent/", "");
+        const row: TapRow = { atTapMs, type };
+        if (typeof payload.receivedAtFacetMs === "number")
+          row.receivedAtFacetMs = payload.receivedAtFacetMs;
+        if (typeof payload.sentAtFacetMs === "number") row.sentAtFacetMs = payload.sentAtFacetMs;
+        if (type === "spk-frame") {
+          if (typeof payload.deviceSpeakerFrameSeq === "number")
+            row.deviceSpeakerFrameSeq = payload.deviceSpeakerFrameSeq;
+          if (typeof payload.pcm === "string") row.pcmB64Length = payload.pcm.length;
+          if (payload.lastFrameOfAnswer === true) row.lastFrameOfAnswer = true;
+          if (payload.clearSpeakerBufferBeforeFrame === true)
+            row.clearSpeakerBufferBeforeFrame = true;
+        } else if (type === "grok-event") {
+          if (typeof payload.type === "string") row.providerType = payload.type;
+          if (typeof payload.deltaBytes === "number") row.deltaBytes = payload.deltaBytes;
+          const { type: _t, deltaBytes: _b, delta: _d, receivedAtFacetMs: _r, ...rest } = payload;
+          row.payload = rest;
+        } else if (type === "mic-frame") {
+          if (typeof payload.pcm === "string") row.pcmB64Length = payload.pcm.length;
+        } else {
+          row.payload = payload;
+        }
+        fs.writeSync(file, `${JSON.stringify(row)}\n`);
+        rows += 1;
+      }
+    },
+  });
+  console.log(`tapping ${options.path} for ${minutes} min → ${options.out}`);
+  await new Promise((resolve) => setTimeout(resolve, minutes * 60_000));
+  fs.closeSync(file);
+  console.log(`${rows} rows`);
+}


### PR DESCRIPTION
The voicelab host CLI played one 20 ms block in every 100 ms chunk for the rest of any turn in which the agent consulted a colleague — the "jittery and jumpy" audio after asking it to check what example.com says. Reproduced three times on prd (templestein on the packaged agent twice, the `iterate` project's older copy once), so it predates the package work.

## What was happening

The CLI keeps an answer's playout timeline — frame N belongs 20N ms after the first one played — and skips frames when playback is behind it. The first answer ends, the ring runs dry for the nine seconds the back office takes, the follow-up answers arrive with the sender's four-second lead and then at exactly playback rate. Measured against the **first** answer's clock that is nine seconds "late" with four seconds queued, which is precisely the catch-up rule's trigger, so it discarded four frames in five of a 71-second answer without the lag ever moving (371 frames received, 542 speaker buffers played; 1,502 starved buffers; the recording is 20 ms of speech per 100 ms). The facet-side pacer was healthy throughout (a 4 s lead, then 1×); whispers and status events are not involved.

The board fixed the same failure on 2026-09-06 ("a later answer plays whole too"): when the ring goes dry and the clock settles back to priming, forget the timeline. The CLI's live-audio dry path returned before it ever asked the clock, so it never got that reset. Two copies of one rule, each fixed on a path the other had not.

## What changed

**One playout step for both targets.** `components/core/src/voice_playout.c` — `iterate_kit_voice_playout_step` — is the speaker pass the board (`voice_loop.c`) and the CLI (`main.c`) both run: prime, take one frame, a dry ring is a hole or the end, skip a late frame with backlog behind it, hand the rest to the speaker, report what was played. Only the ring and the sink are injected (a few callbacks each): the board keeps its FreeRTOS queue generations, reprime handshake and bounded codec wait; the CLI keeps its room lead and decides who conceals. The counters both report — `spkPlayed`, `spkSoftDryTicks`, `spkCatchup`, `spkLagMaxMs`, the margins — are the step's, so they mean the same thing in a board's `health()` as in the CLI's report. The firmware README records why this is shared where the transport deliberately is not (single-owner on both targets; no atomic inside the step).

**The answer's timeline lives in the shared clock.** `iterate_kit_voice_playback_clock` now owns `answer_started_ms` / `answer_emitted_ms` / `lag_max_ms`; `reprime` and a dry-ring `WAIT` forget it, `frame` measures against it and charges a skipped frame to it, `played` starts and advances it. No owner can skip the reset by skipping a branch — the board's and the CLI's copies of that bookkeeping (and the board's atomics for it) are gone.

**The catch-up rule requires the backlog to carry the threshold.** A timeline that says seconds while the ring holds one chunk is a timeline that lost its footing, not a stall; skipping into one chunk recovers 20 ms a frame against arrival at the same rate, so the lag never moves and every frame pays. Belt to the braces above.

**`voicelab tap`** records a stream's live lane (`spk-frame`, `grok-event`, statuses, transcripts) to JSONL with facet and client timestamps. It is how the facet side was cleared.

## Proof on prd (templestein, unattended, colleague turn every time)

```
doppler run --project os --config prd -- pnpm cli voicelab talk --project templestein --auto \
  --provider openai --converse 2 --colleague-every 1 --utterance-dir apps/os/scripts/voicelab/utterances \
  --pretend-speaker <out>.wav
```

| build | frames received | speaker buffers played | starved buffers | ring lead during the answer |
|---|---|---|---|---|
| before (2026-09-09 morning) | 371 | 542 | 1,502 | ≈100 ms |
| clock fix only | 369 | 1,844 | 263 | 3.9 s |
| this PR (shared step) | 658 | 3,287 | 489 | 3.9 s |

Every received 100 ms frame is played as five 20 ms buffers; starvation is confined to the wait before the answer (all 489 buffers in one stretch ending at +22 s, none in the following 90 s of answer including the back-office pause). Three underruns are now reported on the live path where none were before: they are three short holes at the very opening of the answer (ring at 108 ms, before the sender's lead has built), the same thing the board has always counted there — the old live path simply never asked the clock, so it could never count them.

## Tests

- `tests/voice_playout_test.c` (new): the step against a ring that is an array and a sink that counts — prefill, a whole answer then settle, a hole concealed only by a sink that can, **the back-office turn at the step** (answer ends, nine seconds, follow-up with a four-second lead plays whole, zero skips), a stalled answer given up past the conceal limit, skip-until-level (900 ms late with two seconds queued is exactly twenty skips), abandoned frames, refused vs replaced writes, the stamp taken before the write.
- `tests/voice_playback_clock_test.c`: rewritten around the timeline the clock now owns (the reset on dry, on give-up, on reprime; the worst lag remembered; a chunk-deep ring never skipped).
- `tests/cli_paced_sink_test.c`: the rig now drives the shared step through the CLI's real ring and converter.
- `tests/voice_loop_answer_clock_test.c` (unchanged) still passes through the shared step: the first answer, a later one, a superseded one, and audio with no clear at all.
- 61/61 host tests green, sanitized (`pnpm firmware:test:host`). ESP-IDF build of the HAVPE target: see the checklist below.

## Risk map

- **Riskiest: `voice_loop.c`'s playback step.** It is now a switch over the shared step's outcome plus four callbacks; every board effect (phases, the starve stamp, `speaker_last_write_ms`, the mouth tap, generation checks in the write loop, the reprime requeue) was moved, not rewritten, but this file only runs for real on a board. The host answer-clock test covers the sequence; it does not cover FreeRTOS timing.
- **Accounting deltas on the CLI's live path:** `conceal` and `under` in the pulse can now be non-zero (see above). Nothing in `apps/os/scripts/voicelab` gates on either.
- **`speaker_write_failures` on the CLI** no longer double-counts a WAV write failure (the step counts a refused write; the recorder just stops the run).
- No backwards-compatibility shims: the CLI's timeline fields and per-owner counters are deleted, not aliased.

**Suggested review order:** `components/core/include/iterate/kit/voice_playout.h` → `voice_playout.c` → `tests/voice_playout_test.c` → `voice_playback_clock.{h,c}` and its test → `targets/host_cli/main.c` (the callbacks and `cli_main_feed_playback`) → `components/voice/src/voice_loop.c` (the callbacks and the step) → `cli_runtime.h`, `cli_capabilities.c`, `cli_paced_sink_test.c` → `apps/kit/firmware/README.md` → `apps/os/scripts/voicelab/tap.ts`.

Side note for the record: an earlier control run of `talk` against the `iterate` project (to show the failure predates the package) wrote the inert `@iterate-com/voice-agent` dependency line into that project's config repo (commit 0d3ed540 there). It changes nothing until a `voice-agent.ts` names it; revert on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes realtime speaker playout on device and host CLI; behavior is heavily tested on host but FreeRTOS-specific playback wiring is harder to fully exercise off-board.
> 
> **Overview**
> Fixes **jittery playback after a back-office pause** on the host CLI by unifying speaker playout with the board instead of keeping two copies of the same rules.
> 
> **Shared playout step** (`voice_playout.c`): board `voice_loop.c` and host CLI `main.c` now call **`iterate_kit_voice_playout_step`** with target-specific ring/sink callbacks (FreeRTOS queue + codec vs byte ring + CoreAudio/file). Shared **`spk*`** stats and outcomes live on **`struct iterate_kit_voice_playout`**.
> 
> **Answer timeline moves into `voice_playback_clock`**: per-answer lag tracking, reset on **reprime** and when a dry ring settles at the live edge, **`played()`** with timestamp **before** the write, and catch-up skips only when **backlog ≥ lag threshold**—each skipped frame still advances the timeline so skip-until-level terminates.
> 
> Board and CLI drop duplicate timeline atomics/counters; **`voicelab tap`** records live stream events (facet timestamps) to JSONL for server-side timing diagnosis; **`probe-audio`**’s stream connection exposes **`close()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcee5c46bd5fda0bada6ff523f4c9c0ee88bf4c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +121 -117 | +118 -116 🟩⬜⬜⬜⬜ |
| UI components | +707 -369 | +669 -367 🟩🟩🟩🟥🟥 |
| Tests | +611 -48 | +568 -47 🟩🟩🟩⬜⬜ |
| CI & scripts | +132 -1 | +74 -0 🟩⬜⬜⬜⬜ |
| Docs | +17 -0 | +15 -0 🟩⬜⬜⬜⬜ |
| **Total** | **+1,588 -535** | **+1,444 -530** 🟩🟩🟩🟩🟥 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 7a6face and dcee5c4, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-09-09T10:57:43.854Z",
      "deployedAt": "2026-09-09T10:48:19.151Z",
      "headSha": "dcee5c46bd5fda0bada6ff523f4c9c0ee88bf4c3",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/116439059838877",
      "shortSha": "dcee5c4",
      "cleanupDurationMs": 99197,
      "deployDurationMs": 57894,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 57759,
      "deployReadinessDurationMs": 133,
      "deployedWorkerName": "os-preview-4",
      "deployedWorkerVersion": "453f19bd-f212-4b7c-8eb4-ea8da26d8646",
      "testDurationMs": 226654,
      "testRetries": "1 retried: mobile/approvals.spec.ts › approve and reject script bursts from inside the chat thread › mobile (playwright x1) — TimeoutError: locator.fill: Timeout 1ms exceeded. Call log: \u001b[2m - waiting for getByLabel('Organization name')\u001b[22m \u001b[33m If this is a slow operation, update the product code to add a spinner while it's running. This will improve the user experience and buy you more time for this assertion. To ad...",
      "workerSizeKib": 21058.18,
      "workerGzipKib": 5310.7,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5322.51
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-09-09T10:56:08.439Z",
      "deployedAt": "2026-09-09T10:47:43.529Z",
      "headSha": "dcee5c46bd5fda0bada6ff523f4c9c0ee88bf4c3",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-4.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/116439059838877",
      "shortSha": "dcee5c4",
      "cleanupDurationMs": 3779,
      "deployDurationMs": 23559,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 22135,
      "deployReadinessDurationMs": 1421,
      "deployedWorkerName": "docs-preview-4",
      "deployedWorkerVersion": "32f02cd3-e38e-48cd-9797-4a531347a1f4",
      "testDurationMs": 2825,
      "testRetries": null,
      "workerSizeKib": 4735.6,
      "workerGzipKib": 1112.21,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-09-09T10:56:09.355Z",
      "deployedAt": "2026-09-09T10:47:49.616Z",
      "headSha": "dcee5c46bd5fda0bada6ff523f4c9c0ee88bf4c3",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/116439059838877",
      "shortSha": "dcee5c4",
      "cleanupDurationMs": 4694,
      "deployDurationMs": 28549,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 28221,
      "deployReadinessDurationMs": 324,
      "deployedWorkerName": "auth-preview-4",
      "deployedWorkerVersion": "c30aa79d-3fd7-41a3-b596-71135f911388",
      "testDurationMs": 8337,
      "testRetries": null,
      "workerSizeKib": 4179,
      "workerGzipKib": 855.39,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-09-09T10:56:09.418Z",
      "deployedAt": "2026-09-09T10:47:38.693Z",
      "headSha": "dcee5c46bd5fda0bada6ff523f4c9c0ee88bf4c3",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/116439059838877",
      "shortSha": "dcee5c4",
      "cleanupDurationMs": 4755,
      "deployDurationMs": 17727,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 17297,
      "deployReadinessDurationMs": 424,
      "deployedWorkerName": "streams-example-app-preview-4",
      "deployedWorkerVersion": "daf3af0b-5b92-47c9-a529-5fd57f891d30",
      "testDurationMs": 75952,
      "testRetries": null,
      "workerSizeKib": 5671.5,
      "workerGzipKib": 1604.26,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-09-09T10:56:05.839Z",
      "deployedAt": "2026-09-09T10:34:26.378Z",
      "headSha": "dcee5c46bd5fda0bada6ff523f4c9c0ee88bf4c3",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-4.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/116439059838877",
      "shortSha": "dcee5c4",
      "cleanupDurationMs": 1173,
      "deployDurationMs": 186,
      "deployConfigDurationMs": 6,
      "deployReuseProofDurationMs": 157,
      "deployedWorkerName": "dummy-petshop-preview-4",
      "deployedWorkerVersion": "1f6d4237-a89b-427d-926e-9678bbe8f8af",
      "testDurationMs": 7556,
      "testRetries": null,
      "workerSizeKib": 1331.5,
      "workerGzipKib": 232.81,
      "deployedFingerprint": "c321865fd82cf1ce04086fcbe3c487f157babc45+c5abf1055de73f3b4ffbc5e5b742dff1f0b5ee52",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `dcee5c4` | [https://auth.iterate-preview-4.com](https://auth.iterate-preview-4.com) | 855.4 KiB | 28.5s | 8.3s |  | 4.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/116439059838877) | 2026-09-09T10:56:09.355Z | Preview app released. |
| Docs | released | `dcee5c4` | [https://docs-preview-4.iterate-dev-preview.workers.dev](https://docs-preview-4.iterate-dev-preview.workers.dev) | 1.09 MiB | 23.6s | 2.8s |  | 3.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/116439059838877) | 2026-09-09T10:56:08.439Z | Preview app released. |
| Dummy Petshop | released | `dcee5c4` | [https://dummy-petshop.iterate-preview-4.com](https://dummy-petshop.iterate-preview-4.com) | 232.8 KiB | 186ms | 7.6s |  | 1.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/116439059838877) | 2026-09-09T10:56:05.839Z | Preview app released. |
| OS | released | `dcee5c4` | [https://os.iterate-preview-4.com](https://os.iterate-preview-4.com) | 5.19 MiB (-11.8 KiB vs main) | 57.9s | 226.7s | 1 retried: mobile/approvals.spec.ts › approve and reject script bursts from inside the chat thread › mobile (playwright x1) — TimeoutError: locator.fill: Timeout 1ms exceeded. Call log: [2m - waiting for getByLabel('Organization name')[22m [33m If this is a slow operation, update the product code to add a spinner while it's running. This will improve the user experience and buy you more time for this assertion. To ad... | 99.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/116439059838877) | 2026-09-09T10:57:43.854Z | Preview app released. |
| Streams Example App | released | `dcee5c4` | [https://streams.iterate-preview-4.com](https://streams.iterate-preview-4.com) | 1.57 MiB | 17.7s | 76.0s |  | 4.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/116439059838877) | 2026-09-09T10:56:09.418Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->