### PR TITLE
Grandfather existing lint violations by Git blame date

### DIFF
--- a/.depot/workflows/autofix.yml
+++ b/.depot/workflows/autofix.yml
@@ -20,6 +20,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: false
+          # grandfatherRule needs the actual author dates of existing lines.
+          fetch-depth: 0
       - name: install and update lockfile
         run: pnpm install --no-frozen-lockfile --prefer-offline
       - name: fix lint issues

--- a/.depot/workflows/lint-typecheck.yml
+++ b/.depot/workflows/lint-typecheck.yml
@@ -21,6 +21,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: false
+          # grandfatherRule needs the actual author dates of existing lines.
+          fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Reconcile dependencies (baked)
         run: pnpm install --frozen-lockfile --prefer-offline

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -120,6 +120,7 @@
     "iterate/no-raw-durable-object-binding-access": "error",
     "iterate/no-implied-eval": "error",
     "iterate/no-single-use-helpers": "error",
+    "iterate/no-shouting-constants": "error",
     "iterate/colocate-single-use-types": "error",
     "iterate/no-single-use-types": "error",
     "iterate/prefer-logical-and-spread": "error",

--- a/lint/grandfather-rule.md
+++ b/lint/grandfather-rule.md
@@ -3,14 +3,18 @@
 ```ts
 import { grandfatherRule } from "./grandfather-rule.ts";
 
-export const noShoutingConstants = grandfatherRule(
-  {
-    create(context) {
-      /* any normal StrictRule */
-    },
+export const noShoutingConstants = grandfatherRule({
+  allowedUpTo: new Date("2026-11-10"),
+  meta: {
+    /* normal rule metadata */
   },
-  { allowedUpTo: new Date("2026-11-10") },
-);
+  create(context) {
+    /* normal rule listeners */
+  },
+});
+
+// Or wrap a pre-built StrictRule:
+const wrapped = grandfatherRule({ allowedUpTo: new Date("2026-11-10"), ...existingRule });
 ```
 
 Reports at or before the cutoff are suppressed using the start line's Git

--- a/lint/grandfather-rule.md
+++ b/lint/grandfather-rule.md
@@ -1,0 +1,37 @@
+# Grandfather existing violations
+
+```ts
+import { grandfatherRule } from "./grandfather-rule.ts";
+
+export const noShoutingConstants = grandfatherRule(
+  {
+    create(context) {
+      /* any normal StrictRule */
+    },
+  },
+  { allowedUpTo: new Date("2026-11-10") },
+);
+```
+
+Reports at or before the cutoff are suppressed using the start line's Git
+**author timestamp**. An explicit report location takes precedence over the
+node location. A date-only string means midnight UTC, not the end of that day.
+
+The wrapper blames the actual linted source, including unsaved edits. Changed
+and uncommitted lines always count as new. Adding lines above an unchanged
+violation does not change its age. Blame measures when the line last changed,
+not when the surrounding code first became a violation.
+
+Rules keep their metadata, listeners, options, messages, suggestions and fixes.
+Suppressed reports do not apply fixes. Git runs lazily on the first report and
+is reused for subsequent reports from that rule on that file. Each new rule
+creation reads fresh history/source, including oxlint autofix passes.
+
+Files without history and reports without a known start line are checked.
+Shallow boundary lines are also checked because their true age is unknown;
+CI lint/autofix jobs fetch full history. Unexpected Git failures stop linting
+instead of silently granting exemptions. No Git fetch or write is performed.
+
+The shouting rule uses the example cutoff above. Until that date, committing
+an edit can make it exempt even though it was flagged while uncommitted. Use
+a past rollout timestamp when the goal is to block every new committed edit.

