### PR TITLE
voice-agent: `say`, and a farewell before the idle hang-up (contract 20.0.0)

### DIFF
--- a/apps/os/scripts/voicelab/voice-agent.test.ts
+++ b/apps/os/scripts/voicelab/voice-agent.test.ts
@@ -3439,13 +3439,8 @@ describe("edges nothing was holding down", () => {
   });
 });
 
-/*
- * A CALL IS NEVER ENDED SILENTLY WHEN THERE IS A VOICE TO SAY SO. `say` is
- * the one path for a line somebody outside the model wants said now — an
- * operator's script, a colleague, the idle reaper — and `thenHangUp` is the
- * announced ending: the line PLAYS, then the call closes, with the asker's
- * reason as the obituary.
- */
+/* `say`: a line somebody outside the model wants said now; `thenHangUp` is
+ * the announced ending — the line plays, then the call closes. */
 describe("say, and the announced farewell", () => {
   const instructionsSent = (h: Harness) =>
     h.provider

--- a/apps/os/scripts/voicelab/voice-agent.test.ts
+++ b/apps/os/scripts/voicelab/voice-agent.test.ts
@@ -3594,4 +3594,51 @@ describe("say, and the announced farewell", () => {
     await stepTime(h, IDLE_FAREWELL_GRACE_MS + 5_000);
     expect(eventsOfType(h, "conversation-ended")).toHaveLength(0);
   });
+
+  /*
+   * THE WINDOW BETWEEN THE FAREWELL AND ITS RESPONSE. `response.create` has
+   * gone out; the provider has not answered it yet; the listener presses. The
+   * provider then starts the goodbye anyway — that is the normal case, not
+   * the exception — and the hang-up parked for it must NOT be armed by that
+   * created: the press un-decided it. The goodbye is just a line.
+   */
+  it("a press between the farewell and its response keeps the call, goodbye and all", async () => {
+    const h = makeHarness();
+    await callIsLive(h, CLIENT_TAKES_TURNS);
+    await idleDeadline(h);
+    expect(eventsOfType(h, "say")).toHaveLength(1);
+    expect(h.provider.sentOfType("response.create")).toHaveLength(1);
+    await h.append({ type: "events.iterate.com/voice-agent/ptt-start", payload: {} });
+    await h.settle();
+    h.provider.responseCreated();
+    h.provider.answerAudio(200);
+    h.provider.answerComplete();
+    await playOutEverything(h, 400);
+    await stepTime(h, IDLE_FAREWELL_GRACE_MS + 5_000);
+    expect(eventsOfType(h, "conversation-end-requested")).toHaveLength(0);
+    /* And the deadline restarted from the press: seen off again a minute on. */
+    await idleDeadline(h);
+    expect(eventsOfType(h, "say")).toHaveLength(2);
+  });
+
+  /*
+   * A REFUSED FAREWELL DOES NOT DISARM THE REAPER. The reason is parked before
+   * the append; if the append throws, nothing may be left believing a hang-up
+   * is coming, or every later tick defers to it and the call is never reaped.
+   */
+  it("a farewell the stream refuses is retried at the next tick, and the reaper still ends the call", async () => {
+    const h = makeHarness();
+    await callIsLive(h);
+    h.stream.failAppendsOfType = "events.iterate.com/voice-agent/say";
+    await idleDeadline(h);
+    expect(eventsOfType(h, "say")).toHaveLength(0);
+    expect(eventsOfType(h, "conversation-end-requested")).toHaveLength(0);
+    /* The outage passes; the next tick says goodbye. */
+    h.stream.failAppendsOfType = undefined;
+    await stepTime(h, 10_000);
+    expect(eventsOfType(h, "say")).toHaveLength(1);
+    /* And a provider that never starts it still gets the silent end. */
+    await stepTime(h, IDLE_FAREWELL_GRACE_MS + 5_000);
+    expect(endReason(h)).toBe("no input from the device for 60s; the farewell was never spoken");
+  });
 });

--- a/apps/os/scripts/voicelab/voice-agent.test.ts
+++ b/apps/os/scripts/voicelab/voice-agent.test.ts
@@ -3636,4 +3636,45 @@ describe("say, and the announced farewell", () => {
     await stepTime(h, IDLE_FAREWELL_GRACE_MS + 5_000);
     expect(endReason(h)).toBe("no input from the device for 60s; the farewell was never spoken");
   });
+
+  /*
+   * A NOTE BEHIND A PENDING SAY. The re-create at response.done comes back
+   * as ONE kind; a note that lands after a thenHangUp say has pended must
+   * not turn that re-create into a note, or the hang-up is never armed and
+   * the reaper defers forever to a reason nothing collects.
+   */
+  it("a note that lands behind a pending hang-up say does not lose the hang-up", async () => {
+    const h = makeHarness();
+    await callIsLive(h);
+    await h.append({
+      type: "events.iterate.com/voice-agent/colleague-note",
+      payload: { text: "The shop is done." },
+    });
+    await h.settle();
+    expect(h.provider.sentOfType("response.create")).toHaveLength(1);
+    h.provider.responseCreated();
+    h.provider.answerAudio(200, "item_note");
+    /* The say pends behind the note answer, which is protected. */
+    await h.append({
+      type: "events.iterate.com/voice-agent/say",
+      payload: { text: "Closing this call now.", reason: "operator: done", thenHangUp: true },
+    });
+    await h.settle();
+    expect(h.provider.sentOfType("response.create")).toHaveLength(1);
+    await h.append({
+      type: "events.iterate.com/voice-agent/colleague-note",
+      payload: { text: "One more thing." },
+    });
+    await h.settle();
+    /* The note answer settles: the pending re-create is the SAY's. */
+    h.provider.answerComplete();
+    await h.settle();
+    expect(h.provider.sentOfType("response.create")).toHaveLength(2);
+    h.provider.responseCreated();
+    h.provider.answerAudio(200);
+    h.provider.answerComplete();
+    await playOutEverything(h, 800);
+    expect(eventsOfType(h, "conversation-ended")).toHaveLength(1);
+    expect(endReason(h)).toBe("operator: done");
+  });
 });

--- a/apps/os/scripts/voicelab/voice-agent.test.ts
+++ b/apps/os/scripts/voicelab/voice-agent.test.ts
@@ -3710,6 +3710,36 @@ describe("say, and the announced farewell", () => {
   });
 
   /*
+   * A HANG-UP SAY PARKED BEHIND A BARGED TURN. The press cancelled the
+   * answer; the say pends, waiting for a settled turn; the listener never
+   * gives one. The reaper, past its deadline, asks for the line itself and
+   * arms the grace, instead of deferring to the parked reason for ever.
+   */
+  it("a hang-up say pended behind a barged turn is asked for by the reaper, and the call still ends", async () => {
+    const h = makeHarness();
+    await callIsLive(h, CLIENT_TAKES_TURNS);
+    h.provider.responseCreated();
+    h.provider.answerAudio(200);
+    /* The press barges the answer; the provider never settles it. */
+    await h.append({ type: "events.iterate.com/voice-agent/ptt-start", payload: {} });
+    await h.settle();
+    const createsBefore = h.provider.sentOfType("response.create").length;
+    await h.append({
+      type: "events.iterate.com/voice-agent/say",
+      payload: { text: "Closing this call now.", reason: "operator: done", thenHangUp: true },
+    });
+    await h.settle();
+    expect(h.provider.sentOfType("response.create")).toHaveLength(createsBefore);
+    await idleDeadline(h);
+    /* The reaper asked for the parked line rather than adding a farewell. */
+    expect(h.provider.sentOfType("response.create")).toHaveLength(createsBefore + 1);
+    expect(eventsOfType(h, "say")).toHaveLength(1);
+    await stepTime(h, IDLE_FAREWELL_GRACE_MS + 5_000);
+    expect(eventsOfType(h, "conversation-end-requested")).toHaveLength(1);
+    expect(endReason(h)).toBe("operator: done; the line was never spoken");
+  });
+
+  /*
    * A NOTE BEHIND A PENDING SAY. The re-create at response.done comes back
    * as ONE kind; a note that lands after a thenHangUp say has pended must
    * not turn that re-create into a note, or the hang-up is never armed and

--- a/apps/os/scripts/voicelab/voice-agent.test.ts
+++ b/apps/os/scripts/voicelab/voice-agent.test.ts
@@ -3712,10 +3712,11 @@ describe("say, and the announced farewell", () => {
   /*
    * A HANG-UP SAY PARKED BEHIND A BARGED TURN. The press cancelled the
    * answer; the say pends, waiting for a settled turn; the listener never
-   * gives one. The reaper, past its deadline, asks for the line itself and
-   * arms the grace, instead of deferring to the parked reason for ever.
+   * gives one. The reaper, past its deadline, does not defer to the parked
+   * reason for ever, and does not try to speak the line either: it ends
+   * the call without it, as it ended every idle call before there were lines.
    */
