### PR TITLE
Compact live-state field addresses and text appends

### DIFF
--- a/apps/os/docs/streaming-performance.md
+++ b/apps/os/docs/streaming-performance.md
@@ -1,6 +1,6 @@
 # Streaming state and rendering
 
-Decision and local measurements, 10 September 2026. Research:
+Decision and local measurements, 10–11 September 2026. Research:
 [Phoenix LiveView](./liveview-streaming-performance-research.md) and
 [React streaming](./react-streaming-performance-research.md).
 
@@ -13,8 +13,9 @@ response-window array and no repeated full-prefix comparison.
 ## State transport
 
 - Generic positional array patches preserve unchanged nested objects after
-  JSON transport. Subscription version 2 opts into the new array opcode;
-  unversioned subscribers keep the existing replacement representation.
+  JSON transport. Version 3 adds compact field addresses and bounded string
+  appends. Already-open version 2 subscribers keep structural array patches;
+  unversioned subscribers keep array replacements until they reconnect.
 - Facets expose finite `readLiveState({ epoch, revision })` reads. One retained
   delta is sufficient for the serialized parent reader; a missed revision or
   new incarnation returns a snapshot. No facet callback keeps a DO awake.
@@ -47,6 +48,45 @@ prototype using `startsWith(previous)` to infer string suffixes took roughly
 The prior simulated full-state path sent approximately 6.17 MB per hop for
 64 KiB and 1.126 GB per hop for an uncapped 1 MiB stream. These simulations
 explain the design choice; deployed proof must separately cover RPC and state.
+
+### Compact wire protocol (11 September)
+
+The 1 KiB benchmark above understates small-token overhead: version 2 sends the
+whole changed block and repeats its field path on each update. Version 3 uses
+`{s: [revision, state]}` snapshots and `{p: [from, to, patch]}` deltas. Within a
+patch, an existing field's address is its position among the **sorted, defined
+keys of the previous object**. New fields carry `+name`; arrays use indices and
+send `#` only when their length changes. Primitives replace directly, `[value]`
+replaces an object or array, `[]` removes a field, and `[previousLength, suffix]`
+appends text. All addresses resolve against the original baseline before any
+keys are added or deleted. A snapshot reconstructs everything needed to decode
+future patches; there is no separately synchronized dictionary.
+
+String-prefix comparisons are restricted to previous strings of 16–4,096 UTF-16
+units. This includes immutable text blocks without scanning a whole response.
+Edits and larger ordinary strings use replacement. Malformed addresses or an
+incorrect append length fail before replacing the held state. The React hook
+keeps the last valid value, reports the error, and permits two automatic resyncs;
+receiving a valid delta or explicitly refreshing resets that recovery budget.
+
+`scripts/benchmarks/live-state-wire.ts` sends 64 KiB of text through a real local
+WebSocket using the production Cap'n Web serializer, with a flush per append.
+These are complete, uncompressed RPC callback messages including the initial
+snapshot and Cap'n Web's literal-array escaping; control messages are excluded:
+
+| Append size | Version 2 mean message | Version 3 mean message | Traffic reduction |
+| ----------- | ---------------------: | ---------------------: | ----------------: |
+| 16 B        |                  842 B |                  142 B |               83% |
+| 48 B        |                  874 B |                  173 B |               80% |
+| 128 B       |                  897 B |                  252 B |               72% |
+| 1 KiB       |                1,323 B |                1,123 B |               15% |
+
+The separate three-JSON-boundary benchmark includes 12 unchanged 2 KB code
+steps. For 48 B appends, bytes per hop drop from 1,187,465 to 278,618; synchronous
+CPU across all three hops is about 77 ms for either codec. It checks exact text
+and sealed-group identity at 64 KiB, 1 MiB and 4 MiB. CPU timings vary with host
+load; neither benchmark includes internet latency or WebSocket compression.
+The raw measurements are in `scripts/benchmarks/results/compact-live-state-*.json`.
 
 ## React and browser layout
 

--- a/apps/os/e2e/vitest/live-state.e2e.test.ts
+++ b/apps/os/e2e/vitest/live-state.e2e.test.ts
@@ -5,7 +5,7 @@
 // stateless one (`itx.liveDemo.ticker`, driven by a timer in the request
 // isolate with no DO).
 import { expect, test } from "vitest";
-import { applyPatch, type LiveUpdate } from "iterate/sdk/capnweb";
+import { createLiveStateStore, isLiveStateSnapshot, type LiveUpdate } from "iterate/sdk/capnweb";
 import { LIVE_STATE_PAGER_HEADER } from "../../src/domains/live-state-pager.ts";
 import type { AgentCollectionProcessorState } from "../../src/itx-api.generated.ts";
 import type { ProjectLiveState } from "../../src/domains/projects/project-live-state.ts";
@@ -22,7 +22,7 @@ test("itx.liveState pushes a snapshot then a minimal diff; the DO-backed counter
   await project.__describe();
 
   const track = trackLiveState<ProjectLiveState>();
-  using subscription = await project.liveState.subscribe(track.onUpdate);
+  using subscription = await project.liveState.subscribe(track.onUpdate, { patchVersion: 3 });
 
   // The subscribe-time frame is a full snapshot: current state IS the first paint.
   await waitForCondition(() => track.state() !== undefined, {
@@ -261,17 +261,16 @@ function trackLiveState<State>(): {
   state: () => State | undefined;
   patchCount: () => number;
 } {
-  let state: State | undefined;
+  const store = createLiveStateStore<State>();
   let patches = 0;
   return {
     onUpdate: (update) => {
-      if (update.type === "snapshot") state = update.state;
-      else {
-        patches += 1;
-        state = applyPatch(state as State, update.patch);
-      }
+      store.apply(update, () => {
+        throw new Error("Live-state e2e revision gap");
+      });
+      if (!isLiveStateSnapshot(update)) patches += 1;
     },
-    state: () => state,
+    state: store.getState,
     patchCount: () => patches,
   };
 }

--- a/apps/os/scripts/benchmarks/README.md
+++ b/apps/os/scripts/benchmarks/README.md
@@ -4,7 +4,15 @@ Run the transport benchmark from the repository root:
 
 ```sh
 pnpm --dir apps/os exec tsx scripts/benchmarks/live-state.ts
+pnpm --dir apps/os exec tsx scripts/benchmarks/live-state-wire.ts
 ```
+
+The first compares codecs 2 and 3 across three JSON boundaries, with 16, 48,
+128 and 1,024 byte appends. The second measures complete, uncompressed Cap'n Web
+callback messages over a real local WebSocket. Both verify final text and sealed
+group identity. Wire timings include socket scheduling; use the first for
+synchronous CPU. The `compact-live-state-*.json` results were recorded on
+11 September 2026 with Node 26.5.0 on an Apple M4 Max.
 
 For browser rendering, start the OS dev server to supply the generated app
 CSS. Build the actual component with React's production profiling renderer:

--- a/apps/os/scripts/benchmarks/live-state-wire.ts
+++ b/apps/os/scripts/benchmarks/live-state-wire.ts
@@ -1,0 +1,99 @@
+/** Run with `pnpm --dir apps/os exec tsx scripts/benchmarks/live-state-wire.ts`.
+ * Actual uncompressed Cap'n Web WebSocket messages, including array escaping.
+ * Timings include local network scheduling; synchronous CPU is measured by live-state.ts.
+ */
+import { once } from "node:events";
+import { appendText, sliceText } from "@iterate-com/shared/chunked-text";
+import { WebSocketServer } from "ws";
+import {
+  createLiveStateStore,
+  LiveState,
+  LiveStateRpcTarget,
+  newWebSocketRpcSession,
+} from "iterate/sdk/capnweb";
+
+async function benchmark(chunkSize: number, patchVersion: 2 | 3) {
+  const size = 65536;
+  let text = appendText("", "");
+  const snapshot = () => ({
+    agent: { live: { steps: [{ responseText: text }] } },
+  });
+  const engine = new LiveState(snapshot());
+  const server = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+  server.on("connection", (socket) => {
+    // ws supplies the browser WebSocket methods used by this adapter, with
+    // different DOM event declarations in its TypeScript interface.
+    newWebSocketRpcSession(socket as unknown as WebSocket, new LiveStateRpcTarget(engine));
+  });
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Missing benchmark socket address");
+  try {
+    const socket = new WebSocket(`ws://127.0.0.1:${address.port}`);
+    let bytes = 0;
+    const frameSizes: number[] = [];
+    let firstPatch: string | undefined;
+    socket.addEventListener("message", (event) => {
+      const frame = String(event.data);
+      // This deterministic fixture sends only state through callback pushes.
+      // Count the whole Cap'n Web message, excluding RPC control messages.
+      if (!frame.startsWith('["push",["pipeline",')) return;
+      bytes += Buffer.byteLength(frame);
+      frameSizes.push(Buffer.byteLength(frame));
+      if (frameSizes.length === 2) firstPatch = frame;
+    });
+    using remote = newWebSocketRpcSession<LiveStateRpcTarget<ReturnType<typeof snapshot>>>(socket);
+    const store = createLiveStateStore<ReturnType<typeof snapshot>>();
+    let applied = Promise.withResolvers<void>();
+    let sealedGroup: object | undefined;
+    using subscription = await remote.subscribe(
+      (update) => {
+        store.apply(update, () => {
+          throw new Error("Unexpected benchmark revision gap");
+        });
+        const current = store.getState()!.agent.live.steps[0]!.responseText;
+        if (current.length >= 32768 && sealedGroup === undefined) sealedGroup = current.groups[0];
+        if (current.length > 32768 && current.groups[0] !== sealedGroup)
+          throw new Error("Sealed group replaced");
+        applied.resolve();
+      },
+      { patchVersion },
+    );
+    const started = performance.now();
+    for (let offset = 0; offset < size; offset += chunkSize) {
+      applied = Promise.withResolvers<void>();
+      text = appendText(text, "x".repeat(Math.min(chunkSize, size - offset)));
+      engine.setState(snapshot());
+      engine.readSince(); // force a flush per append, without debounce hiding cost
+      await applied.promise;
+    }
+    const elapsedMs = performance.now() - started;
+    if (sliceText(store.getState()!.agent.live.steps[0]!.responseText) !== "x".repeat(size)) {
+      throw new Error("Benchmark text was lost or duplicated");
+    }
+    await subscription.unsubscribe();
+    frameSizes.sort((a, b) => a - b);
+    return {
+      size,
+      chunkSize,
+      patchVersion,
+      bytes,
+      frames: frameSizes.length,
+      meanFrameBytes: bytes / frameSizes.length,
+      p95FrameBytes: frameSizes[Math.floor(frameSizes.length * 0.95)],
+      elapsedMs,
+      firstPatch,
+    };
+  } finally {
+    for (const socket of server.clients) socket.terminate();
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+}
+
+const results = [];
+for (const version of [2, 3] as const) {
+  for (const chunkSize of [16, 48, 128, 1024]) results.push(await benchmark(chunkSize, version));
+}
+console.log(JSON.stringify(results, null, 2));

--- a/apps/os/scripts/benchmarks/live-state.ts
+++ b/apps/os/scripts/benchmarks/live-state.ts
@@ -3,7 +3,12 @@
  * No network latency is included; bytes and synchronous CPU are the measurements. */
 import { appendText, sliceText } from "@iterate-com/shared/chunked-text";
 import { createJsonByteLength } from "@iterate-com/shared/json-byte-length";
-import { createLiveStateStore, LiveState, type LiveStateCursor } from "iterate/sdk/capnweb";
+import {
+  createLiveStateStore,
+  LiveState,
+  liveStateRevision,
+  type LiveStateCursor,
+} from "iterate/sdk/capnweb";
 
 const fixedSteps = Array.from({ length: 12 }, (_, index) => ({
   id: `code-${index}`,
@@ -14,7 +19,7 @@ const snapshot = (text: ReturnType<typeof appendText>) => ({
   steps: [...fixedSteps, { id: "llm", kind: "llm", text }],
 });
 
-function benchmark(size: number, chunkSize: number) {
+function benchmark(size: number, chunkSize: number, patchVersion: 2 | 3) {
   let text = appendText("", "");
   const links: {
     engine: LiveState<ReturnType<typeof snapshot>>;
@@ -40,7 +45,7 @@ function benchmark(size: number, chunkSize: number) {
     byteLength(state);
     for (const link of links) {
       link.engine.setState(state);
-      const read = link.engine.readSince(link.cursor);
+      const read = link.engine.readSince(link.cursor, { patchVersion });
       const encoded = JSON.stringify(read);
       link.bytes += encoder.encode(encoded).byteLength;
       link.frames += 1;
@@ -53,12 +58,13 @@ function benchmark(size: number, chunkSize: number) {
       });
       link.cursor = {
         epoch: decoded.epoch,
-        revision: decoded.update.type === "snapshot" ? decoded.update.revision : decoded.update.to,
+        revision: liveStateRevision(decoded.update),
       };
       state = link.mirror.getState()!;
       const currentText = state.steps.at(-1)!;
       if (!("text" in currentText)) throw new Error("Missing live text");
-      if (text.length === 32768) link.sealedGroup = currentText.text.groups[0];
+      if (text.length >= 32768 && link.sealedGroup === undefined)
+        link.sealedGroup = currentText.text.groups[0];
       if (text.length > 32768 && link.sealedGroup !== currentText.text.groups[0]) {
         throw new Error("Transport replaced a sealed text group");
       }
@@ -72,6 +78,7 @@ function benchmark(size: number, chunkSize: number) {
   return {
     size,
     chunkSize,
+    patchVersion,
     durationMs,
     links: links.map(({ bytes, frames }) => ({ bytes, frames })),
   };
@@ -79,7 +86,10 @@ function benchmark(size: number, chunkSize: number) {
 
 console.log(
   JSON.stringify(
-    [65536, 1048576, 4194304].map((size) => benchmark(size, 1024)),
+    ([2, 3] as const).flatMap((version) => [
+      ...[16, 48, 128, 1024].map((chunkSize) => benchmark(65536, chunkSize, version)),
+      ...[1048576, 4194304].map((size) => benchmark(size, 1024, version)),
+    ]),
     null,
     2,
   ),

--- a/apps/os/scripts/benchmarks/results/compact-live-state-json.json
+++ b/apps/os/scripts/benchmarks/results/compact-live-state-json.json
@@ -1,0 +1,242 @@
+[
+  {
+    "size": 65536,
+    "chunkSize": 16,
+    "patchVersion": 2,
+    "durationMs": 265.854959,
+    "links": [
+      {
+        "bytes": 3380621,
+        "frames": 4096
+      },
+      {
+        "bytes": 3380621,
+        "frames": 4096
+      },
+      {
+        "bytes": 3380621,
+        "frames": 4096
+      }
+    ]
+  },
+  {
+    "size": 65536,
+    "chunkSize": 48,
+    "patchVersion": 2,
+    "durationMs": 76.78558300000003,
+    "links": [
+      {
+        "bytes": 1187465,
+        "frames": 1366
+      },
+      {
+        "bytes": 1187465,
+        "frames": 1366
+      },
+      {
+        "bytes": 1187465,
+        "frames": 1366
+      }
+    ]
+  },
+  {
+    "size": 65536,
+    "chunkSize": 128,
+    "patchVersion": 2,
+    "durationMs": 30.351083000000074,
+    "links": [
+      {
+        "bytes": 472875,
+        "frames": 512
+      },
+      {
+        "bytes": 472875,
+        "frames": 512
+      },
+      {
+        "bytes": 472875,
+        "frames": 512
+      }
+    ]
+  },
+  {
+    "size": 65536,
+    "chunkSize": 1024,
+    "patchVersion": 2,
+    "durationMs": 4.297250000000076,
+    "links": [
+      {
+        "bytes": 108763,
+        "frames": 64
+      },
+      {
+        "bytes": 108763,
+        "frames": 64
+      },
+      {
+        "bytes": 108763,
+        "frames": 64
+      }
+    ]
+  },
+  {
+    "size": 1048576,
+    "chunkSize": 1024,
+    "patchVersion": 2,
+    "durationMs": 98.48850000000004,
+    "links": [
+      {
+        "bytes": 1380148,
+        "frames": 1024
+      },
+      {
+        "bytes": 1380148,
+        "frames": 1024
+      },
+      {
+        "bytes": 1380148,
+        "frames": 1024
+      }
+    ]
+  },
+  {
+    "size": 4194304,
+    "chunkSize": 1024,
+    "patchVersion": 2,
+    "durationMs": 588.7018330000001,
+    "links": [
+      {
+        "bytes": 5465748,
+        "frames": 4096
+      },
+      {
+        "bytes": 5465748,
+        "frames": 4096
+      },
+      {
+        "bytes": 5465748,
+        "frames": 4096
+      }
+    ]
+  },
+  {
+    "size": 65536,
+    "chunkSize": 16,
+    "patchVersion": 3,
+    "durationMs": 222.33520799999997,
+    "links": [
+      {
+        "bytes": 658179,
+        "frames": 4096
+      },
+      {
+        "bytes": 658179,
+        "frames": 4096
+      },
+      {
+        "bytes": 658179,
+        "frames": 4096
+      }
+    ]
+  },
+  {
+    "size": 65536,
+    "chunkSize": 48,
+    "patchVersion": 3,
+    "durationMs": 76.75420899999995,
+    "links": [
+      {
+        "bytes": 278618,
+        "frames": 1366
+      },
+      {
+        "bytes": 278618,
+        "frames": 1366
+      },
+      {
+        "bytes": 278618,
+        "frames": 1366
+      }
+    ]
+  },
+  {
+    "size": 65536,
+    "chunkSize": 128,
+    "patchVersion": 3,
+    "durationMs": 31.848833000000013,
+    "links": [
+      {
+        "bytes": 160209,
+        "frames": 512
+      },
+      {
+        "bytes": 160209,
+        "frames": 512
+      },
+      {
+        "bytes": 160209,
+        "frames": 512
+      }
+    ]
+  },
+  {
+    "size": 65536,
+    "chunkSize": 1024,
+    "patchVersion": 3,
+    "durationMs": 3.4729580000000624,
+    "links": [
+      {
+        "bytes": 98350,
+        "frames": 64
+      },
+      {
+        "bytes": 98350,
+        "frames": 64
+      },
+      {
+        "bytes": 98350,
+        "frames": 64
+      }
+    ]
+  },
+  {
+    "size": 1048576,
+    "chunkSize": 1024,
+    "patchVersion": 3,
+    "durationMs": 97.44949999999994,
+    "links": [
+      {
+        "bytes": 1211477,
+        "frames": 1024
+      },
+      {
+        "bytes": 1211477,
+        "frames": 1024
+      },
+      {
+        "bytes": 1211477,
+        "frames": 1024
+      }
+    ]
+  },
+  {
+    "size": 4194304,
+    "chunkSize": 1024,
+    "patchVersion": 3,
+    "durationMs": 533.2456249999998,
+    "links": [
+      {
+        "bytes": 4790360,
+        "frames": 4096
+      },
+      {
+        "bytes": 4790360,
+        "frames": 4096
+      },
+      {
+        "bytes": 4790360,
+        "frames": 4096
+      }
+    ]
+  }
+]

--- a/apps/os/scripts/benchmarks/results/compact-live-state-wire.json
+++ b/apps/os/scripts/benchmarks/results/compact-live-state-wire.json
@@ -1,0 +1,90 @@
+[
+  {
+    "size": 65536,
+    "chunkSize": 16,
+    "patchVersion": 2,
+    "bytes": 3450588,
+    "frames": 4097,
+    "meanFrameBytes": 842.2230900659018,
+    "p95FrameBytes": 1299,
+    "elapsedMs": 301.300833,
+    "firstPatch": "[\"push\",[\"pipeline\",-1,[],[{\"type\":\"patch\",\"from\":0,\"to\":1,\"patch\":{\"fields\":{\"agent\":{\"fields\":{\"live\":{\"fields\":{\"steps\":{\"array\":{\"length\":1,\"items\":[[[[0,{\"fields\":{\"responseText\":{\"fields\":{\"length\":{\"set\":16},\"blockCount\":{\"set\":1},\"groups\":{\"fields\":{\"0\":{\"set\":{\"0\":\"xxxxxxxxxxxxxxxx\"}}}}}}}}]]]]}}}}}}}}}]]]"
+  },
+  {
+    "size": 65536,
+    "chunkSize": 48,
+    "patchVersion": 2,
+    "bytes": 1194642,
+    "frames": 1367,
+    "meanFrameBytes": 873.9151426481346,
+    "p95FrameBytes": 1331,
+    "elapsedMs": 96.28387500000002,
+    "firstPatch": "[\"push\",[\"pipeline\",-1,[],[{\"type\":\"patch\",\"from\":0,\"to\":1,\"patch\":{\"fields\":{\"agent\":{\"fields\":{\"live\":{\"fields\":{\"steps\":{\"array\":{\"length\":1,\"items\":[[[[0,{\"fields\":{\"responseText\":{\"fields\":{\"length\":{\"set\":48},\"blockCount\":{\"set\":1},\"groups\":{\"fields\":{\"0\":{\"set\":{\"0\":\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"}}}}}}}}]]]]}}}}}}}}}]]]"
+  },
+  {
+    "size": 65536,
+    "chunkSize": 128,
+    "patchVersion": 2,
+    "bytes": 460410,
+    "frames": 513,
+    "meanFrameBytes": 897.485380116959,
+    "p95FrameBytes": 1345,
+    "elapsedMs": 33.20554200000004,
+    "firstPatch": "[\"push\",[\"pipeline\",-1,[],[{\"type\":\"patch\",\"from\":0,\"to\":1,\"patch\":{\"fields\":{\"agent\":{\"fields\":{\"live\":{\"fields\":{\"steps\":{\"array\":{\"length\":1,\"items\":[[[[0,{\"fields\":{\"responseText\":{\"fields\":{\"length\":{\"set\":128},\"blockCount\":{\"set\":1},\"groups\":{\"fields\":{\"0\":{\"set\":{\"0\":\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"}}}}}}}}]]]]}}}}}}}}}]]]"
+  },
+  {
+    "size": 65536,
+    "chunkSize": 1024,
+    "patchVersion": 2,
+    "bytes": 85994,
+    "frames": 65,
+    "meanFrameBytes": 1322.9846153846154,
+    "p95FrameBytes": 1342,
+    "elapsedMs": 4.608291000000008,
+    "firstPatch": "[\"push\",[\"pipeline\",-1,[],[{\"type\":\"patch\",\"from\":0,\"to\":1,\"patch\":{\"fields\":{\"agent\":{\"fields\":{\"live\":{\"fields\":{\"steps\":{\"array\":{\"length\":1,\"items\":[[[[0,{\"fields\":{\"responseText\":{\"fields\":{\"length\":{\"set\":1024},\"blockCount\":{\"set\":1},\"groups\":{\"fields\":{\"0\":{\"set\":{\"0\":\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"}}}}}}}}]]]]}}}}}}}}}]]]"
+  },
+  {
+    "size": 65536,
+    "chunkSize": 16,
+    "patchVersion": 3,
+    "bytes": 580416,
+    "frames": 4097,
+    "meanFrameBytes": 141.66853795460094,
+    "p95FrameBytes": 143,
+    "elapsedMs": 248.13525000000004,
+    "firstPatch": "[\"push\",[\"pipeline\",-1,[],[{\"p\":[[0,1,{\"0\":{\"0\":{\"0\":{\"0\":{\"0\":{\"0\":1,\"1\":{\"+0\":[[{\"0\":\"xxxxxxxxxxxxxxxx\"}]]},\"2\":16}}}}}}]]}]]]"
+  },
+  {
+    "size": 65536,
+    "chunkSize": 48,
+    "patchVersion": 3,
+    "bytes": 236429,
+    "frames": 1367,
+    "meanFrameBytes": 172.95464520848574,
+    "p95FrameBytes": 175,
+    "elapsedMs": 80.77041599999995,
+    "firstPatch": "[\"push\",[\"pipeline\",-1,[],[{\"p\":[[0,1,{\"0\":{\"0\":{\"0\":{\"0\":{\"0\":{\"0\":1,\"1\":{\"+0\":[[{\"0\":\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"}]]},\"2\":48}}}}}}]]}]]]"
+  },
+  {
+    "size": 65536,
+    "chunkSize": 128,
+    "patchVersion": 3,
+    "bytes": 129038,
+    "frames": 513,
+    "meanFrameBytes": 251.53606237816763,
+    "p95FrameBytes": 253,
+    "elapsedMs": 27.227916999999934,
+    "firstPatch": "[\"push\",[\"pipeline\",-1,[],[{\"p\":[[0,1,{\"0\":{\"0\":{\"0\":{\"0\":{\"0\":{\"0\":1,\"1\":{\"+0\":[[{\"0\":\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"}]]},\"2\":128}}}}}}]]}]]]"
+  },
+  {
+    "size": 65536,
+    "chunkSize": 1024,
+    "patchVersion": 3,
+    "bytes": 73003,
+    "frames": 65,
+    "meanFrameBytes": 1123.123076923077,
+    "p95FrameBytes": 1139,
+    "elapsedMs": 3.4183750000000828,
+    "firstPatch": "[\"push\",[\"pipeline\",-1,[],[{\"p\":[[0,1,{\"0\":{\"0\":{\"0\":{\"0\":{\"0\":{\"0\":1,\"1\":{\"+0\":[[{\"0\":\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"}]]},\"2\":1024}}}}}}]]}]]]"
+  }
+]