--- a/lint/grandfather-rule.test.ts
+++ b/lint/grandfather-rule.test.ts
@@ -1,0 +1,203 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { expect, test } from "vitest";
+import { grandfatherRule } from "./grandfather-rule.ts";
+
+test("grandfathers through the inclusive author-date cutoff, despite shifted line numbers", () => {
+  using fixture = createFixture();
+  fixture.write("const BAD_OLD = 1;\n");
+  fixture.commit("2020-01-01T00:00:00Z");
+  fixture.write("const BAD_OLD = 1;\nconst BAD_BOUNDARY = 2;\n");
+  fixture.commit("2021-01-01T00:00:00Z");
+  fixture.write(
+    "// inserted above old declarations\nconst BAD_OLD = 1;\nconst BAD_BOUNDARY = 2;\nconst BAD_NEW = 3;\n",
+  );
+  fixture.commit("2021-01-01T00:00:01Z");
+
+  expect(fixture.lint()).toMatchObject({ status: 1, names: ["BAD_NEW"] });
+});
+
+test("checks unstaged and staged edits even when the cutoff is in the future", () => {
+  using fixture = createFixture();
+  fixture.write("const BAD_OLD = 1;\nconst BAD_EDITED = 2;\n");
+  fixture.commit("2020-01-01T00:00:00Z");
+  fixture.write("const BAD_OLD = 1;\nconst BAD_EDITED = 3;\nconst BAD_ADDED = 4;\n");
+  writeFileSync(
+    fixture.plugin,
+    readFileSync(fixture.plugin, "utf8").replace("2021-01-01", "2999-01-01"),
+  );
+
+  expect(fixture.lint()).toMatchObject({ status: 1, names: ["BAD_EDITED", "BAD_ADDED"] });
+  fixture.git(["add", "input.ts"]);
+  expect(fixture.lint()).toMatchObject({ status: 1, names: ["BAD_EDITED", "BAD_ADDED"] });
+});
+
+test("checks files without committed history and files outside Git", () => {
+  using fixture = createFixture();
+  fixture.write("const BAD_UNTRACKED = 1;\n");
+  expect(fixture.lint()).toMatchObject({ status: 1, names: ["BAD_UNTRACKED"] });
+  fixture.git(["add", "input.ts"]);
+  expect(fixture.lint()).toMatchObject({ status: 1, names: ["BAD_UNTRACKED"] });
+  fixture.git(["reset"]);
+  fixture.git(["add", "plugin.ts"]);
+  fixture.git(["commit", "--quiet", "-m", "Plugin only"]);
+  expect(fixture.lint()).toMatchObject({ status: 1, names: ["BAD_UNTRACKED"] });
+  fixture.git(["add", "input.ts"]);
+  expect(fixture.lint()).toMatchObject({ status: 1, names: ["BAD_UNTRACKED"] });
+  rmSync(join(fixture.root, ".git"), { recursive: true });
+  expect(fixture.lint()).toMatchObject({ status: 1, names: ["BAD_UNTRACKED"] });
+});
+
+test("uses explicit report locations before node locations, including location-only reports", () => {
+  using fixture = createFixture();
+  fixture.write("const BAD_OLD = 1;\n");
+  fixture.commit("2020-01-01T00:00:00Z");
+  fixture.write("const BAD_OLD = 1;\nconst BAD_NEW = 2;\n");
+  fixture.commit("2022-01-01T00:00:00Z");
+  const plugin = readFileSync(fixture.plugin, "utf8");
+  writeFileSync(
+    fixture.plugin,
+    plugin.replace("{ node, messageId:", "{ node, loc: { line: 1, column: 0 }, messageId:"),
+  );
+  expect(fixture.lint()).toMatchObject({ status: 0, names: [] });
+  writeFileSync(
+    fixture.plugin,
+    plugin.replace(
+      "{ node, messageId:",
+      "{ loc: { start: { line: 2, column: 0 }, end: { line: 2, column: 5 } }, messageId:",
+    ),
+  );
+  expect(fixture.lint()).toMatchObject({ status: 1, names: ["BAD_OLD", "BAD_NEW"] });
+});
+
+test("keeps rule metadata and fixes, fixing only new violations", () => {
+  using fixture = createFixture();
+  fixture.write("const BAD_OLD = 1;\n");
+  fixture.commit("2020-01-01T00:00:00Z");
+  fixture.write("const BAD_OLD = 1;\nconst BAD_NEW = 2;\n");
+  expect(fixture.lint("--fix")).toMatchObject({ status: 0, names: [] });
+  expect(readFileSync(fixture.file, "utf8")).toBe("const BAD_OLD = 1;\nconst goodNEW = 2;\n");
+});
+
+test("checks shallow boundary lines whose true author date is unavailable", () => {
+  using fixture = createFixture();
+  fixture.write("const BAD_OLD = 1;\n");
+  fixture.commit("2020-01-01T00:00:00Z");
+  fixture.write("const BAD_OLD = 1;\n// second commit\n");
+  fixture.commit("2020-06-01T00:00:00Z");
+  fixture.git([
+    "clone",
+    "--quiet",
+    "--depth=1",
+    "file://" + fixture.root,
+    join(fixture.root, "shallow"),
+  ]);
+  expect(fixture.lint()).toMatchObject({ status: 0, names: [] });
+  expect(fixture.lint("shallow/input.ts")).toMatchObject({ status: 1, names: ["BAD_OLD"] });
+});
+
+test("resolves history in linked worktrees", () => {
+  using fixture = createFixture();
+  fixture.write("const BAD_OLD = 1;\n");
+  fixture.commit("2020-01-01T00:00:00Z");
+  fixture.git(["worktree", "add", "--detach", join(fixture.root, "linked"), "HEAD"]);
+  expect(fixture.lint("linked/input.ts")).toMatchObject({ status: 0, names: [] });
+});
+
+test("surfaces Git failures instead of silently exempting violations", () => {
+  using fixture = createFixture();
+  fixture.write("const BAD_OLD = 1;\n");
+  fixture.commit("2020-01-01T00:00:00Z");
+  fixture.git(["config", "blame.ignoreRevsFile", "missing-ignore-revs"]);
+  expect(fixture.lint()).toMatchObject({
+    status: 1,
+    output: expect.stringContaining("missing-ignore-revs"),
+  });
+});
+
+test("rejects invalid cutoff dates", () => {
+  expect(() =>
+    grandfatherRule({ create: () => ({}) }, { allowedUpTo: new Date("invalid") }),
+  ).toThrow("valid allowedUpTo date");
+});
+
+const repoRoot = resolve(import.meta.dirname, "..");
+
+function createFixture() {
+  const root = mkdtempSync(join(tmpdir(), "grandfather-rule-"));
+  const file = join(root, "input.ts");
+  writeFileSync(
+    join(root, "plugin.ts"),
+    `
+    import { grandfatherRule } from ${JSON.stringify(join(repoRoot, "lint/grandfather-rule.ts"))};
+    export default {
+      meta: { name: "fixture" },
+      rules: { old: grandfatherRule({
+        meta: { type: "suggestion", fixable: "code", messages: { banned: "Found {{name}}" } },
+        create(context) {
+          return { Identifier(node) {
+            if (!node.name.startsWith("BAD_")) return;
+            context.report({ node, messageId: "banned", data: { name: node.name },
+              fix(fixer) { return fixer.replaceText(node, "good" + node.name.slice(4)); }
+            });
+          } };
+        }
+      }, { allowedUpTo: new Date("2021-01-01") }) }
+    };
+  `,
+  );
+  writeFileSync(
+    join(root, ".oxlintrc.json"),
+    JSON.stringify({
+      categories: { correctness: "off" },
+      jsPlugins: [join(root, "plugin.ts")],
+      rules: { "fixture/old": "error" },
+    }),
+  );
+  function git(args: string[], env: Record<string, string> = {}) {
+    const result = spawnSync("git", args, {
+      cwd: root,
+      encoding: "utf8",
+      env: { ...process.env, ...env },
+    });
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+    return result.stdout.trim();
+  }
+  git(["init", "--quiet"]);
+  git(["config", "user.name", "Lint Test"]);
+  git(["config", "user.email", "lint@test.invalid"]);
+  return {
+    root,
+    file,
+    plugin: join(root, "plugin.ts"),
+    git,
+    write(contents: string) {
+      writeFileSync(file, contents);
+    },
+    commit(date: string) {
+      git(["add", "input.ts"]);
+      git(["commit", "--quiet", "-m", "Change source"], {
+        GIT_AUTHOR_DATE: date,
+        GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z",
+      });
+    },
+    lint(...args: string[]) {
+      const result = spawnSync(
+        join(repoRoot, "node_modules/.bin/oxlint"),
+        ["input.ts", "--config", join(root, ".oxlintrc.json"), "--threads", "1", ...args],
+        { cwd: root, encoding: "utf8" },
+      );
+      const output = result.stdout + result.stderr;
+      return {
+        status: result.status,
+        names: [...output.matchAll(/Found (BAD_\w+)/g)].map((match) => match[1]),
+        output,
+      };
+    },
+    [Symbol.dispose]() {
+      rmSync(root, { recursive: true, force: true });
+    },
+  };
+}