-  it("a hang-up say pended behind a barged turn is asked for by the reaper, and the call still ends", async () => {
+  it("a hang-up say pended behind a barged turn is ended by the reaper without the line", async () => {
     const h = makeHarness();
     await callIsLive(h, CLIENT_TAKES_TURNS);
     h.provider.responseCreated();
@@ -3731,10 +3732,9 @@ describe("say, and the announced farewell", () => {
     await h.settle();
     expect(h.provider.sentOfType("response.create")).toHaveLength(createsBefore);
     await idleDeadline(h);
-    /* The reaper asked for the parked line rather than adding a farewell. */
-    expect(h.provider.sentOfType("response.create")).toHaveLength(createsBefore + 1);
+    /* No create from the reaper, no farewell of its own: the call ends. */
+    expect(h.provider.sentOfType("response.create")).toHaveLength(createsBefore);
     expect(eventsOfType(h, "say")).toHaveLength(1);
-    await stepTime(h, IDLE_FAREWELL_GRACE_MS + 5_000);
     expect(eventsOfType(h, "conversation-end-requested")).toHaveLength(1);
     expect(endReason(h)).toBe("operator: done; the line was never spoken");
   });

--- a/apps/os/scripts/voicelab/voice-agent.test.ts
+++ b/apps/os/scripts/voicelab/voice-agent.test.ts
@@ -3556,7 +3556,7 @@ describe("say, and the announced farewell", () => {
     expect(eventsOfType(h, "conversation-ended")).toHaveLength(0);
     await stepTime(h, IDLE_FAREWELL_GRACE_MS + 5_000);
     expect(eventsOfType(h, "conversation-ended")).toHaveLength(1);
-    expect(endReason(h)).toBe("no input from the device for 60s; the farewell was never spoken");
+    expect(endReason(h)).toBe("idle: no input from the device for 60s; the line was never spoken");
   });
 
   it("a listener who comes back before the goodbye even starts keeps the call too", async () => {
@@ -3634,7 +3634,46 @@ describe("say, and the announced farewell", () => {
     expect(eventsOfType(h, "say")).toHaveLength(1);
     /* And a provider that never starts it still gets the silent end. */
     await stepTime(h, IDLE_FAREWELL_GRACE_MS + 5_000);
-    expect(endReason(h)).toBe("no input from the device for 60s; the farewell was never spoken");
+    expect(endReason(h)).toBe("idle: no input from the device for 60s; the line was never spoken");
+  });
+
+  /*
+   * AN OPEN-MIC LISTENER WHO STARTS SPEAKING IN THE WINDOW. Nothing is
+   * playing, so the onset is only held — it never reaches #bargeAnswer —
+   * and the goodbye's created must read it as the person coming back.
+   */
+  it("an open-mic listener who starts speaking before the goodbye starts keeps the call", async () => {
+    const h = makeHarness();
+    await callIsLive(h, GROK_LISTENS);
+    await idleDeadline(h);
+    expect(eventsOfType(h, "say")).toHaveLength(1);
+    h.provider.speechStarted();
+    await h.settle();
+    h.provider.responseCreated();
+    h.provider.answerAudio(200);
+    h.provider.answerComplete();
+    await playOutEverything(h, 400);
+    await stepTime(h, IDLE_FAREWELL_GRACE_MS + 5_000);
+    expect(eventsOfType(h, "conversation-end-requested")).toHaveLength(0);
+  });
+
+  /*
+   * EVERY HANG-UP SAY HAS A START GRACE, not only the reaper's: a parked
+   * reason makes the idle tick defer, so an operator's line the provider
+   * never starts would otherwise leave the call unreapable for ever.
+   */
+  it("a hang-up say the provider never starts ends the call after the grace, and says so", async () => {
+    const h = makeHarness();
+    await callIsLive(h);
+    await h.append({
+      type: "events.iterate.com/voice-agent/say",
+      payload: { text: "Closing this call now.", reason: "operator: done", thenHangUp: true },
+    });
+    await h.settle();
+    expect(h.provider.sentOfType("response.create")).toHaveLength(1);
+    await stepTime(h, IDLE_FAREWELL_GRACE_MS + 5_000);
+    expect(eventsOfType(h, "conversation-end-requested")).toHaveLength(1);
+    expect(endReason(h)).toBe("operator: done; the line was never spoken");
   });
 
   /*

--- a/apps/os/scripts/voicelab/voice-agent.test.ts
+++ b/apps/os/scripts/voicelab/voice-agent.test.ts
@@ -18,6 +18,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeProcessorHarness } from "iterate/processors/testing";
 import {
   dialProviderSocket,
+  IDLE_FAREWELL_GRACE_MS,
   IDLE_TIMEOUT_MS,
   MAX_DEVICE_SPEAKER_BACKLOG_BYTES,
   MAX_SPEAKER_PAYLOAD_BYTES,
@@ -369,6 +370,32 @@ async function playOutEverything(h: Harness, ms: number): Promise<void> {
     spent += step;
   }
 }
+
+/**
+ * Time in steps, settling between them. The harness clock releases only the
+ * sleeps pending when an advance BEGAN, so a chain that arms its next sleep
+ * mid-advance — the idle reaper's tick, the farewell's grace — needs the
+ * clock to move in pieces.
+ */
+async function stepTime(h: Harness, ms: number, step = 5_000): Promise<void> {
+  for (let spent = 0; spent < ms; ) {
+    const size = Math.min(step, ms - spent);
+    await h.advanceTime(size);
+    await h.settle();
+    spent += size;
+  }
+}
+
+/** Past the idle deadline: the reaper has appended its farewell and asked
+ * for the line; its grace has NOT run out yet. (The reaper ticks every 5 s
+ * from the call's start, so the farewell lands within one tick of the
+ * deadline; the grace is 8 s beyond that.) */
+const idleDeadline = (h: Harness) => stepTime(h, IDLE_TIMEOUT_MS + 5_000);
+
+/** Past the deadline AND the farewell's grace: a provider that never spoke
+ * the goodbye has had the call buried under it. */
+const idleOut = (h: Harness) =>
+  stepTime(h, IDLE_TIMEOUT_MS + 10_000 + IDLE_FAREWELL_GRACE_MS + 5_000);
 
 beforeEach(() => {
   vi.unstubAllGlobals();
@@ -1181,8 +1208,7 @@ describe("tools on the birth certificate", () => {
 
     /* The person waits quietly for the answer, so the idle deadline kills
      * the call while the colleague is still thinking. */
-    await h.advanceTime(IDLE_TIMEOUT_MS + 10_000);
-    await h.settle();
+    await idleOut(h);
     expect(eventsOfType(h, "conversation-ended")).toHaveLength(1);
 
     /* The colleague's first reply lands BETWEEN calls — spoken to nobody,
@@ -1290,8 +1316,7 @@ describe("tools on the birth certificate", () => {
      * extra beat before the press clears the 1.5s dying-breath mint
      * cooldown — a press in the same instant as the obituary is treated as
      * the dead call's own drained input, by design. */
-    await h.advanceTime(IDLE_TIMEOUT_MS + 10_000);
-    await h.settle();
+    await idleOut(h);
     expect(eventsOfType(h, "conversation-ended")).toHaveLength(1);
     await h.advanceTime(2_000);
     await h.settle();
@@ -1381,8 +1406,7 @@ describe("tools on the birth certificate", () => {
 
     /* The reconnect's briefing carries the folded status, mid-task framing
      * and all — the line that stops a fresh session re-sending the note. */
-    await h.advanceTime(IDLE_TIMEOUT_MS + 10_000);
-    await h.settle();
+    await idleOut(h);
     await h.advanceTime(2_000);
     await h.settle();
     await h.append({ type: "events.iterate.com/voice-agent/ptt-start", payload: {} });
@@ -1733,8 +1757,7 @@ describe("tools on the birth certificate", () => {
     }
     expect(eventsOfType(h, "conversation-ended")).toHaveLength(0);
     /* The heartbeat stops; the reaper takes it from there. */
-    await h.advanceTime(IDLE_TIMEOUT_MS + 10_000);
-    await h.settle();
+    await idleOut(h);
     expect(eventsOfType(h, "conversation-ended")).toHaveLength(1);
   });
 
@@ -2995,8 +3018,7 @@ describe("ending a call", () => {
   it("ends after a minute with no input from the device", async () => {
     const h = makeHarness();
     await callIsLive(h);
-    await h.advanceTime(IDLE_TIMEOUT_MS + 10_000);
-    await h.settle();
+    await idleOut(h);
 
     const requested = eventsOfType(h, "conversation-end-requested");
     expect(requested).toHaveLength(1);
@@ -3025,8 +3047,7 @@ describe("ending a call", () => {
     await h.settle();
     expect(eventsOfType(h, "call-started")).toHaveLength(1);
 
-    await h.advanceTime(IDLE_TIMEOUT_MS + 10_000);
-    await h.settle();
+    await idleOut(h);
     const requested = eventsOfType(h, "conversation-end-requested");
     expect(requested).toHaveLength(1);
     expect((requested[0]!.payload as { reason: string }).reason).toContain("no input");
@@ -3054,6 +3075,9 @@ describe("ending a call", () => {
     /* Three minutes of answer, which is longer than the deadline. */
     h.provider.answerAudio(180_000);
     await h.settle();
+    /* One jump, not steps: stepping would PLAY the answer through this
+     * stretch and shorten what the 200 s below has left to play, which is
+     * the thing the third phase's deadline is measured from. */
     await h.advanceTime(IDLE_TIMEOUT_MS + 10_000);
     await h.settle();
     expect(eventsOfType(h, "conversation-end-requested")).toHaveLength(0);
@@ -3076,8 +3100,7 @@ describe("ending a call", () => {
 
     /* A minute of silence AFTER it stopped talking does end it: the deadline is
      * postponed and restarted, never removed. */
-    await h.advanceTime(IDLE_TIMEOUT_MS + 10_000);
-    await h.settle();
+    await idleOut(h);
     expect(eventsOfType(h, "conversation-end-requested")).toHaveLength(1);
   });
 
@@ -3128,8 +3151,7 @@ describe("ending a call", () => {
       payload: { conversationId, reason: "the person said goodbye" },
     });
     await h.settle();
-    await h.advanceTime(IDLE_TIMEOUT_MS + 10_000);
-    await h.settle();
+    await idleOut(h);
     expect(eventsOfType(h, "conversation-end-requested")).toHaveLength(1);
     expect(eventsOfType(h, "conversation-ended")).toHaveLength(1);
   });
@@ -3414,5 +3436,162 @@ describe("edges nothing was holding down", () => {
     expect(seen[2]!.headers.Authorization).toContain("/secrets/openai");
     expect(seen[2]!.url).toContain("api.openai.com");
     expect(seen[2]!.url).toContain("model=gpt-realtime");
+  });
+});
+
+/*
+ * A CALL IS NEVER ENDED SILENTLY WHEN THERE IS A VOICE TO SAY SO. `say` is
+ * the one path for a line somebody outside the model wants said now — an
+ * operator's script, a colleague, the idle reaper — and `thenHangUp` is the
+ * announced ending: the line PLAYS, then the call closes, with the asker's
+ * reason as the obituary.
+ */
+describe("say, and the announced farewell", () => {
+  const instructionsSent = (h: Harness) =>
+    h.provider
+      .sentOfType("conversation.item.create")
+      .map((message) => (message.item as { content: { text: string }[] }).content[0]!.text);
+  const endReason = (h: Harness) =>
+    (eventsOfType(h, "conversation-end-requested")[0]!.payload as { reason: string }).reason;
+
+  it("speaks a say through the live call and records it as a say answer", async () => {
+    const h = makeHarness();
+    await callIsLive(h);
+    await h.append({
+      type: "events.iterate.com/voice-agent/say",
+      payload: { text: "Your taxi is outside.", by: "operator" },
+    });
+    await h.settle();
+    expect(instructionsSent(h).at(-1)).toContain('"Your taxi is outside."');
+    expect(instructionsSent(h).at(-1)).not.toContain("do not call any tool");
+    expect(h.provider.sentOfType("response.create")).toHaveLength(1);
+    h.provider.responseCreated();
+    h.provider.answerAudio(200, "item_say");
+    h.provider.push({
+      type: "response.output_audio_transcript.done",
+      item_id: "item_say",
+      transcript: "Your taxi is outside.",
+    });
+    h.provider.answerComplete();
+    await playOutEverything(h, 400);
+    const transcripts = eventsOfType(h, "answer-transcript").map(
+      (event) => event.payload as { text: string; kind?: string },
+    );
+    expect(transcripts.at(-1)).toMatchObject({ text: "Your taxi is outside.", kind: "say" });
+    /* Said, not ended: no thenHangUp. */
+    expect(eventsOfType(h, "conversation-ended")).toHaveLength(0);
+  });
+
+  it("thenHangUp ends the call only after the line has played, with the asker's reason", async () => {
+    const h = makeHarness();
+    await callIsLive(h);
+    await h.append({
+      type: "events.iterate.com/voice-agent/say",
+      payload: {
+        text: "I'm closing this call now; the shop is done.",
+        reason: "operator: shop complete",
+        by: "operator",
+        thenHangUp: true,
+      },
+    });
+    await h.settle();
+    expect(instructionsSent(h).at(-1)).toContain("do not call any tool");
+    h.provider.responseCreated();
+    h.provider.answerAudio(200);
+    h.provider.answerComplete();
+    await h.settle();
+    /* Generated is not heard: the call is still up while the line plays. */
+    expect(eventsOfType(h, "conversation-ended")).toHaveLength(0);
+    await playOutEverything(h, 400);
+    expect(eventsOfType(h, "conversation-ended")).toHaveLength(1);
+    expect(endReason(h)).toBe("operator: shop complete");
+  });
+
+  it("a say addressed to another conversation is ignored, hang-up and all", async () => {
+    const h = makeHarness();
+    await callIsLive(h);
+    const itemsBefore = instructionsSent(h).length;
+    await h.append({
+      type: "events.iterate.com/voice-agent/say",
+      payload: { text: "Hello?", conversationId: "conv_from_last_week", thenHangUp: true },
+    });
+    await h.settle();
+    expect(instructionsSent(h)).toHaveLength(itemsBefore);
+    expect(h.provider.sentOfType("response.create")).toHaveLength(0);
+    await playOutEverything(h, 400);
+    expect(eventsOfType(h, "conversation-ended")).toHaveLength(0);
+  });
+
+  it("the idle reaper says goodbye first, and hangs up once the goodbye has played", async () => {
+    const h = makeHarness();
+    await callIsLive(h, CLIENT_TAKES_TURNS);
+    await idleDeadline(h);
+    const farewells = eventsOfType(h, "say").map(
+      (event) => event.payload as { text: string; by: string; thenHangUp: boolean },
+    );
+    expect(farewells).toHaveLength(1);
+    expect(farewells[0]).toMatchObject({ by: "idle-reaper", thenHangUp: true });
+    /* Worded for a client that presses to come back. */
+    expect(farewells[0]!.text).toContain("Press the button when you want me back");
+    expect(h.provider.sentOfType("response.create")).toHaveLength(1);
+    expect(eventsOfType(h, "conversation-ended")).toHaveLength(0);
+    h.provider.responseCreated();
+    h.provider.answerAudio(200);
+    h.provider.answerComplete();
+    await h.settle();
+    expect(eventsOfType(h, "conversation-ended")).toHaveLength(0);
+    await playOutEverything(h, 400);
+    expect(eventsOfType(h, "conversation-ended")).toHaveLength(1);
+    expect(endReason(h)).toBe("idle: no input from the device for 60s");
+  });
+
+  it("an open-mic board is told to press AND talk", async () => {
+    const h = makeHarness();
+    await callIsLive(h, GROK_LISTENS);
+    await idleDeadline(h);
+    const farewell = eventsOfType(h, "say")[0]!.payload as { text: string };
+    expect(farewell.text).toContain("Press the button and start talking");
+  });
+
+  it("a farewell the provider never starts is followed by the silent end, which says so", async () => {
+    const h = makeHarness();
+    await callIsLive(h);
+    await idleDeadline(h);
+    expect(eventsOfType(h, "say")).toHaveLength(1);
+    expect(eventsOfType(h, "conversation-ended")).toHaveLength(0);
+    await stepTime(h, IDLE_FAREWELL_GRACE_MS + 5_000);
+    expect(eventsOfType(h, "conversation-ended")).toHaveLength(1);
+    expect(endReason(h)).toBe("no input from the device for 60s; the farewell was never spoken");
+  });
+
+  it("a listener who comes back before the goodbye even starts keeps the call too", async () => {
+    const h = makeHarness();
+    await callIsLive(h, CLIENT_TAKES_TURNS);
+    await idleDeadline(h);
+    expect(eventsOfType(h, "say")).toHaveLength(1);
+    /* The press lands inside the grace, with no response.created yet. */
+    await h.append({ type: "events.iterate.com/voice-agent/ptt-start", payload: {} });
+    await h.settle();
+    await stepTime(h, IDLE_FAREWELL_GRACE_MS + 5_000);
+    expect(eventsOfType(h, "conversation-end-requested")).toHaveLength(0);
+    /* And the deadline restarted from the press: a minute later it is
+     * seen off again, with a fresh farewell. */
+    await idleDeadline(h);
+    expect(eventsOfType(h, "say")).toHaveLength(2);
+  });
+
+  it("a listener who answers the farewell keeps the call", async () => {
+    const h = makeHarness();
+    await callIsLive(h, CLIENT_TAKES_TURNS);
+    await idleDeadline(h);
+    h.provider.responseCreated();
+    h.provider.answerAudio(200);
+    /* The press barges the goodbye and un-decides the hang-up. */
+    await h.append({ type: "events.iterate.com/voice-agent/ptt-start", payload: {} });
+    await h.settle();
+    h.provider.answerComplete();
+    await playOutEverything(h, 400);
+    await stepTime(h, IDLE_FAREWELL_GRACE_MS + 5_000);
+    expect(eventsOfType(h, "conversation-ended")).toHaveLength(0);
   });
 });

--- a/apps/os/scripts/voicelab/voice-agent.test.ts
+++ b/apps/os/scripts/voicelab/voice-agent.test.ts
@@ -3677,6 +3677,39 @@ describe("say, and the announced farewell", () => {
   });
 
   /*
+   * THE GRACE STARTS WHEN THE PROVIDER IS ASKED, NOT WHEN THE SAY IS PARKED.
+   * A line pended behind a protected note answer is waiting its turn; ending
+   * the call at 8 s would cut off the answer still holding the floor.
+   */
+  it("a hang-up say waiting behind a note answer is not given up on until it is asked for", async () => {
+    const h = makeHarness();
+    await callIsLive(h);
+    await h.append({
+      type: "events.iterate.com/voice-agent/colleague-note",
+      payload: { text: "The shop is done." },
+    });
+    await h.settle();
+    h.provider.responseCreated();
+    h.provider.answerAudio(200, "item_note");
+    await h.append({
+      type: "events.iterate.com/voice-agent/say",
+      payload: { text: "Closing this call now.", reason: "operator: done", thenHangUp: true },
+    });
+    await h.settle();
+    expect(h.provider.sentOfType("response.create")).toHaveLength(1);
+    /* The note answer holds the floor well past the grace: nothing ends. */
+    await stepTime(h, IDLE_FAREWELL_GRACE_MS + 5_000);
+    expect(eventsOfType(h, "conversation-end-requested")).toHaveLength(0);
+    /* It settles; the say is asked for; THIS provider never starts it. */
+    h.provider.answerComplete();
+    await h.settle();
+    expect(h.provider.sentOfType("response.create")).toHaveLength(2);
+    await stepTime(h, IDLE_FAREWELL_GRACE_MS + 5_000);
+    expect(eventsOfType(h, "conversation-end-requested")).toHaveLength(1);
+    expect(endReason(h)).toBe("operator: done; the line was never spoken");
+  });
+
+  /*
    * A NOTE BEHIND A PENDING SAY. The re-create at response.done comes back
    * as ONE kind; a note that lands after a thenHangUp say has pended must
    * not turn that re-create into a note, or the hang-up is never armed and

--- a/packages/voice-agent/INSTALL.md
+++ b/packages/voice-agent/INSTALL.md
@@ -64,7 +64,9 @@ export default class extends IterateWorkerEntrypoint {
 returns null for everything else, so the worker's own routing carries on.
 `this.#voice.setup({ streamPath, colleaguePath, instructions, tools, … })`
 puts the agent on a stream; `this.#voice.remove({ streamPath })` takes it
-off. The package README documents every option.
+off; `this.#voice.say({ streamPath, text, reason?, thenHangUp? })` has the
+live call speak a line now (and hang up after it, if asked). The package
+README documents every option.
 
 ## Before the first call: a provider secret
 

--- a/packages/voice-agent/README.md
+++ b/packages/voice-agent/README.md
@@ -144,6 +144,19 @@ const line = await this.#voice.setup({
 // → { streamPath, warmMs }
 
 await this.#voice.remove({ streamPath: line.streamPath });
+
+// Have the live call say a line now — an operator's script, a cron, an agent.
+// With thenHangUp the call closes once the line has PLAYED, and the obituary
+// carries the reason: a call is never ended silently when there is a voice
+// to say so. (The idle reaper's own farewell goes through the same path.)
+await this.#voice.say({
+  streamPath: line.streamPath,
+  text: "I'm closing this call now; the shop is done.",
+  reason: "operator: shop complete",
+  thenHangUp: true,
+});
+// → { streamPath, offset }; afterwards the stream reads say → answer-transcript
+//   (kind "say") → conversation-end-requested → conversation-ended.
 ```
 
 `create(env)` takes the worker's `this.env` (anything with an `ITX` binding
@@ -239,7 +252,7 @@ project's key.
 — and the subscription that wakes the facet for that stream (the worker ref
 above). Then it waits for the facet to fold the certificate (a cold build is
 most of the wait; `warmMs` in the result is that clock), so a returned
-`setup` means the line is live. Contract version `19.0.0`.
+`setup` means the line is live. Contract version `20.0.0`.
 
 Every stream is born with a **colleague**: a normal text agent
 (`/agents/voice-notes/…` by default, or the chat you named in
@@ -257,19 +270,20 @@ and slow, on one stream.
 A client is anything that can append to the stream and receive its ephemeral
 events. Every type below is prefixed `events.iterate.com/voice-agent/`.
 
-| Event                        | Direction | Durable   | Payload                                                                                                         |
-| ---------------------------- | --------- | --------- | --------------------------------------------------------------------------------------------------------------- |
-| `ptt-start`                  | client →  | durable   | `{}` — the user began speaking; opens a call if none is up (push-to-talk clients only)                          |
-| `mic-frame`                  | client →  | ephemeral | `{ conversationId, seq, pcm }` — 20 ms of base64 PCM16 mono 16 kHz, numbered by the device                      |
-| `ptt-end`                    | client →  | durable   | `{}` — the turn is complete                                                                                     |
-| `conversation-end-requested` | either    | durable   | `{ conversationId, reason }` — somebody decided the call is over (the hang-up button, the `hang_up` tool, idle) |
-| `call-started`               | ← server  | durable   | `{ conversationId }` — the server opened a call                                                                 |
-| `conversation-accepted`      | ← server  | durable   | `{ conversationId, handshakeTookMs, heldMicFrames }` — the provider accepted the session; the call is live      |
-| `spk-frame`                  | ← server  | ephemeral | `{ conversationId, deviceSpeakerFrameSeq, pcm, drop?, last? }` — one paced chunk of the answer                  |
-| `utterance-transcript`       | ← server  | durable   | `{ conversationId, text }` — the provider's transcription of one finished listener turn                         |
-| `answer-transcript`          | ← server  | durable   | `{ conversationId, text, cancelled?, kind? }` — one finished answer, in words                                   |
-| `conversation-ended`         | ← server  | durable   | `{ conversationId, reason }` — the call is over                                                                 |
-| `colleague-note`             | ← server  | durable   | `{ text }` — one message from the colleague, spoken into the live call                                          |
+| Event                        | Direction | Durable   | Payload                                                                                                                                                                                    |
+| ---------------------------- | --------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ptt-start`                  | client →  | durable   | `{}` — the user began speaking; opens a call if none is up (push-to-talk clients only)                                                                                                     |
+| `mic-frame`                  | client →  | ephemeral | `{ conversationId, seq, pcm }` — 20 ms of base64 PCM16 mono 16 kHz, numbered by the device                                                                                                 |
+| `ptt-end`                    | client →  | durable   | `{}` — the turn is complete                                                                                                                                                                |
+| `conversation-end-requested` | either    | durable   | `{ conversationId, reason }` — somebody decided the call is over (the hang-up button, the `hang_up` tool, idle)                                                                            |
+| `call-started`               | ← server  | durable   | `{ conversationId }` — the server opened a call                                                                                                                                            |
+| `conversation-accepted`      | ← server  | durable   | `{ conversationId, handshakeTookMs, heldMicFrames }` — the provider accepted the session; the call is live                                                                                 |
+| `spk-frame`                  | ← server  | ephemeral | `{ conversationId, deviceSpeakerFrameSeq, pcm, drop?, last? }` — one paced chunk of the answer                                                                                             |
+| `utterance-transcript`       | ← server  | durable   | `{ conversationId, text }` — the provider's transcription of one finished listener turn                                                                                                    |
+| `answer-transcript`          | ← server  | durable   | `{ conversationId, text, cancelled?, kind? }` — one finished answer, in words                                                                                                              |
+| `conversation-ended`         | ← server  | durable   | `{ conversationId, reason }` — the call is over                                                                                                                                            |
+| `colleague-note`             | ← server  | durable   | `{ text }` — one message from the colleague, spoken into the live call                                                                                                                     |
+| `say`                        | either    | durable   | `{ text, reason?, by?, thenHangUp?, conversationId? }` — a line for the live call's voice to say now; `thenHangUp` closes the call once it has played (the idle reaper's farewell uses it) |
 
 **A client's entire speaker policy is three lines.** On a `spk-frame`: if
 `drop`, clear the speaker buffer (the listener barged in; discard what has not
@@ -442,3 +456,10 @@ The agent's behavioural tests live with the lab tooling in
 - **A migrated project still lists `face.ts` and friends** — harmless dead
   weight; `voicelab deploy --prune-legacy` or `removeLegacyGuest` removes
   them.
+- **`say` (or any newly consumed event) is appended but the call never
+  speaks it** — the stream's facet subscription filters on a SNAPSHOT of
+  `contract.consumes`, taken by whichever build ran setup. A stream set up
+  before an event type joined `consumes` never receives it. Re-run
+  `setupVoiceAgent` on that stream (the CLI's `talk` does so on every run):
+  the subscription's idempotency key is a hash of its filter, so a changed
+  `consumes` installs the new filter and an unchanged one is a no-op.

--- a/packages/voice-agent/README.md
+++ b/packages/voice-agent/README.md
@@ -145,18 +145,14 @@ const line = await this.#voice.setup({
 
 await this.#voice.remove({ streamPath: line.streamPath });
 
-// Have the live call say a line now — an operator's script, a cron, an agent.
-// With thenHangUp the call closes once the line has PLAYED, and the obituary
-// carries the reason: a call is never ended silently when there is a voice
-// to say so. (The idle reaper's own farewell goes through the same path.)
+// Have the live call say a line now; with thenHangUp it closes once the
+// line has PLAYED, with the reason as the obituary.
 await this.#voice.say({
   streamPath: line.streamPath,
   text: "I'm closing this call now; the shop is done.",
   reason: "operator: shop complete",
   thenHangUp: true,
 });
-// → { streamPath, offset }; afterwards the stream reads say → answer-transcript
-//   (kind "say") → conversation-end-requested → conversation-ended.
 ```
 
 `create(env)` takes the worker's `this.env` (anything with an `ITX` binding
@@ -270,20 +266,20 @@ and slow, on one stream.
 A client is anything that can append to the stream and receive its ephemeral
 events. Every type below is prefixed `events.iterate.com/voice-agent/`.
 
-| Event                        | Direction | Durable   | Payload                                                                                                                                                                                    |
-| ---------------------------- | --------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ptt-start`                  | client →  | durable   | `{}` — the user began speaking; opens a call if none is up (push-to-talk clients only)                                                                                                     |
-| `mic-frame`                  | client →  | ephemeral | `{ conversationId, seq, pcm }` — 20 ms of base64 PCM16 mono 16 kHz, numbered by the device                                                                                                 |
-| `ptt-end`                    | client →  | durable   | `{}` — the turn is complete                                                                                                                                                                |
-| `conversation-end-requested` | either    | durable   | `{ conversationId, reason }` — somebody decided the call is over (the hang-up button, the `hang_up` tool, idle)                                                                            |
-| `call-started`               | ← server  | durable   | `{ conversationId }` — the server opened a call                                                                                                                                            |
-| `conversation-accepted`      | ← server  | durable   | `{ conversationId, handshakeTookMs, heldMicFrames }` — the provider accepted the session; the call is live                                                                                 |
-| `spk-frame`                  | ← server  | ephemeral | `{ conversationId, deviceSpeakerFrameSeq, pcm, drop?, last? }` — one paced chunk of the answer                                                                                             |
-| `utterance-transcript`       | ← server  | durable   | `{ conversationId, text }` — the provider's transcription of one finished listener turn                                                                                                    |
-| `answer-transcript`          | ← server  | durable   | `{ conversationId, text, cancelled?, kind? }` — one finished answer, in words                                                                                                              |
-| `conversation-ended`         | ← server  | durable   | `{ conversationId, reason }` — the call is over                                                                                                                                            |
-| `colleague-note`             | ← server  | durable   | `{ text }` — one message from the colleague, spoken into the live call                                                                                                                     |
-| `say`                        | either    | durable   | `{ text, reason?, by?, thenHangUp?, conversationId? }` — a line for the live call's voice to say now; `thenHangUp` closes the call once it has played (the idle reaper's farewell uses it) |
+| Event                        | Direction | Durable   | Payload                                                                                                         |
+| ---------------------------- | --------- | --------- | --------------------------------------------------------------------------------------------------------------- |
+| `ptt-start`                  | client →  | durable   | `{}` — the user began speaking; opens a call if none is up (push-to-talk clients only)                          |
+| `mic-frame`                  | client →  | ephemeral | `{ conversationId, seq, pcm }` — 20 ms of base64 PCM16 mono 16 kHz, numbered by the device                      |
+| `ptt-end`                    | client →  | durable   | `{}` — the turn is complete                                                                                     |
+| `conversation-end-requested` | either    | durable   | `{ conversationId, reason }` — somebody decided the call is over (the hang-up button, the `hang_up` tool, idle) |
+| `call-started`               | ← server  | durable   | `{ conversationId }` — the server opened a call                                                                 |
+| `conversation-accepted`      | ← server  | durable   | `{ conversationId, handshakeTookMs, heldMicFrames }` — the provider accepted the session; the call is live      |
+| `spk-frame`                  | ← server  | ephemeral | `{ conversationId, deviceSpeakerFrameSeq, pcm, drop?, last? }` — one paced chunk of the answer                  |
+| `utterance-transcript`       | ← server  | durable   | `{ conversationId, text }` — the provider's transcription of one finished listener turn                         |
+| `answer-transcript`          | ← server  | durable   | `{ conversationId, text, cancelled?, kind? }` — one finished answer, in words                                   |
+| `conversation-ended`         | ← server  | durable   | `{ conversationId, reason }` — the call is over                                                                 |
+| `colleague-note`             | ← server  | durable   | `{ text }` — one message from the colleague, spoken into the live call                                          |
+| `say`                        | either    | durable   | `{ text, reason?, by?, thenHangUp?, conversationId? }` — say a line now; `thenHangUp` ends the call after it    |
 
 **A client's entire speaker policy is three lines.** On a `spk-frame`: if
 `drop`, clear the speaker buffer (the listener barged in; discard what has not
@@ -456,10 +452,6 @@ The agent's behavioural tests live with the lab tooling in
 - **A migrated project still lists `face.ts` and friends** — harmless dead
   weight; `voicelab deploy --prune-legacy` or `removeLegacyGuest` removes
   them.
-- **`say` (or any newly consumed event) is appended but the call never
-  speaks it** — the stream's facet subscription filters on a SNAPSHOT of
-  `contract.consumes`, taken by whichever build ran setup. A stream set up
-  before an event type joined `consumes` never receives it. Re-run
-  `setupVoiceAgent` on that stream (the CLI's `talk` does so on every run):
-  the subscription's idempotency key is a hash of its filter, so a changed
-  `consumes` installs the new filter and an unchanged one is a no-op.
+- **`say` is appended but the call never speaks it** — the stream's facet
+  subscription filters on a snapshot of `contract.consumes` taken when setup
+  last ran. Re-run `setupVoiceAgent` on that stream (`talk` does, every run).

--- a/packages/voice-agent/src/app.test.ts
+++ b/packages/voice-agent/src/app.test.ts
@@ -3,7 +3,7 @@ import { VoiceAgentApp } from "./app.ts";
 import { voiceAgentEntrypointRef } from "./ref.ts";
 
 /** A project handle that records what was dialed and whether it was released. */
-function fakeEnv(guest: Partial<Record<"setupVoiceAgent" | "removeVoiceAgent", unknown>>) {
+function fakeEnv(guest: Partial<Record<"setupVoiceAgent" | "removeVoiceAgent" | "say", unknown>>) {
   const log: string[] = [];
   const env = {
     ITX: {
@@ -56,6 +56,10 @@ describe("VoiceAgentApp", () => {
         warmMs: 12,
       }),
       removeVoiceAgent: async (options: { streamPath: string }) => options,
+      say: async (options: { streamPath: string; text: string }) => ({
+        streamPath: options.streamPath,
+        offset: options.text.length,
+      }),
     });
     const app = VoiceAgentApp.create(env);
     expect(await app.setup({ streamPath: "/agents/voice/x", provider: "openai" })).toEqual({
@@ -66,8 +70,11 @@ describe("VoiceAgentApp", () => {
     expect(await app.remove({ streamPath: "/agents/voice/x" })).toEqual({
       streamPath: "/agents/voice/x",
     });
+    expect(
+      await app.say({ streamPath: "/agents/voice/x", text: "bye now", thenHangUp: true }),
+    ).toEqual({ streamPath: "/agents/voice/x", offset: 7 });
     expect(log).toEqual(
-      Array(3).fill(["workers.get entrypoint ref", "guest disposed", "project disposed"]).flat(),
+      Array(4).fill(["workers.get entrypoint ref", "guest disposed", "project disposed"]).flat(),
     );
   });
 

--- a/packages/voice-agent/src/app.ts
+++ b/packages/voice-agent/src/app.ts
@@ -1,5 +1,7 @@
 import { voiceAgentEntrypointRef } from "./ref.ts";
 import type {
+  SayOptions,
+  SayResult,
   SetupVoiceAgentOptions,
   SetupVoiceAgentResult,
   VoiceAgentRpc,
@@ -85,6 +87,8 @@ export const VoiceAgentApp = {
       /** Take the agent off a stream. */
       remove: (target: { streamPath: string }): Promise<{ streamPath: string }> =>
         dial((guest) => guest.removeVoiceAgent(target)),
+      /** Have the live call on a stream say a line now — and hang up after it, if asked. */
+      say: (line: SayOptions): Promise<SayResult> => dial((guest) => guest.say(line)),
     };
   },
 };

--- a/packages/voice-agent/src/index.ts
+++ b/packages/voice-agent/src/index.ts
@@ -27,6 +27,8 @@ export {
 // enable and reach it.
 export type {
   ItxExpressionStepInput,
+  SayOptions,
+  SayResult,
   SetupVoiceAgentOptions,
   SetupVoiceAgentResult,
   VoiceAgentHealth,

--- a/packages/voice-agent/src/setup-options.ts
+++ b/packages/voice-agent/src/setup-options.ts
@@ -111,13 +111,8 @@ export interface VoiceAgentHealth {
  * method signatures: the declaration bundler's printer cannot emit the latter
  * inside an interface, and a class method satisfies either.
  */
-/**
- * A line for the live call's voice to say now — the idle reaper's farewell
- * uses the same path. One durable `say` event lands on the stream; the facet
- * speaks it through whichever call is live (an idle stream just keeps the
- * record that somebody tried), and `thenHangUp` closes the call once the
- * line has finished playing, with `reason` as the obituary.
- */
+/** A line for the live call's voice to say now; the idle reaper's farewell
+ * uses the same path. An idle stream just keeps the record. */
 export interface SayOptions {
   /** The conversation stream the line is for. */
   streamPath: string;

--- a/packages/voice-agent/src/setup-options.ts
+++ b/packages/voice-agent/src/setup-options.ts
@@ -111,8 +111,37 @@ export interface VoiceAgentHealth {
  * method signatures: the declaration bundler's printer cannot emit the latter
  * inside an interface, and a class method satisfies either.
  */
+/**
+ * A line for the live call's voice to say now — the idle reaper's farewell
+ * uses the same path. One durable `say` event lands on the stream; the facet
+ * speaks it through whichever call is live (an idle stream just keeps the
+ * record that somebody tried), and `thenHangUp` closes the call once the
+ * line has finished playing, with `reason` as the obituary.
+ */
+export interface SayOptions {
+  /** The conversation stream the line is for. */
+  streamPath: string;
+  /** What to say, as close to word-for-word as natural speech allows. */
+  text: string;
+  /** Why — recorded on the event and, with `thenHangUp`, on the obituary. */
+  reason?: string;
+  /** Who asked; defaults to "entrypoint.say". */
+  by?: string;
+  /** Close the call once the line has PLAYED (never before). */
+  thenHangUp?: boolean;
+  /** Address one call; absent, whichever call is live. */
+  conversationId?: string;
+}
+
+/** What `say` appended: the stream and the event's offset. */
+export interface SayResult {
+  streamPath: string;
+  offset: number;
+}
+
 export interface VoiceAgentRpc {
   health: () => Promise<VoiceAgentHealth>;
   setupVoiceAgent: (options?: SetupVoiceAgentOptions) => Promise<SetupVoiceAgentResult>;
   removeVoiceAgent: (options: { streamPath: string }) => Promise<{ streamPath: string }>;
+  say: (options: SayOptions) => Promise<SayResult>;
 }

--- a/packages/voice-agent/src/voice-agent.ts
+++ b/packages/voice-agent/src/voice-agent.ts
@@ -1953,6 +1953,8 @@ interface Dial {
   sayHangUpReason: string | null;
   /** Who asked for the hang-up say — the obituary's key class. */
   sayHangUpBy: string | null;
+  /** The provider has been asked for the parked line (its start grace runs). */
+  sayHangUpAsked: boolean;
   /** Which request-to-speak the running start grace belongs to, so only the
    * latest grace can bury the call. */
   sayHangUpEpisode: number;
@@ -2002,6 +2004,7 @@ const freshDial = (
   pendingFollowUpKind: "note",
   sayHangUpReason: null,
   sayHangUpBy: null,
+  sayHangUpAsked: false,
   sayHangUpEpisode: 0,
   buried: false,
   idleFarewells: 0,
@@ -2743,6 +2746,7 @@ export class VoiceAgentProcessor extends StreamProcessor<
               : `asked to hang up${asker === null ? "" : ` by ${asker}`}`;
           dial.sayHangUpReason = reason;
           dial.sayHangUpBy = asker;
+          dial.sayHangUpAsked = false;
         }
         this.#sendControl(
           dial,
@@ -3761,7 +3765,32 @@ export class VoiceAgentProcessor extends StreamProcessor<
        * behind it — a listener who answers barges the goodbye and un-decides
        * the hang-up (#bargeAnswer), and the deadline starts again.
        */
-      if (dial.hangUpAfterAnswerDrains !== null || dial.sayHangUpReason !== null) {
+      if (dial.hangUpAfterAnswerDrains !== null) {
+        this.runInBackground(idleTick);
+        return;
+      }
+      if (dial.sayHangUpReason !== null) {
+        /*
+         * A HANG-UP LINE IS PARKED. Asked for already: its start grace
+         * decides, and this tick defers. Still pended — behind a turn a
+         * barge cancelled and nobody finished, or a tool that never came
+         * back — it would stay parked for ever, because the re-create waits
+         * for a settled turn a silent listener never gives it. Idle IS the
+         * floor being free: ask for the line now where nothing is streaming
+         * and no tool is open, and arm the grace either way, so the call
+         * ends with the line or, past the grace, without it.
+         */
+        if (!dial.sayHangUpAsked && dial.ready && dial.socket !== null) {
+          if (dial.answer.phase !== "streaming" && dial.openToolCallIds.size === 0) {
+            dial.pendingNoteResponse = false;
+            dial.answerCancelledForNote = false;
+            dial.followUpResponsePending = true;
+            dial.followUpKind = "say";
+            dial.pendingFollowUpKind = "note";
+            this.#sendControl(dial, { type: "response.create" }, append);
+          }
+          this.#armSayStartGrace(dial, append);
+        }
         this.runInBackground(idleTick);
         return;
       }
@@ -4152,6 +4181,7 @@ export class VoiceAgentProcessor extends StreamProcessor<
     const by = dial.sayHangUpBy;
     const episode = ++dial.sayHangUpEpisode;
     const askedAtMs = this.deps.nowAtFacetMs();
+    dial.sayHangUpAsked = true;
     this.runInBackground(async () => {
       await this.deps.sleep(IDLE_FAREWELL_GRACE_MS);
       if (this.#dial !== dial || dial.sayHangUpEpisode !== episode) return;

--- a/packages/voice-agent/src/voice-agent.ts
+++ b/packages/voice-agent/src/voice-agent.ts
@@ -151,6 +151,8 @@ import { createFace } from "./face.ts";
  * load-bearing rather than cosmetic. */
 import { voiceAgentFacetRef } from "./ref.ts";
 import type {
+  SayOptions,
+  SayResult,
   SetupVoiceAgentOptions,
   SetupVoiceAgentResult,
   VoiceAgentHealth,
@@ -346,6 +348,27 @@ const IDLE_STAMP_STEP_MS = 5_000;
 
 /** How often the idle countdown looks at the facet clock. */
 const IDLE_TICK_MS = 5_000;
+/**
+ * How long the idle reaper waits for its farewell to START before giving up
+ * on saying it and burying the call silently. A provider that has not even
+ * created the response in this long is not going to; a farewell that HAS
+ * started is owned by the drain point, which ends the call once it has
+ * played. Under IDLE_TIMEOUT_MS's own slack on purpose: an announced end
+ * must never make a dead call outlive the deadline by more than this.
+ */
+export const IDLE_FAREWELL_GRACE_MS = 8_000;
+
+/**
+ * What the reaper says before it hangs up. Said in the model's own voice
+ * through the ordinary `say` path, so the transcript shows it like anything
+ * else the assistant said. Worded per client: a push-to-talk client presses
+ * to come back; an open-mic board presses AND talks.
+ */
+function idleFarewell(clientTakesTurns: boolean): string {
+  return clientTakesTurns
+    ? "I haven't heard anything for a minute, so I'm closing this call now. Press the button when you want me back."
+    : "I haven't heard anything for a minute, so I'm closing this call now. Press the button and start talking when you want me back.";
+}
 
 /**
  * How long after a dial failure before anything may dial again.
@@ -1214,7 +1237,18 @@ export const VoiceAgentContract = defineProcessorContract({
    * greets with the thread in mind, and every provider session's whole
    * briefing is recorded (`session-configured`) so the stream shows how
    * the frontend was initialized. Clean break as ever. */
-  version: "19.0.0",
+  /* 20.0.0: a call is never ended silently when there is a voice to say
+   * so. `say` — a durable event anybody outside the model may append (the
+   * idle reaper, an operator's script through the entrypoint's `say()`, a
+   * colleague) — is spoken through the live call in the model's own voice,
+   * recorded as an answer-transcript of kind "say", and with `thenHangUp`
+   * closes the call once the line has PLAYED, the obituary carrying the
+   * asker's reason. The idle reaper uses it: a farewell first, then the
+   * hang-up, and the silent obituary only if the provider never starts the
+   * line. `consumes` grows by one type, so a stream set up by an older
+   * build needs its setup re-run before it hears a `say`. Clean break as
+   * ever. */
+  version: "20.0.0",
   description: "Runs a voice call in the stream's own Durable Object, one flush watermark deep.",
   stateSchema: VoiceState,
   events: {
@@ -1406,6 +1440,23 @@ export const VoiceAgentContract = defineProcessorContract({
         "to an existing chat greets with the thread in mind, and a reconnect keeps it.",
       payloadSchema: z.looseObject({ text: z.string() }),
     },
+    "events.iterate.com/voice-agent/say": {
+      description:
+        "Somebody outside the model wants the listener told something, now, in the model's own " +
+        "voice: the idle reaper's farewell, an operator's script, a colleague. Durable so the " +
+        "record shows who asked (`by`) and why (`reason`); what was actually said follows as an " +
+        'answer-transcript of kind "say". `thenHangUp` closes the call once the line has ' +
+        "finished PLAYING, with `reason` as the obituary — the precedent: a call is never ended " +
+        "silently when there is a voice to say so. `conversationId` scopes it to one call; " +
+        "absent, it addresses whichever call is live.",
+      payloadSchema: z.looseObject({
+        text: z.string(),
+        reason: z.string().optional(),
+        by: z.string().optional(),
+        thenHangUp: z.boolean().optional(),
+        conversationId: z.string().optional(),
+      }),
+    },
     "events.iterate.com/voice-agent/session-configured": {
       description:
         "The whole briefing one provider session was configured with — instructions " +
@@ -1503,6 +1554,9 @@ export const VoiceAgentContract = defineProcessorContract({
     "events.iterate.com/voice-agent/colleague-note",
     /* Appended by the dial's own recap fetch; consumed for the fold only. */
     "events.iterate.com/voice-agent/colleague-recap",
+    /* A line to be spoken now — by the idle reaper (this processor's own
+     * append), a script through the entrypoint's `say`, or a colleague. */
+    "events.iterate.com/voice-agent/say",
     /* The live half. Naming them is the whole opt-in — `"*"` never matches an
      * ephemeral event, so nobody gets this firehose by accident. */
     "events.iterate.com/voice-agent/ptt-start",
@@ -1513,6 +1567,7 @@ export const VoiceAgentContract = defineProcessorContract({
     "events.iterate.com/voice-agent/keepalive",
   ],
   emits: [
+    "events.iterate.com/voice-agent/say",
     "events.iterate.com/voice-agent/call-started",
     "events.iterate.com/voice-agent/conversation-accepted",
     "events.iterate.com/voice-agent/conversation-end-requested",
@@ -1547,7 +1602,7 @@ interface Answer {
    * (measured 2026-08-29: two waffly status lines played out in full while
    * the found answer waited behind them).
    */
-  kind: "turn" | "status" | "note" | "tool";
+  kind: "turn" | "status" | "note" | "tool" | "say";
   /**
    * The provider's identity for the answer now playing, beside the two
    * clocks a truthful interruption needs (`receivedMs`, `sentMs`). On a
@@ -1879,7 +1934,7 @@ interface Dial {
   /** What asked for the pending follow-up — stamped onto the answer
    * at response.created so the note-barge can tell commentary from
    * conversation. */
-  followUpKind: "status" | "note" | "tool";
+  followUpKind: "status" | "note" | "tool" | "say";
   /** A colleague note cancelled the streaming answer (status commentary
    * or the person's hold music); its response.done is the cue to create
    * the note's response (creating before the provider settles the
@@ -1912,6 +1967,25 @@ interface Dial {
    * press the button again to hear an answer that had already arrived.
    */
   pendingNoteResponse: boolean;
+  /**
+   * Which follow-up the pending re-create at `response.done` draws — a
+   * colleague note, or a `say`. A say that lands while a note answer holds
+   * the floor waits exactly like a note would, but must come back as ITSELF:
+   * its answer kind is what the transcript records and what arms the
+   * hang-up below.
+   */
+  pendingFollowUpKind: "note" | "say";
+  /**
+   * A `say` with `thenHangUp` is queued or about to play: the obituary's
+   * reason. Moved onto `hangUpAfterAnswerDrains` at the say's own
+   * `response.created`, so the line PLAYS before the call ends — the same
+   * drain-point discipline as the model's hang_up tool. Still set once the
+   * reaper's grace has passed means the provider never started the line.
+   */
+  sayHangUpReason: string | null;
+  /** Idle farewells announced on this dial — the per-episode key suffix,
+   * so a listener who came back once can be seen off again later. */
+  idleFarewells: number;
   /** The answer in flight — replaced wholesale at `response.created`. */
   answer: Answer;
 }
@@ -1951,6 +2025,9 @@ const freshDial = (
   lastColleagueActivity: null,
   lastStatusSpokenAtMs: null,
   pendingNoteResponse: false,
+  pendingFollowUpKind: "note",
+  sayHangUpReason: null,
+  idleFarewells: 0,
   answer: freshAnswer(),
 });
 
@@ -2698,6 +2775,90 @@ export class VoiceAgentProcessor extends StreamProcessor<
         return;
       }
 
+      case "events.iterate.com/voice-agent/say": {
+        /*
+         * A LINE SOMEBODY OUTSIDE THE MODEL WANTS SAID — the idle reaper's
+         * farewell, an operator's script through the entrypoint, a colleague
+         * — spoken through the same channel as a note: one system item, one
+         * response.create when the floor is free, the same precedence over
+         * commentary and hold music, the same patience behind a note or tool
+         * answer. Durable and offset-deduped like the note, so a redelivery
+         * does not say it twice. Both providers speak this dialect.
+         *
+         * `thenHangUp` does NOT end the call here. It parks the reason on the
+         * dial; the say's own `response.created` moves it onto the model's
+         * hang-up path, so the line plays out before the obituary is written
+         * and the obituary carries the reason the asker gave.
+         */
+        if (event.offset <= this.#lastSayOffset) return;
+        this.#lastSayOffset = event.offset;
+        const sayText = event.payload.text;
+        if (typeof sayText !== "string" || sayText.trim() === "") return;
+        const dial = this.#dial;
+        if (dial === null) return;
+        if (
+          typeof event.payload.conversationId === "string" &&
+          event.payload.conversationId !== dial.conversationId
+        ) {
+          return; /* addressed to a call that is already over */
+        }
+        const thenHangUp = event.payload.thenHangUp === true;
+        if (thenHangUp) {
+          const by = typeof event.payload.by === "string" ? ` by ${event.payload.by}` : "";
+          dial.sayHangUpReason =
+            typeof event.payload.reason === "string" && event.payload.reason !== ""
+              ? event.payload.reason
+              : `asked to hang up${by}`;
+        }
+        this.#sendControl(
+          dial,
+          {
+            type: "conversation.item.create",
+            item: {
+              type: "message",
+              role: "system",
+              content: [
+                {
+                  type: "input_text",
+                  text:
+                    "[instruction] Say this to the listener now, as close to word-for-word as " +
+                    `natural speech allows, and nothing else: "${sayText}"` +
+                    (thenHangUp
+                      ? " The call closes by itself once you have said it; do not call any tool."
+                      : ""),
+                },
+              ],
+            },
+          },
+          append,
+        );
+        if (
+          dial.openToolCallIds.size === 0 &&
+          dial.answer.phase === "settled" &&
+          !dial.followUpResponsePending
+        ) {
+          dial.followUpResponsePending = true;
+          dial.followUpKind = "say";
+          this.#sendControl(dial, { type: "response.create" }, append);
+        } else if (
+          dial.answer.phase === "streaming" &&
+          (dial.answer.kind === "status" || dial.answer.kind === "turn")
+        ) {
+          /* Same precedence as a note: commentary and hold music yield;
+           * the say speaks when the provider settles the cancelled one. */
+          this.#dropAnswerInFlight(dial, this.deps.nowAtFacetMs(), append);
+          dial.answer.endsWhenQueueDrains = false;
+          this.#sendControl(dial, { type: "response.cancel" }, append);
+          dial.answerCancelledForNote = true;
+          dial.pendingNoteResponse = true;
+          dial.pendingFollowUpKind = "say";
+        } else {
+          dial.pendingNoteResponse = true;
+          dial.pendingFollowUpKind = "say";
+        }
+        return;
+      }
+
       case "events.iterate.com/voice-agent/conversation-ended": {
         /*
          * THE ARM THAT WAS DELETED AS DEAD, AND WHY IT IS BACK. Reduce nulls
@@ -3320,6 +3481,15 @@ export class VoiceAgentProcessor extends StreamProcessor<
             }
             dial.answer = freshAnswer();
             dial.answer.kind = followUp ? dial.followUpKind : "turn";
+            /* A farewell's response has started: from here the drain point
+             * owns the ending, exactly as after the hang_up tool. Moving the
+             * reason here rather than at the say's arrival is what makes
+             * "say it, THEN hang up" true — set earlier, the drain point
+             * would have settled the hang-up before the line existed. */
+            if (followUp && dial.followUpKind === "say" && dial.sayHangUpReason !== null) {
+              dial.hangUpAfterAnswerDrains = dial.sayHangUpReason;
+              dial.sayHangUpReason = null;
+            }
             /* A new answer supersedes any cancelled-status bookkeeping. */
             dial.answerCancelledForNote = false;
             dial.answer.phase = "streaming";
@@ -3533,7 +3703,8 @@ export class VoiceAgentProcessor extends StreamProcessor<
               dial.pendingNoteResponse = false;
               dial.answerCancelledForNote = false;
               dial.followUpResponsePending = true;
-              dial.followUpKind = "note";
+              dial.followUpKind = dial.pendingFollowUpKind;
+              dial.pendingFollowUpKind = "note";
               this.#sendControl(dial, { type: "response.create" }, append);
             }
             return;
@@ -3622,9 +3793,14 @@ export class VoiceAgentProcessor extends StreamProcessor<
      * milliseconds from Cloudflare's own clock and the deadline is a
      * minute. Anything tighter than that would need a single clock.
      */
+    /* Set by the farewell's grace once it has buried the call: the tick and
+     * the grace can come due in the same clock step, and a tick that ran
+     * between the obituary's append and its fold would otherwise read "no
+     * farewell pending" and say goodbye to a call already ended. */
+    let buriedByReaper = false;
     const idleTick = async (): Promise<void> => {
       await this.deps.sleep(IDLE_TICK_MS);
-      if (this.#dial !== dial) return;
+      if (this.#dial !== dial || buriedByReaper) return;
       const nowAtFacetMs = this.deps.nowAtFacetMs();
       /*
        * IDLE SINCE THE LAST THING THAT HAPPENED, whichever end it happened
@@ -3668,12 +3844,75 @@ export class VoiceAgentProcessor extends StreamProcessor<
         this.runInBackground(idleTick);
         return;
       }
-      await this.#requestEnd(
-        conversationId,
-        "idle",
-        `no input from the device for ${IDLE_TIMEOUT_MS / 1000}s`,
-        append,
-      );
+      const idleReason = `no input from the device for ${IDLE_TIMEOUT_MS / 1000}s`;
+      /*
+       * SAY SO, THEN HANG UP. The reaper used to bury the call in silence:
+       * the listener heard nothing, and the record showed an obituary with
+       * no goodbye. Now it appends a `say` with `thenHangUp` — the same
+       * path a script or a colleague would use — and the call ends the
+       * moment the farewell has finished playing, with the obituary
+       * carrying this reason. The precedent this sets: whoever ends a call
+       * tells the listener what is happening and why, and leaves events
+       * behind that read that way afterwards.
+       *
+       * The chain keeps ticking behind the farewell: a listener who answers
+       * it barges the answer and un-decides the hang-up (#bargeAnswer), and
+       * from there the deadline simply starts again.
+       */
+      if (dial.hangUpAfterAnswerDrains !== null || dial.sayHangUpReason !== null) {
+        this.runInBackground(idleTick);
+        return;
+      }
+      if (!dial.ready || dial.socket === null) {
+        /* Nobody to say it: a dial that never resolved, or a dead socket.
+         * The silent end is the honest one here. */
+        await this.#requestEnd(conversationId, "idle", idleReason, append);
+        return;
+      }
+      const farewellReason = `idle: ${idleReason}`;
+      /* Set BEFORE the append: the say arm confirms it when the event comes
+       * back round, and a say that never comes back (append refused, facet
+       * evicted) still leaves the grace below with something to bury. */
+      dial.sayHangUpReason = farewellReason;
+      const episode = ++dial.idleFarewells;
+      const farewellAtMs = nowAtFacetMs;
+      await append({
+        type: "events.iterate.com/voice-agent/say",
+        idempotencyKey: this.idempotencyKey(`say:idle:${conversationId}:${episode}`),
+        payload: {
+          conversationId,
+          text: idleFarewell(state.clientTakesTurns),
+          reason: farewellReason,
+          by: "idle-reaper",
+          thenHangUp: true,
+        },
+      });
+      this.runInBackground(async () => {
+        await this.deps.sleep(IDLE_FAREWELL_GRACE_MS);
+        if (this.#dial !== dial) return;
+        /* Null means one of two good things: the farewell's response was
+         * created (the drain point now owns the end), or a returning
+         * listener un-decided it. Still set means the provider never
+         * started the line — bury the call the old way, and say so. */
+        if (dial.sayHangUpReason === null) return;
+        /* Unless the listener came back in the meantime: a press inside the
+         * grace, before the provider had even started the goodbye, is a
+         * person who wants the call, and the reaper's deadline has already
+         * restarted from it. Forget the farewell; nothing is buried. */
+        if (this.#lastDeviceInputAtStreamMsMirror > farewellAtMs) {
+          dial.sayHangUpReason = null;
+          return;
+        }
+        dial.sayHangUpReason = null;
+        buriedByReaper = true;
+        await this.#requestEnd(
+          conversationId,
+          "idle",
+          `${idleReason}; the farewell was never spoken`,
+          append,
+        );
+      });
+      this.runInBackground(idleTick);
     };
     this.runInBackground(idleTick);
   }
@@ -3953,6 +4192,9 @@ export class VoiceAgentProcessor extends StreamProcessor<
   /** Highest colleague-note offset already injected into a session — the
    * redelivery dedupe for the note whisper (see the colleague-note arm). */
   #lastInjectedNoteOffset = 0;
+
+  /** Highest `say` offset already spoken — the same redelivery dedupe as the note's. */
+  #lastSayOffset = 0;
 
   /** The last note's text and when it was injected — the belt behind the
    * offset dedupe: a stale duplicate FORWARDER (the legacy shared-name
@@ -5172,6 +5414,57 @@ export default class VoiceAgentEntrypoint extends IterateWorkerEntrypoint implem
       return { streamPath, warmMs: Date.now() - warmStartedAt };
     } finally {
       disposeRpcStub(stream, "setup stream");
+    }
+  }
+
+  /**
+   * Have the live call's voice say something now — the scripted equivalent
+   * of a slash command, for an operator, a cron, or an agent:
+   *
+   *   await itx.workers.get(voiceAgentEntrypointRef).say({
+   *     streamPath: "/agents/voice/home-assistant-voice-preview-edition",
+   *     text: "I'm closing this call now; the shop is done.",
+   *     reason: "operator: shop complete",
+   *     thenHangUp: true,
+   *   });
+   *
+   * One durable `say` event; the facet speaks it through whichever call is
+   * live on that stream (nothing happens on an idle stream, and the event
+   * still records that somebody tried), and `thenHangUp` closes the call
+   * once the line has finished playing. Afterwards the stream reads:
+   * say → answer-transcript (kind "say") → conversation-end-requested →
+   * conversation-ended — who asked, why, what was said, that it ended.
+   */
+  async say(options: SayOptions): Promise<SayResult> {
+    if (!options.streamPath.startsWith("/")) {
+      throw new Error(
+        `say streamPath must be absolute; received ${JSON.stringify(options.streamPath)}`,
+      );
+    }
+    if (options.text.trim() === "") throw new Error("say needs something to say");
+    const project = await this.itx;
+    const stream = project.streams.get(options.streamPath);
+    try {
+      const appended = await stream.append({
+        type: "events.iterate.com/voice-agent/say",
+        idempotencyKey: `voice-agent/say:${options.streamPath}:${crypto.randomUUID()}`,
+        payload: {
+          text: options.text,
+          by: options.by ?? "entrypoint.say",
+          ...(options.reason !== undefined && { reason: options.reason }),
+          ...(options.thenHangUp === true && { thenHangUp: true }),
+          ...(options.conversationId !== undefined && { conversationId: options.conversationId }),
+        },
+      });
+      let offset = 0;
+      try {
+        for (const event of appended) offset = Math.max(offset, event.offset);
+      } finally {
+        disposeRpcStub(appended, "say append result");
+      }
+      return { streamPath: options.streamPath, offset };
+    } finally {
+      disposeRpcStub(stream, "say stream");
     }
   }
 

--- a/packages/voice-agent/src/voice-agent.ts
+++ b/packages/voice-agent/src/voice-agent.ts
@@ -1951,8 +1951,10 @@ interface Dial {
    * moved onto `hangUpAfterAnswerDrains` at the say's own `response.created`
    * so the line PLAYS first. Still set after the reaper's grace: never started. */
   sayHangUpReason: string | null;
-  /** Which thenHangUp say the parked reason belongs to: its start grace
-   * checks it, so a later say's grace is the only one that can bury the call. */
+  /** Who asked for the hang-up say — the obituary's key class. */
+  sayHangUpBy: string | null;
+  /** Which request-to-speak the running start grace belongs to, so only the
+   * latest grace can bury the call. */
   sayHangUpEpisode: number;
   /** A grace has ended this call; the idle tick must not say goodbye again. */
   buried: boolean;
@@ -1999,6 +2001,7 @@ const freshDial = (
   pendingNoteResponse: false,
   pendingFollowUpKind: "note",
   sayHangUpReason: null,
+  sayHangUpBy: null,
   sayHangUpEpisode: 0,
   buried: false,
   idleFarewells: 0,
@@ -2739,30 +2742,7 @@ export class VoiceAgentProcessor extends StreamProcessor<
               ? event.payload.reason
               : `asked to hang up${asker === null ? "" : ` by ${asker}`}`;
           dial.sayHangUpReason = reason;
-          const episode = ++dial.sayHangUpEpisode;
-          const parkedAtMs = this.deps.nowAtFacetMs();
-          /*
-           * EVERY HANG-UP SAY GETS A START GRACE, not only the reaper's. A
-           * parked reason makes the idle tick defer; a provider that never
-           * starts the line would otherwise leave it parked for ever and the
-           * call unreapable. Past the grace, still parked, the call is ended
-           * without the line — unless the listener came back meanwhile.
-           */
-          runInBackground(async () => {
-            await this.deps.sleep(IDLE_FAREWELL_GRACE_MS);
-            if (this.#dial !== dial || dial.sayHangUpEpisode !== episode) return;
-            if (dial.sayHangUpReason === null) return; /* started, or un-decided */
-            dial.sayHangUpReason = null;
-            /* Backstop for the press-inside-the-grace case #bargeAnswer covers. */
-            if (this.#lastDeviceInputAtStreamMsMirror > parkedAtMs) return;
-            dial.buried = true;
-            await this.#requestEnd(
-              dial.conversationId,
-              asker === "idle-reaper" ? "idle" : "hang-up",
-              `${reason}; the line was never spoken`,
-              append,
-            );
-          });
+          dial.sayHangUpBy = asker;
         }
         this.#sendControl(
           dial,
@@ -3639,6 +3619,7 @@ export class VoiceAgentProcessor extends StreamProcessor<
               dial.followUpKind = dial.pendingFollowUpKind;
               dial.pendingFollowUpKind = "note";
               this.#sendControl(dial, { type: "response.create" }, append);
+              if (dial.followUpKind === "say") this.#armSayStartGrace(dial, append);
             }
             return;
           }
@@ -4111,6 +4092,7 @@ export class VoiceAgentProcessor extends StreamProcessor<
       dial.followUpResponsePending = true;
       dial.followUpKind = kind;
       this.#sendControl(dial, { type: "response.create" }, append);
+      if (kind === "say") this.#armSayStartGrace(dial, append);
     } else if (
       dial.answer.phase === "streaming" &&
       (dial.answer.kind === "status" || dial.answer.kind === "turn")
@@ -4153,6 +4135,38 @@ export class VoiceAgentProcessor extends StreamProcessor<
    */
   #pendFollowUp(dial: Dial, kind: "note" | "say"): void {
     if (kind === "say") dial.pendingFollowUpKind = "say";
+  }
+
+  /**
+   * EVERY HANG-UP SAY GETS A START GRACE, not only the reaper's — armed when
+   * the provider is ASKED for the line, not when the say was parked: a line
+   * pended behind a note or tool answer is waiting its turn, not failing to
+   * start. A parked reason makes the idle tick defer, so a provider that
+   * never starts the line would otherwise leave the call unreapable. Past
+   * the grace, still parked, the call is ended without the line — unless
+   * the listener came back meanwhile.
+   */
+  #armSayStartGrace(dial: Dial, append: ProcessEventArgs<VoiceAgentContract>["append"]): void {
+    const reason = dial.sayHangUpReason;
+    if (reason === null) return;
+    const by = dial.sayHangUpBy;
+    const episode = ++dial.sayHangUpEpisode;
+    const askedAtMs = this.deps.nowAtFacetMs();
+    this.runInBackground(async () => {
+      await this.deps.sleep(IDLE_FAREWELL_GRACE_MS);
+      if (this.#dial !== dial || dial.sayHangUpEpisode !== episode) return;
+      if (dial.sayHangUpReason === null) return; /* started, or un-decided */
+      dial.sayHangUpReason = null;
+      /* Backstop for the press-inside-the-grace case #bargeAnswer covers. */
+      if (this.#lastDeviceInputAtStreamMsMirror > askedAtMs) return;
+      dial.buried = true;
+      await this.#requestEnd(
+        dial.conversationId,
+        by === "idle-reaper" ? "idle" : "hang-up",
+        `${reason}; the line was never spoken`,
+        append,
+      );
+    });
   }
 
   /** The last note's text and when it was injected — the belt behind the

--- a/packages/voice-agent/src/voice-agent.ts
+++ b/packages/voice-agent/src/voice-agent.ts
@@ -348,22 +348,12 @@ const IDLE_STAMP_STEP_MS = 5_000;
 
 /** How often the idle countdown looks at the facet clock. */
 const IDLE_TICK_MS = 5_000;
-/**
- * How long the idle reaper waits for its farewell to START before giving up
- * on saying it and burying the call silently. A provider that has not even
- * created the response in this long is not going to; a farewell that HAS
- * started is owned by the drain point, which ends the call once it has
- * played. Under IDLE_TIMEOUT_MS's own slack on purpose: an announced end
- * must never make a dead call outlive the deadline by more than this.
- */
+/** How long the idle reaper waits for the provider to START its farewell
+ * before burying the call silently; a farewell that has started is the
+ * drain point's to finish. Under IDLE_TIMEOUT_MS's own slack on purpose. */
 export const IDLE_FAREWELL_GRACE_MS = 8_000;
 
-/**
- * What the reaper says before it hangs up. Said in the model's own voice
- * through the ordinary `say` path, so the transcript shows it like anything
- * else the assistant said. Worded per client: a push-to-talk client presses
- * to come back; an open-mic board presses AND talks.
- */
+/** The reaper's goodbye, worded per client: press, or press and talk, to come back. */
 function idleFarewell(clientTakesTurns: boolean): string {
   return clientTakesTurns
     ? "I haven't heard anything for a minute, so I'm closing this call now. Press the button when you want me back."
@@ -1237,17 +1227,9 @@ export const VoiceAgentContract = defineProcessorContract({
    * greets with the thread in mind, and every provider session's whole
    * briefing is recorded (`session-configured`) so the stream shows how
    * the frontend was initialized. Clean break as ever. */
-  /* 20.0.0: a call is never ended silently when there is a voice to say
-   * so. `say` — a durable event anybody outside the model may append (the
-   * idle reaper, an operator's script through the entrypoint's `say()`, a
-   * colleague) — is spoken through the live call in the model's own voice,
-   * recorded as an answer-transcript of kind "say", and with `thenHangUp`
-   * closes the call once the line has PLAYED, the obituary carrying the
-   * asker's reason. The idle reaper uses it: a farewell first, then the
-   * hang-up, and the silent obituary only if the provider never starts the
-   * line. `consumes` grows by one type, so a stream set up by an older
-   * build needs its setup re-run before it hears a `say`. Clean break as
-   * ever. */
+  /* 20.0.0: `say` — a line anybody outside the model may have the live
+   * call speak, with `thenHangUp` — and the idle reaper's announced
+   * farewell. `consumes` grows by one type: see the README's troubleshooting. */
   version: "20.0.0",
   description: "Runs a voice call in the stream's own Durable Object, one flush watermark deep.",
   stateSchema: VoiceState,
@@ -1442,13 +1424,10 @@ export const VoiceAgentContract = defineProcessorContract({
     },
     "events.iterate.com/voice-agent/say": {
       description:
-        "Somebody outside the model wants the listener told something, now, in the model's own " +
-        "voice: the idle reaper's farewell, an operator's script, a colleague. Durable so the " +
-        "record shows who asked (`by`) and why (`reason`); what was actually said follows as an " +
-        'answer-transcript of kind "say". `thenHangUp` closes the call once the line has ' +
-        "finished PLAYING, with `reason` as the obituary — the precedent: a call is never ended " +
-        "silently when there is a voice to say so. `conversationId` scopes it to one call; " +
-        "absent, it addresses whichever call is live.",
+        "A line for the live call's voice to say now — the idle reaper's farewell, an operator's " +
+        "script, a colleague. Durable: `by` and `reason` are the record; what was said follows as an " +
+        'answer-transcript of kind "say". `thenHangUp` closes the call once the line has PLAYED, ' +
+        "with `reason` as the obituary. `conversationId` scopes it to one call.",
       payloadSchema: z.looseObject({
         text: z.string(),
         reason: z.string().optional(),
@@ -1554,8 +1533,6 @@ export const VoiceAgentContract = defineProcessorContract({
     "events.iterate.com/voice-agent/colleague-note",
     /* Appended by the dial's own recap fetch; consumed for the fold only. */
     "events.iterate.com/voice-agent/colleague-recap",
-    /* A line to be spoken now — by the idle reaper (this processor's own
-     * append), a script through the entrypoint's `say`, or a colleague. */
     "events.iterate.com/voice-agent/say",
     /* The live half. Naming them is the whole opt-in — `"*"` never matches an
      * ephemeral event, so nobody gets this firehose by accident. */
@@ -1967,24 +1944,14 @@ interface Dial {
    * press the button again to hear an answer that had already arrived.
    */
   pendingNoteResponse: boolean;
-  /**
-   * Which follow-up the pending re-create at `response.done` draws — a
-   * colleague note, or a `say`. A say that lands while a note answer holds
-   * the floor waits exactly like a note would, but must come back as ITSELF:
-   * its answer kind is what the transcript records and what arms the
-   * hang-up below.
-   */
+  /** What the pending re-create at `response.done` speaks: a say that waits
+   * behind a note answer must come back as ITSELF, kind and hang-up included. */
   pendingFollowUpKind: "note" | "say";
-  /**
-   * A `say` with `thenHangUp` is queued or about to play: the obituary's
-   * reason. Moved onto `hangUpAfterAnswerDrains` at the say's own
-   * `response.created`, so the line PLAYS before the call ends — the same
-   * drain-point discipline as the model's hang_up tool. Still set once the
-   * reaper's grace has passed means the provider never started the line.
-   */
+  /** A `thenHangUp` say is queued or about to play: the obituary's reason,
+   * moved onto `hangUpAfterAnswerDrains` at the say's own `response.created`
+   * so the line PLAYS first. Still set after the reaper's grace: never started. */
   sayHangUpReason: string | null;
-  /** Idle farewells announced on this dial — the per-episode key suffix,
-   * so a listener who came back once can be seen off again later. */
+  /** Farewells announced on this dial: the per-episode idempotency suffix. */
   idleFarewells: number;
   /** The answer in flight — replaced wholesale at `response.created`. */
   answer: Answer;
@@ -2736,60 +2703,15 @@ export class VoiceAgentProcessor extends StreamProcessor<
          * code now") is not dropped to the next press: pendingNoteResponse
          * re-creates at `response.done`, so the answer follows the status
          * straight away. */
-        if (
-          dial.openToolCallIds.size === 0 &&
-          dial.answer.phase === "settled" &&
-          !dial.followUpResponsePending
-        ) {
-          dial.followUpResponsePending = true;
-          dial.followUpKind = "note";
-          this.#sendControl(dial, { type: "response.create" }, append);
-        } else if (
-          dial.answer.phase === "streaming" &&
-          (dial.answer.kind === "status" || dial.answer.kind === "turn")
-        ) {
-          /* THE AWAITED ANSWER OUTRANKS WHATEVER IS PLAYING — the facet's
-           * own status commentary, and the person's turn-answers too:
-           * anyone listening while a note is pending is waiting, and hold
-           * music ("count to 100 while it works") must lose to the thing
-           * being waited for. Only note/tool answers stay protected — the
-           * previous answer's delivery must not be cut by the next one.
-           * Cancel + silence the device; the note speaks the moment the
-           * provider settles the cancelled response (creating before its
-           * response.done is a provider error, so the done arm below
-           * finishes the job). */
-          this.#dropAnswerInFlight(dial, this.deps.nowAtFacetMs(), append);
-          dial.answer.endsWhenQueueDrains = false;
-          this.#sendControl(dial, { type: "response.cancel" }, append);
-          dial.answerCancelledForNote = true;
-          dial.pendingNoteResponse = true;
-        } else {
-          /* ALWAYS pend when we did not create. The note item goes out
-           * AFTER any in-flight response.create, so it never rides that
-           * response — assuming it would left an answered note unspoken
-           * until the caller pressed again (observed live, 2026-08-29:
-           * "the backend says it's answered... I'm waiting for the actual
-           * note", with the note already in context). */
-          dial.pendingNoteResponse = true;
-        }
+        this.#askForFollowUp(dial, "note", append);
         return;
       }
 
       case "events.iterate.com/voice-agent/say": {
-        /*
-         * A LINE SOMEBODY OUTSIDE THE MODEL WANTS SAID — the idle reaper's
-         * farewell, an operator's script through the entrypoint, a colleague
-         * — spoken through the same channel as a note: one system item, one
-         * response.create when the floor is free, the same precedence over
-         * commentary and hold music, the same patience behind a note or tool
-         * answer. Durable and offset-deduped like the note, so a redelivery
-         * does not say it twice. Both providers speak this dialect.
-         *
-         * `thenHangUp` does NOT end the call here. It parks the reason on the
-         * dial; the say's own `response.created` moves it onto the model's
-         * hang-up path, so the line plays out before the obituary is written
-         * and the obituary carries the reason the asker gave.
-         */
+        /* A line somebody outside the model wants said — spoken through the
+         * same channel as a colleague note, offset-deduped like it. `thenHangUp`
+         * only PARKS the reason: the say's own `response.created` moves it onto
+         * the hang-up path, so the line plays out before the obituary. */
         if (event.offset <= this.#lastSayOffset) return;
         this.#lastSayOffset = event.offset;
         const sayText = event.payload.text;
@@ -2832,30 +2754,7 @@ export class VoiceAgentProcessor extends StreamProcessor<
           },
           append,
         );
-        if (
-          dial.openToolCallIds.size === 0 &&
-          dial.answer.phase === "settled" &&
-          !dial.followUpResponsePending
-        ) {
-          dial.followUpResponsePending = true;
-          dial.followUpKind = "say";
-          this.#sendControl(dial, { type: "response.create" }, append);
-        } else if (
-          dial.answer.phase === "streaming" &&
-          (dial.answer.kind === "status" || dial.answer.kind === "turn")
-        ) {
-          /* Same precedence as a note: commentary and hold music yield;
-           * the say speaks when the provider settles the cancelled one. */
-          this.#dropAnswerInFlight(dial, this.deps.nowAtFacetMs(), append);
-          dial.answer.endsWhenQueueDrains = false;
-          this.#sendControl(dial, { type: "response.cancel" }, append);
-          dial.answerCancelledForNote = true;
-          dial.pendingNoteResponse = true;
-          dial.pendingFollowUpKind = "say";
-        } else {
-          dial.pendingNoteResponse = true;
-          dial.pendingFollowUpKind = "say";
-        }
+        this.#askForFollowUp(dial, "say", append);
         return;
       }
 
@@ -3481,11 +3380,8 @@ export class VoiceAgentProcessor extends StreamProcessor<
             }
             dial.answer = freshAnswer();
             dial.answer.kind = followUp ? dial.followUpKind : "turn";
-            /* A farewell's response has started: from here the drain point
-             * owns the ending, exactly as after the hang_up tool. Moving the
-             * reason here rather than at the say's arrival is what makes
-             * "say it, THEN hang up" true — set earlier, the drain point
-             * would have settled the hang-up before the line existed. */
+            /* A thenHangUp say's response has started: from here the drain
+             * point owns the ending, exactly as after the hang_up tool. */
             if (followUp && dial.followUpKind === "say" && dial.sayHangUpReason !== null) {
               dial.hangUpAfterAnswerDrains = dial.sayHangUpReason;
               dial.sayHangUpReason = null;
@@ -3793,10 +3689,8 @@ export class VoiceAgentProcessor extends StreamProcessor<
      * milliseconds from Cloudflare's own clock and the deadline is a
      * minute. Anything tighter than that would need a single clock.
      */
-    /* Set by the farewell's grace once it has buried the call: the tick and
-     * the grace can come due in the same clock step, and a tick that ran
-     * between the obituary's append and its fold would otherwise read "no
-     * farewell pending" and say goodbye to a call already ended. */
+    /* Set once the farewell's grace has buried the call, so a tick due in the
+     * same clock step does not say goodbye to a call already ended. */
     let buriedByReaper = false;
     const idleTick = async (): Promise<void> => {
       await this.deps.sleep(IDLE_TICK_MS);
@@ -3846,18 +3740,11 @@ export class VoiceAgentProcessor extends StreamProcessor<
       }
       const idleReason = `no input from the device for ${IDLE_TIMEOUT_MS / 1000}s`;
       /*
-       * SAY SO, THEN HANG UP. The reaper used to bury the call in silence:
-       * the listener heard nothing, and the record showed an obituary with
-       * no goodbye. Now it appends a `say` with `thenHangUp` — the same
-       * path a script or a colleague would use — and the call ends the
-       * moment the farewell has finished playing, with the obituary
-       * carrying this reason. The precedent this sets: whoever ends a call
-       * tells the listener what is happening and why, and leaves events
-       * behind that read that way afterwards.
-       *
-       * The chain keeps ticking behind the farewell: a listener who answers
-       * it barges the answer and un-decides the hang-up (#bargeAnswer), and
-       * from there the deadline simply starts again.
+       * SAY SO, THEN HANG UP. A call is never ended silently when there is a
+       * voice to say so: the reaper appends a `say` with `thenHangUp`, and
+       * the call ends once the farewell has played. The chain keeps ticking
+       * behind it — a listener who answers barges the goodbye and un-decides
+       * the hang-up (#bargeAnswer), and the deadline starts again.
        */
       if (dial.hangUpAfterAnswerDrains !== null || dial.sayHangUpReason !== null) {
         this.runInBackground(idleTick);
@@ -3870,8 +3757,7 @@ export class VoiceAgentProcessor extends StreamProcessor<
         return;
       }
       const farewellReason = `idle: ${idleReason}`;
-      /* Set BEFORE the append: the say arm confirms it when the event comes
-       * back round, and a say that never comes back (append refused, facet
+      /* Set BEFORE the append, so a say that never comes back round (facet
        * evicted) still leaves the grace below with something to bury. */
       dial.sayHangUpReason = farewellReason;
       const episode = ++dial.idleFarewells;
@@ -3889,15 +3775,9 @@ export class VoiceAgentProcessor extends StreamProcessor<
           },
         });
       } catch (error) {
-        /*
-         * A REFUSED FAREWELL MUST NOT DISARM THE REAPER. The reason was set
-         * before the append so a say that never comes back round still has
-         * something for the grace to bury — but if the append itself throws,
-         * neither the grace nor the next tick below is ever armed, and with
-         * the reason still set every later tick would defer to a hang-up
-         * that is not coming. Forget this attempt and tick on: the next
-         * deadline tries again under a fresh episode key.
-         */
+        /* A refused farewell must not disarm the reaper: with the reason
+         * left set, every later tick would defer to a hang-up that is not
+         * coming. Forget this attempt; the next tick tries again. */
         console.error("voice-agent idle farewell could not be queued", { error });
         dial.sayHangUpReason = null;
         this.runInBackground(idleTick);
@@ -3906,15 +3786,11 @@ export class VoiceAgentProcessor extends StreamProcessor<
       this.runInBackground(async () => {
         await this.deps.sleep(IDLE_FAREWELL_GRACE_MS);
         if (this.#dial !== dial) return;
-        /* Null means one of two good things: the farewell's response was
-         * created (the drain point now owns the end), or a returning
-         * listener un-decided it. Still set means the provider never
-         * started the line — bury the call the old way, and say so. */
+        /* Null: the farewell's response was created (the drain point owns
+         * the end) or a returning listener un-decided it. Still set: the
+         * provider never started the line — bury the call the old way. */
         if (dial.sayHangUpReason === null) return;
-        /* Unless the listener came back in the meantime: a press inside the
-         * grace, before the provider had even started the goodbye, is a
-         * person who wants the call, and the reaper's deadline has already
-         * restarted from it. Forget the farewell; nothing is buried. */
+        /* Backstop for the press-inside-the-grace case #bargeAnswer covers. */
         if (this.#lastDeviceInputAtStreamMsMirror > farewellAtMs) {
           dial.sayHangUpReason = null;
           return;
@@ -4211,6 +4087,56 @@ export class VoiceAgentProcessor extends StreamProcessor<
 
   /** Highest `say` offset already spoken — the same redelivery dedupe as the note's. */
   #lastSayOffset = 0;
+
+  /**
+   * Ask the provider to speak an item just placed in context — a colleague
+   * note or a `say` — with a note's precedence: created at once when the
+   * floor is free; otherwise the awaited line outranks whatever is playing.
+   */
+  #askForFollowUp(
+    dial: Dial,
+    kind: "note" | "say",
+    append: ProcessEventArgs<VoiceAgentContract>["append"],
+  ): void {
+    if (
+      dial.openToolCallIds.size === 0 &&
+      dial.answer.phase === "settled" &&
+      !dial.followUpResponsePending
+    ) {
+      dial.followUpResponsePending = true;
+      dial.followUpKind = kind;
+      this.#sendControl(dial, { type: "response.create" }, append);
+    } else if (
+      dial.answer.phase === "streaming" &&
+      (dial.answer.kind === "status" || dial.answer.kind === "turn")
+    ) {
+      /* THE AWAITED ANSWER OUTRANKS WHATEVER IS PLAYING — the facet's
+       * own status commentary, and the person's turn-answers too:
+       * anyone listening while a note is pending is waiting, and hold
+       * music ("count to 100 while it works") must lose to the thing
+       * being waited for. Only note/tool answers stay protected — the
+       * previous answer's delivery must not be cut by the next one.
+       * Cancel + silence the device; the note speaks the moment the
+       * provider settles the cancelled response (creating before its
+       * response.done is a provider error, so the done arm
+       * finishes the job). */
+      this.#dropAnswerInFlight(dial, this.deps.nowAtFacetMs(), append);
+      dial.answer.endsWhenQueueDrains = false;
+      this.#sendControl(dial, { type: "response.cancel" }, append);
+      dial.answerCancelledForNote = true;
+      dial.pendingNoteResponse = true;
+      dial.pendingFollowUpKind = kind;
+    } else {
+      /* ALWAYS pend when we did not create. The note item goes out
+       * AFTER any in-flight response.create, so it never rides that
+       * response — assuming it would left an answered note unspoken
+       * until the caller pressed again (observed live, 2026-08-29:
+       * "the backend says it's answered... I'm waiting for the actual
+       * note", with the note already in context). */
+      dial.pendingNoteResponse = true;
+      dial.pendingFollowUpKind = kind;
+    }
+  }
 
   /** The last note's text and when it was injected — the belt behind the
    * offset dedupe: a stale duplicate FORWARDER (the legacy shared-name
@@ -4810,16 +4736,10 @@ export class VoiceAgentProcessor extends StreamProcessor<
     cancel: boolean,
   ): void {
     dial.hangUpAfterAnswerDrains = null;
-    /*
-     * AND A FAREWELL NOT YET STARTED. `sayHangUpReason` is parked on the
-     * dial between a `thenHangUp` say arriving and its `response.created`;
-     * that window is normally under a second, but a press inside it is a
-     * person who wants the call, and the created arm would otherwise arm
-     * the hang-up anyway — the reaper's grace only looks at this AFTER the
-     * provider has had 8 s to start the line, which is too late to stop a
-     * response.create that already went out. Cleared here, the goodbye (if
-     * the provider does say it) is just a line, and the call stays up.
-     */
+    /* And a farewell not yet started: a press between a thenHangUp say and
+     * its response.created is a person who wants the call, and the created
+     * arm would otherwise arm the hang-up anyway. Cleared, the goodbye (if
+     * the provider still says it) is just a line. */
     dial.sayHangUpReason = null;
     dial.face?.barge(decidedAtFacetMs);
     /* Read BEFORE the repair moves a streaming answer to "cancelled". */
@@ -5445,22 +5365,10 @@ export default class VoiceAgentEntrypoint extends IterateWorkerEntrypoint implem
   }
 
   /**
-   * Have the live call's voice say something now — the scripted equivalent
-   * of a slash command, for an operator, a cron, or an agent:
-   *
-   *   await itx.workers.get(voiceAgentEntrypointRef).say({
-   *     streamPath: "/agents/voice/home-assistant-voice-preview-edition",
-   *     text: "I'm closing this call now; the shop is done.",
-   *     reason: "operator: shop complete",
-   *     thenHangUp: true,
-   *   });
-   *
-   * One durable `say` event; the facet speaks it through whichever call is
-   * live on that stream (nothing happens on an idle stream, and the event
-   * still records that somebody tried), and `thenHangUp` closes the call
-   * once the line has finished playing. Afterwards the stream reads:
-   * say → answer-transcript (kind "say") → conversation-end-requested →
-   * conversation-ended — who asked, why, what was said, that it ended.
+   * Have the live call's voice say something now. One durable `say` event;
+   * the facet speaks it through whichever call is live on that stream (an
+   * idle stream just keeps the record), and `thenHangUp` closes the call
+   * once the line has finished playing.
    */
   async say(options: SayOptions): Promise<SayResult> {
     if (!options.streamPath.startsWith("/")) {

--- a/packages/voice-agent/src/voice-agent.ts
+++ b/packages/voice-agent/src/voice-agent.ts
@@ -4125,7 +4125,7 @@ export class VoiceAgentProcessor extends StreamProcessor<
       this.#sendControl(dial, { type: "response.cancel" }, append);
       dial.answerCancelledForNote = true;
       dial.pendingNoteResponse = true;
-      dial.pendingFollowUpKind = kind;
+      this.#pendFollowUp(dial, kind);
     } else {
       /* ALWAYS pend when we did not create. The note item goes out
        * AFTER any in-flight response.create, so it never rides that
@@ -4134,8 +4134,20 @@ export class VoiceAgentProcessor extends StreamProcessor<
        * "the backend says it's answered... I'm waiting for the actual
        * note", with the note already in context). */
       dial.pendingNoteResponse = true;
-      dial.pendingFollowUpKind = kind;
+      this.#pendFollowUp(dial, kind);
     }
+  }
+
+  /**
+   * A PENDING SAY OUTRANKS A NOTE. The re-create at `response.done` comes
+   * back as ONE kind, and a `thenHangUp` say's hang-up is armed only if
+   * that kind is "say" — so a note that lands behind a pending say must not
+   * overwrite it (the note's text is in context and is spoken regardless).
+   * Overwritten, the call never hung up and the reaper deferred forever to
+   * a reason nothing was going to collect.
+   */
+  #pendFollowUp(dial: Dial, kind: "note" | "say"): void {
+    if (kind === "say") dial.pendingFollowUpKind = "say";
   }
 
   /** The last note's text and when it was injected — the belt behind the

--- a/packages/voice-agent/src/voice-agent.ts
+++ b/packages/voice-agent/src/voice-agent.ts
@@ -348,9 +348,9 @@ const IDLE_STAMP_STEP_MS = 5_000;
 
 /** How often the idle countdown looks at the facet clock. */
 const IDLE_TICK_MS = 5_000;
-/** How long the idle reaper waits for the provider to START its farewell
- * before burying the call silently; a farewell that has started is the
- * drain point's to finish. Under IDLE_TIMEOUT_MS's own slack on purpose. */
+/** How long a `thenHangUp` say's response may take to START before the call
+ * is ended without it; a line that has started is the drain point's to
+ * finish. Under IDLE_TIMEOUT_MS's own slack on purpose. */
 export const IDLE_FAREWELL_GRACE_MS = 8_000;
 
 /** The reaper's goodbye, worded per client: press, or press and talk, to come back. */
@@ -1951,6 +1951,11 @@ interface Dial {
    * moved onto `hangUpAfterAnswerDrains` at the say's own `response.created`
    * so the line PLAYS first. Still set after the reaper's grace: never started. */
   sayHangUpReason: string | null;
+  /** Which thenHangUp say the parked reason belongs to: its start grace
+   * checks it, so a later say's grace is the only one that can bury the call. */
+  sayHangUpEpisode: number;
+  /** A grace has ended this call; the idle tick must not say goodbye again. */
+  buried: boolean;
   /** Farewells announced on this dial: the per-episode idempotency suffix. */
   idleFarewells: number;
   /** The answer in flight — replaced wholesale at `response.created`. */
@@ -1994,6 +1999,8 @@ const freshDial = (
   pendingNoteResponse: false,
   pendingFollowUpKind: "note",
   sayHangUpReason: null,
+  sayHangUpEpisode: 0,
+  buried: false,
   idleFarewells: 0,
   answer: freshAnswer(),
 });
@@ -2726,11 +2733,36 @@ export class VoiceAgentProcessor extends StreamProcessor<
         }
         const thenHangUp = event.payload.thenHangUp === true;
         if (thenHangUp) {
-          const by = typeof event.payload.by === "string" ? ` by ${event.payload.by}` : "";
-          dial.sayHangUpReason =
+          const asker = typeof event.payload.by === "string" ? event.payload.by : null;
+          const reason =
             typeof event.payload.reason === "string" && event.payload.reason !== ""
               ? event.payload.reason
-              : `asked to hang up${by}`;
+              : `asked to hang up${asker === null ? "" : ` by ${asker}`}`;
+          dial.sayHangUpReason = reason;
+          const episode = ++dial.sayHangUpEpisode;
+          const parkedAtMs = this.deps.nowAtFacetMs();
+          /*
+           * EVERY HANG-UP SAY GETS A START GRACE, not only the reaper's. A
+           * parked reason makes the idle tick defer; a provider that never
+           * starts the line would otherwise leave it parked for ever and the
+           * call unreapable. Past the grace, still parked, the call is ended
+           * without the line — unless the listener came back meanwhile.
+           */
+          runInBackground(async () => {
+            await this.deps.sleep(IDLE_FAREWELL_GRACE_MS);
+            if (this.#dial !== dial || dial.sayHangUpEpisode !== episode) return;
+            if (dial.sayHangUpReason === null) return; /* started, or un-decided */
+            dial.sayHangUpReason = null;
+            /* Backstop for the press-inside-the-grace case #bargeAnswer covers. */
+            if (this.#lastDeviceInputAtStreamMsMirror > parkedAtMs) return;
+            dial.buried = true;
+            await this.#requestEnd(
+              dial.conversationId,
+              asker === "idle-reaper" ? "idle" : "hang-up",
+              `${reason}; the line was never spoken`,
+              append,
+            );
+          });
         }
         this.#sendControl(
           dial,
@@ -3373,6 +3405,7 @@ export class VoiceAgentProcessor extends StreamProcessor<
              * at the committed arm; both arms share the no-op guard. */
             const followUp = dial.followUpResponsePending;
             dial.followUpResponsePending = false;
+            const listenerSpeaking = dial.tentativeOnset !== null && !dial.tentativeOnset.retracted;
             if (followUp) {
               dial.tentativeOnset = null;
             } else {
@@ -3381,9 +3414,13 @@ export class VoiceAgentProcessor extends StreamProcessor<
             dial.answer = freshAnswer();
             dial.answer.kind = followUp ? dial.followUpKind : "turn";
             /* A thenHangUp say's response has started: from here the drain
-             * point owns the ending, exactly as after the hang_up tool. */
+             * point owns the ending, exactly as after the hang_up tool — unless
+             * an open-mic listener started speaking while the line was queued.
+             * That onset never reaches #bargeAnswer (nothing was playing to
+             * barge), so it is read here: the person wants the call, and the
+             * line is just a line. */
             if (followUp && dial.followUpKind === "say" && dial.sayHangUpReason !== null) {
-              dial.hangUpAfterAnswerDrains = dial.sayHangUpReason;
+              if (!listenerSpeaking) dial.hangUpAfterAnswerDrains = dial.sayHangUpReason;
               dial.sayHangUpReason = null;
             }
             /* A new answer supersedes any cancelled-status bookkeeping. */
@@ -3689,12 +3726,9 @@ export class VoiceAgentProcessor extends StreamProcessor<
      * milliseconds from Cloudflare's own clock and the deadline is a
      * minute. Anything tighter than that would need a single clock.
      */
-    /* Set once the farewell's grace has buried the call, so a tick due in the
-     * same clock step does not say goodbye to a call already ended. */
-    let buriedByReaper = false;
     const idleTick = async (): Promise<void> => {
       await this.deps.sleep(IDLE_TICK_MS);
-      if (this.#dial !== dial || buriedByReaper) return;
+      if (this.#dial !== dial || dial.buried) return;
       const nowAtFacetMs = this.deps.nowAtFacetMs();
       /*
        * IDLE SINCE THE LAST THING THAT HAPPENED, whichever end it happened
@@ -3756,12 +3790,10 @@ export class VoiceAgentProcessor extends StreamProcessor<
         await this.#requestEnd(conversationId, "idle", idleReason, append);
         return;
       }
-      const farewellReason = `idle: ${idleReason}`;
-      /* Set BEFORE the append, so a say that never comes back round (facet
-       * evicted) still leaves the grace below with something to bury. */
-      dial.sayHangUpReason = farewellReason;
+      /* The say arm parks the reason and arms its start grace when the
+       * farewell comes back round; nothing is decided here, so a refused
+       * append simply leaves the next tick to try again. */
       const episode = ++dial.idleFarewells;
-      const farewellAtMs = nowAtFacetMs;
       try {
         await append({
           type: "events.iterate.com/voice-agent/say",
@@ -3769,41 +3801,14 @@ export class VoiceAgentProcessor extends StreamProcessor<
           payload: {
             conversationId,
             text: idleFarewell(state.clientTakesTurns),
-            reason: farewellReason,
+            reason: `idle: ${idleReason}`,
             by: "idle-reaper",
             thenHangUp: true,
           },
         });
       } catch (error) {
-        /* A refused farewell must not disarm the reaper: with the reason
-         * left set, every later tick would defer to a hang-up that is not
-         * coming. Forget this attempt; the next tick tries again. */
         console.error("voice-agent idle farewell could not be queued", { error });
-        dial.sayHangUpReason = null;
-        this.runInBackground(idleTick);
-        return;
       }
-      this.runInBackground(async () => {
-        await this.deps.sleep(IDLE_FAREWELL_GRACE_MS);
-        if (this.#dial !== dial) return;
-        /* Null: the farewell's response was created (the drain point owns
-         * the end) or a returning listener un-decided it. Still set: the
-         * provider never started the line — bury the call the old way. */
-        if (dial.sayHangUpReason === null) return;
-        /* Backstop for the press-inside-the-grace case #bargeAnswer covers. */
-        if (this.#lastDeviceInputAtStreamMsMirror > farewellAtMs) {
-          dial.sayHangUpReason = null;
-          return;
-        }
-        dial.sayHangUpReason = null;
-        buriedByReaper = true;
-        await this.#requestEnd(
-          conversationId,
-          "idle",
-          `${idleReason}; the farewell was never spoken`,
-          append,
-        );
-      });
       this.runInBackground(idleTick);
     };
     this.runInBackground(idleTick);

--- a/packages/voice-agent/src/voice-agent.ts
+++ b/packages/voice-agent/src/voice-agent.ts
@@ -1955,6 +1955,8 @@ interface Dial {
   sayHangUpBy: string | null;
   /** The provider has been asked for the parked line (its start grace runs). */
   sayHangUpAsked: boolean;
+  /** When the line was parked; the reaper gives an unasked one this long. */
+  sayHangUpParkedAtMs: number;
   /** Which request-to-speak the running start grace belongs to, so only the
    * latest grace can bury the call. */
   sayHangUpEpisode: number;
@@ -2005,6 +2007,7 @@ const freshDial = (
   sayHangUpReason: null,
   sayHangUpBy: null,
   sayHangUpAsked: false,
+  sayHangUpParkedAtMs: 0,
   sayHangUpEpisode: 0,
   buried: false,
   idleFarewells: 0,
@@ -2747,6 +2750,7 @@ export class VoiceAgentProcessor extends StreamProcessor<
           dial.sayHangUpReason = reason;
           dial.sayHangUpBy = asker;
           dial.sayHangUpAsked = false;
+          dial.sayHangUpParkedAtMs = this.deps.nowAtFacetMs();
         }
         this.#sendControl(
           dial,
@@ -3771,27 +3775,33 @@ export class VoiceAgentProcessor extends StreamProcessor<
       }
       if (dial.sayHangUpReason !== null) {
         /*
-         * A HANG-UP LINE IS PARKED. Asked for already: its start grace
-         * decides, and this tick defers. Still pended — behind a turn a
-         * barge cancelled and nobody finished, or a tool that never came
-         * back — it would stay parked for ever, because the re-create waits
-         * for a settled turn a silent listener never gives it. Idle IS the
-         * floor being free: ask for the line now where nothing is streaming
-         * and no tool is open, and arm the grace either way, so the call
-         * ends with the line or, past the grace, without it.
+         * A HANG-UP LINE IS PARKED. Asked for: its start grace decides, and
+         * this tick defers. Never asked — pended behind a turn a barge
+         * cancelled and nobody finished, or a tool that never came back —
+         * and the call idle past its deadline: nobody is going to ask. The
+         * reaper does not try to speak it (a create from here raced the
+         * follow-up sites, and a grace from here buried calls still busy);
+         * it ends the call now, without the line, exactly as it ended every
+         * idle call before there were lines. A line parked within the last
+         * grace is given that long to be asked for.
          */
-        if (!dial.sayHangUpAsked && dial.ready && dial.socket !== null) {
-          if (dial.answer.phase !== "streaming" && dial.openToolCallIds.size === 0) {
-            dial.pendingNoteResponse = false;
-            dial.answerCancelledForNote = false;
-            dial.followUpResponsePending = true;
-            dial.followUpKind = "say";
-            dial.pendingFollowUpKind = "note";
-            this.#sendControl(dial, { type: "response.create" }, append);
-          }
-          this.#armSayStartGrace(dial, append);
+        if (
+          dial.sayHangUpAsked ||
+          nowAtFacetMs - dial.sayHangUpParkedAtMs < IDLE_FAREWELL_GRACE_MS
+        ) {
+          this.runInBackground(idleTick);
+          return;
         }
-        this.runInBackground(idleTick);
+        const reason = dial.sayHangUpReason;
+        const by = dial.sayHangUpBy;
+        dial.sayHangUpReason = null;
+        dial.buried = true;
+        await this.#requestEnd(
+          conversationId,
+          by === "idle-reaper" ? "idle" : "hang-up",
+          `${reason}; the line was never spoken`,
+          append,
+        );
         return;
       }
       if (!dial.ready || dial.socket === null) {
@@ -3800,9 +3810,14 @@ export class VoiceAgentProcessor extends StreamProcessor<
         await this.#requestEnd(conversationId, "idle", idleReason, append);
         return;
       }
-      /* The say arm parks the reason and arms its start grace when the
-       * farewell comes back round; nothing is decided here, so a refused
-       * append simply leaves the next tick to try again. */
+      /* Parked here as well as by the say arm when the farewell comes back
+       * round, so a slow delivery cannot draw a second farewell from the next
+       * tick. The arm asks for the line and arms its start grace. */
+      const farewellReason = `idle: ${idleReason}`;
+      dial.sayHangUpReason = farewellReason;
+      dial.sayHangUpBy = "idle-reaper";
+      dial.sayHangUpAsked = false;
+      dial.sayHangUpParkedAtMs = nowAtFacetMs;
       const episode = ++dial.idleFarewells;
       try {
         await append({
@@ -3811,13 +3826,15 @@ export class VoiceAgentProcessor extends StreamProcessor<
           payload: {
             conversationId,
             text: idleFarewell(state.clientTakesTurns),
-            reason: `idle: ${idleReason}`,
+            reason: farewellReason,
             by: "idle-reaper",
             thenHangUp: true,
           },
         });
       } catch (error) {
+        /* A refused farewell must not sit parked: the next tick tries again. */
         console.error("voice-agent idle farewell could not be queued", { error });
+        dial.sayHangUpReason = null;
       }
       this.runInBackground(idleTick);
     };

--- a/packages/voice-agent/src/voice-agent.ts
+++ b/packages/voice-agent/src/voice-agent.ts
@@ -3876,17 +3876,33 @@ export class VoiceAgentProcessor extends StreamProcessor<
       dial.sayHangUpReason = farewellReason;
       const episode = ++dial.idleFarewells;
       const farewellAtMs = nowAtFacetMs;
-      await append({
-        type: "events.iterate.com/voice-agent/say",
-        idempotencyKey: this.idempotencyKey(`say:idle:${conversationId}:${episode}`),
-        payload: {
-          conversationId,
-          text: idleFarewell(state.clientTakesTurns),
-          reason: farewellReason,
-          by: "idle-reaper",
-          thenHangUp: true,
-        },
-      });
+      try {
+        await append({
+          type: "events.iterate.com/voice-agent/say",
+          idempotencyKey: this.idempotencyKey(`say:idle:${conversationId}:${episode}`),
+          payload: {
+            conversationId,
+            text: idleFarewell(state.clientTakesTurns),
+            reason: farewellReason,
+            by: "idle-reaper",
+            thenHangUp: true,
+          },
+        });
+      } catch (error) {
+        /*
+         * A REFUSED FAREWELL MUST NOT DISARM THE REAPER. The reason was set
+         * before the append so a say that never comes back round still has
+         * something for the grace to bury — but if the append itself throws,
+         * neither the grace nor the next tick below is ever armed, and with
+         * the reason still set every later tick would defer to a hang-up
+         * that is not coming. Forget this attempt and tick on: the next
+         * deadline tries again under a fresh episode key.
+         */
+        console.error("voice-agent idle farewell could not be queued", { error });
+        dial.sayHangUpReason = null;
+        this.runInBackground(idleTick);
+        return;
+      }
       this.runInBackground(async () => {
         await this.deps.sleep(IDLE_FAREWELL_GRACE_MS);
         if (this.#dial !== dial) return;
@@ -4794,6 +4810,17 @@ export class VoiceAgentProcessor extends StreamProcessor<
     cancel: boolean,
   ): void {
     dial.hangUpAfterAnswerDrains = null;
+    /*
+     * AND A FAREWELL NOT YET STARTED. `sayHangUpReason` is parked on the
+     * dial between a `thenHangUp` say arriving and its `response.created`;
+     * that window is normally under a second, but a press inside it is a
+     * person who wants the call, and the created arm would otherwise arm
+     * the hang-up anyway — the reaper's grace only looks at this AFTER the
+     * provider has had 8 s to start the line, which is too late to stop a
+     * response.create that already went out. Cleared here, the goodbye (if
+     * the provider does say it) is just a line, and the call stays up.
+     */
+    dial.sayHangUpReason = null;
     dial.face?.barge(decidedAtFacetMs);
     /* Read BEFORE the repair moves a streaming answer to "cancelled". */
     const responseWasStreaming = dial.answer.phase === "streaming";


### PR DESCRIPTION
A call is never ended silently when there is a voice to say so. This ports the templestein project's fork of the voice agent (2026-09-07, two days ahead of the package) into `@iterate-com/voice-agent`: a `say` event, a `say()` RPC, and an idle reaper that says goodbye before it hangs up.

## What changed

- **`events.iterate.com/voice-agent/say`** — `{ text, reason?, by?, thenHangUp?, conversationId? }`, durable, consumed and emitted by the facet. The facet injects the line as a system item and asks for one response when the floor is free, with the same precedence a colleague note has (commentary and hold music yield; a note or tool answer finishes first). Offset-deduped like the note, so a redelivery does not say it twice. The transcript records it as an `answer-transcript` of kind `"say"`. `conversationId` scopes it to one call; a say for a finished call is ignored, hang-up and all.
- **`thenHangUp`** parks the reason on the dial; the say's own `response.created` moves it onto `hangUpAfterAnswerDrains`, so the line plays before the obituary is written and the obituary carries the asker's reason. Same drain-point discipline as the model's `hang_up` tool.
- **The idle reaper** appends a farewell `say` with `thenHangUp` instead of ending the call in silence, worded per client (press, or press and talk, to come back). Every `thenHangUp` say arms a start grace (`IDLE_FAREWELL_GRACE_MS`, 8 s) from the moment the provider is asked for the line (not from when the say was parked, so a line waiting behind a note or tool answer is not given up on): if the provider has not started it by then, the call is ended without it, with `"; the line was never spoken"` appended to the reason — unless the listener came back meanwhile. A listener who answers the farewell barges it and keeps the call; a press between the farewell and its `response.created` keeps it too: the press un-decides the parked hang-up in `#bargeAnswer` (where a press and a confirmed VAD onset both arrive), so a goodbye the provider then starts is only a line. The grace still checks the device-input stamp as a backstop. A farewell the stream refuses to append does not disarm the reaper: the parked reason is forgotten and the tick chain retries at the next deadline. Once the grace has buried a call the tick chain stops, so a tick that comes due in the same clock step cannot say goodbye to a call already ended.
- **RPC surface**: `VoiceAgentEntrypoint.say(options)` and `VoiceAgentApp.say(line)`, typed as `SayOptions` / `SayResult` on `VoiceAgentRpc`, exported from the package root.
- **Contract 20.0.0**, following the file's convention of a major bump per feature (the comment block records why).
- README (VoiceAgentApp example, protocol table, troubleshooting) and INSTALL.

Versus the fork: the say arm and the colleague-note arm share one follow-up helper (`#askForFollowUp`) instead of two copies of the create/outrank/pend branch; the types live in `setup-options.ts` and are exported; `say()` is on `VoiceAgentRpc` and `VoiceAgentApp`; the reaper stops its tick after the grace buries a call (the fork could append a second farewell when the grace and the tick came due together — caught by the new tests); a press inside the grace no longer gets the call buried under it; the version is bumped (the fork stayed on 19.0.0); the payload spreads use the repo's `cond && obj` form.

## The subscription-snapshot caveat

A stream's facet subscription filter is a snapshot of `contract.consumes` taken by whichever build ran setup. Streams set up before this change never receive `say` — the reaper's farewell is appended but never comes back round, so those calls are reaped the old way, silently, one tick later. Re-running `setupVoiceAgent` on a stream fixes it: the subscription's idempotency key is a content hash of its filter, so a changed `consumes` installs the new filter (and an unchanged one is a no-op). `voicelab talk` does this on every run; a board's stream needs it done once. Documented in the README's troubleshooting. Not automated here: setup already reconfigures on re-run, and an installer that re-runs setup on every stream it does not know about would be a bigger change than this one.

## Tests

`apps/os/scripts/voicelab/voice-agent.test.ts` (107 pass):

- New: a say is spoken and recorded as kind "say"; `thenHangUp` ends the call only after the line has played, with the asker's reason; a say for another conversation is ignored; the reaper says goodbye first and hangs up after it has played (push-to-talk wording); an open-mic board is told to press and talk; a farewell the provider never starts is followed by the silent end, which says so; so is an operator's hang-up say the provider never starts, and one waiting behind a note answer is only given up on once it has been asked for; one parked behind a barged turn, never asked for, is ended by the reaper past its deadline without the line, as every idle call was before; an open-mic listener who starts speaking before the goodbye starts keeps the call; a listener who answers the farewell keeps the call, and so does one who presses before the goodbye starts (and is seen off again a minute later); a press between the farewell and its `response.created`, with the provider then starting the goodbye, keeps the call (Bugbot's case); a farewell the stream refuses is retried at the next tick and the reaper still ends the call.
- Changed: the nine tests that jumped past the idle deadline in one `advanceTime` now step through it (`idleOut`), because the harness clock releases only the sleeps pending when an advance began, and the farewell's grace is armed mid-advance. One long-answer test keeps its first jump on purpose (stepping would play the answer through the "idle" stretch and change what the third phase measures).
- `packages/voice-agent/src/app.test.ts`: `say` dials and releases the handles like the other methods.

## Risk map

- **Riskiest: the reaper.** It now appends a farewell and keeps ticking behind it; a parked line the provider was never asked for (busy floor, hung tool) is ended without the line once idle, which is the pre-PR outcome. The grace/tick same-step case is tested; a facet evicted between the farewell append and its fold has no grace timer, and the durable stamp still ends the call on the next incarnation's tick (as before, silently).
- **Every existing stream** is on an older subscription filter until setup is re-run: their idle hang-ups gain an 8 s delay and the "never spoken" reason. No audio or state change.
- **Persisted 19.0.0 folds** are re-reduced under 20.0.0 (state schema unchanged).

**Suggested review order:** `packages/voice-agent/src/voice-agent.ts` (the contract entry, the `say` arm after the colleague-note arm, the `response.created` and `response.done` touches, the reaper, `say()` on the entrypoint) → `setup-options.ts`, `app.ts`, `index.ts` → the new `describe("say, and the announced farewell")` block and the `idleOut` helper in the voicelab test → README, INSTALL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live call teardown and idle timing in the voice facet; behavior is heavily tested but existing streams may see delayed silent idle ends until setup is re-run.
> 
> **Overview**
> Adds **`say`** so operators (and the facet) can queue scripted speech on a live call, with optional **`thenHangUp`** that ends the call only after playback—same drain-point behavior as the model’s `hang_up` tool. The durable **`events.iterate.com/voice-agent/say`** event is consumed by the facet (contract **20.0.0**), surfaced as **`VoiceAgentApp.say` / `VoiceAgentRpc.say`**, and documented in README/INSTALL.
> 
> The **idle reaper** no longer ends calls in silence when a provider is available: it appends a farewell `say` with `thenHangUp`, arms an **8s start grace** (`IDLE_FAREWELL_GRACE_MS`) once the line is requested, and handles barges, late presses, refused appends, and “line never spoken” fallbacks. Colleague-note follow-up logic is refactored into shared **`#askForFollowUp`** so notes and says share precedence/pending rules.
> 
> **Tests** gain `stepTime` / `idleOut` helpers so harness time advances match reaper ticks and farewell grace; a large new **`say, and the announced farewell`** block covers operator and idle paths. **Caveat:** streams set up before this change need **`setupVoiceAgent` re-run** so the subscription filter includes `say` (otherwise farewell events are not consumed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88240fd332eed563f17fe7ecc062b567215b500b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +380 -44 | +228 -26 🟩🟩🟩🟩⬜ |
| Tests | +389 -18 | +297 -18 🟩🟩🟩🟩🟩 |
| Docs | +17 -2 | +16 -2 🟩⬜⬜⬜⬜ |
| **Total** | **+786 -64** | **+541 -46** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 2abde4d and 88240fd, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-09-11T08:57:15.338Z",
      "deployedAt": "2026-09-09T16:16:26.429Z",
      "headSha": "88240fd332eed563f17fe7ecc062b567215b500b",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/101545947953975",
      "shortSha": "88240fd",
      "cleanupDurationMs": 97838,
      "deployDurationMs": 87744,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 85885,
      "deployReadinessDurationMs": 1856,
      "deployedWorkerName": "os-preview-17",
      "deployedWorkerVersion": "aa8fe565-d758-4bab-9515-e5f3e2d73906",
      "testDurationMs": 279342,
      "testRetries": "2 retried: agents.liveState subscribed before any agent exists serves the empty catalog, then pushes the first agent and its title (vitest x1) — expected { birthCertificate: {}, …(2) } to deeply equal { birthCertificate: {}, …(2) } · stream-resume-after-suspend.spec.ts › feed resumes after page freeze + socket death (mobile suspend shape) › preview-resilience (playwright x1) — TimeoutError: locator.waitFor: Timeout 90000ms exceeded. Call log: \u001b[2m - waiting for getByText('marker: after-freeze') to be visible\u001b[22m",
      "workerSizeKib": 21965.92,
      "workerGzipKib": 5523.27,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5533.78
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-09-11T08:55:41.632Z",
      "deployedAt": "2026-09-09T16:15:27.687Z",
      "headSha": "88240fd332eed563f17fe7ecc062b567215b500b",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-17.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/101545947953975",
      "shortSha": "88240fd",
      "cleanupDurationMs": 4129,
      "deployDurationMs": 31111,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 27142,
      "deployReadinessDurationMs": 3966,
      "deployedWorkerName": "docs-preview-17",
      "deployedWorkerVersion": "d37fc994-fefd-4639-91bb-a41f4cd4ae94",
      "testDurationMs": 2948,
      "testRetries": null,
      "workerSizeKib": 4793.39,
      "workerGzipKib": 1126.74,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-09-11T08:55:42.355Z",
      "deployedAt": "2026-09-09T16:15:35.020Z",
      "headSha": "88240fd332eed563f17fe7ecc062b567215b500b",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/101545947953975",
      "shortSha": "88240fd",
      "cleanupDurationMs": 4850,
      "deployDurationMs": 34895,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 34474,
      "deployReadinessDurationMs": 416,
      "deployedWorkerName": "auth-preview-17",
      "deployedWorkerVersion": "e8825f8e-1de1-4061-abb8-c4ae35d20f93",
      "testDurationMs": 24079,
      "testRetries": null,
      "workerSizeKib": 4179,
      "workerGzipKib": 855.56,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-09-11T08:55:42.329Z",
      "deployedAt": "2026-09-09T16:15:33.319Z",
      "headSha": "88240fd332eed563f17fe7ecc062b567215b500b",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/101545947953975",
      "shortSha": "88240fd",
      "cleanupDurationMs": 4822,
      "deployDurationMs": 33291,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 32772,
      "deployReadinessDurationMs": 514,
      "deployedWorkerName": "streams-example-app-preview-17",
      "deployedWorkerVersion": "fbbd0eda-d0cf-425e-80cf-0bd601da42bb",
      "testDurationMs": 75129,
      "testRetries": null,
      "workerSizeKib": 5671.69,
      "workerGzipKib": 1604.13,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-09-11T08:55:39.461Z",
      "deployedAt": "2026-09-09T16:15:09.338Z",
      "headSha": "88240fd332eed563f17fe7ecc062b567215b500b",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-17.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/101545947953975",
      "shortSha": "88240fd",
      "cleanupDurationMs": 1952,
      "deployDurationMs": 9178,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 8761,
      "deployReadinessDurationMs": 382,
      "deployedWorkerName": "dummy-petshop-preview-17",
      "deployedWorkerVersion": "3c2f133e-b66e-450c-9ee8-738f901edbd7",
      "testDurationMs": 13721,
      "testRetries": null,
      "workerSizeKib": 1331.5,
      "workerGzipKib": 232.81,
      "deployedFingerprint": "c321865fd82cf1ce04086fcbe3c487f157babc45+c5abf1055de73f3b4ffbc5e5b742dff1f0b5ee52",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `88240fd` | [https://auth.iterate-preview-17.com](https://auth.iterate-preview-17.com) | 855.6 KiB | 34.9s | 24.1s |  | 4.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/101545947953975) | 2026-09-11T08:55:42.355Z | Preview app released. |
| Docs | released | `88240fd` | [https://docs-preview-17.iterate-dev-preview.workers.dev](https://docs-preview-17.iterate-dev-preview.workers.dev) | 1.10 MiB | 31.1s | 2.9s |  | 4.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/101545947953975) | 2026-09-11T08:55:41.632Z | Preview app released. |
| Dummy Petshop | released | `88240fd` | [https://dummy-petshop.iterate-preview-17.com](https://dummy-petshop.iterate-preview-17.com) | 232.8 KiB | 9.2s | 13.7s |  | 2.0s | [Workflow run](https://github.com/iterate/iterate/actions/runs/101545947953975) | 2026-09-11T08:55:39.461Z | Preview app released. |
| OS | released | `88240fd` | [https://os.iterate-preview-17.com](https://os.iterate-preview-17.com) | 5.39 MiB (-10.5 KiB vs main) | 87.7s | 279.3s | 2 retried: agents.liveState subscribed before any agent exists serves the empty catalog, then pushes the first agent and its title (vitest x1) — expected { birthCertificate: {}, …(2) } to deeply equal { birthCertificate: {}, …(2) } · stream-resume-after-suspend.spec.ts › feed resumes after page freeze + socket death (mobile suspend shape) › preview-resilience (playwright x1) — TimeoutError: locator.waitFor: Timeout 90000ms exceeded. Call log: [2m - waiting for getByText('marker: after-freeze') to be visible[22m | 97.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/101545947953975) | 2026-09-11T08:57:15.338Z | Preview app released. |
| Streams Example App | released | `88240fd` | [https://streams.iterate-preview-17.com](https://streams.iterate-preview-17.com) | 1.57 MiB | 33.3s | 75.1s |  | 4.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/101545947953975) | 2026-09-11T08:55:42.329Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->