--- a/apps/os/src/components/agent-progress.test.ts
+++ b/apps/os/src/components/agent-progress.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from "vitest";
+import { ZERO_AGENT_RUNTIME } from "@iterate-com/shared/agent-events";
+import { presentAgentProgress } from "./agent-progress.ts";
+
+const script = {
+  sinceOffset: 10,
+  since: new Date(10).toISOString(),
+  runtime: { ...ZERO_AGENT_RUNTIME, runningScripts: 1 },
+};
+const followUp = {
+  sinceOffset: 20,
+  since: new Date(20).toISOString(),
+  runtime: { ...ZERO_AGENT_RUNTIME, triggers: { pending: 1, runnable: 1 } },
+};
+const idle = { ...followUp, runtime: ZERO_AGENT_RUNTIME };
+
+test("new follow-up progress replaces older active feed progress immediately", () => {
+  expect(
+    presentAgentProgress(script, {
+      runtimeChange: followUp,
+      inputAcknowledgedThroughOffset: 22,
+    }),
+  ).toEqual({ agentRuntime: followUp.runtime, inputAcknowledgedThroughOffset: 0 });
+});
+
+test("idle waits for the settled feed publications before releasing progress and input", () => {
+  const agent = { runtimeChange: idle, inputAcknowledgedThroughOffset: 22 };
+  expect(presentAgentProgress(script, agent)).toEqual({
+    agentRuntime: script.runtime,
+    inputAcknowledgedThroughOffset: 0,
+  });
+  expect(presentAgentProgress(idle, agent)).toEqual({
+    agentRuntime: idle.runtime,
+    inputAcknowledgedThroughOffset: 22,
+  });
+});
+
+test("a newer feed transition wins over an older agent subscription", () => {
+  expect(
+    presentAgentProgress(idle, { runtimeChange: script, inputAcknowledgedThroughOffset: 12 })
+      .agentRuntime,
+  ).toBe(idle.runtime);
+});
+
+test("inputs with unchanged runtime counts are acknowledged beyond the transition offset", () => {
+  expect(
+    presentAgentProgress(followUp, {
+      runtimeChange: followUp,
+      inputAcknowledgedThroughOffset: 30,
+    }).inputAcknowledgedThroughOffset,
+  ).toBe(30);
+});
+
+test("a replacement lifetime has no acknowledgement until its new agent snapshot arrives", () => {
+  expect(presentAgentProgress(undefined, undefined)).toEqual({
+    agentRuntime: undefined,
+    inputAcknowledgedThroughOffset: 0,
+  });
+  expect(presentAgentProgress(script, undefined)).toEqual({
+    agentRuntime: script.runtime,
+    inputAcknowledgedThroughOffset: 0,
+  });
+});

--- a/apps/os/src/components/agent-progress.ts
+++ b/apps/os/src/components/agent-progress.ts
@@ -1,0 +1,26 @@
+import { isAgentRuntimeVisiblyActive } from "@iterate-com/ui/components/events/agent-ui-reducer";
+import type { AgentLiveState } from "../itx-api.generated.ts";
+
+/** Combines agent progress with the runtime whose feed publications are already on screen. */
+export function presentAgentProgress(
+  presented: AgentLiveState["runtimeChange"],
+  agent: AgentLiveState | undefined,
+) {
+  const current = agent?.runtimeChange;
+  const latest =
+    current && current.sinceOffset > (presented?.sinceOffset ?? 0)
+      ? current
+      : (presented ?? current);
+  // New work is visible immediately. An idle transition waits until the
+  // corresponding feed publications arrive, so progress never vanishes early.
+  const agentRuntime = isAgentRuntimeVisiblyActive(latest?.runtime)
+    ? latest?.runtime
+    : (presented?.runtime ?? latest?.runtime);
+  // Counts can stay unchanged across inputs. Compare runtime revisions, not
+  // the submitted input offset, before releasing the local submission state.
+  const runtimePresented = (presented?.sinceOffset ?? 0) >= (current?.sinceOffset ?? 0);
+  const inputAcknowledgedThroughOffset = runtimePresented
+    ? (agent?.inputAcknowledgedThroughOffset ?? 0)
+    : 0;
+  return { agentRuntime, inputAcknowledgedThroughOffset };
+}