--- a/lint/grandfather-rule.test.ts
+++ b/lint/grandfather-rule.test.ts
@@ -127,9 +127,9 @@ test("handles renamed paths containing Git pathspec characters", () => {
 });
 
 test("rejects invalid cutoff dates", () => {
-  expect(() =>
-    grandfatherRule({ create: () => ({}) }, { allowedUpTo: new Date("invalid") }),
-  ).toThrow("valid allowedUpTo date");
+  expect(() => grandfatherRule({ allowedUpTo: new Date("invalid"), create: () => ({}) })).toThrow(
+    "valid allowedUpTo date",
+  );
 });
 
 const repoRoot = resolve(import.meta.dirname, "..");
@@ -144,6 +144,7 @@ function createFixture() {
     export default {
       meta: { name: "fixture" },
       rules: { old: grandfatherRule({
+        allowedUpTo: new Date("2021-01-01"),
         meta: { type: "suggestion", fixable: "code", messages: { banned: "Found {{name}}" } },
         create(context) {
           return { Identifier(node) {
@@ -153,7 +154,7 @@ function createFixture() {
             });
           } };
         }
-      }, { allowedUpTo: new Date("2021-01-01") }) }
+      }) }
     };
   `,
   );

--- a/lint/grandfather-rule.test.ts
+++ b/lint/grandfather-rule.test.ts
@@ -117,6 +117,15 @@ test("surfaces Git failures instead of silently exempting violations", () => {
   });
 });
 
+test("handles renamed paths containing Git pathspec characters", () => {
+  using fixture = createFixture();
+  fixture.write("const BAD_OLD = 1;\n");
+  fixture.commit("2020-01-01T00:00:00Z");
+  fixture.git(["mv", "input.ts", "input[1].ts"]);
+  fixture.git(["commit", "--quiet", "-m", "Rename file"]);
+  expect(fixture.lint("input[1].ts")).toMatchObject({ status: 0, names: [] });
+});
+
 test("rejects invalid cutoff dates", () => {
   expect(() =>
     grandfatherRule({ create: () => ({}) }, { allowedUpTo: new Date("invalid") }),

--- a/lint/grandfather-rule.ts
+++ b/lint/grandfather-rule.ts
@@ -8,10 +8,10 @@ import type { StrictRule } from "./types.ts";
  * Uncommitted lines and lines without provable history are always checked.
  * Uses the linted source, so editor buffers and fixes retain correct line numbers.
  */
-export function grandfatherRule(
-  rule: StrictRule,
-  { allowedUpTo }: { allowedUpTo: Date },
-): StrictRule {
+export function grandfatherRule({
+  allowedUpTo,
+  ...rule
+}: StrictRule & { allowedUpTo: Date }): StrictRule {
   const cutoff = allowedUpTo.getTime();
   if (!Number.isFinite(cutoff))
     throw new Error("grandfatherRule requires a valid allowedUpTo date");

--- a/lint/grandfather-rule.ts
+++ b/lint/grandfather-rule.ts
@@ -1,0 +1,97 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import type { Rule } from "eslint";
+import type { StrictRule } from "./types.ts";
+
+/** Suppress reports whose start line was last authored at or before the cutoff.
+ * Uncommitted lines and lines without provable history are always checked.
+ * Uses the linted source, so editor buffers and fixes retain correct line numbers.
+ */
+export function grandfatherRule(
+  rule: StrictRule,
+  { allowedUpTo }: { allowedUpTo: Date },
+): StrictRule {
+  const cutoff = allowedUpTo.getTime();
+  if (!Number.isFinite(cutoff))
+    throw new Error("grandfatherRule requires a valid allowedUpTo date");
+
+  return {
+    ...rule,
+    create(context) {
+      let dates: Map<number, number> | undefined;
+      const wrapped = Object.create(context, {
+        report: {
+          value(descriptor: Rule.ReportDescriptor) {
+            const location =
+              ("loc" in descriptor && descriptor.loc) ||
+              ("node" in descriptor && descriptor.node.loc);
+            const line = location && ("start" in location ? location.start.line : location.line);
+            if (line) {
+              dates ||= blameDates(context);
+              const date = dates.get(line);
+              if (date !== undefined && date <= cutoff) return;
+            }
+            context.report(descriptor);
+          },
+        },
+      });
+      return rule.create(wrapped);
+    },
+  };
+}
+
+function blameDates(context: Rule.RuleContext) {
+  const dates = new Map<number, number>();
+  const filename = context.physicalFilename;
+  if (!filename || filename.startsWith("<")) return dates;
+  const file = resolve(context.cwd, filename);
+  let root = dirname(file);
+  while (!existsSync(resolve(root, ".git"))) {
+    const parent = dirname(root);
+    if (root === parent) return dates;
+    root = parent;
+  }
+  // Keep the encoding literal so both Git APIs return text rather than buffers.
+  const options = {
+    cwd: root,
+    encoding: "utf8",
+    timeout: 10_000,
+    maxBuffer: 32 * 1024 * 1024,
+  } as const;
+  const head = spawnSync("git", ["rev-parse", "--verify", "--quiet", "HEAD"], options);
+  if (head.status === 1) return dates; // An unborn repository has no committed lines.
+  if (head.error) throw head.error;
+  if (head.status !== 0) throw new Error(`grandfatherRule: ${head.stderr}`);
+  const path = relative(root, file);
+  const tracked = execFileSync("git", ["ls-tree", "--name-only", "HEAD", "--", path], options);
+  if (!tracked.trim()) return dates; // Includes staged additions as well as untracked files.
+  const shallow =
+    execFileSync("git", ["rev-parse", "--is-shallow-repository"], options).trim() === "true";
+  const blame = execFileSync("git", ["blame", "--line-porcelain", "--contents", "-", "--", path], {
+    ...options,
+    input: context.sourceCode.text,
+  });
+  let line = 0;
+  let authorTime = Number.NaN;
+  let uncommitted = false;
+  let boundary = false;
+  for (const entry of blame.split("\n")) {
+    const header = /^([a-f0-9]{40,64}) \d+ (\d+)(?: \d+)?$/.exec(entry);
+    if (header) {
+      line = Number(header[2]);
+      authorTime = Number.NaN;
+      uncommitted = /^0+$/.test(header[1]);
+      boundary = false;
+    } else if (entry.startsWith("author-time ")) {
+      authorTime = Number(entry.slice("author-time ".length)) * 1000;
+    } else if (entry === "boundary") {
+      boundary = true;
+    } else if (entry.startsWith("\t") && !uncommitted && !(shallow && boundary)) {
+      if (!Number.isFinite(authorTime))
+        throw new Error(`grandfatherRule: missing blame author time for ${file}:${line}`);
+      dates.set(line, authorTime);
+    }
+  }
+  return dates;
+}

--- a/lint/oxlint-plugin-iterate.ts
+++ b/lint/oxlint-plugin-iterate.ts
@@ -9,6 +9,7 @@ import type { Program, Node } from "estree";
 import { mechanicalClassImplRule } from "./rules/mechanical-class-impl.ts";
 import { tseslintRules } from "./rules/tseslint.ts";
 import type { StrictPlugin, StrictRule } from "./types.ts";
+import { grandfatherRule } from "./grandfather-rule.ts";
 
 type ImportKindNode = {
   importKind?: string;
@@ -314,6 +315,16 @@ function needsParensInsideLogicalAnd(node: any) {
   );
 }
 
+function isPlainLiteral(init: any) {
+  if (init.type === "Literal") {
+    return typeof init.value === "number" || typeof init.value === "string";
+  }
+  if (init.type === "TemplateLiteral") return init.expressions.length === 0;
+  if (init.type === "UnaryExpression" && init.operator === "-") {
+    return init.argument.type === "Literal" && typeof init.argument.value === "number";
+  }
+  return false;
+}
 function findVariableInScopeChain(scope: Scope.Scope | null, name: string) {
   for (let current = scope; current; current = current.upper) {
     const variable = current.variables.find((v: any) => v.name === name);
@@ -1003,6 +1014,61 @@ const plugin: StrictPlugin = {
         };
       },
     },
+    "no-shouting-constants": grandfatherRule(
+      {
+        meta: {
+          type: "suggestion",
+          docs: {
+            description:
+              "Flag module-scope SCREAMING_SNAKE consts that hold a plain literal and are read once. The literal belongs inline at its use site.",
+          },
+        },
+        create(context) {
+          return {
+            VariableDeclarator(node) {
+              // Oxlint supplies parent links beyond ESTree's declared node shape.
+              const declaration = node.parent as any;
+              if (declaration.type !== "VariableDeclaration" || declaration.kind !== "const")
+                return;
+              // Module scope only. `export const` has an ExportNamedDeclaration
+              // parent, so exported consts fall out here too.
+              if (declaration.parent?.type !== "Program") return;
+              if (node.id.type !== "Identifier" || !node.init) return;
+              if (!/^[A-Z][A-Z0-9_]+$/.test(node.id.name)) return;
+              if (!isPlainLiteral(node.init)) return;
+              // A JSDoc block right above is a written rationale for the name —
+              // same escape hatch as no-single-use-helpers.
+              if (hasLeadingJsDocComment(context.sourceCode, declaration)) return;
+
+              const variable = findVariableInScopeChain(
+                context.sourceCode.getScope(node),
+                node.id.name,
+              );
+              if (!variable) return;
+              const reads = variable.references.filter((ref: any) => ref.isRead());
+              // `export { X }` / `export default X` make it part of the module's surface
+              const isExportedReference = reads.some((ref: any) => {
+                const parentType = ref.identifier.parent?.type;
+                return (
+                  parentType === "ExportSpecifier" || parentType === "ExportDefaultDeclaration"
+                );
+              });
+              if (isExportedReference) return;
+              if (reads.length !== 1) return;
+
+              context.report({
+                node: node.id,
+                message:
+                  `${node.id.name} is a SCREAMING_SNAKE constant holding a plain literal that is used once. ` +
+                  `Write the literal inline at its use site instead of naming it at module scope ` +
+                  `(expect(x).toBeLessThan(1_000_000), not const MAX_BYTES = 1_000_000).`,
+              });
+            },
+          };
+        },
+      },
+      { allowedUpTo: new Date("2026-11-10") },
+    ),
     "colocate-single-use-types": {
       meta: {
         type: "suggestion",

--- a/lint/oxlint-plugin-iterate.ts
+++ b/lint/oxlint-plugin-iterate.ts
@@ -1014,61 +1014,56 @@ const plugin: StrictPlugin = {
         };
       },
     },
-    "no-shouting-constants": grandfatherRule(
-      {
-        meta: {
-          type: "suggestion",
-          docs: {
-            description:
-              "Flag module-scope SCREAMING_SNAKE consts that hold a plain literal and are read once. The literal belongs inline at its use site.",
-          },
-        },
-        create(context) {
-          return {
-            VariableDeclarator(node) {
-              // Oxlint supplies parent links beyond ESTree's declared node shape.
-              const declaration = node.parent as any;
-              if (declaration.type !== "VariableDeclaration" || declaration.kind !== "const")
-                return;
-              // Module scope only. `export const` has an ExportNamedDeclaration
-              // parent, so exported consts fall out here too.
-              if (declaration.parent?.type !== "Program") return;
-              if (node.id.type !== "Identifier" || !node.init) return;
-              if (!/^[A-Z][A-Z0-9_]+$/.test(node.id.name)) return;
-              if (!isPlainLiteral(node.init)) return;
-              // A JSDoc block right above is a written rationale for the name —
-              // same escape hatch as no-single-use-helpers.
-              if (hasLeadingJsDocComment(context.sourceCode, declaration)) return;
-
-              const variable = findVariableInScopeChain(
-                context.sourceCode.getScope(node),
-                node.id.name,
-              );
-              if (!variable) return;
-              const reads = variable.references.filter((ref: any) => ref.isRead());
-              // `export { X }` / `export default X` make it part of the module's surface
-              const isExportedReference = reads.some((ref: any) => {
-                const parentType = ref.identifier.parent?.type;
-                return (
-                  parentType === "ExportSpecifier" || parentType === "ExportDefaultDeclaration"
-                );
-              });
-              if (isExportedReference) return;
-              if (reads.length !== 1) return;
-
-              context.report({
-                node: node.id,
-                message:
-                  `${node.id.name} is a SCREAMING_SNAKE constant holding a plain literal that is used once. ` +
-                  `Write the literal inline at its use site instead of naming it at module scope ` +
-                  `(expect(x).toBeLessThan(1_000_000), not const MAX_BYTES = 1_000_000).`,
-              });
-            },
-          };
+    "no-shouting-constants": grandfatherRule({
+      allowedUpTo: new Date("2026-11-10"),
+      meta: {
+        type: "suggestion",
+        docs: {
+          description:
+            "Flag module-scope SCREAMING_SNAKE consts that hold a plain literal and are read once. The literal belongs inline at its use site.",
         },
       },
-      { allowedUpTo: new Date("2026-11-10") },
-    ),
+      create(context) {
+        return {
+          VariableDeclarator(node) {
+            // Oxlint supplies parent links beyond ESTree's declared node shape.
+            const declaration = node.parent as any;
+            if (declaration.type !== "VariableDeclaration" || declaration.kind !== "const") return;
+            // Module scope only. `export const` has an ExportNamedDeclaration
+            // parent, so exported consts fall out here too.
+            if (declaration.parent?.type !== "Program") return;
+            if (node.id.type !== "Identifier" || !node.init) return;
+            if (!/^[A-Z][A-Z0-9_]+$/.test(node.id.name)) return;
+            if (!isPlainLiteral(node.init)) return;
+            // A JSDoc block right above is a written rationale for the name —
+            // same escape hatch as no-single-use-helpers.
+            if (hasLeadingJsDocComment(context.sourceCode, declaration)) return;
+
+            const variable = findVariableInScopeChain(
+              context.sourceCode.getScope(node),
+              node.id.name,
+            );
+            if (!variable) return;
+            const reads = variable.references.filter((ref: any) => ref.isRead());
+            // `export { X }` / `export default X` make it part of the module's surface
+            const isExportedReference = reads.some((ref: any) => {
+              const parentType = ref.identifier.parent?.type;
+              return parentType === "ExportSpecifier" || parentType === "ExportDefaultDeclaration";
+            });
+            if (isExportedReference) return;
+            if (reads.length !== 1) return;
+
+            context.report({
+              node: node.id,
+              message:
+                `${node.id.name} is a SCREAMING_SNAKE constant holding a plain literal that is used once. ` +
+                `Write the literal inline at its use site instead of naming it at module scope ` +
+                `(expect(x).toBeLessThan(1_000_000), not const MAX_BYTES = 1_000_000).`,
+            });
+          },
+        };
+      },
+    }),
     "colocate-single-use-types": {
       meta: {
         type: "suggestion",

--- a/lint/oxlint-plugin-no-shouting-constants.test.ts
+++ b/lint/oxlint-plugin-no-shouting-constants.test.ts
@@ -1,0 +1,192 @@
+// Tests for iterate/no-shouting-constants: a module-scope SCREAMING_SNAKE
+// const that holds a plain literal and is read once is an indirection the
+// reader has to chase — the literal belongs inline at its use site. Each test
+// runs the real oxlint binary against a temp project with the plugin armed.
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import assert from "node:assert/strict";
+
+import { test } from "vitest";
+
+test("flags single-use number, string, template and negative-number consts", () => {
+  using fixture = createOxlintFixture();
+  fixture.write(
+    "shouting.ts",
+    [
+      "const MAX_BYTES = 1_000_000;",
+      'const GREETING = "hello";',
+      "const LABEL = `plain template`;",
+      "const FLOOR = -1;",
+      "export const sizes = [MAX_BYTES, GREETING.length, LABEL.length, FLOOR];",
+      "",
+    ].join("\n"),
+  );
+
+  const output = fixture.runOxlint(["shouting.ts"], { expectFailure: true });
+  assert.match(output, /MAX_BYTES is a SCREAMING_SNAKE constant holding a plain literal/);
+  assert.match(output, /Write the literal inline at its use site/);
+  assert.deepEqual(reportedNames(output), ["MAX_BYTES", "GREETING", "LABEL", "FLOOR"]);
+});
+
+test("leaves exported consts alone", () => {
+  using fixture = createOxlintFixture();
+  fixture.write(
+    "exported.ts",
+    [
+      "export const PUBLIC_LIMIT = 10;",
+      "const REEXPORTED_LIMIT = 20;",
+      "export { REEXPORTED_LIMIT };",
+      "const DEFAULT_LIMIT = 30;",
+      "export default DEFAULT_LIMIT;",
+      "export const total = PUBLIC_LIMIT + REEXPORTED_LIMIT + DEFAULT_LIMIT;",
+      "",
+    ].join("\n"),
+  );
+
+  fixture.runOxlint(["exported.ts"]);
+});
+
+test("leaves non-literal initializers alone", () => {
+  using fixture = createOxlintFixture();
+  fixture.write(
+    "non-literal.ts",
+    [
+      "declare const region: string;",
+      "const HEADERS = { accept: 'application/json' };",
+      "const RETRY_DELAYS_MS = [100, 200];",
+      "const IS_PROD = () => false;",
+      "const SLUG_PATTERN = /^[a-z-]+$/;",
+      "const HOST = `https://${region}.example`;",
+      'const MODE = "strict" as const;',
+      "const STARTED_AT = Date.now();",
+      "const SHARED = 5n;",
+      "export const bag = [HEADERS, RETRY_DELAYS_MS, IS_PROD, SLUG_PATTERN, HOST, MODE, STARTED_AT, SHARED];",
+      "",
+    ].join("\n"),
+  );
+
+  fixture.runOxlint(["non-literal.ts"]);
+});
+
+test("leaves consts read more than once alone, counting typeof as a read", () => {
+  using fixture = createOxlintFixture();
+  fixture.write(
+    "multi-use.ts",
+    [
+      'const EVENT_TYPE = "events.example/thing-happened";',
+      "export const first = { type: EVENT_TYPE };",
+      "export const second = { type: EVENT_TYPE };",
+      'const MODE = "strict";',
+      "export type Mode = typeof MODE;",
+      "export const mode = MODE;",
+      "",
+    ].join("\n"),
+  );
+
+  fixture.runOxlint(["multi-use.ts"]);
+});
+
+test("a JSDoc block above the const is an escape hatch; a line comment is not", () => {
+  using fixture = createOxlintFixture();
+  fixture.write(
+    "commented.ts",
+    [
+      "/** workerd rejects settlements above this size; see the isolate limits doc. */",
+      "const MAX_SETTLEMENT_BYTES = 1_000_000;",
+      "// this one is just a note",
+      "const MAX_SCRIPT_BYTES = 200_000;",
+      "export const limits = [MAX_SETTLEMENT_BYTES, MAX_SCRIPT_BYTES];",
+      "",
+    ].join("\n"),
+  );
+
+  const output = fixture.runOxlint(["commented.ts"], { expectFailure: true });
+  assert.deepEqual(reportedNames(output), ["MAX_SCRIPT_BYTES"]);
+});
+
+test("only module-scope SCREAMING_SNAKE names are in scope", () => {
+  using fixture = createOxlintFixture();
+  fixture.write(
+    "scope.ts",
+    [
+      "const maxBytes = 1_000_000;",
+      "const MaxBytes = 2_000_000;",
+      "export function limit() {",
+      "  const LOCAL_LIMIT = 3;",
+      "  return maxBytes + MaxBytes + LOCAL_LIMIT;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+
+  fixture.runOxlint(["scope.ts"]);
+});
+
+const repoRoot = resolve(import.meta.dirname, "..");
+const pluginPath = join(repoRoot, "lint", "oxlint-plugin-iterate.ts");
+const oxlintBin = join(repoRoot, "node_modules", ".bin", "oxlint");
+
+/** Names the rule reported, in source order, pulled from oxlint's stylish output. */
+function reportedNames(output: string) {
+  return [...output.matchAll(/(\w+) is a SCREAMING_SNAKE constant/g)].map((match) => match[1]);
+}
+
+/** Same fixture shape as oxlint-plugin-logical-and-spread.test.ts: a temp
+ * project with the real plugin armed, linted by the real oxlint binary. */
+function createOxlintFixture() {
+  const root = mkdtempSync(join(tmpdir(), "iterate-oxlint-no-shouting-constants-"));
+  const configPath = join(root, ".oxlintrc.json");
+
+  writeFileSync(
+    configPath,
+    JSON.stringify(
+      {
+        categories: {
+          correctness: "off",
+          nursery: "off",
+          pedantic: "off",
+          perf: "off",
+          restriction: "off",
+          style: "off",
+          suspicious: "off",
+        },
+        env: {
+          builtin: true,
+          node: true,
+        },
+        jsPlugins: [pluginPath],
+        rules: { "iterate/no-shouting-constants": "error" },
+      },
+      null,
+      2,
+    ),
+  );
+
+  return {
+    root,
+    [Symbol.dispose]() {
+      rmSync(root, { force: true, recursive: true });
+    },
+    runOxlint(args: string[], options: { expectFailure?: boolean } = {}) {
+      const result = spawnSync(
+        oxlintBin,
+        [...args, "--config", configPath, "--threads", "1", "--format", "stylish"],
+        { cwd: root, encoding: "utf8" },
+      );
+      const output = result.stdout + result.stderr;
+      if (options.expectFailure) {
+        assert.notEqual(result.status, 0, output);
+      } else {
+        assert.equal(result.status, 0, output);
+      }
+      return output;
+    },
+    write(path: string, contents: string) {
+      mkdirSync(dirname(join(root, path)), { recursive: true });
+      writeFileSync(join(root, path), contents);
+    },
+  };
+}

--- a/tasks/complete/2026-09-10-grandfather-lint-rules.md
+++ b/tasks/complete/2026-09-10-grandfather-lint-rules.md
@@ -1,7 +1,7 @@
 # Grandfather existing lint violations
 
-Status: implemented. Wrapper, shouting-rule rollout, and 47 lint tests pass.
-Repository lint, typecheck, format, and knip pass; full tests and PR CI/review remain.
+Status: implementation complete. Wrapper and shouting-rule rollout pass local
+validation, including the full repository test suite. PR CI/reviews are monitored.
 
 ## Request and decisions
 
@@ -18,11 +18,11 @@ commits cannot prove a line's age. Preserve rule metadata, listeners, and fixes.
 
 ## Checklist
 
-- [x] Integration spec using real dated Git commits and real oxlint. _Nine wrapper tests in `lint/grandfather-rule.test.ts`._
+- [x] Integration spec using real dated Git commits and real oxlint. _Ten wrapper tests in `lint/grandfather-rule.test.ts`._
 - [x] Reusable wrapper with lazy blame lookup per linted source. _`lint/grandfather-rule.ts`; documented in the adjacent Markdown file._
 - [x] Carry over and enable the shouting rule with the wrapper. _Plugin registration uses the requested cutoff; root config sets error severity._
 - [x] Check cutoff boundary, edits/new files, report locations, and metadata/fixes. _Real Git/oxlint coverage also includes shallow clones, worktrees, and Git errors._
-- [ ] Run validation, update draft PR, and arrange review monitoring.
+- [x] Run validation, update draft PR, and arrange review monitoring. _Full repository install, lint, typecheck, format, knip, and tests pass. Draft PR #2620 has a 24-hour monitor._
 
 ## Implementation log
 
@@ -30,4 +30,7 @@ Created from current origin/main, carrying only the relevant rule from
 `no-shouting-constants`; the old worktree remains available.
 
 CI lint and autofix now fetch full history. Monitor `monitor-grandfather-lint-pr`
-checks PR #2620 every 20 minutes through 2026-09-11 10:00 UTC.
+checks PR #2620 every 20 minutes through 2026-09-11 09:00 UTC.
+
+All local checks passed. OS: 3,121 passed, 18 expected failures, one existing
+skip. The wrapper also covers history across renamed paths with brackets.

--- a/tasks/complete/2026-09-10-grandfather-lint-rules.md
+++ b/tasks/complete/2026-09-10-grandfather-lint-rules.md
@@ -5,7 +5,7 @@ validation, including the full repository test suite. PR CI/reviews are monitore
 
 ## Request and decisions
 
-Add `grandfatherRule(rule: StrictRule, { allowedUpTo: Date })` and carry over
+Add `grandfatherRule({ allowedUpTo, ...rule }: StrictRule & { allowedUpTo: Date })` and carry over
 `no-shouting-constants` from the existing worktree, enabling it with the wrapper.
 Use the requested example cutoff, `2026-11-10T00:00:00Z` (inclusive).
 
@@ -34,3 +34,6 @@ checks PR #2620 every 20 minutes through 2026-09-11 09:00 UTC.
 
 All local checks passed. OS: 3,121 passed, 18 expected failures, one existing
 skip. The wrapper also covers history across renamed paths with brackets.
+
+API follow-up: `allowedUpTo` now sits at the top of the rule object; pre-built
+rules can be spread into that same argument. Blame behavior is unchanged.

--- a/tasks/grandfather-lint-rules.md
+++ b/tasks/grandfather-lint-rules.md
@@ -1,6 +1,7 @@
 # Grandfather existing lint violations
 
-Status: specified; implementation and validation remain.
+Status: implemented. Wrapper, shouting-rule rollout, and 47 lint tests pass.
+Repository lint, typecheck, format, and knip pass; full tests and PR CI/review remain.
 
 ## Request and decisions
 
@@ -17,13 +18,16 @@ commits cannot prove a line's age. Preserve rule metadata, listeners, and fixes.
 
 ## Checklist
 
-- [ ] Integration spec using real dated Git commits and real oxlint.
-- [ ] Reusable wrapper with lazy blame lookup per linted source.
-- [ ] Carry over and enable the shouting rule with the wrapper.
-- [ ] Check cutoff boundary, edits/new files, report locations, and metadata/fixes.
+- [x] Integration spec using real dated Git commits and real oxlint. _Nine wrapper tests in `lint/grandfather-rule.test.ts`._
+- [x] Reusable wrapper with lazy blame lookup per linted source. _`lint/grandfather-rule.ts`; documented in the adjacent Markdown file._
+- [x] Carry over and enable the shouting rule with the wrapper. _Plugin registration uses the requested cutoff; root config sets error severity._
+- [x] Check cutoff boundary, edits/new files, report locations, and metadata/fixes. _Real Git/oxlint coverage also includes shallow clones, worktrees, and Git errors._
 - [ ] Run validation, update draft PR, and arrange review monitoring.
 
 ## Implementation log
 
 Created from current origin/main, carrying only the relevant rule from
 `no-shouting-constants`; the old worktree remains available.
+
+CI lint and autofix now fetch full history. Monitor `monitor-grandfather-lint-pr`
+checks PR #2620 every 20 minutes through 2026-09-11 10:00 UTC.

--- a/tasks/grandfather-lint-rules.md
+++ b/tasks/grandfather-lint-rules.md
@@ -1,0 +1,29 @@
+# Grandfather existing lint violations
+
+Status: specified; implementation and validation remain.
+
+## Request and decisions
+
+Add `grandfatherRule(rule: StrictRule, { allowedUpTo: Date })` and carry over
+`no-shouting-constants` from the existing worktree, enabling it with the wrapper.
+Use the requested example cutoff, `2026-11-10T00:00:00Z` (inclusive).
+
+Blame the source actually being linted. A diagnostic's start line determines
+its age, using Git author time. Uncommitted/untracked lines remain violations,
+even before a future cutoff. Only proven old lines are suppressed. Missing
+history must not silently exempt code: report violations when no repository or
+file history exists, and surface unexpected Git failures. Shallow boundary
+commits cannot prove a line's age. Preserve rule metadata, listeners, and fixes.
+
+## Checklist
+
+- [ ] Integration spec using real dated Git commits and real oxlint.
+- [ ] Reusable wrapper with lazy blame lookup per linted source.
+- [ ] Carry over and enable the shouting rule with the wrapper.
+- [ ] Check cutoff boundary, edits/new files, report locations, and metadata/fixes.
+- [ ] Run validation, update draft PR, and arrange review monitoring.
+
+## Implementation log
+
+Created from current origin/main, carrying only the relevant rule from
+`no-shouting-constants`; the old worktree remains available.


### PR DESCRIPTION
Enable `iterate/no-shouting-constants` for new lines without rewriting existing constants. Any normal `StrictRule` can opt into the same policy:

```ts
export const noShoutingConstants = grandfatherRule({
  allowedUpTo: new Date("2026-11-10"),
  meta: { /* normal rule metadata */ },
  create(context) { /* normal rule listeners */ },
});

// A pre-built rule works too:
const wrapped = grandfatherRule({ allowedUpTo: new Date("2026-11-10"), ...existingRule });
```

The report's start line is exempt when Git blame proves its author timestamp is at or before the cutoff. Uncommitted edits and files without history are checked. Inserting lines above an old violation preserves its exemption. The rule retains its metadata, listeners, messages, suggestions, and fixes.

**The example cutoff is in the future:** committing an edit before November 10 can exempt it even though it was flagged while uncommitted. A past rollout date would block all subsequent committed edits.

Lint and autofix CI now fetch full history; shallow boundary lines cannot establish eligibility. Unexpected Git failures stop linting. The helper never fetches or writes Git state.

## Validation

- 48 lint integration tests pass, including ten wrapper tests using real dated commits and oxlint.
- Repository lint, typecheck, format, and knip pass.
- Full repository test suite passes (OS: 3,121 passed, 18 expected failures, one existing skip).
- CI passed before the single-object API follow-up. That follow-up passes all 48 lint tests, lint typechecking, and focused lint; CI is rerunning. Review monitoring remains active.

## Risk map

Review `lint/grandfather-rule.ts` first: report locations, working-source blame, and incomplete history determine exemptions. Tests cover the inclusive boundary, author versus committer date, shifted lines, staged/unstaged changes, new files, locations, fixes, shallow clones, linked worktrees, and Git failures.

Then review the shouting-rule registration and CI checkout changes. On merge, new uncommitted single-use shouting constants become lint errors; existing committed constants before the cutoff remain untouched. Blame tracks line edits, not semantic changes elsewhere that make an old line newly violate a rule.

Worktree: `/Users/mmkal/src/worktrees/iterate/grandfather-lint-rules`

Codex session: 01a08a86-bbfa-7140-a095-b80ab2d67142

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Tests | +405 -0 | +350 -0 🟩🟩🟩🟩🟩 |
| CI & scripts | +4 -0 | +4 -0 🟩⬜⬜⬜⬜ |
| Docs | +80 -0 | +61 -0 🟩⬜⬜⬜⬜ |
| Other | +159 -0 | +141 -0 🟩🟩⬜⬜⬜ |
| **Total** | **+648 -0** | **+556 -0** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 4f7ccc8 and e14fe6e, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Lint now shells out to Git during rule execution and CI depends on full history; mis-blame or Git failures can change which lines fail, though failures are intended to surface rather than hide issues.
> 
> **Overview**
> Adds **`grandfatherRule`**, an oxlint rule wrapper that skips diagnostics when Git blame shows the report line’s **author time** is on or before an `allowedUpTo` cutoff. Uncommitted, untracked, and unprovable lines still fail; shallow blame boundaries and Git errors do not silently waive violations. Lint/autofix CI checkouts now use **`fetch-depth: 0`** so blame dates are available.
> 
> Turns on **`iterate/no-shouting-constants`** (error) via that wrapper with cutoff **2026-11-10**, so new or edited single-use module-scope `SCREAMING_SNAKE` plain literals are flagged while older committed lines stay exempt until edited. Includes wrapper + rule integration tests and short docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e14fe6ee2e5e61759b1f9be13b618add95976af5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->