--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -273,10 +273,14 @@ function BrowserDatabaseProjectStreamView({
           autoFocusMessage={autoFocusMessageComposer}
           defaultComposerMode={defaultComposerMode}
           interrupt={interrupt}
-          messageComposer={messageComposer}
-          agentSource={agentSource}
-          agentLiveState={streamData.agentLiveState}
-          runtimeChange={presentedFeed?.runtimeChange}
+          messageComposer={
+            messageComposer && {
+              ...messageComposer,
+              acknowledgedThroughOffset:
+                streamData.inputAcknowledgedThroughOffset ??
+                messageComposer.acknowledgedThroughOffset,
+            }
+          }
           onNudgeDeliveries={nudgeDeliveries}
           presence={presence}
           store={store}
@@ -404,10 +408,6 @@ function ProjectStreamFeed({
 
 /** Keeps cached-connection feedback and queued input attached to the composer. */
 function StreamComposerFooter({
-  agentSource,
-  agentLiveState,
-  runtimeChange,
-  messageComposer,
   agentFeed,
   agentUiState,
   defaultComposerMode,
@@ -416,9 +416,6 @@ function StreamComposerFooter({
   connectionError,
   ...composer
 }: Omit<ComponentProps<typeof StreamViewComposer>, "defaultMode"> & {
-  agentSource: ProjectStreamViewProps["agentSource"];
-  agentLiveState: ReturnType<typeof useProjectStreamData>["agentLiveState"];
-  runtimeChange: FeedLiveState["runtimeChange"];
   agentFeed: boolean;
   agentUiState: FeedLiveState["agent"] | null;
   defaultComposerMode: ProjectStreamViewProps["defaultComposerMode"];
@@ -457,46 +454,10 @@ function StreamComposerFooter({
             isInterrupting={composer.interrupt?.isInterrupting ?? false}
             onInterrupt={composer.disabled ? undefined : composer.interrupt?.run}
           />
-          <AcknowledgedStreamComposer
-            defaultMode={defaultMode}
-            {...composer}
-            messageComposer={messageComposer}
-            agentSource={agentSource}
-            agentLiveState={agentLiveState}
-            runtimeChange={runtimeChange}
-          />
+          <StreamViewComposer defaultMode={defaultMode} {...composer} />
         </div>
       </div>
     </div>
-  );
-}
-
-/** Releases a submitted message only after its resulting runtime is presented. */
-function AcknowledgedStreamComposer({
-  agentSource,
-  agentLiveState,
-  runtimeChange,
-  messageComposer,
-  ...composer
-}: ComponentProps<typeof StreamViewComposer> & {
-  agentSource: ProjectStreamViewProps["agentSource"];
-  agentLiveState: ReturnType<typeof useProjectStreamData>["agentLiveState"];
-  runtimeChange: FeedLiveState["runtimeChange"];
-}) {
-  // Do not release the submitted message until its resulting runtime is on screen.
-  const acknowledgedThroughOffset = Math.min(
-    agentLiveState?.inputAcknowledgedThroughOffset ?? 0,
-    runtimeChange?.sinceOffset ?? 0,
-  );
-  return (
-    <StreamViewComposer
-      {...composer}
-      messageComposer={
-        messageComposer && agentSource
-          ? { ...messageComposer, acknowledgedThroughOffset }
-          : messageComposer
-      }
-    />
   );
 }
 
@@ -618,6 +579,13 @@ function useProjectStreamData({
   const agentRuntime = isAgentRuntimeVisiblyActive(feedRuntime)
     ? feedRuntime
     : (agentLiveState?.runtimeChange?.runtime ?? feedRuntime);
+  // Release the submitted message only once its resulting runtime is on screen.
+  const inputAcknowledgedThroughOffset = agentSource
+    ? Math.min(
+        agentLiveState?.inputAcknowledgedThroughOffset ?? 0,
+        presentedFeed?.runtimeChange?.sinceOffset ?? 0,
+      )
+    : undefined;
   // Readers need actual shared history, not merely a pending writer election.
   // Both roles wait for the current live snapshot's publications to reach SQLite.
   const streamTransportReady =
@@ -629,7 +597,7 @@ function useProjectStreamData({
     resolvedStreamSource,
     ...browserStore,
     eventCount,
-    agentLiveState,
+    inputAcknowledgedThroughOffset,
     agentRuntime,
     feed,
     presentedFeed,

--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -14,7 +14,6 @@ import { Sheet, SheetContent, SheetTitle } from "@iterate-com/ui/components/shee
 import { toast } from "@iterate-com/ui/components/sonner";
 import {
   isAgentUiActivityWorking,
-  isAgentRuntimeVisiblyActive,
   type AgentUiLlmStep,
   type AgentUiRuntimeTransition,
   type AgentUiStep,
@@ -23,6 +22,7 @@ import { connectItx, connectIterateSession, reportTransportSuspicion } from "ite
 import { useLiveState } from "iterate/sdk/capnweb/react";
 import type { Agent, Stream } from "../itx-api.generated.ts";
 import type { FeedLiveState } from "~/domains/streams/feed-contract.ts";
+import { presentAgentProgress } from "~/components/agent-progress.ts";
 import { FeedPreviewNotice } from "~/components/feed-preview-notice.tsx";
 import { useStreamQuery } from "~/domains/streams/client-libraries/browser/hooks/use-stream-query.ts";
 import { useEventSynchronizedLiveState } from "~/domains/streams/client-libraries/browser/hooks/use-event-synchronized-live-state.ts";
@@ -573,19 +573,7 @@ function useProjectStreamData({
     agentSource ? { makeConnection: agentSource } : { root: undefined, enabled: false },
   ).value;
   const presentedFeed = useEventSynchronizedLiveState(store.streamDatabase, feed.value);
-  // Keep displayed work active until its publications arrive, and show new work
-  // as soon as the agent reports it. Both subscriptions reset with the source lifetime.
-  const feedRuntime = presentedFeed?.runtimeChange?.runtime;
-  const agentRuntime = isAgentRuntimeVisiblyActive(feedRuntime)
-    ? feedRuntime
-    : (agentLiveState?.runtimeChange?.runtime ?? feedRuntime);
-  // Release the submitted message only once its resulting runtime is on screen.
-  const inputAcknowledgedThroughOffset = agentSource
-    ? Math.min(
-        agentLiveState?.inputAcknowledgedThroughOffset ?? 0,
-        presentedFeed?.runtimeChange?.sinceOffset ?? 0,
-      )
-    : undefined;
+  const progress = presentAgentProgress(presentedFeed?.runtimeChange, agentLiveState);
   // Readers need actual shared history, not merely a pending writer election.
   // Both roles wait for the current live snapshot's publications to reach SQLite.
   const streamTransportReady =
@@ -597,8 +585,10 @@ function useProjectStreamData({
     resolvedStreamSource,
     ...browserStore,
     eventCount,
-    inputAcknowledgedThroughOffset,
-    agentRuntime,
+    inputAcknowledgedThroughOffset: agentSource
+      ? progress.inputAcknowledgedThroughOffset
+      : undefined,
+    agentRuntime: progress.agentRuntime,
     feed,
     presentedFeed,
     streamTransportReady,

--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -20,7 +20,7 @@ import {
 } from "@iterate-com/ui/components/events/agent-ui-reducer";
 import { connectItx, connectIterateSession, reportTransportSuspicion } from "iterate/sdk/itx/react";
 import { useLiveState } from "iterate/sdk/capnweb/react";
-import type { Stream } from "../itx-api.generated.ts";
+import type { Agent, Stream } from "../itx-api.generated.ts";
 import type { FeedLiveState } from "~/domains/streams/feed-contract.ts";
 import { FeedPreviewNotice } from "~/components/feed-preview-notice.tsx";
 import { useStreamQuery } from "~/domains/streams/client-libraries/browser/hooks/use-stream-query.ts";
@@ -60,12 +60,8 @@ import type { BrowserStreamSubscriberUser } from "~/domains/streams/client-libra
 type ItxStreamSource = (streamPath: string) => Stream | Promise<Stream>;
 
 type ProjectStreamViewProps = {
-  /**
-   * Runtime supplied by a parent which already listens to the selected agent's
-   * live state. `undefined` lets this generic stream view open its own listener;
-   * `null` means the parent has no transition yet.
-   */
-  agentRuntimeTransition?: AgentUiRuntimeTransition | null;
+  /** A domain agent supplies acknowledgement state, scoped to the current stream lifetime. */
+  agentSource?: () => Agent | Promise<Agent>;
   autoFocusMessageComposer?: boolean;
   /** Domain identity shown directly below the generic stream header. */
   contextHeader?: ReactNode;
@@ -161,7 +157,7 @@ function FullPanelProjectStreamView({
 }
 
 function BrowserDatabaseProjectStreamView({
-  agentRuntimeTransition: suppliedAgentRuntimeTransition,
+  agentSource,
   autoFocusMessageComposer = false,
   defaultComposerMode,
   emptyLabel = "No events in this stream yet.",
@@ -203,8 +199,9 @@ function BrowserDatabaseProjectStreamView({
     void store.nudge();
   }, [store]);
 
-  const agentRuntimeTransition = suppliedAgentRuntimeTransition ?? presentedFeed?.runtimeChange;
-  const agentRuntime = agentRuntimeTransition?.runtime;
+  // Runtime and presentation must describe the same source lifetime and revision.
+  // A separate agent subscription may already be idle or still hold a deleted stream.
+  const agentRuntime = presentedFeed?.runtimeChange?.runtime;
 
   const runningLlmRequestId = agentUiState?.live?.steps.find(isRunningLlmStep)?.llmRequestOffset;
   const interrupt = useAgentInterrupt({
@@ -277,6 +274,8 @@ function BrowserDatabaseProjectStreamView({
           defaultComposerMode={defaultComposerMode}
           interrupt={interrupt}
           messageComposer={messageComposer}
+          agentSource={agentSource}
+          runtimeChange={presentedFeed?.runtimeChange}
           onNudgeDeliveries={nudgeDeliveries}
           presence={presence}
           store={store}
@@ -404,6 +403,9 @@ function ProjectStreamFeed({
 
 /** Keeps cached-connection feedback and queued input attached to the composer. */
 function StreamComposerFooter({
+  agentSource,
+  runtimeChange,
+  messageComposer,
   agentFeed,
   agentUiState,
   defaultComposerMode,
@@ -412,6 +414,8 @@ function StreamComposerFooter({
   connectionError,
   ...composer
 }: Omit<ComponentProps<typeof StreamViewComposer>, "defaultMode"> & {
+  agentSource: ProjectStreamViewProps["agentSource"];
+  runtimeChange: FeedLiveState["runtimeChange"];
   agentFeed: boolean;
   agentUiState: FeedLiveState["agent"] | null;
   defaultComposerMode: ProjectStreamViewProps["defaultComposerMode"];
@@ -450,10 +454,51 @@ function StreamComposerFooter({
             isInterrupting={composer.interrupt?.isInterrupting ?? false}
             onInterrupt={composer.disabled ? undefined : composer.interrupt?.run}
           />
-          <StreamViewComposer defaultMode={defaultMode} {...composer} />
+          <AcknowledgedStreamComposer
+            defaultMode={defaultMode}
+            {...composer}
+            messageComposer={messageComposer}
+            agentSource={agentSource}
+            runtimeChange={runtimeChange}
+          />
         </div>
       </div>
     </div>
+  );
+}
+
+/** Owns the acknowledgement subscription for this composer's stream lifetime. */
+function AcknowledgedStreamComposer({
+  agentSource,
+  runtimeChange,
+  messageComposer,
+  ...composer
+}: ComponentProps<typeof StreamViewComposer> & {
+  agentSource: ProjectStreamViewProps["agentSource"];
+  runtimeChange: FeedLiveState["runtimeChange"];
+}) {
+  // This component remounts with the event mirror's source lifetime, so the
+  // acknowledgement subscription cannot retain a deleted agent's cursor.
+  const agentLiveState = useLiveState(
+    (agent: Agent) => agent.liveState,
+    (state) => state,
+    [],
+    agentSource ? { makeConnection: agentSource } : { root: undefined, enabled: false },
+  ).value;
+  // Do not release the submitted message until its resulting runtime is on screen.
+  const acknowledgedThroughOffset = Math.min(
+    agentLiveState?.inputAcknowledgedThroughOffset ?? 0,
+    runtimeChange?.sinceOffset ?? 0,
+  );
+  return (
+    <StreamViewComposer
+      {...composer}
+      messageComposer={
+        messageComposer && agentSource
+          ? { ...messageComposer, acknowledgedThroughOffset }
+          : messageComposer
+      }
+    />
   );
 }
 

--- a/apps/os/src/components/project-stream-view.tsx
+++ b/apps/os/src/components/project-stream-view.tsx
@@ -14,6 +14,7 @@ import { Sheet, SheetContent, SheetTitle } from "@iterate-com/ui/components/shee
 import { toast } from "@iterate-com/ui/components/sonner";
 import {
   isAgentUiActivityWorking,
+  isAgentRuntimeVisiblyActive,
   type AgentUiLlmStep,
   type AgentUiRuntimeTransition,
   type AgentUiStep,
@@ -174,6 +175,7 @@ function BrowserDatabaseProjectStreamView({
 }: ProjectStreamViewProps) {
   const subscriberUser = useStreamSubscriberUser();
   const streamData = useProjectStreamData({
+    agentSource,
     projectId,
     resetStreamSourceTransport,
     subscriberUser,
@@ -199,9 +201,7 @@ function BrowserDatabaseProjectStreamView({
     void store.nudge();
   }, [store]);
 
-  // Runtime and presentation must describe the same source lifetime and revision.
-  // A separate agent subscription may already be idle or still hold a deleted stream.
-  const agentRuntime = presentedFeed?.runtimeChange?.runtime;
+  const agentRuntime = streamData.agentRuntime;
 
   const runningLlmRequestId = agentUiState?.live?.steps.find(isRunningLlmStep)?.llmRequestOffset;
   const interrupt = useAgentInterrupt({
@@ -275,6 +275,7 @@ function BrowserDatabaseProjectStreamView({
           interrupt={interrupt}
           messageComposer={messageComposer}
           agentSource={agentSource}
+          agentLiveState={streamData.agentLiveState}
           runtimeChange={presentedFeed?.runtimeChange}
           onNudgeDeliveries={nudgeDeliveries}
           presence={presence}
@@ -404,6 +405,7 @@ function ProjectStreamFeed({
 /** Keeps cached-connection feedback and queued input attached to the composer. */
 function StreamComposerFooter({
   agentSource,
+  agentLiveState,
   runtimeChange,
   messageComposer,
   agentFeed,
@@ -415,6 +417,7 @@ function StreamComposerFooter({
   ...composer
 }: Omit<ComponentProps<typeof StreamViewComposer>, "defaultMode"> & {
   agentSource: ProjectStreamViewProps["agentSource"];
+  agentLiveState: ReturnType<typeof useProjectStreamData>["agentLiveState"];
   runtimeChange: FeedLiveState["runtimeChange"];
   agentFeed: boolean;
   agentUiState: FeedLiveState["agent"] | null;
@@ -459,6 +462,7 @@ function StreamComposerFooter({
             {...composer}
             messageComposer={messageComposer}
             agentSource={agentSource}
+            agentLiveState={agentLiveState}
             runtimeChange={runtimeChange}
           />
         </div>
@@ -467,24 +471,18 @@ function StreamComposerFooter({
   );
 }
 
-/** Owns the acknowledgement subscription for this composer's stream lifetime. */
+/** Releases a submitted message only after its resulting runtime is presented. */
 function AcknowledgedStreamComposer({
   agentSource,
+  agentLiveState,
   runtimeChange,
   messageComposer,
   ...composer
 }: ComponentProps<typeof StreamViewComposer> & {
   agentSource: ProjectStreamViewProps["agentSource"];
+  agentLiveState: ReturnType<typeof useProjectStreamData>["agentLiveState"];
   runtimeChange: FeedLiveState["runtimeChange"];
 }) {
-  // This component remounts with the event mirror's source lifetime, so the
-  // acknowledgement subscription cannot retain a deleted agent's cursor.
-  const agentLiveState = useLiveState(
-    (agent: Agent) => agent.liveState,
-    (state) => state,
-    [],
-    agentSource ? { makeConnection: agentSource } : { root: undefined, enabled: false },
-  ).value;
   // Do not release the submitted message until its resulting runtime is on screen.
   const acknowledgedThroughOffset = Math.min(
     agentLiveState?.inputAcknowledgedThroughOffset ?? 0,
@@ -520,6 +518,7 @@ function useStreamSubscriberUser() {
 
 /** Owns the server live snapshot and local event mirror, including their publication barrier. */
 function useProjectStreamData({
+  agentSource,
   projectId,
   resetStreamSourceTransport,
   streamSource,
@@ -527,7 +526,7 @@ function useProjectStreamData({
   streamPath,
 }: Pick<
   ProjectStreamViewProps,
-  "projectId" | "resetStreamSourceTransport" | "streamSource" | "streamPath"
+  "agentSource" | "projectId" | "resetStreamSourceTransport" | "streamSource" | "streamPath"
 > & { subscriberUser?: BrowserStreamSubscriberUser }) {
   const streamRuntimeProjectKey = projectId ?? NULL_DURABLE_OBJECT_PROJECT_ID;
   // The browser stream database receives events over the ONE shared session socket — the same connection
@@ -606,7 +605,19 @@ function useProjectStreamData({
     [streamPath, browserStore.snapshot.clearVersion],
     { makeConnection: makeFeedConnection },
   );
+  const agentLiveState = useLiveState(
+    (agent: Agent) => agent.liveState,
+    (state) => state,
+    [streamPath, browserStore.snapshot.clearVersion],
+    agentSource ? { makeConnection: agentSource } : { root: undefined, enabled: false },
+  ).value;
   const presentedFeed = useEventSynchronizedLiveState(store.streamDatabase, feed.value);
+  // Keep displayed work active until its publications arrive, and show new work
+  // as soon as the agent reports it. Both subscriptions reset with the source lifetime.
+  const feedRuntime = presentedFeed?.runtimeChange?.runtime;
+  const agentRuntime = isAgentRuntimeVisiblyActive(feedRuntime)
+    ? feedRuntime
+    : (agentLiveState?.runtimeChange?.runtime ?? feedRuntime);
   // Readers need actual shared history, not merely a pending writer election.
   // Both roles wait for the current live snapshot's publications to reach SQLite.
   const streamTransportReady =
@@ -618,6 +629,8 @@ function useProjectStreamData({
     resolvedStreamSource,
     ...browserStore,
     eventCount,
+    agentLiveState,
+    agentRuntime,
     feed,
     presentedFeed,
     streamTransportReady,

--- a/apps/os/src/components/stream-view-composer.test.tsx
+++ b/apps/os/src/components/stream-view-composer.test.tsx
@@ -20,7 +20,7 @@ test("keeps submission pending between append response and server acknowledgemen
   vi.useFakeTimers();
   const host = document.createElement("div");
   const root = createRoot(host);
-  const committed = StreamEvent.parse({
+  let committed = StreamEvent.parse({
     path: "/agents/test",
     offset: 10,
     createdAt: new Date(0).toISOString(),
@@ -71,6 +71,25 @@ test("keeps submission pending between append response and server acknowledgemen
       await view.props!.message!.onSubmit();
     });
     expect(host.textContent).toBe("ready");
+    // A later agent-ahead/feed-behind interval must not re-open an acknowledged send.
+    await render(0);
+    expect(host.textContent).toBe("ready");
+    expect(view.props!.error).toBeUndefined();
+    await act(async () => vi.advanceTimersByTimeAsync(30_000));
+    expect(host.textContent).toBe("ready");
+    expect(view.props!.error).toBeUndefined();
+    // Retiring that send must not prematurely release a later submission.
+    committed = { ...committed, offset: 20 };
+    await act(async () => view.props!.message!.onValueChange({ content: "New message" }));
+    await act(async () => {
+      await view.props!.message!.onSubmit();
+    });
+    expect(host.textContent).toBe("pending");
+    await render(20);
+    expect(host.textContent).toBe("ready");
+    await render(0);
+    expect(host.textContent).toBe("ready");
+    expect(view.props!.error).toBeUndefined();
   } finally {
     await act(async () => root.unmount());
     vi.useRealTimers();

--- a/apps/os/src/components/use-stream-submission.ts
+++ b/apps/os/src/components/use-stream-submission.ts
@@ -8,7 +8,11 @@ export function useStreamSubmission(acknowledgedThroughOffset = Infinity) {
   const [overdueOffset, setOverdueOffset] = useState(0);
   const awaitingAcknowledgement = submittedOffset > acknowledgedThroughOffset;
   useEffect(() => {
-    if (!awaitingAcknowledgement) return;
+    if (!awaitingAcknowledgement) {
+      // Acknowledged sends are finished. Later feed delays cannot re-open them.
+      if (submittedOffset) setSubmittedOffset(0);
+      return;
+    }
     // A saved input can outlive a halted processor. End the spinner with an
     // explicit explanation; never append the message again automatically.
     const timer = setTimeout(() => setOverdueOffset(submittedOffset), 30_000);

--- a/apps/os/src/domains/agents/agent-input-progress.test.ts
+++ b/apps/os/src/domains/agents/agent-input-progress.test.ts
@@ -119,3 +119,77 @@ test("slash input hands off to its exact script request; disabled interpretation
       .pendingInputConsequences,
   ).toEqual({});
 });
+
+test.each([
+  { status: "succeeded", result: ["89", "97"] },
+  { status: "succeeded", result: null },
+  {
+    status: "failed",
+    error: "typecheck rejected",
+    phase: "typecheck",
+    failureKind: "typecheck",
+    executionMayHaveOccurred: false,
+    cancellation: "not-applicable",
+  },
+])("a script settlement stays queued until its feedback is consumed: %j", (settlement) => {
+  const state = AgentProcessorContract.stateSchema.parse({
+    contextItems: [
+      { kind: "section", key: "system", offset: 1, payload: { role: "system", content: "Help" } },
+    ],
+    activeScriptExecutions: [
+      { executionId: "agent-output:10", requestedAt: new Date(10).toISOString() },
+    ],
+  });
+  const settled = fold(
+    20,
+    "events.iterate.com/capability-host/script-run-settled",
+    { executionId: "agent-output:10", settlement },
+    state,
+  );
+  expect(settled.runtimeChange?.runtime).toMatchObject({
+    runningScripts: 0,
+    triggers: { pending: 1, runnable: 1 },
+  });
+  expect(settled.pendingLlmRequestTrigger).toBeNull(); // Feedback must enter the prompt before scheduling.
+  const feedback = {
+    role: "developer",
+    content: "Script result",
+    actor: { type: "script", executionId: "agent-output:10" },
+    llmRequestPolicy: { behaviour: "after-current-request" },
+  };
+  expect(fold(21, context, feedback, settled).pendingInputConsequences).toEqual(
+    settled.pendingInputConsequences,
+  );
+  expect(fold(21, context, feedback, settled, 19).pendingInputConsequences).toEqual(
+    settled.pendingInputConsequences,
+  );
+  const ready = fold(22, context, feedback, settled, 20);
+  expect(ready.pendingInputConsequences).toEqual({});
+  expect(ready.runtimeChange?.runtime.triggers).toEqual({ pending: 1, runnable: 1 });
+  expect(ready.pendingLlmRequestTrigger?.offset).toBe(22);
+});
+
+test.each([
+  { interpretResponses: true, executionId: "agent-output:10", result: undefined },
+  { interpretResponses: false, executionId: "agent-output:10", result: "ignored" },
+  { interpretResponses: true, executionId: "external-script", result: "ignored" },
+])("only interpreted, agent-owned results owe follow-up input: %j", (input) => {
+  const state = AgentProcessorContract.stateSchema.parse({
+    config: { interpretResponses: input.interpretResponses },
+    activeScriptExecutions: [
+      { executionId: "agent-output:10", requestedAt: new Date(10).toISOString() },
+    ],
+  });
+  const settled = fold(
+    20,
+    "events.iterate.com/capability-host/script-run-settled",
+    {
+      executionId: input.executionId,
+      settlement: { status: "succeeded", result: input.result },
+    },
+    state,
+  );
+  expect(settled.pendingInputConsequences).toEqual({});
+  expect(settled.pendingLlmRequestTrigger).toBeNull();
+  expect(settled.runtimeChange?.runtime.triggers.pending ?? 0).toBe(0);
+});

--- a/apps/os/src/domains/agents/agent-presence.ts
+++ b/apps/os/src/domains/agents/agent-presence.ts
@@ -253,6 +253,7 @@ export function foldAgentSummaryUpdated({
 }
 
 type AgentRuntimeSource = {
+  pendingInputConsequences?: Readonly<Record<string, number>>;
   activeScriptExecutions: readonly unknown[];
   contextItems: readonly { kind: string; payload?: { role: string } }[];
   openRequest: null | { requestedAtOffset: number };
@@ -260,7 +261,15 @@ type AgentRuntimeSource = {
 };
 
 export function deriveAgentRuntime(state: AgentRuntimeSource): AgentRuntimeRecord {
-  const pending = state.pendingLlmRequestTrigger === null ? 0 : 1;
+  // A settled script's result still owes model input. Keep that follow-up
+  // visible while it is materialized, without scheduling before the input exists.
+  const pending =
+    state.pendingLlmRequestTrigger !== null ||
+    Object.keys(state.pendingInputConsequences ?? {}).some((key) =>
+      key.startsWith("script-result:"),
+    )
+      ? 1
+      : 0;
   // Key-agnostic (the kernel knows no section key by name): a pending
   // trigger counts as runnable once ANY system-role section exists. Purely
   // a presentation facet; the turn loop itself no longer gates on it (every

--- a/apps/os/src/domains/agents/agent-processor-contract.ts
+++ b/apps/os/src/domains/agents/agent-processor-contract.ts
@@ -43,7 +43,7 @@ export const AgentProcessorContract = defineProcessorContract({
   stateSchema: z.object({
     pendingInputConsequences: z.record(z.string(), z.number().int().positive()).default({}).meta({
       description:
-        "Unresolved mention or slash-command consequences, keyed by their expected result identity and carrying the original input offset. Removed when the processor reduces that result.",
+        "Unresolved mention, slash-command, or script-result consequences, keyed by their expected result identity and carrying the original input offset. Removed when the processor reduces that result.",
     }),
     birthCertificate: z
       .object({

--- a/apps/os/src/domains/agents/agent-prompt-fold.ts
+++ b/apps/os/src/domains/agents/agent-prompt-fold.ts
@@ -92,12 +92,27 @@ function reducePendingInputConsequences({
       };
     }
   }
+  if (
+    event.type === "events.iterate.com/capability-host/script-run-settled" &&
+    state.config.interpretResponses &&
+    state.activeScriptExecutions.some(
+      (execution) => execution.executionId === event.payload.executionId,
+    ) &&
+    (event.payload.settlement.status === "failed" || event.payload.settlement.result !== undefined)
+  ) {
+    return { ...pending, [`script-result:${event.payload.executionId}`]: event.offset };
+  }
   const source = event.source?.processor;
   if (source?.slug !== AgentProcessorContract.slug || source.stream.path !== event.path)
     return pending;
   let key: string | undefined;
   if (event.type === "events.iterate.com/capability-host/script-run-requested") {
     key = event.payload.executionId;
+  } else if (
+    event.type === "events.iterate.com/agents/context-added" &&
+    event.payload.actor?.type === "script"
+  ) {
+    key = `script-result:${event.payload.actor.executionId}`;
   } else if (
     event.type === "events.iterate.com/agents/context-added" &&
     event.payload.actor?.type === "integration" &&

--- a/apps/os/src/domains/live-state-pager.test.ts
+++ b/apps/os/src/domains/live-state-pager.test.ts
@@ -72,52 +72,75 @@ describe("LiveStatePagers", () => {
     vi.useRealTimers();
   });
 
-  it("sends small patches, independently seeds joiners, and re-seeds surviving sockets after eviction", () => {
-    const watcher = fakeSocket(2);
-    const sockets = [watcher];
-    let state = { rows: [{ body: "a".repeat(64_000) }, { body: "tail" }] };
-    const hooks = { sockets, readState: () => state };
-    const { host } = socketsOver(hooks);
-    const mirror = createLiveStateStore<typeof state>();
-    const apply = (frame: string) => {
-      const page = parseLiveStatePage(frame);
-      if (!page || !("update" in page)) throw new Error("expected an update");
-      mirror.apply(page.update as LiveUpdate<typeof state>, () => {
-        throw new Error("revision gap");
+  it.each([2, 3])(
+    "sends version %i patches and re-seeds joiners and surviving sockets after eviction",
+    (version) => {
+      const watcher = fakeSocket(version);
+      const sockets = [watcher];
+      let state = { rows: [{ body: "a".repeat(64_000) }, { body: "tail" }] };
+      const hooks = { sockets, readState: () => state };
+      const { host } = socketsOver(hooks);
+      const mirror = createLiveStateStore<typeof state>();
+      const apply = (frame: string) => {
+        const page = parseLiveStatePage(frame);
+        if (!page || !("update" in page)) throw new Error("expected an update");
+        mirror.apply(page.update as LiveUpdate<typeof state>, () => {
+          throw new Error("revision gap");
+        });
+      };
+      host.scheduleFlush();
+      vi.runAllTimers();
+      apply(watcher.sent[0]!);
+      const first = mirror.getState()!;
+      state = { rows: [state.rows[0]!, { body: "tail appended" }] };
+      host.scheduleFlush();
+      vi.runAllTimers();
+      expect(watcher.sent[1]!.length).toBeLessThan(400);
+      apply(watcher.sent[1]!);
+      expect(mirror.getState()).toEqual(state);
+      expect(mirror.getState()!.rows[0]).toBe(first.rows[0]);
+
+      const joiner = fakeSocket(version);
+      sockets.push(joiner);
+      host.scheduleFlush();
+      vi.runAllTimers();
+      expect(watcher.sent).toHaveLength(2);
+      expect(parseLiveStatePage(joiner.sent[0])).toMatchObject({
+        update: version === 3 ? { s: [expect.any(Number), state] } : { type: "snapshot", state },
       });
-    };
-    host.scheduleFlush();
-    vi.runAllTimers();
-    apply(watcher.sent[0]!);
-    const first = mirror.getState()!;
-    state = { rows: [state.rows[0]!, { body: "tail appended" }] };
-    host.scheduleFlush();
-    vi.runAllTimers();
-    expect(watcher.sent[1]!.length).toBeLessThan(400);
-    apply(watcher.sent[1]!);
-    expect(mirror.getState()).toEqual(state);
-    expect(mirror.getState()!.rows[0]).toBe(first.rows[0]);
 
-    const joiner = fakeSocket(2);
-    sockets.push(joiner);
+      const restarted = socketsOver(hooks).host;
+      restarted.scheduleFlush();
+      vi.runAllTimers();
+      const fresh = parseLiveStatePage(watcher.sent[2]);
+      expect(fresh).toMatchObject({
+        update: version === 3 ? { s: [expect.any(Number), state] } : { type: "snapshot", state },
+      });
+      expect(fresh).not.toMatchObject({
+        epoch: (JSON.parse(watcher.sent[0]!) as { epoch: string }).epoch,
+      });
+      apply(watcher.sent[2]!);
+      expect(mirror.getState()).toEqual(state);
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
+
+  it("serves all negotiated versions from one baseline during deployment skew", () => {
+    const sockets = [fakeSocket(1), fakeSocket(2), fakeSocket(3)];
+    let state = { text: "x".repeat(100) };
+    const { host } = socketsOver({ sockets, readState: () => state });
     host.scheduleFlush();
     vi.runAllTimers();
-    expect(watcher.sent).toHaveLength(2);
-    expect(parseLiveStatePage(joiner.sent[0])).toMatchObject({
-      update: { type: "snapshot", state },
-    });
-
-    const restarted = socketsOver(hooks).host;
-    restarted.scheduleFlush();
+    state = { text: state.text + " tail" };
+    host.scheduleFlush();
     vi.runAllTimers();
-    const fresh = parseLiveStatePage(watcher.sent[2]);
-    expect(fresh).toMatchObject({ update: { type: "snapshot", state } });
-    expect(fresh).not.toMatchObject({
-      epoch: (JSON.parse(watcher.sent[0]!) as { epoch: string }).epoch,
+    expect(parseLiveStatePage(sockets[0]!.sent[1])).toEqual({ state });
+    expect(parseLiveStatePage(sockets[1]!.sent[1])).toMatchObject({
+      update: { type: "patch", patch: { fields: { text: { set: state.text } } } },
     });
-    apply(watcher.sent[2]!);
-    expect(mirror.getState()).toEqual(state);
-    expect(vi.getTimerCount()).toBe(0);
+    expect(parseLiveStatePage(sockets[2]!.sent[1])).toMatchObject({
+      update: { p: [1, 2, { 0: [100, " tail"] }] },
+    });
   });
 
   it("ignores requests without the lane header so hosts fall through", async () => {
@@ -314,6 +337,61 @@ function collectUpdates() {
 }
 
 describe("openRelayedLiveState", () => {
+  it("applies compact pages and closes a relay with an invalid append baseline", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const socket = fakeRelaySocket();
+      const relay = openRelayedLiveState<{ text: string }>({
+        dialPager: async () => ({ status: 101, webSocket: socket }),
+        readSnapshot: async () => ({ text: "" }),
+        pagerFailureDegrade: "reject",
+        label: "compact test",
+      });
+      const store = createLiveStateStore<{ text: string }>();
+      const pending = relay.subscribe(
+        (update) =>
+          store.apply(update, () => {
+            throw new Error("revision gap");
+          }),
+        { patchVersion: 3 },
+      );
+      await Promise.resolve();
+      socket.emitRaw(
+        JSON.stringify({
+          type: "update",
+          epoch: "first",
+          update: { s: [0, { text: "x".repeat(100) }] },
+        }),
+      );
+      using subscription = await pending;
+      socket.emitRaw(
+        JSON.stringify({
+          type: "update",
+          epoch: "first",
+          update: { p: [0, 1, { 0: [100, " tail"] }] },
+        }),
+      );
+      vi.advanceTimersByTime(100);
+      expect(store.getState()).toEqual({ text: "x".repeat(100) + " tail" });
+      socket.emitRaw(
+        JSON.stringify({
+          type: "update",
+          epoch: "first",
+          update: { p: [1, 2, { 0: [99, " invalid"] }] },
+        }),
+      );
+      expect(subscription.ping()).toBe(false);
+      expect(socket.closed).toContainEqual({
+        code: 1000,
+        reason: "Live-state append does not match its string baseline",
+      });
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+      vi.useRealTimers();
+    }
+  });
   it("applies ordered patches and reports a revision gap as a dead subscription", async () => {
     vi.useFakeTimers();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/apps/os/src/domains/live-state-pager.ts
+++ b/apps/os/src/domains/live-state-pager.ts
@@ -25,7 +25,10 @@
 import { z } from "zod";
 import {
   createLiveStateStore,
+  isLiveStateSnapshot,
+  liveStateRevision,
   LiveState,
+  type CompactLiveStatePatch,
   type LiveStateCursor,
   type LiveStatePatch,
   type LiveStateSubscription,
@@ -120,13 +123,30 @@ const Patch: z.ZodType<LiveStatePatch> = z.lazy(() =>
   ]),
 );
 
+const CompactPatch: z.ZodType<CompactLiveStatePatch> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.tuple([]),
+    z.tuple([z.unknown()]),
+    z.tuple([z.number().int().nonnegative(), z.string()]),
+    z.record(z.string(), CompactPatch),
+  ]),
+);
+
 const LiveStatePage = z.union([
   // Existing relays keep their full-state protocol until their socket closes.
   z.object({ type: z.literal("state"), state: z.unknown() }),
   z.object({
     type: z.literal("update"),
     epoch: z.string(),
-    update: z.discriminatedUnion("type", [
+    update: z.union([
+      z.object({ s: z.tuple([z.number().int().nonnegative(), z.unknown()]) }),
+      z.object({
+        p: z.tuple([z.number().int().nonnegative(), z.number().int().nonnegative(), CompactPatch]),
+      }),
       z.object({
         type: z.literal("snapshot"),
         revision: z.number().int().nonnegative(),
@@ -212,9 +232,8 @@ export class LiveStatePagers {
     }
     const pair = new WebSocketPair();
     this.#hooks.acceptWebSocket(pair[1], [LIVE_STATE_PAGER_TAG]);
-    pair[1].serializeAttachment(
-      request.headers.get(LIVE_STATE_PAGER_HEADER) === "watch-v2" ? 2 : 1,
-    );
+    const codec = request.headers.get(LIVE_STATE_PAGER_HEADER);
+    pair[1].serializeAttachment(codec === "watch-v3" ? 3 : codec === "watch-v2" ? 2 : 1);
     this.#hooks.waitUntil(
       Promise.resolve()
         .then(() => this.#hooks.refresh())
@@ -340,27 +359,36 @@ export class LiveStatePagers {
       // unknown here because hosts have unrelated domain shapes.
       this.#wire.setState(state as object);
       const read = this.#wire.readSince(this.#cursor);
+      const compactRead = this.#wire.readSince(this.#cursor, { patchVersion: 3 });
       this.#cursor = read.update
         ? {
             epoch: read.epoch,
-            revision: read.update.type === "snapshot" ? read.update.revision : read.update.to,
+            revision: liveStateRevision(read.update),
           }
         : this.#cursor;
-      let snapshot: string | undefined;
-      let patch: string | undefined;
+      const snapshots = new Map<number, string>();
+      const patches = new Map<number, string>();
       let legacy: string | undefined;
       for (const ws of sockets) {
         let page: string;
-        if (ws.deserializeAttachment() !== 2) {
+        const version: unknown = ws.deserializeAttachment();
+        if (version !== 2 && version !== 3) {
           legacy ??= JSON.stringify({ type: "state", state });
           page = legacy;
         } else if (!this.#seeded.has(ws)) {
-          snapshot ??= JSON.stringify({ type: "update", ...this.#wire.readSince() });
-          page = snapshot;
+          page =
+            snapshots.get(version) ??
+            JSON.stringify({
+              type: "update",
+              ...this.#wire.readSince(undefined, { patchVersion: version }),
+            });
+          snapshots.set(version, page);
         } else {
           if (!read.update) continue;
-          patch ??= JSON.stringify({ type: "update", ...read });
-          page = patch;
+          page =
+            patches.get(version) ??
+            JSON.stringify({ type: "update", ...(version === 3 ? compactRead : read) });
+          patches.set(version, page);
         }
         try {
           ws.send(page);
@@ -397,7 +425,7 @@ export async function dialLiveStatePager(
       ? LIVE_STATE_PAGER_URL
       : `${LIVE_STATE_PAGER_URL}lane/${encodeURIComponent(options.lane)}`;
   return await stub.fetch(url, {
-    headers: { Upgrade: "websocket", [LIVE_STATE_PAGER_HEADER]: "watch-v2" },
+    headers: { Upgrade: "websocket", [LIVE_STATE_PAGER_HEADER]: "watch-v3" },
   });
 }
 
@@ -509,7 +537,7 @@ export function openRelayedLiveState<State extends object>(input: {
                 // Legacy host during deployment skew; its domain owns state.
                 engine.setState(page.state as State);
               } else {
-                if (page.epoch !== epoch && page.update.type !== "snapshot") {
+                if (page.epoch !== epoch && !isLiveStateSnapshot(page.update)) {
                   throw new Error("incarnation changed without snapshot");
                 }
                 // The protocol validates the envelope; the typed host owns

--- a/apps/os/src/domains/streams/stream-durable-object.ts
+++ b/apps/os/src/domains/streams/stream-durable-object.ts
@@ -23,6 +23,8 @@ import { StreamEventInput as StreamEventInputSchema } from "iterate/processors";
 import { StreamRuntimeMetrics } from "iterate/processors";
 import {
   createLiveStateStore,
+  isLiveStateSnapshot,
+  liveStateRevision,
   disposeIgnoredRpcResult,
   LiveState,
   LiveStateRpcTarget,
@@ -1106,13 +1108,13 @@ export class StreamDurableObject extends DurableObject<Env> {
         try {
           const { epoch, update } = read;
           if (!update) return;
-          if (epoch !== cursor?.epoch && update.type !== "snapshot") {
+          if (epoch !== cursor?.epoch && !isLiveStateSnapshot(update)) {
             throw new Error("Facet live-state incarnation changed without a snapshot");
           }
           mirror.apply(update, () => {
             throw new Error("Facet live-state revision gap");
           });
-          cursor = { epoch, revision: update.type === "snapshot" ? update.revision : update.to };
+          cursor = { epoch, revision: liveStateRevision(update) };
         } finally {
           disposeAcknowledgedRpcResult(read, "facet-live-state");
         }

--- a/apps/os/src/domains/streams/stream-durable-object.ts
+++ b/apps/os/src/domains/streams/stream-durable-object.ts
@@ -404,6 +404,7 @@ type ProcessorFacetStub = {
   readLiveState(args: {
     streamId: string;
     cursor?: LiveStateCursor;
+    patchVersion?: 2 | 3;
   }): Promise<LiveStateRead<Record<string, unknown>>>;
   invokeCapability(input: { args?: unknown[]; path: string[] }): Promise<unknown>;
   provideCapability(
@@ -1103,7 +1104,7 @@ export class StreamDurableObject extends DurableObject<Env> {
           throw new Error("stream identity is unavailable after stream creation");
         }
         const read = await this.#callProcessorFacet(name, (facet) =>
-          facet.readLiveState({ streamId, cursor }),
+          facet.readLiveState({ streamId, cursor, patchVersion: 3 }),
         );
         try {
           const { epoch, update } = read;

--- a/apps/os/src/itx-api-graph.generated.ts
+++ b/apps/os/src/itx-api-graph.generated.ts
@@ -1354,16 +1354,16 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
     name: "LiveUpdate",
     kind: "typeAlias",
     sourceText:
-      '/**\n * One message pushed down a live-state subscription. The first is always a\n * `snapshot` (a resync sends a fresh one); every message after carries only the\n * diff from revision `from` to `to`. Revisions are monotonic for the life of one\n * subscription, so a gap (`from` ≠ the client\'s revision) means a message was\n * missed and the client should resubscribe.\n *\n * `State` is asserted by the caller of `useLiveState` — the wire itself is\n * structure-agnostic.\n */\nexport type LiveUpdate<State = unknown> =\n  | { type: "snapshot"; revision: number; state: State }\n  | { type: "patch"; from: number; to: number; patch: LiveStatePatch };',
+      '/**\n * One message pushed down a live-state subscription. The first is always a\n * `snapshot` (a resync sends a fresh one); every message after carries only the\n * diff from revision `from` to `to`. Revisions are monotonic for the life of one\n * subscription, so a gap (`from` ≠ the client\'s revision) means a message was\n * missed and the client should resubscribe.\n *\n * `State` is asserted by the caller of `useLiveState` — the wire itself is\n * structure-agnostic.\n */\nexport type LiveUpdate<State = unknown> =\n  | { type: "snapshot"; revision: number; state: State }\n  | { type: "patch"; from: number; to: number; patch: LiveStatePatch }\n  | { s: [revision: number, state: State] }\n  | { p: [from: number, to: number, patch: CompactLiveStatePatch] };',
     summary: "One message pushed down a live-state subscription.",
     memberSummaries: {},
-    referencedTypeNames: ["LiveStatePatch"],
+    referencedTypeNames: ["LiveStatePatch", "CompactLiveStatePatch"],
   },
   {
     name: "LiveStateSubscriptionOptions",
     kind: "typeAlias",
     sourceText:
-      "/** Explicit codec negotiation keeps already-open clients valid across deploys. */\nexport type LiveStateSubscriptionOptions = { patchVersion?: 2 };",
+      "/** Explicit codec negotiation keeps already-open clients valid across deploys. */\nexport type LiveStateSubscriptionOptions = { patchVersion?: 2 | 3 };",
     summary: "Explicit codec negotiation keeps already-open clients valid across deploys.",
     memberSummaries: {},
     referencedTypeNames: [],
@@ -2275,6 +2275,16 @@ export const ITX_API_DECLARATIONS: readonly ItxApiDeclaration[] = [
     sourceText:
       "/**\n * A structural patch turning a previous JSON value into the next one. Three\n * shapes, discriminated by `set`, `array`, or an object patch:\n * - `{ set }` — replace this position wholesale. Used for primitives,\n *   `null`, type changes,\n *   and newly-added object keys.\n * - `{ fields?, drop? }` — descend into a plain object: `fields` maps each\n *   changed key to its own patch; `drop` lists keys that disappeared. At least\n *   one is present (an empty descend never gets emitted).\n * - `{ array }` — patch changed positions and set the resulting length. Kept\n *   elements retain their identity, including immutable text blocks inside a\n *   changed step. This form is sent only to subscribers requesting version 2.\n */\nexport type LiveStatePatch =\n  | { set: unknown }\n  | { array: { length: number; items: [number, LiveStatePatch][] } }\n  | { fields?: Record<string, LiveStatePatch>; drop?: string[] };",
     summary: "A structural patch turning a previous JSON value into the next one.",
+    memberSummaries: {},
+    referencedTypeNames: [],
+  },
+  {
+    name: "CompactLiveStatePatch",
+    kind: "typeAlias",
+    sourceText:
+      "/**\n * Version 3 addresses existing object fields by their sorted baseline position;\n * new fields use `+name`. Arrays use indices and an optional `#` length.\n * Primitives replace directly, `[value]` replaces other values, `[length, text]`\n * appends to a string, and `[]` deletes an object field. No dictionary survives\n * an update: every address refers to the acknowledged baseline of that patch.\n */\nexport type CompactLiveStatePatch =\n  | string\n  | number\n  | boolean\n  | null\n  | []\n  | [unknown]\n  | [number, string]\n  | { [address: string]: CompactLiveStatePatch };",
+    summary:
+      "Version 3 addresses existing object fields by their sorted baseline position; new fields use `+name`.",
     memberSummaries: {},
     referencedTypeNames: [],
   },

--- a/apps/os/src/itx-api.generated.ts
+++ b/apps/os/src/itx-api.generated.ts
@@ -2577,10 +2577,12 @@ export type StreamProcessorWakeResponse = {
  */
 export type LiveUpdate<State = unknown> =
   | { type: "snapshot"; revision: number; state: State }
-  | { type: "patch"; from: number; to: number; patch: LiveStatePatch };
+  | { type: "patch"; from: number; to: number; patch: LiveStatePatch }
+  | { s: [revision: number, state: State] }
+  | { p: [from: number, to: number, patch: CompactLiveStatePatch] };
 
 /** Explicit codec negotiation keeps already-open clients valid across deploys. */
-export type LiveStateSubscriptionOptions = { patchVersion?: 2 };
+export type LiveStateSubscriptionOptions = { patchVersion?: 2 | 3 };
 
 /** Owned handle for one live-state subscription. */
 export type LiveStateSubscriptionHandle = Disposable & {
@@ -4819,6 +4821,23 @@ export type LiveStatePatch =
   | { set: unknown }
   | { array: { length: number; items: [number, LiveStatePatch][] } }
   | { fields?: Record<string, LiveStatePatch>; drop?: string[] };
+
+/**
+ * Version 3 addresses existing object fields by their sorted baseline position;
+ * new fields use `+name`. Arrays use indices and an optional `#` length.
+ * Primitives replace directly, `[value]` replaces other values, `[length, text]`
+ * appends to a string, and `[]` deletes an object field. No dictionary survives
+ * an update: every address refers to the acknowledged baseline of that patch.
+ */
+export type CompactLiveStatePatch =
+  | string
+  | number
+  | boolean
+  | null
+  | []
+  | [unknown]
+  | [number, string]
+  | { [address: string]: CompactLiveStatePatch };
 
 /**
  * One intercepted/* invocation as the interceptor sees it. `source` discriminates the

--- a/apps/os/src/routes/_app/projects/$projectSlug/agents/streams/$.tsx
+++ b/apps/os/src/routes/_app/projects/$projectSlug/agents/streams/$.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { connectItx, useLiveState } from "iterate/sdk/itx/react";
 import { AgentDetailsSheet } from "~/components/agents/agent-details-sheet.tsx";
@@ -42,14 +43,10 @@ function ProjectAgentDetailContent() {
       (state) => state.agents,
       [],
     ).value ?? {};
-  const agentLiveState = useLiveState(
-    (itx) => itx.agents.get(streamPath).liveState,
-    (state) => state,
-    [streamPath],
-    { slug: project.id },
-  ).value;
-
-  const agentRuntimeTransition = agentLiveState?.runtimeChange;
+  const agentSource = useCallback(
+    async () => (await connectItx(project.id)).agents.get(streamPath),
+    [project.id, streamPath],
+  );
 
   // The stream view subscribes live, so a send needs no cache invalidation —
   // the new events arrive over the socket. Agent setup is represented by
@@ -121,12 +118,10 @@ function ProjectAgentDetailContent() {
               path={streamPath}
               projectId={project.id}
               projectSlug={project.slug}
-              runtimeTransition={agentRuntimeTransition}
             />
           }
           emptyLabel={null}
           messageComposer={{
-            acknowledgedThroughOffset: agentLiveState?.inputAcknowledgedThroughOffset ?? 0,
             onInterrupt: interruptAgentMessage,
             onSubmit: submitAgentMessage,
             onSubmitFiles: submitAgentFiles,
@@ -135,7 +130,7 @@ function ProjectAgentDetailContent() {
           }}
           projectId={project.id}
           projectSlug={project.slug}
-          agentRuntimeTransition={agentRuntimeTransition ?? null}
+          agentSource={agentSource}
           streamPath={streamPath}
         />
       </div>

--- a/packages/iterate/src/itx-api.generated.ts
+++ b/packages/iterate/src/itx-api.generated.ts
@@ -2577,10 +2577,12 @@ export type StreamProcessorWakeResponse = {
  */
 export type LiveUpdate<State = unknown> =
   | { type: "snapshot"; revision: number; state: State }
-  | { type: "patch"; from: number; to: number; patch: LiveStatePatch };
+  | { type: "patch"; from: number; to: number; patch: LiveStatePatch }
+  | { s: [revision: number, state: State] }
+  | { p: [from: number, to: number, patch: CompactLiveStatePatch] };
 
 /** Explicit codec negotiation keeps already-open clients valid across deploys. */
-export type LiveStateSubscriptionOptions = { patchVersion?: 2 };
+export type LiveStateSubscriptionOptions = { patchVersion?: 2 | 3 };
 
 /** Owned handle for one live-state subscription. */
 export type LiveStateSubscriptionHandle = Disposable & {
@@ -4819,6 +4821,23 @@ export type LiveStatePatch =
   | { set: unknown }
   | { array: { length: number; items: [number, LiveStatePatch][] } }
   | { fields?: Record<string, LiveStatePatch>; drop?: string[] };
+
+/**
+ * Version 3 addresses existing object fields by their sorted baseline position;
+ * new fields use `+name`. Arrays use indices and an optional `#` length.
+ * Primitives replace directly, `[value]` replaces other values, `[length, text]`
+ * appends to a string, and `[]` deletes an object field. No dictionary survives
+ * an update: every address refers to the acknowledged baseline of that patch.
+ */
+export type CompactLiveStatePatch =
+  | string
+  | number
+  | boolean
+  | null
+  | []
+  | [unknown]
+  | [number, string]
+  | { [address: string]: CompactLiveStatePatch };
 
 /**
  * One intercepted/* invocation as the interceptor sees it. `source` discriminates the

--- a/packages/iterate/src/processors/processor-facet.test-worker.ts
+++ b/packages/iterate/src/processors/processor-facet.test-worker.ts
@@ -369,6 +369,7 @@ type FacetStub = {
   readLiveState(args: {
     streamId: string;
     cursor?: import("../sdk/capnweb/live-state/protocol.ts").LiveStateCursor;
+    patchVersion?: 2 | 3;
   }): Promise<unknown>;
   wakeStreamProcessor(request: StreamProcessorWakeRequest): Promise<StreamProcessorWakeResponse>;
   handleAlarm(info?: AlarmInvocationInfo): Promise<void>;
@@ -512,10 +513,12 @@ export class FacetTestParent extends DurableObject<Env> {
 
   async facetLiveRead(args: {
     cursor?: import("../sdk/capnweb/live-state/protocol.ts").LiveStateCursor;
+    patchVersion?: 2 | 3;
   }) {
     return await this.#facet().readLiveState({
       streamId: this.ctx.storage.kv.get<string>("stream-id") ?? FACET_STREAM_ID,
       cursor: args.cursor,
+      patchVersion: args.patchVersion,
     });
   }
 

--- a/packages/iterate/src/processors/processor-facet.test.ts
+++ b/packages/iterate/src/processors/processor-facet.test.ts
@@ -17,6 +17,7 @@ import { build } from "esbuild";
 import { Miniflare } from "miniflare";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import type { LiveStateRead } from "../sdk/capnweb/live-state/protocol.ts";
+import { liveStateRevision } from "../sdk/capnweb/live-state/protocol.ts";
 import type { StreamEvent } from "./schemas.ts";
 
 // Mirrors of the worker's constants — the worker module cannot be imported
@@ -79,9 +80,9 @@ describe("ProcessorFacet in real workerd (Miniflare)", () => {
     const run = "live-reads";
     await invoke(run, "configureFacet");
     const seed = await invoke<LiveStateRead<{ count: number }>>(run, "facetLiveRead", {});
-    if (seed.update?.type !== "snapshot") throw new Error("Expected seed snapshot");
-    expect(seed.update.state.count).toBe(0);
-    const cursor = { epoch: seed.epoch, revision: seed.update.revision };
+    if (!seed.update || !("s" in seed.update)) throw new Error("Expected compact seed snapshot");
+    expect(seed.update.s[1].count).toBe(0);
+    const cursor = { epoch: seed.epoch, revision: liveStateRevision(seed.update) };
     const loaded = await invoke<{ eventPageReads: number }>(run, "facetReadProof");
     expect(loaded.eventPageReads).toBeGreaterThan(0);
     const unchanged = await invoke<LiveStateRead<{ count: number }>>(run, "facetLiveRead", {
@@ -106,22 +107,21 @@ describe("ProcessorFacet in real workerd (Miniflare)", () => {
     });
     expect(changed.epoch).toBe(seed.epoch);
     expect(changed.update).toMatchObject({
-      type: "patch",
-      patch: { fields: { count: { set: 1 } } },
+      p: [cursor.revision, cursor.revision + 1, { "0": 1 }],
     });
     await invoke(run, "abortFacet");
     const restarted = await invoke<LiveStateRead<{ count: number }>>(run, "facetLiveRead", {
       cursor,
     });
     expect(restarted.epoch).not.toBe(seed.epoch);
-    expect(restarted.update).toMatchObject({ type: "snapshot", state: { count: 1 } });
+    expect(restarted.update).toMatchObject({ s: [expect.any(Number), { count: 1 }] });
     const reloaded = await invoke<{ eventPageReads: number }>(run, "facetReadProof");
     expect(reloaded.eventPageReads).toBeGreaterThan(loaded.eventPageReads);
 
     const replacementId = "22222222-2222-4222-8222-222222222222";
     await invoke(run, "replaceWithEmptyStream", { streamId: replacementId });
     const replaced = await invoke<LiveStateRead<{ count: number }>>(run, "facetLiveRead", {});
-    expect(replaced.update).toMatchObject({ type: "snapshot", state: { count: 0 } });
+    expect(replaced.update).toMatchObject({ s: [expect.any(Number), { count: 0 }] });
     expect(await invoke(run, "facetReadProof")).toMatchObject({
       progress: { streamId: replacementId, processing: { acknowledgedThroughOffset: 0 } },
     });

--- a/packages/iterate/src/processors/processor-facet.test.ts
+++ b/packages/iterate/src/processors/processor-facet.test.ts
@@ -79,14 +79,19 @@ describe("ProcessorFacet in real workerd (Miniflare)", () => {
   test("transient live reads cross Workers RPC as deltas and reset after facet eviction", async () => {
     const run = "live-reads";
     await invoke(run, "configureFacet");
-    const seed = await invoke<LiveStateRead<{ count: number }>>(run, "facetLiveRead", {});
+    const seed = await invoke<LiveStateRead<{ count: number }>>(run, "facetLiveRead", {
+      patchVersion: 3,
+    });
     if (!seed.update || !("s" in seed.update)) throw new Error("Expected compact seed snapshot");
     expect(seed.update.s[1].count).toBe(0);
+    const legacy = await invoke<LiveStateRead<{ count: number }>>(run, "facetLiveRead", {});
+    expect(legacy.update).toMatchObject({ type: "snapshot", state: { count: 0 } });
     const cursor = { epoch: seed.epoch, revision: liveStateRevision(seed.update) };
     const loaded = await invoke<{ eventPageReads: number }>(run, "facetReadProof");
     expect(loaded.eventPageReads).toBeGreaterThan(0);
     const unchanged = await invoke<LiveStateRead<{ count: number }>>(run, "facetLiveRead", {
       cursor,
+      patchVersion: 3,
     });
     expect(unchanged.update).toBeNull();
     expect(await invoke(run, "facetReadProof")).toMatchObject({
@@ -104,15 +109,28 @@ describe("ProcessorFacet in real workerd (Miniflare)", () => {
     });
     const changed = await invoke<LiveStateRead<{ count: number }>>(run, "facetLiveRead", {
       cursor,
+      patchVersion: 3,
     });
     expect(changed.epoch).toBe(seed.epoch);
     expect(changed.update).toMatchObject({
       p: [cursor.revision, cursor.revision + 1, { "0": 1 }],
     });
+    const legacyDelta = await invoke<LiveStateRead<{ count: number }>>(run, "facetLiveRead", {
+      cursor,
+    });
+    expect(legacyDelta.update).toMatchObject({
+      type: "patch",
+      patch: { fields: { count: { set: 1 } } },
+    });
     await invoke(run, "abortFacet");
     const restarted = await invoke<LiveStateRead<{ count: number }>>(run, "facetLiveRead", {
       cursor,
+      patchVersion: 3,
     });
+    const legacyRestart = await invoke<LiveStateRead<{ count: number }>>(run, "facetLiveRead", {
+      cursor,
+    });
+    expect(legacyRestart.update).toMatchObject({ type: "snapshot", state: { count: 1 } });
     expect(restarted.epoch).not.toBe(seed.epoch);
     expect(restarted.update).toMatchObject({ s: [expect.any(Number), { count: 1 }] });
     const reloaded = await invoke<{ eventPageReads: number }>(run, "facetReadProof");
@@ -120,7 +138,9 @@ describe("ProcessorFacet in real workerd (Miniflare)", () => {
 
     const replacementId = "22222222-2222-4222-8222-222222222222";
     await invoke(run, "replaceWithEmptyStream", { streamId: replacementId });
-    const replaced = await invoke<LiveStateRead<{ count: number }>>(run, "facetLiveRead", {});
+    const replaced = await invoke<LiveStateRead<{ count: number }>>(run, "facetLiveRead", {
+      patchVersion: 3,
+    });
     expect(replaced.update).toMatchObject({ s: [expect.any(Number), { count: 0 }] });
     expect(await invoke(run, "facetReadProof")).toMatchObject({
       progress: { streamId: replacementId, processing: { acknowledgedThroughOffset: 0 } },

--- a/packages/iterate/src/processors/processor-facet.ts
+++ b/packages/iterate/src/processors/processor-facet.ts
@@ -346,7 +346,7 @@ export abstract class ProcessorFacet<Env = unknown> extends DurableObject<Env> {
     } else {
       registry.refreshLive();
     }
-    return registry.live.readSince(args.cursor);
+    return registry.live.readSince(args.cursor, { patchVersion: 3 });
   }
 
   /** Direct subscriptions retain their callbacks across the Workers RPC hop. */

--- a/packages/iterate/src/processors/processor-facet.ts
+++ b/packages/iterate/src/processors/processor-facet.ts
@@ -334,7 +334,7 @@ export abstract class ProcessorFacet<Env = unknown> extends DurableObject<Env> {
    * Cold or replaced processors hydrate from durable progress. Warm reads use
    * committed local state: polling must not call back into the parent stream
    * for every processor while it is delivering events to this facet. */
-  async readLiveState(args: { streamId: string; cursor?: LiveStateCursor }) {
+  async readLiveState(args: { streamId: string; cursor?: LiveStateCursor; patchVersion?: 2 | 3 }) {
     const { registry } = this.#requireHost();
     if (
       registry.names.some((name) => {
@@ -346,7 +346,8 @@ export abstract class ProcessorFacet<Env = unknown> extends DurableObject<Env> {
     } else {
       registry.refreshLive();
     }
-    return registry.live.readSince(args.cursor, { patchVersion: 3 });
+    // An omitted version keeps warm parents on the pre-deploy wire format.
+    return registry.live.readSince(args.cursor, { patchVersion: args.patchVersion });
   }
 
   /** Direct subscriptions retain their callbacks across the Workers RPC hop. */

--- a/packages/iterate/src/sdk/capnweb/live-state/compact.test.ts
+++ b/packages/iterate/src/sdk/capnweb/live-state/compact.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { applyCompactPatch, compactPatch } from "./compact.ts";
+import { applyPatch, diff } from "./diff.ts";
+
+describe("compact live-state codec", () => {
+  it.each([
+    [
+      { z: 1, a: 2 },
+      { z: 3, b: 4 },
+    ],
+    [
+      { "0": 1, "+": 2, "#": 3, "": 4 },
+      { "0": 8, "+": 9, "#": 10, "": 11 },
+    ],
+    [
+      { absent: undefined, z: 1 },
+      { absent: undefined, z: 2 },
+    ],
+    [[{ n: 1 }, { n: 2 }], [{ n: 3 }]],
+    [[1], [1, { n: [2, 3] }]],
+    [[1, 2], []],
+    [{ value: null }, { value: { text: "new" } }],
+    [{ value: { text: "old" } }, { value: [false, null, 4] }],
+    [Object.fromEntries([["__proto__", { n: 1 }]]), Object.fromEntries([["__proto__", { n: 2 }]])],
+    [{}, Object.fromEntries([["__proto__", { n: 2 }]])],
+  ])("round-trips structural changes from %j to %j", (previous, next) => {
+    const patch = compactPatch(previous, diff(previous, next)!);
+    expect(applyCompactPatch(previous, patch)).toEqual(applyPatch(previous, diff(previous, next)!));
+    // Both transports may change property insertion order and omit undefined.
+    const baseline: unknown = JSON.parse(JSON.stringify(previous));
+    expect(JSON.stringify(applyCompactPatch(baseline, patch))).toBe(JSON.stringify(next));
+    expect(Object.getPrototypeOf(applyCompactPatch(previous, patch))).toBe(
+      Object.getPrototypeOf(next),
+    );
+  });
+
+  it("resolves all addresses against the baseline before fields are added or deleted", () => {
+    const previous = { zebra: 1, middle: 2, apple: 3 };
+    const next = { zebra: 4, aardvark: 5, middle: 6 };
+    const patch = compactPatch(previous, diff(previous, next)!);
+    expect(applyCompactPatch({ apple: 3, middle: 2, zebra: 1 }, patch)).toEqual(next);
+  });
+
+  it("appends bounded text, preserves surrogate pairs, and replaces edits or long strings", () => {
+    const previous = "x".repeat(100) + "\ud83d";
+    const patch = compactPatch(previous, { set: previous + "\ude80 next" });
+    expect(patch).toEqual([101, "\ude80 next"]);
+    expect(applyCompactPatch(previous, patch)).toBe("x".repeat(100) + "🚀 next");
+    expect(compactPatch(previous, { set: "edited" })).toBe("edited");
+    const long = "x".repeat(1_048_576);
+    expect(compactPatch(long, { set: long + " next" })).toBe(long + " next");
+  });
+
+  it("retains sealed text and unrelated branches while a tail grows", () => {
+    const sealed = { 0: "x".repeat(1024) };
+    const untouched = { title: "same" };
+    const previous = { groups: { 0: sealed, 1: { 0: "a".repeat(100) } }, untouched };
+    const next = {
+      ...previous,
+      groups: { ...previous.groups, 1: { 0: "a".repeat(100) + " tail" } },
+    };
+    const result = applyCompactPatch(previous, compactPatch(previous, diff(previous, next)!));
+    expect(result).toEqual(next);
+    expect(result.groups[0]).toBe(sealed);
+    expect(result.untouched).toBe(untouched);
+  });
+
+  it("rejects invalid addresses and append baselines instead of corrupting state", () => {
+    expect(() => applyCompactPatch({ n: 1 }, { 1: 2 })).toThrow("address");
+    expect(() => applyCompactPatch({ n: 1 }, { "01": 2 })).toThrow("address");
+    expect(() => applyCompactPatch({ n: 1 }, { "+n": 2 })).toThrow("already exists");
+    expect(() => applyCompactPatch({ n: 1 }, { "+missing": [] })).toThrow("delete a new field");
+    expect(() => applyCompactPatch([1], { "#": -1 })).toThrow("length");
+    expect(() => applyCompactPatch([1], { 1: 2 })).toThrow("address");
+    expect(() => applyCompactPatch("old", [2, " append"])).toThrow("baseline");
+  });
+
+  it("matches structural diff across repeated dictionary edits and transport reordering", () => {
+    let previous: Record<string, unknown> = {};
+    for (let step = 0; step < 500; step++) {
+      const next = {
+        ...previous,
+        [`key-${step % 13}`]: { text: "x".repeat(step % 100), rows: [step, true] },
+      };
+      if (step % 3 === 0) delete next[`key-${(step + 7) % 13}`];
+      const patch = diff(previous, next)!;
+      const reordered = Object.fromEntries(Object.entries(previous).reverse());
+      expect(applyCompactPatch(reordered, compactPatch(previous, patch))).toEqual(next);
+      previous = next;
+    }
+  });
+});

--- a/packages/iterate/src/sdk/capnweb/live-state/compact.ts
+++ b/packages/iterate/src/sdk/capnweb/live-state/compact.ts
@@ -1,0 +1,139 @@
+import { isPlainObject } from "./diff.ts";
+import type { CompactLiveStatePatch, LiveStatePatch } from "./protocol.ts";
+
+const fieldAddresses = new WeakMap<object, { keys: string[]; indices: Map<string, number> }>();
+
+function addresses(value: Record<string, unknown>) {
+  let cached = fieldAddresses.get(value);
+  if (!cached) {
+    // Undefined object fields are absent after a JSON transport. They must not
+    // shift addresses on either side of the next update.
+    const keys = Object.keys(value)
+      .filter((key) => value[key] !== undefined)
+      .sort();
+    cached = { keys, indices: new Map(keys.map((key, index) => [key, index])) };
+    fieldAddresses.set(value, cached);
+  }
+  return cached;
+}
+
+/** Encode only the changed paths of an existing structural diff. */
+export function compactPatch(previous: unknown, patch: LiveStatePatch): CompactLiveStatePatch {
+  if ("set" in patch) {
+    const next = patch.set;
+    if (
+      typeof previous === "string" &&
+      typeof next === "string" &&
+      previous.length >= 16 &&
+      // Bound prefix checks even for a multi-megabyte string. Immutable text
+      // blocks are ~1 KiB; larger ordinary strings retain replacement semantics.
+      previous.length <= 4096 &&
+      next.length > previous.length &&
+      next.startsWith(previous)
+    )
+      return [previous.length, next.slice(previous.length)];
+    if (
+      next === null ||
+      typeof next === "string" ||
+      typeof next === "number" ||
+      typeof next === "boolean"
+    )
+      return next;
+    return [next];
+  }
+  if ("array" in patch) {
+    if (!Array.isArray(previous))
+      throw new Error("Live-state array patch requires an array baseline");
+    const result: Record<string, CompactLiveStatePatch> = {};
+    if (patch.array.length !== previous.length) result["#"] = patch.array.length;
+    for (const [index, child] of patch.array.items)
+      result[index] = compactPatch(previous[index], child);
+    return result;
+  }
+  if (!isPlainObject(previous))
+    throw new Error("Live-state object patch requires an object baseline");
+  const { indices } = addresses(previous);
+  const fields: [string, CompactLiveStatePatch][] = [];
+  for (const [key, child] of Object.entries(patch.fields ?? {})) {
+    const index = indices.get(key);
+    fields.push([
+      index === undefined ? `+${key}` : String(index),
+      compactPatch(index === undefined ? undefined : previous[key], child),
+    ]);
+  }
+  for (const key of patch.drop ?? []) {
+    const index = indices.get(key);
+    // An undefined field was already absent on the wire.
+    if (index !== undefined) fields.push([String(index), []]);
+  }
+  return Object.fromEntries(fields);
+}
+
+/** Apply a version 3 patch, retaining every untouched object's identity. */
+export function applyCompactPatch<State>(previous: State, patch: CompactLiveStatePatch): State {
+  // Like applyPatch, the wire operation preserves the caller's State contract;
+  // TypeScript cannot infer that contract from a recursive, generic JSON codec.
+  return applyCompactValue(previous, patch) as State;
+}
+
+function applyCompactValue(previous: unknown, patch: CompactLiveStatePatch): unknown {
+  if (patch === null || typeof patch !== "object") return patch;
+  if (Array.isArray(patch)) {
+    if (patch.length === 1) return patch[0];
+    if (patch.length !== 2 || typeof previous !== "string" || previous.length !== patch[0]) {
+      throw new Error("Live-state append does not match its string baseline");
+    }
+    return previous + patch[1];
+  }
+  if (Array.isArray(previous)) {
+    const length = Object.hasOwn(patch, "#") ? patch["#"] : previous.length;
+    if (
+      typeof length !== "number" ||
+      !Number.isSafeInteger(length) ||
+      length < 0 ||
+      length > 0xffffffff
+    ) {
+      throw new Error("Live-state array patch has an invalid length");
+    }
+    const next = previous.slice(0, length);
+    next.length = length;
+    for (const [address, child] of Object.entries(patch)) {
+      if (address === "#") continue;
+      const index = position(address, length);
+      next[index] = applyCompactValue(previous[index], child);
+    }
+    return next;
+  }
+  if (!isPlainObject(previous))
+    throw new Error("Live-state object patch requires an object baseline");
+  const { keys } = addresses(previous);
+  const next = { ...previous };
+  for (const [address, child] of Object.entries(patch)) {
+    const added = address.startsWith("+");
+    const key = added ? address.slice(1) : keys[position(address, keys.length)]!;
+    if (added && Object.hasOwn(previous, key) && previous[key] !== undefined) {
+      throw new Error("Live-state new field already exists in its baseline");
+    }
+    if (Array.isArray(child) && child.length === 0) {
+      if (added) throw new Error("Live-state cannot delete a new field");
+      delete next[key];
+    } else {
+      // Define own properties, including __proto__, without mutating prototypes.
+      Object.defineProperty(next, key, {
+        value: applyCompactValue(added ? undefined : previous[key], child),
+        enumerable: true,
+        writable: true,
+        configurable: true,
+      });
+    }
+  }
+  return next;
+}
+
+function position(address: string, length: number): number {
+  const index = Number(address);
+  if (!Number.isSafeInteger(index) || index < 0 || index >= length || String(index) !== address) {
+    throw new Error("Live-state field address is outside its baseline");
+  }
+  return index;
+}

--- a/packages/iterate/src/sdk/capnweb/live-state/diff.ts
+++ b/packages/iterate/src/sdk/capnweb/live-state/diff.ts
@@ -128,7 +128,7 @@ export function applyPatch<State>(prev: State, patch: LiveStatePatch): State {
  * their own enumerable keys, so per-key diffing would misread them (see the
  * `diff` docstring) — they are leaves, replaced wholesale.
  */
-function isPlainObject(value: unknown): value is Record<string, unknown> {
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
   if (typeof value !== "object" || value === null) return false;
   const proto: unknown = Object.getPrototypeOf(value);
   return proto === Object.prototype || proto === null;

--- a/packages/iterate/src/sdk/capnweb/live-state/engine.test.ts
+++ b/packages/iterate/src/sdk/capnweb/live-state/engine.test.ts
@@ -51,36 +51,67 @@ describe("LiveState", () => {
     expect(engine.observed).toBe(false);
   });
 
-  it("bounds a slow sink to one outstanding call and coalesces its next update", async () => {
-    const engine = new LiveState({ n: 0 }, { debounceMs: 0 });
-    const store = createLiveStateStore<{ n: number }>();
-    const updates: LiveUpdate<{ n: number }>[] = [];
-    let acknowledge: () => void = () => {};
-    const handle = engine.subscribe(
+  it.each([2, 3] as const)(
+    "bounds a slow version %i sink and coalesces its next update",
+    async (patchVersion) => {
+      const engine = new LiveState({ n: 0 }, { debounceMs: 0 });
+      const store = createLiveStateStore<{ n: number }>();
+      const updates: LiveUpdate<{ n: number }>[] = [];
+      let acknowledge: () => void = () => {};
+      const handle = engine.subscribe(
+        (update) => {
+          updates.push(update);
+          store.apply(update, () => {
+            throw new Error("unexpected revision gap");
+          });
+          return new Promise<void>((resolve) => {
+            acknowledge = resolve;
+          });
+        },
+        { patchVersion },
+      );
+      for (let n = 1; n <= 100; n++) {
+        engine.assign({ n });
+        vi.advanceTimersByTime(0);
+      }
+      expect(updates).toHaveLength(1);
+      acknowledge();
+      await Promise.resolve();
+      expect(updates).toHaveLength(2);
+      expect(store.getState()).toEqual({ n: 100 });
+      acknowledge();
+      await Promise.resolve();
+      expect(vi.getTimerCount()).toBe(0);
+      handle.unsubscribe();
+    },
+  );
+
+  it("coalesces compact addresses and text appends from the slow subscriber's baseline", async () => {
+    const initial = { zebra: "z".repeat(100), removed: "old" };
+    const engine = new LiveState<Record<string, string>>(initial, { debounceMs: 0 });
+    const store = createLiveStateStore<Record<string, string>>();
+    const seed = Promise.withResolvers<void>();
+    let count = 0;
+    using subscription = engine.subscribe(
       (update) => {
-        updates.push(update);
         store.apply(update, () => {
-          throw new Error("unexpected revision gap");
+          throw new Error("Unexpected revision gap");
         });
-        return new Promise<void>((resolve) => {
-          acknowledge = resolve;
-        });
+        count++;
+        return count === 1 ? seed.promise : undefined;
       },
-      { patchVersion: 2 },
+      { patchVersion: 3 },
     );
     for (let n = 1; n <= 100; n++) {
-      engine.assign({ n });
+      engine.setState({ zebra: initial.zebra + "x".repeat(n), added: String(n) });
       vi.advanceTimersByTime(0);
     }
-    expect(updates).toHaveLength(1);
-    acknowledge();
+    expect(count).toBe(1);
+    seed.resolve();
     await Promise.resolve();
-    expect(updates).toHaveLength(2);
-    expect(store.getState()).toEqual({ n: 100 });
-    acknowledge();
-    await Promise.resolve();
-    expect(vi.getTimerCount()).toBe(0);
-    handle.unsubscribe();
+    expect(count).toBe(2);
+    expect(store.getState()).toEqual(engine.getState());
+    expect(subscription.ping()).toBe(true);
   });
 
   it("drops a sink that never acknowledges and releases its timer", () => {

--- a/packages/iterate/src/sdk/capnweb/live-state/engine.ts
+++ b/packages/iterate/src/sdk/capnweb/live-state/engine.ts
@@ -5,6 +5,7 @@ import {
   type RetainedCallback,
 } from "./retain.ts";
 import { diff } from "./diff.ts";
+import { compactPatch } from "./compact.ts";
 import type {
   LiveStateCursor,
   LiveStateRead,
@@ -24,7 +25,7 @@ const DEFAULT_DEBOUNCE_MS = 100;
 const ACK_TIMEOUT_MS = 10_000;
 
 type Subscriber<State> = {
-  version: 1 | 2;
+  version: 1 | 2 | 3;
   state: State;
   revision: number;
   busy: boolean;
@@ -56,6 +57,7 @@ export class LiveState<State extends object> {
   #revision = 0;
   readonly #epoch = crypto.randomUUID();
   #lastUpdate: Extract<LiveUpdate<State>, { type: "patch" }> | undefined;
+  #lastCompactUpdate: Extract<LiveUpdate<State>, { p: unknown }> | undefined;
   readonly #subscribers = new Map<RetainedCallback<LiveUpdate<State>>, Subscriber<State>>();
   readonly #debounceMs: number;
   #flushTimer: ReturnType<typeof setTimeout> | undefined;
@@ -73,19 +75,28 @@ export class LiveState<State extends object> {
 
   /** One retained delta bounds history while a single parent can pull incrementally.
    * A late reader or a new incarnation receives an explicit snapshot instead. */
-  readSince(cursor?: LiveStateCursor): LiveStateRead<State> {
+  readSince(
+    cursor?: LiveStateCursor,
+    options: LiveStateSubscriptionOptions = {},
+  ): LiveStateRead<State> {
     if (this.#flushTimer !== undefined) clearTimeout(this.#flushTimer);
     this.#flushTimer = undefined;
     this.#flush();
     if (cursor?.epoch === this.#epoch) {
       if (cursor.revision === this.#revision) return { epoch: this.#epoch, update: null };
       if (cursor.revision === this.#lastUpdate?.from) {
-        return { epoch: this.#epoch, update: this.#lastUpdate };
+        return {
+          epoch: this.#epoch,
+          update: options.patchVersion === 3 ? this.#lastCompactUpdate! : this.#lastUpdate,
+        };
       }
     }
     return {
       epoch: this.#epoch,
-      update: { type: "snapshot", revision: this.#revision, state: this.#broadcast },
+      update:
+        options.patchVersion === 3
+          ? { s: [this.#revision, this.#broadcast] }
+          : { type: "snapshot", revision: this.#revision, state: this.#broadcast },
     };
   }
 
@@ -126,7 +137,12 @@ export class LiveState<State extends object> {
     retained.onRpcBroken?.(() => this.#drop(retained));
     // The initial snapshot is the first paint — delivered now, never debounced.
     // A synchronously-throwing sink is dropped here and never becomes live.
-    this.#deliver(retained, { type: "snapshot", revision: this.#revision, state: this.#broadcast });
+    this.#deliver(
+      retained,
+      options.patchVersion === 3
+        ? { s: [this.#revision, this.#broadcast] }
+        : { type: "snapshot", revision: this.#revision, state: this.#broadcast },
+    );
 
     return {
       ping: () => this.#subscribers.has(retained),
@@ -151,6 +167,7 @@ export class LiveState<State extends object> {
     this.#broadcast = this.#current;
     const update = { type: "patch", from, to, patch } satisfies LiveUpdate<State>;
     this.#lastUpdate = update;
+    this.#lastCompactUpdate = { p: [from, to, compactPatch(previous, patch)] };
     for (const subscriber of this.#subscribers.keys()) {
       this.#sendLatest(subscriber);
     }
@@ -160,6 +177,17 @@ export class LiveState<State extends object> {
   #sendLatest(subscriber: RetainedCallback<LiveUpdate<State>>): void {
     const held = this.#subscribers.get(subscriber);
     if (!held || held.busy || held.revision === this.#revision) return;
+    if (held.version === 3) {
+      if (held.revision === this.#lastUpdate?.from) {
+        this.#deliver(subscriber, this.#lastCompactUpdate!);
+      } else {
+        const patch = diff(held.state, this.#broadcast);
+        this.#deliver(subscriber, {
+          p: [held.revision, this.#revision, patch ? compactPatch(held.state, patch) : {}],
+        });
+      }
+      return;
+    }
     const patch =
       held.version === 2 && held.revision === this.#lastUpdate?.from
         ? this.#lastUpdate.patch

--- a/packages/iterate/src/sdk/capnweb/live-state/index.ts
+++ b/packages/iterate/src/sdk/capnweb/live-state/index.ts
@@ -19,7 +19,10 @@ type RefreshingLiveStateSource<State extends object> = {
 
 export { createLiveStateStore, type LiveStateStore } from "./store.ts";
 export { applyPatch, diff } from "./diff.ts";
+export { compactPatch, applyCompactPatch } from "./compact.ts";
+export { isLiveStateSnapshot, liveStateRevision } from "./protocol.ts";
 export type {
+  CompactLiveStatePatch,
   LiveStateCursor,
   LiveStateRead,
   LiveStatePatch,

--- a/packages/iterate/src/sdk/capnweb/live-state/protocol.ts
+++ b/packages/iterate/src/sdk/capnweb/live-state/protocol.ts
@@ -27,7 +27,24 @@ export type LiveStatePatch =
   | { fields?: Record<string, LiveStatePatch>; drop?: string[] };
 
 /** Explicit codec negotiation keeps already-open clients valid across deploys. */
-export type LiveStateSubscriptionOptions = { patchVersion?: 2 };
+export type LiveStateSubscriptionOptions = { patchVersion?: 2 | 3 };
+
+/**
+ * Version 3 addresses existing object fields by their sorted baseline position;
+ * new fields use `+name`. Arrays use indices and an optional `#` length.
+ * Primitives replace directly, `[value]` replaces other values, `[length, text]`
+ * appends to a string, and `[]` deletes an object field. No dictionary survives
+ * an update: every address refers to the acknowledged baseline of that patch.
+ */
+export type CompactLiveStatePatch =
+  | string
+  | number
+  | boolean
+  | null
+  | []
+  | [unknown]
+  | [number, string]
+  | { [address: string]: CompactLiveStatePatch };
 
 /** A transient reader's position; a new engine incarnation always has a new epoch. */
 export type LiveStateCursor = { epoch: string; revision: number };
@@ -47,4 +64,18 @@ export type LiveStateRead<State> = { epoch: string; update: LiveUpdate<State> | 
  */
 export type LiveUpdate<State = unknown> =
   | { type: "snapshot"; revision: number; state: State }
-  | { type: "patch"; from: number; to: number; patch: LiveStatePatch };
+  | { type: "patch"; from: number; to: number; patch: LiveStatePatch }
+  | { s: [revision: number, state: State] }
+  | { p: [from: number, to: number, patch: CompactLiveStatePatch] };
+
+export function isLiveStateSnapshot<State>(
+  update: LiveUpdate<State>,
+): update is Extract<LiveUpdate<State>, { type: "snapshot" } | { s: unknown }> {
+  return "s" in update || ("type" in update && update.type === "snapshot");
+}
+
+export function liveStateRevision(update: LiveUpdate): number {
+  if ("s" in update) return update.s[0];
+  if ("p" in update) return update.p[1];
+  return update.type === "snapshot" ? update.revision : update.to;
+}

--- a/packages/iterate/src/sdk/capnweb/live-state/store.test.ts
+++ b/packages/iterate/src/sdk/capnweb/live-state/store.test.ts
@@ -2,6 +2,22 @@ import { describe, expect, it, vi } from "vitest";
 import { createLiveStateStore } from "./store.ts";
 
 describe("createLiveStateStore", () => {
+  it("accepts both codecs, reseeds a compact revision gap, and preserves state after a malformed patch", () => {
+    const store = createLiveStateStore<{ text: string }>();
+    const resync = vi.fn();
+    store.apply({ type: "snapshot", revision: 0, state: { text: "initial" } }, resync);
+    store.apply({ p: [0, 1, { 0: [7, " text"] }] }, resync);
+    expect(store.getState()).toEqual({ text: "initial text" });
+    const previous = store.getState();
+    expect(() => store.apply({ p: [1, 2, { 0: [99, " corrupt"] }] }, resync)).toThrow("baseline");
+    expect(store.getState()).toBe(previous);
+    store.apply({ p: [2, 3, { 0: "missed" }] }, resync);
+    expect(resync).toHaveBeenCalledOnce();
+    expect(store.getState()).toBe(previous);
+    store.apply({ s: [0, { text: "reconnected" }] }, resync);
+    store.apply({ p: [0, 1, { 0: [11, " correctly"] }] }, resync);
+    expect(store.getState()).toEqual({ text: "reconnected correctly" });
+  });
   it("holds nothing until the first snapshot, then folds patches", () => {
     const store = createLiveStateStore<{ n: number }>();
     const resync = vi.fn();

--- a/packages/iterate/src/sdk/capnweb/live-state/store.ts
+++ b/packages/iterate/src/sdk/capnweb/live-state/store.ts
@@ -1,4 +1,5 @@
 import { applyPatch } from "./diff.ts";
+import { applyCompactPatch } from "./compact.ts";
 import type { LiveUpdate } from "./protocol.ts";
 
 /**
@@ -35,13 +36,21 @@ export function createLiveStateStore<State>(): LiveStateStore<State> {
       notify();
     },
     apply: (update: LiveUpdate<State>, resync: () => void) => {
-      if (update.type === "snapshot") {
+      if ("s" in update) {
+        held = { revision: update.s[0], state: update.s[1] };
+      } else if ("p" in update) {
+        if (update.p[0] !== held.revision) {
+          resync();
+          return;
+        }
+        held = { revision: update.p[1], state: applyCompactPatch(held.state, update.p[2]) };
+      } else if (update.type === "snapshot") {
         held = { revision: update.revision, state: update.state };
       } else if (update.from !== held.revision) {
         resync();
         return;
       } else {
-        held = { revision: update.to, state: applyPatch(held.state as State, update.patch) };
+        held = { revision: update.to, state: applyPatch(held.state, update.patch) };
       }
       notify();
     },

--- a/packages/iterate/src/sdk/capnweb/live-state/wire.test.ts
+++ b/packages/iterate/src/sdk/capnweb/live-state/wire.test.ts
@@ -1,0 +1,91 @@
+import { once } from "node:events";
+import { newWebSocketRpcSession } from "@iterate-com/capnweb";
+import { WebSocketServer } from "ws";
+import { expect, it } from "vitest";
+import { LiveState, LiveStateRpcTarget, createLiveStateStore } from "./index.ts";
+
+it("sends a 48-character append in a compact Cap'n Web frame and reseeds a reconnect", async () => {
+  const prefix =
+    "e. The fishermen stared. One by one, their boats followed it into the fog.\n\nElian stood";
+  const suffix = " on the breakwater, calling names into the storm";
+  const initial = {
+    agent: {
+      live: {
+        steps: [{ responseText: { length: 9303, tailOffset: 0, groups: { 0: { 9: prefix } } } }],
+      },
+    },
+  };
+  const engine = new LiveState(initial, { debounceMs: 0 });
+  const server = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+  server.on("connection", (socket) => {
+    // ws implements the WebSocket operations used by Cap'n Web; its DOM event
+    // declarations differ from the browser types accepted by this adapter.
+    newWebSocketRpcSession(socket as unknown as WebSocket, new LiveStateRpcTarget(engine));
+  });
+  await once(server, "listening");
+  const address = server.address();
+  if (typeof address === "string" || !address) throw new Error("Missing test socket address");
+  const url = `ws://127.0.0.1:${address.port}`;
+  try {
+    const socket = new WebSocket(url);
+    const frames: string[] = [];
+    socket.addEventListener("message", (event) => frames.push(String(event.data)));
+    using remote = newWebSocketRpcSession<LiveStateRpcTarget<typeof initial>>(socket);
+    const store = createLiveStateStore<typeof initial>();
+    const applied = Promise.withResolvers<void>();
+    using subscription = await remote.subscribe(
+      (update) => {
+        store.apply(update, () => {
+          throw new Error("Unexpected revision gap");
+        });
+        if (store.getState()?.agent.live.steps[0]?.responseText.length === 9351) applied.resolve();
+      },
+      { patchVersion: 3 },
+    );
+    frames.length = 0;
+    const next = {
+      agent: {
+        live: {
+          steps: [
+            {
+              responseText: {
+                length: 9351,
+                tailOffset: prefix.length,
+                groups: { 0: { 9: prefix + suffix } },
+              },
+            },
+          ],
+        },
+      },
+    };
+    engine.setState(next);
+    await applied.promise;
+    const frame = frames.find((value) => value.includes(suffix));
+    expect(frame).toBeDefined();
+    expect(Buffer.byteLength(frame!)).toBeLessThan(200);
+    expect(frame).not.toContain(prefix);
+    expect(frame).not.toContain("responseText");
+    expect(store.getState()).toEqual(next);
+    await subscription.unsubscribe();
+
+    using reconnected = newWebSocketRpcSession<LiveStateRpcTarget<typeof initial>>(
+      new WebSocket(url),
+    );
+    const restored = createLiveStateStore<typeof initial>();
+    using fresh = await reconnected.subscribe(
+      (update) => {
+        restored.apply(update, () => {
+          throw new Error("Reconnect did not seed its baseline");
+        });
+      },
+      { patchVersion: 3 },
+    );
+    expect(restored.getState()).toEqual(next);
+    await fresh.unsubscribe();
+  } finally {
+    for (const socket of server.clients) socket.terminate();
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+});

--- a/packages/iterate/src/sdk/capnweb/react.test.tsx
+++ b/packages/iterate/src/sdk/capnweb/react.test.tsx
@@ -40,6 +40,11 @@ function makeRoot() {
       sink({ revision: 0, state: { name }, type: "snapshot" });
     },
     root,
+    emit(update: LiveUpdate<State>) {
+      const sink = sinks.at(-1);
+      if (!sink) throw new Error("live-state subscription is not ready");
+      sink(update);
+    },
     unsubscribe,
   };
 }
@@ -208,5 +213,35 @@ test("bounds terminal retries per logical subscription", async () => {
 
   await act(async () => vi.advanceTimersByTimeAsync(60_000));
   expect(subscribe).toHaveBeenCalledTimes(6);
+  await act(async () => reactRoot.unmount());
+});
+
+test("bounds corrupt compact-patch recovery even when each new subscription succeeds", async () => {
+  vi.useFakeTimers();
+  const connection = makeRoot();
+  const subscribe = vi.spyOn(connection.root.liveState, "subscribe");
+  function Harness() {
+    const { status, value, error } = useLiveState(
+      (root: typeof connection.root) => root.liveState,
+      (state) => state.name,
+      [],
+      { root: connection.root },
+    );
+    return createElement("output", { "data-status": status, "data-error": error }, value);
+  }
+  const container = document.body.appendChild(document.createElement("div"));
+  const reactRoot = createRoot(container);
+  await act(async () => reactRoot.render(createElement(Harness)));
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await act(async () => connection.emit({ s: [0, { name: "valid" }] }));
+    await act(async () => connection.emit({ p: [0, 1, { 0: [99, " invalid"] }] }));
+    expect(container.querySelector("output")?.textContent).toBe("valid");
+    expect(container.querySelector("output")?.getAttribute("data-status")).toBe("error");
+    await act(async () => vi.advanceTimersByTimeAsync(10_000));
+  }
+  expect(subscribe).toHaveBeenCalledTimes(3);
+  expect(container.querySelector("output")?.getAttribute("data-error")).toContain("baseline");
+  await act(async () => vi.advanceTimersByTimeAsync(60_000));
+  expect(subscribe).toHaveBeenCalledTimes(3);
   await act(async () => reactRoot.unmount());
 });

--- a/packages/iterate/src/sdk/capnweb/react.tsx
+++ b/packages/iterate/src/sdk/capnweb/react.tsx
@@ -12,6 +12,7 @@ import {
   type ReactNode,
 } from "react";
 import { createLiveStateStore } from "./live-state/store.ts";
+import { isLiveStateSnapshot } from "./live-state/protocol.ts";
 import type { LiveStateRpc, LiveStateSubscriptionHandle } from "./live-state/types.ts";
 
 export type CapnWebRoot = object &
@@ -259,9 +260,10 @@ export function useLiveState<Root extends CapnWebRoot, State, Selected = State>(
   // oxlint-disable-next-line react-hooks/exhaustive-deps -- this memo is intentionally keyed; deps complete the caller's logical-node identity
   const store = useMemo(() => createLiveStateStore<State>(), [scope, ...deps]);
   // oxlint-disable-next-line react-hooks/exhaustive-deps -- store is the logical subscription identity; its replacement must reset the retry budget
-  const subscribeRetries = useMemo(() => ({ count: 0 }), [store]);
+  const subscribeRetries = useMemo(() => ({ count: 0, resyncs: 0 }), [store]);
   const refresh = useCallback(() => {
     subscribeRetries.count = 0;
+    subscribeRetries.resyncs = 0;
     setEpoch((current) => current + 1);
   }, [subscribeRetries]);
   const [subscriptionState, setSubscriptionState] = useState<{
@@ -316,9 +318,20 @@ export function useLiveState<Root extends CapnWebRoot, State, Selected = State>(
         const pending = liveRef.current(root as Root).subscribe(
           (update) => {
             if (disposed || stale) return;
-            store.apply(update, refresh);
+            try {
+              store.apply(update, () => {
+                throw new Error("Live-state revision gap");
+              });
+              if (!isLiveStateSnapshot(update)) subscribeRetries.resyncs = 0;
+            } catch (error) {
+              // A successful subscribe alone cannot reset this budget: a host
+              // could repeatedly seed a valid snapshot followed by a bad patch.
+              const shouldResync = subscribeRetries.resyncs < MAX_SUBSCRIBE_RETRIES;
+              if (shouldResync) subscribeRetries.resyncs += 1;
+              report(error, shouldResync);
+            }
           },
-          { patchVersion: 2 },
+          { patchVersion: 3 },
         );
         timeout = setTimeout(
           () =>


### PR DESCRIPTION
Small live-state updates repeatedly sent field names and the entire changed text block. Negotiate codec 3 across the browser and internal relays: numeric field addresses come from the acknowledged baseline, and bounded string appends send only the suffix. Snapshots, revisions, immutable blocks, structural sharing, and slow-subscriber coalescing remain intact.

For 64 KiB streamed through a real uncompressed Cap’n Web WebSocket, 48-byte appends average **173 bytes per callback message instead of 874 bytes** (80% less traffic). The 16-byte and 128-byte cases reduce traffic by 83% and 72%. These measurements include RPC framing and literal-array escaping; raw results and reproducible benchmarks are committed.

The browser’s feed and agent subscriptions now reset together with the stream lifetime, so recreating an agent cannot reuse the deleted agent’s acknowledgement cursor or idle runtime. The UI keeps existing work visible until its publications arrive and shows follow-up work as soon as the agent reports it. Sending stays pending until the feed has presented the resulting runtime. Acknowledged local sends are retired so a later feed delay cannot make them pending again. Script settlements that owe model feedback now remain queued until the agent consumes that feedback; previously the runtime could briefly go idle between script completion and the next model input.

## Validation

Final merged-head preview CI (`acfc576c3`): all six app suites passed. Agent recreation and script reuse passed on their first attempts. The `discover-tree` REPL example retried once after `Durable Object's isolate exceeded its memory limit and was reset` and then passed; the retry remains visible in CI telemetry. No tests were newly skipped or quarantined by this PR.

- Full workspace install, typecheck, lint, knip, format check, and tests passed; existing expected-failure/skip classifications are unchanged.
- Real WebSocket regression test covers the reported 48-character update and reconnect; the payload is under 200 bytes and excludes the old text and field names.
- Codec tests cover key addition/deletion/reordering, numeric and prototype-sensitive keys, undefined fields, array growth/shrink, bounded text appends, surrogate pairs, invalid baselines, and structural sharing.
- Real Miniflare Workers RPC verifies incremental facet reads, eviction, and stream recreation. Relay tests verify mixed versions and surviving sockets; slow consumers coalesce from their own baseline.
- Invalid browser patches preserve the last valid value, report an error, and stop after two unsuccessful resyncs. The regression test includes successful reconnects followed by repeated bad patches.
- Agent progress: 238 agent/feed tests and 14 targeted progress tests pass, covering successful, failed, void, external, and uninterpreted settlements, causally matched feedback, reordered live-state arrival, and unchanged runtime counts across inputs.
- React Doctor: no new source diagnostics; the remaining finding is the codec test’s intentional JSON round-trip.
- Preview `c04145e5c`, worker `a9d74c25-8ced-4a14-b4eb-96d27c814f3a`: a 16,526-character response settled successfully (180-byte compact feed patches versus 879-byte previous-codec patches on average), both codec subscribers reached identical state, and every subscription stayed healthy throughout a 150-second soak. Durable state was idle with no errors or processor revivals.
- Real browser: a 24,444-character model response completed after opening the agent processor inspector and reloading mid-generation; the full story appeared with no new console errors. The existing agent-recreation browser regression passed three consecutive runs after reproducing the old progress gap twice in three runs. A script-reuse handoff gap also reproduced once in three runs. After correcting runtime continuity, both regressions passed three consecutive runs each on the stable preview (six passes, no retries).
- [Preview session trace](https://dash.cloudflare.com/376ef7ed81b0573f93524de763666c15/observability/traces/e2a5df661c424df027c354f57ff94459): the final untruncated WebSocket invocation completed successfully (1,550 ms CPU over 156 seconds); all 229 correlated telemetry records were informational. Setup handoffs and explicit unsubscribe explain the bounded internal cancellations. The earlier independent long-response proof also had 211 successful ITX calls and no error telemetry.

## Risk map

The highest-risk behavior is resolving field positions against the previous state. Every address uses the original, sorted, defined keys, even if this patch also removes or adds keys. Snapshots re-establish the baseline without a separate dictionary. Invalid positions and append lengths fail before the client replaces its held state.

Already-open clients and hibernated sockets retain their negotiated codec. Facet RPC reads also negotiate explicitly: an omitted version preserves the previous format for a warm parent across facet eviction. New clients also accept the previous protocol during deployment rollout. Event and live-state schemas remain compatible. The existing pending-input consequence map also retains unresolved script-result identities until their processor-produced feedback is consumed.

Review `compact.ts`, then engine/store revision and coalescing behavior, then Pager negotiation and React recovery. Generated API declarations and benchmark results are mechanical.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches live-state wire format, revision/address semantics, and real-time agent UI acknowledgement paths; incorrect baseline resolution or progress merging could corrupt client state or mislead users about pending work.
> 
> **Overview**
> Introduces **live-state codec version 3**: compact `{s: …}` / `{p: …}` updates with sorted baseline field indices, `+name` for new keys, and bounded string **appends** instead of resending field paths and whole text blocks on every token. The engine, client store, Pager (`watch-v3`), facet reads, and React `useLiveState` negotiate v3 by default while v2/legacy sockets stay valid across deploys; malformed patches keep the last good state with a capped resync budget.
> 
> **Agent stream UX** is refactored so progress and send acknowledgement come from a scoped **agent live-state** subscription (`agentSource` + `presentAgentProgress`), not a parent-passed runtime. Idle runtime waits until feed publications catch up; acknowledged sends cannot flip back to pending on later feed lag. **Script settlements** that owe model feedback stay in `pendingInputConsequences` until feedback is consumed, and runtime “pending” reflects that queue.
> 
> Adds wire/JSON benchmarks, recorded results, docs for the compact protocol, and broad tests (codec, pager mixed versions, e2e v3 subscribe).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acfc576c38720a5011a1a7ab747aadb6cf26f4e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +322 -45 | +265 -41 🟩🟩⬜⬜⬜ |
| UI components | +59 -13 | +45 -5 🟩⬜⬜⬜⬜ |
| Tests | +595 -77 | +569 -75 🟩🟩🟩🟩🟥 |
| CI & scripts | +447 -6 | +436 -6 🟩🟩🟩⬜⬜ |
| Docs | +51 -3 | +44 -3 🟩⬜⬜⬜⬜ |
| Generated | +55 -7 | +13 -3 🟩⬜⬜⬜⬜ |
| **Total** | **+1,529 -151** | **+1,372 -133** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between c512c12 and acfc576, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-09-11T12:11:14.607Z",
      "deployedAt": "2026-09-11T12:01:30.826Z",
      "headSha": "acfc576c38720a5011a1a7ab747aadb6cf26f4e1",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/320292769026387",
      "shortSha": "acfc576",
      "cleanupDurationMs": 99843,
      "deployDurationMs": 92328,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 91057,
      "deployReadinessDurationMs": 1268,
      "deployedWorkerName": "os-preview-13",
      "deployedWorkerVersion": "4813a420-404f-4074-9625-792a355312d6",
      "testDurationMs": 250137,
      "testRetries": "1 retried: repl-examples.spec.ts › itx REPL catalogue examples › runs \"discover-tree\" through the project REPL › web (playwright x1) — Error: stream-unavailable: Durable Object's isolate exceeded its memory limit and was reset.",
      "workerSizeKib": 22071.65,
      "workerGzipKib": 5549.62,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5558.97
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-09-11T12:09:39.478Z",
      "deployedAt": "2026-09-11T12:00:25.902Z",
      "headSha": "acfc576c38720a5011a1a7ab747aadb6cf26f4e1",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-13.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/320292769026387",
      "shortSha": "acfc576",
      "cleanupDurationMs": 4710,
      "deployDurationMs": 27627,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 26132,
      "deployReadinessDurationMs": 1491,
      "deployedWorkerName": "docs-preview-13",
      "deployedWorkerVersion": "c5d12539-b28e-496b-b33c-b5c8d70e293b",
      "testDurationMs": 2673,
      "testRetries": null,
      "workerSizeKib": 4775.67,
      "workerGzipKib": 1121.44,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-09-11T12:09:41.626Z",
      "deployedAt": "2026-09-11T12:00:32.372Z",
      "headSha": "acfc576c38720a5011a1a7ab747aadb6cf26f4e1",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/320292769026387",
      "shortSha": "acfc576",
      "cleanupDurationMs": 6851,
      "deployDurationMs": 32934,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 32598,
      "deployReadinessDurationMs": 330,
      "deployedWorkerName": "auth-preview-13",
      "deployedWorkerVersion": "b7cfd92f-5dba-450f-8872-e442e7d2e9f2",
      "testDurationMs": 17638,
      "testRetries": null,
      "workerSizeKib": 4179,
      "workerGzipKib": 855.25,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-09-11T12:09:39.566Z",
      "deployedAt": "2026-09-11T12:00:22.866Z",
      "headSha": "acfc576c38720a5011a1a7ab747aadb6cf26f4e1",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/320292769026387",
      "shortSha": "acfc576",
      "cleanupDurationMs": 4790,
      "deployDurationMs": 23145,
      "deployConfigDurationMs": 7,
      "deployCommandDurationMs": 23090,
      "deployReadinessDurationMs": 47,
      "deployedWorkerName": "streams-example-app-preview-13",
      "deployedWorkerVersion": "7f7ba93d-479d-4c8a-b82d-cc8612f1a37a",
      "testDurationMs": 60326,
      "testRetries": null,
      "workerSizeKib": 5896.49,
      "workerGzipKib": 1663.8,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-09-11T12:09:35.488Z",
      "deployedAt": "2026-09-11T11:42:32.477Z",
      "headSha": "acfc576c38720a5011a1a7ab747aadb6cf26f4e1",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/320292769026387",
      "shortSha": "acfc576",
      "cleanupDurationMs": 707,
      "deployDurationMs": 161,
      "deployConfigDurationMs": 1,
      "deployReuseProofDurationMs": 157,
      "deployedWorkerName": "dummy-petshop-preview-13",
      "deployedWorkerVersion": "bbdfe362-2a38-44e2-9931-e1fc5430d9c3",
      "testDurationMs": 7993,
      "testRetries": null,
      "workerSizeKib": 1331.5,
      "workerGzipKib": 232.81,
      "deployedFingerprint": "c321865fd82cf1ce04086fcbe3c487f157babc45+c5abf1055de73f3b4ffbc5e5b742dff1f0b5ee52",
      "mainWorkerGzipKib": null
    },
    "semaphore": {
      "appDisplayName": "Semaphore",
      "appSlug": "semaphore",
      "status": "released",
      "updatedAt": "2026-09-11T12:09:36.697Z",
      "deployedAt": "2026-09-11T12:00:24.075Z",
      "headSha": "acfc576c38720a5011a1a7ab747aadb6cf26f4e1",
      "message": "Preview app released.",
      "publicUrl": "https://semaphore.iterate-preview-13.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/320292769026387",
      "shortSha": "acfc576",
      "cleanupDurationMs": 1209,
      "deployDurationMs": 24505,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 24303,
      "deployReadinessDurationMs": 197,
      "deployedWorkerName": "semaphore-preview-13",
      "deployedWorkerVersion": "4068d20a-a2b3-481e-922b-83faff8886d2",
      "testDurationMs": 40527,
      "testRetries": null,
      "workerSizeKib": 1960.48,
      "workerGzipKib": 453.78,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `acfc576` | [https://auth.iterate-preview-13.com](https://auth.iterate-preview-13.com) | 855.3 KiB | 32.9s | 17.6s |  | 6.9s | [Workflow run](https://github.com/iterate/iterate/actions/runs/320292769026387) | 2026-09-11T12:09:41.626Z | Preview app released. |
| Docs | released | `acfc576` | [https://docs-preview-13.iterate-dev-preview.workers.dev](https://docs-preview-13.iterate-dev-preview.workers.dev) | 1.10 MiB | 27.6s | 2.7s |  | 4.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/320292769026387) | 2026-09-11T12:09:39.478Z | Preview app released. |
| Dummy Petshop | released | `acfc576` | [https://dummy-petshop.iterate-preview-13.com](https://dummy-petshop.iterate-preview-13.com) | 232.8 KiB | 161ms | 8.0s |  | 707ms | [Workflow run](https://github.com/iterate/iterate/actions/runs/320292769026387) | 2026-09-11T12:09:35.488Z | Preview app released. |
| OS | released | `acfc576` | [https://os.iterate-preview-13.com](https://os.iterate-preview-13.com) | 5.42 MiB (-9.4 KiB vs main) | 92.3s | 250.1s | 1 retried: repl-examples.spec.ts › itx REPL catalogue examples › runs "discover-tree" through the project REPL › web (playwright x1) — Error: stream-unavailable: Durable Object's isolate exceeded its memory limit and was reset. | 99.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/320292769026387) | 2026-09-11T12:11:14.607Z | Preview app released. |
| Semaphore | released | `acfc576` | [https://semaphore.iterate-preview-13.com](https://semaphore.iterate-preview-13.com) | 453.8 KiB | 24.5s | 40.5s |  | 1.2s | [Workflow run](https://github.com/iterate/iterate/actions/runs/320292769026387) | 2026-09-11T12:09:36.697Z | Preview app released. |
| Streams Example App | released | `acfc576` | [https://streams.iterate-preview-13.com](https://streams.iterate-preview-13.com) | 1.62 MiB | 23.1s | 60.3s |  | 4.8s | [Workflow run](https://github.com/iterate/iterate/actions/runs/320292769026387) | 2026-09-11T12:09:39.566Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->







