### PR TITLE
fix(os): load userspace classes only when facets start

### DIFF
--- a/apps/os/e2e/vitest/stateful-worker-websocket-reconnect.e2e.test.ts
+++ b/apps/os/e2e/vitest/stateful-worker-websocket-reconnect.e2e.test.ts
@@ -1,0 +1,154 @@
+import { once } from "node:events";
+import { expect, test } from "vitest";
+import NodeWebSocket from "ws";
+import { newWebSocketRpcSession } from "capnweb";
+import type { StatefulDynamicWorkerRef } from "iterate/sdk";
+import type { DynamicWorkerCapability } from "../../src/domains/workers/schemas.ts";
+import { waitForCondition } from "../test-support/wait-for-condition.ts";
+import { adminSecret, buildUrl, withItxSession } from "./test-helpers.ts";
+
+test("stateful app reconnects without resetting an unchanged live SQLite worker", async () => {
+  using session = withItxSession();
+  using itx = session.authenticate({ type: "admin-secret", secret: adminSecret() });
+  using project = await itx.projects.get(`ws-reconnect-${crypto.randomUUID()}`).create({});
+  const { projectId } = await project.__describe();
+  const appSource = `
+    import { IterateDurableObject } from "iterate/sdk";
+    import { RpcTarget, newWorkersWebSocketRpcResponse } from "iterate/sdk/capnweb";
+    export class ReconnectApp extends IterateDurableObject {
+      instance = crypto.randomUUID();
+      constructor(ctx, env) {
+        super(ctx, env);
+        ctx.storage.sql.exec("CREATE TABLE IF NOT EXISTS counter (id INTEGER PRIMARY KEY, value INTEGER NOT NULL)");
+        ctx.storage.sql.exec("INSERT OR IGNORE INTO counter VALUES (1, 0)");
+      }
+      getState() {
+        return { version: "one", instance: this.instance, value: this.ctx.storage.sql.exec("SELECT value FROM counter WHERE id = 1").one().value };
+      }
+      increment() {
+        this.ctx.storage.sql.exec("UPDATE counter SET value = value + 1 WHERE id = 1");
+        return this.getState();
+      }
+      fetch(request) {
+        if (request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
+          return new Response("<!doctype html><html><head><title>Reconnect probe</title></head><body>Counter</body></html>", { headers: { "content-type": "text/html" } });
+        }
+        return newWorkersWebSocketRpcResponse(request, new Api(this));
+      }
+    }
+    class Api extends RpcTarget {
+      #app;
+      constructor(app) { super(); this.#app = app; }
+      getState() { return this.#app.getState(); }
+      increment() { return this.#app.increment(); }
+    }
+  `;
+  const ref = {
+    type: "stateful",
+    className: "ReconnectApp",
+    durableWorkerKey: "test-reconnect",
+    path: "/",
+    source: {
+      createWorker: {
+        entryPoint: "app.ts",
+        files: {
+          type: "repo",
+          repoPath: "/repos/config",
+          include: ["package.json", "app.ts"],
+        },
+      },
+    },
+  } satisfies StatefulDynamicWorkerRef;
+  const commit = await project.repo.commitFiles({
+    message: "Install the isolated stateful WebSocket reconnect probe",
+    changes: [
+      { path: "app.ts", content: appSource },
+      {
+        path: "worker.ts",
+        content: `
+        import { IterateWorkerEntrypoint } from "iterate/sdk";
+        export default class ProjectWorker extends IterateWorkerEntrypoint {
+          fetch(request) {
+            const headers = new Headers(request.headers);
+            headers.set("x-iterate-worker-dispatch", JSON.stringify({ ref: ${JSON.stringify(ref)}, buildBudgetMs: 15000 }));
+            return this.env.ITX.fetch(new Request(request, { headers }));
+          }
+        }
+      `,
+      },
+    ],
+  });
+  await waitForCondition(
+    async () => {
+      const events = await project.streams.get("/").getEvents({ afterOffset: 0 });
+      return events.some(
+        (event) =>
+          event.type === "events.iterate.com/project/worker-updated" &&
+          event.payload?.commitOid === commit.commitOid,
+      );
+    },
+    {
+      description: "the probe's project worker deployment",
+      // The setup includes a real source build; socket assertions below never retry.
+      timeoutMs: 60_000,
+    },
+  );
+
+  using worker = project.workers.get(ref) as unknown as DynamicWorkerCapability<{
+    getState(): { instance: string; value: number; version: string };
+  }>;
+  expect(await worker.getState()).toMatchObject({ value: 0 });
+
+  const url = buildUrl({ path: `/${projectId}/api`, protocol: "ws" });
+  const sockets: NodeWebSocket[] = [];
+  async function connect() {
+    const page = await fetch(buildUrl({ path: `/${projectId}/` }));
+    expect(page).toMatchObject({ status: 200 });
+    expect(await page.text()).toContain("Reconnect probe");
+    const socket = new NodeWebSocket(url, { handshakeTimeout: 10_000 });
+    sockets.push(socket);
+    await once(socket, "open");
+    return {
+      socket,
+      api: newWebSocketRpcSession<{
+        getState(): { instance: string; value: number };
+        increment(): { instance: string; value: number };
+      }>(socket as unknown as WebSocket),
+    };
+  }
+  try {
+    const first = await connect();
+    using firstApi = first.api;
+    const initial = await firstApi.increment();
+    expect(initial).toMatchObject({ value: 1 });
+
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const next = await connect();
+      using nextApi = next.api;
+      expect(await nextApi.getState()).toEqual(initial);
+      expect(first.socket, "an existing connection must stay open").toMatchObject({
+        readyState: NodeWebSocket.OPEN,
+      });
+      expect(await firstApi.getState()).toEqual(initial);
+      const closed = once(next.socket, "close");
+      nextApi[Symbol.dispose]();
+      await closed;
+    }
+    const firstClosed = once(first.socket, "close");
+    await project.repo.commitFiles({
+      message: "Update app code while preserving the SQLite worker identity",
+      changes: [{ path: "app.ts", content: appSource.replace('version: "one"', 'version: "two"') }],
+    });
+    expect(await worker.getState()).toMatchObject({ version: "two", value: 1 });
+    await firstClosed;
+    firstApi[Symbol.dispose]();
+    // Reproduce a returning browser after all application sockets have closed.
+    await new Promise((resolve) => setTimeout(resolve, 30_000));
+    const reopened = await connect();
+    using reopenedApi = reopened.api;
+    expect(await reopenedApi.getState()).toMatchObject({ version: "two", value: 1 });
+    expect(await worker.getState()).toMatchObject({ version: "two", value: 1 });
+  } finally {
+    for (const socket of sockets) socket.terminate();
+  }
+});

--- a/apps/os/src/domains/streams/stream-durable-object.ts
+++ b/apps/os/src/domains/streams/stream-durable-object.ts
@@ -1416,7 +1416,7 @@ export class StreamDurableObject extends DurableObject<Env> {
     }
     const resolved =
       receiver.source.kind === "userspace"
-        ? await this.#loadUserspaceFacetClass(
+        ? await this.#prepareUserspaceFacetClass(
             name,
             receiver.source.worker,
             this.#facetRecoveryNonce,
@@ -1434,7 +1434,7 @@ export class StreamDurableObject extends DurableObject<Env> {
     // (the OS built-in or the userspace StreamProcessorFacet base), whose RPC
     // surface ProcessorFacetStub over-approximates.
     const facet = this.ctx.facets.get(name, () => ({
-      class: resolved.class,
+      class: resolved.loadClass(),
     })) as unknown as ProcessorFacetStub;
     if (!this.#configuredProcessorFacets.has(name)) {
       const parentName = DurableObjectNameCodec.stringify(this.name, { allowNullProjectId: true });
@@ -1475,7 +1475,7 @@ export class StreamDurableObject extends DurableObject<Env> {
    * (the sibling `ProcessorFacet` export from `iterate/processors/cloudflare`).
    * Its version is a constant: the built-in class only changes on an OS deploy,
    * which evicts every DO anyway. */
-  #builtinFacetClass(name: string): { class: DurableObjectClass; version: string } {
+  #builtinFacetClass(name: string): { loadClass: () => DurableObjectClass; version: string } {
     // Loose lookup on purpose: ctx.exports carries every exported entrypoint by
     // name.
     const entrypoint = name === "feed" ? "FeedFacet" : "ProcessorFacet";
@@ -1485,7 +1485,10 @@ export class StreamDurableObject extends DurableObject<Env> {
     if (facetClass === undefined) {
       throw new Error(`facet-processor subscription ${name} requires the ${entrypoint} entrypoint`);
     }
-    return { class: facetClass, version: name === "feed" ? "builtin:FeedFacet" : "builtin" };
+    return {
+      loadClass: () => facetClass,
+      version: name === "feed" ? "builtin:FeedFacet" : "builtin",
+    };
   }
 
   /** Lazily built loader for userspace facet sources. Shared scope: the
@@ -1511,27 +1514,27 @@ export class StreamDurableObject extends DurableObject<Env> {
     }));
   }
 
-  /** Load a userspace facet class from its source ref. The version marker is
+  /** Prepare a userspace facet class from its source ref. The version marker is
    * `(className, sourceCacheKey)` — the same identity StatefulWorkerDurableObject
    * versions by — so both a config-repo commit and a same-source className
    * re-point rebuild the facet (the shared abort in `#dialProcessorFacet`). */
-  async #loadUserspaceFacetClass(
+  async #prepareUserspaceFacetClass(
     name: string,
     ref: StatefulDynamicWorkerRef,
     freshInstanceNonce?: string,
-  ): Promise<{ class: DurableObjectClass; version: string }> {
+  ): Promise<{ loadClass: () => DurableObjectClass; version: string }> {
     const projectId = this.name.projectId;
     if (projectId === null) {
       throw new Error(`userspace facet "${name}" requires a project stream`);
     }
-    const loaded = await this.#workerRunnerForFacets(projectId).loadStatefulClass(
+    const loaded = await this.#workerRunnerForFacets(projectId).prepareStatefulClass(
       ref,
       undefined,
       freshInstanceNonce,
     );
     if (!loaded.ok) throw new WorkerBuildFailedError(loaded.failure);
     return {
-      class: loaded.klass,
+      loadClass: loaded.loadClass,
       version: JSON.stringify({ className: ref.className, cacheKey: loaded.resolved.cacheKey }),
     };
   }

--- a/apps/os/src/domains/workers/stateful-worker-durable-object.test.ts
+++ b/apps/os/src/domains/workers/stateful-worker-durable-object.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, expect, it, vi } from "vitest";
+import type { Env } from "../../env.ts";
+import { DurableObjectNameCodec } from "../durable-object-names.ts";
+import type { StatefulDynamicWorkerRef } from "./schemas.ts";
+import { StatefulWorkerDurableObject } from "./stateful-worker-durable-object.ts";
+import { withWorkerFetchDispatchHeader } from "./worker-fetch-dispatch.ts";
+import { WORKER_SERVE_HEADER } from "./worker-serve-info.ts";
+
+const h = vi.hoisted(() => ({
+  loadResolvedWorker: vi.fn(),
+  resolveWorkerSource: vi.fn(),
+}));
+
+vi.mock("../../env.ts", () => ({ itxEnv: {} }));
+vi.mock("../itx/utils.ts", () => ({
+  itxEntrypointBinding: () => ({}),
+  itxEntrypointProps: (input: unknown) => input,
+}));
+vi.mock("../projects/utils.ts", () => ({ projectEgressFetcher: () => ({}) }));
+vi.mock("./worker-loader.ts", () => ({
+  ...h,
+  isWorkerBuildInProgressError: () => false,
+}));
+
+const ref = {
+  type: "stateful",
+  path: "/",
+  className: "Notes",
+  durableWorkerKey: "notes",
+  source: {
+    createWorker: { files: { type: "repo", repoPath: "/repos/config" } },
+  },
+} satisfies StatefulDynamicWorkerRef;
+
+function host() {
+  const storage = new Map<string, unknown>();
+  const running = new Map<string, object>();
+  const target = {
+    fetch: vi.fn(async () => new Response("notes")),
+    invokeCapability: vi.fn(),
+    listNotes: vi.fn(async () => ["saved note"]),
+  };
+  const start = vi.fn();
+  const abort = vi.fn((name: string) => running.delete(name));
+  const ctx = {
+    exports: {},
+    id: {
+      name: DurableObjectNameCodec.stringify({
+        projectId: "prj_reconnect",
+        path: ref.path,
+        props: { durableWorkerKey: ref.durableWorkerKey },
+      }),
+    },
+    storage: { kv: { get: (key: string) => storage.get(key), put: storage.set.bind(storage) } },
+    facets: {
+      abort,
+      get(name: string, startup: () => { class: object }) {
+        // The runtime invokes startup only when this facet needs a class.
+        // A warm facet ignores the new callback and keeps its existing class.
+        return Object.fromEntries(
+          Object.entries(target).map(([method, invoke]) => [
+            method,
+            async () => {
+              if (!running.has(name)) {
+                const options = startup();
+                start(options);
+                running.set(name, options.class);
+              }
+              return await invoke();
+            },
+          ]),
+        );
+      },
+    },
+  } as unknown as DurableObjectState;
+  const object = new StatefulWorkerDurableObject(ctx, {} as Env);
+  return {
+    abort,
+    object,
+    running,
+    start,
+    target,
+    fetch: () =>
+      object.fetch(
+        withWorkerFetchDispatchHeader(new Request("https://notes.example/api"), { ref }),
+      ),
+  };
+}
+
+beforeEach(() => {
+  h.loadResolvedWorker.mockReset().mockImplementation(() => ({
+    getDurableObjectClass: () => ({}),
+  }));
+  h.resolveWorkerSource.mockReset().mockResolvedValue({
+    ok: true,
+    source: { cacheKey: "build-one", commitOid: "a".repeat(40) },
+  });
+});
+
+it("propagates a startup failure without retrying it through the user request", async () => {
+  const app = host();
+  const failure = new Error("worker class failed to load");
+  h.loadResolvedWorker.mockImplementation(() => {
+    throw failure;
+  });
+
+  await expect(app.fetch()).rejects.toBe(failure);
+  expect(h.loadResolvedWorker).toHaveBeenCalledTimes(1);
+  expect(app.target.fetch).not.toHaveBeenCalled();
+});
+
+it("reuses a warm facet without loading another worker for HTTP or RPC requests", async () => {
+  const app = host();
+  await app.fetch();
+  expect(h.loadResolvedWorker).toHaveBeenCalledTimes(1);
+
+  await app.fetch();
+  await expect(
+    app.object.invokeCapability({ ref, path: ["listNotes"], buildFailureNonce: "failure" }),
+  ).resolves.toEqual(["saved note"]);
+
+  expect(h.resolveWorkerSource).toHaveBeenCalledTimes(3);
+  expect(h.loadResolvedWorker).toHaveBeenCalledTimes(1);
+  expect(app.start).toHaveBeenCalledTimes(1);
+  expect(app.abort).not.toHaveBeenCalled();
+});
+
+it("restarts changed source and loads a cold facet from the resolved build", async () => {
+  const app = host();
+  await app.fetch();
+  h.resolveWorkerSource.mockResolvedValue({
+    ok: true,
+    source: { cacheKey: "build-two", commitOid: "b".repeat(40) },
+  });
+
+  const response = await app.fetch();
+  expect(response.headers.get(WORKER_SERVE_HEADER)).toBe("b".repeat(40));
+  expect(app.abort).toHaveBeenCalledTimes(1);
+  expect(app.start).toHaveBeenCalledTimes(2);
+  expect(h.loadResolvedWorker).toHaveBeenLastCalledWith(
+    expect.objectContaining({ resolved: expect.objectContaining({ cacheKey: "build-two" }) }),
+  );
+
+  app.running.clear(); // A hibernated facet needs its startup callback again.
+  await app.fetch();
+  expect(app.start).toHaveBeenCalledTimes(3);
+  expect(h.loadResolvedWorker).toHaveBeenCalledTimes(3);
+  expect(app.abort).toHaveBeenCalledTimes(1);
+});

--- a/apps/os/src/domains/workers/stateful-worker-durable-object.ts
+++ b/apps/os/src/domains/workers/stateful-worker-durable-object.ts
@@ -224,16 +224,19 @@ export class StatefulWorkerDurableObject extends DurableObject<Env> {
     { commitOid?: string; ok: true; target: unknown } | { failure: WorkerBuildFailure; ok: false }
   > {
     this.#assertRefMatchesName(ref);
-    const loaded = await this.#workerRunner.loadStatefulClass(ref, buildBudgetMs);
+    const loaded = await this.#workerRunner.prepareStatefulClass(ref, buildBudgetMs);
     if (!loaded.ok) return loaded;
-    const { klass, resolved } = loaded;
+    const { resolved } = loaded;
     const version = statefulWorkerVersion(ref, resolved.cacheKey);
     const previous = this.ctx.storage.kv.get<string>(VERSION_STORAGE_KEY);
     if (previous && previous !== version) {
       this.ctx.facets.abort(FACET_NAME, `stateful worker source changed for ${this.ctx.id.name}`);
     }
     if (previous !== version) this.ctx.storage.kv.put(VERSION_STORAGE_KEY, version);
-    const target = this.ctx.facets.get(FACET_NAME, () => ({ class: klass }));
+    // Loading an isolate on a warm request can replace the class beneath the
+    // live facet even when the build is unchanged. Let the runtime request a
+    // class only on startup, as in Cloudflare's Durable Object facets example.
+    const target = this.ctx.facets.get(FACET_NAME, () => ({ class: loaded.loadClass() }));
 
     // A facet cannot learn its own ref through ctx.facets.get(), so offer it
     // once before traffic. Plain DurableObject classes may omit this SDK door.
@@ -246,7 +249,8 @@ export class StatefulWorkerDurableObject extends DurableObject<Env> {
         const cannotAcceptIdentity =
           isMissingInvokeCapabilityError(error) ||
           (error instanceof Error && error.message.includes('"__stashSelfRef" is not a method'));
-        if (cannotAcceptIdentity) this.#identityDelivered = identity;
+        if (!cannotAcceptIdentity) throw error;
+        this.#identityDelivered = identity;
       }
     }
 

--- a/apps/os/src/domains/workers/worker-runner.ts
+++ b/apps/os/src/domains/workers/worker-runner.ts
@@ -166,26 +166,37 @@ export class DynamicWorkerRunner {
   }
 
   /**
-   * Stateful refs resolve only to a class plus source identity. The outer
-   * Durable Object owns storage/facet lifetime and is the only place that should
-   * instantiate or restart the hosted class.
+   * Resolve the immutable build now, but load its class only when requested.
+   * Facet hosts must call loadClass inside their startup callback: Worker
+   * Loader caching does not guarantee that another get returns the same
+   * isolate, while a running facet must keep the class it started with.
    */
-  async loadStatefulClass<T extends DurableObjectClass = DurableObjectClass>(
+  async prepareStatefulClass<T extends DurableObjectClass = DurableObjectClass>(
     ref: StatefulDynamicWorkerRef,
     buildBudgetMs?: number,
     /** Supplied only by a caller that just classified a clone-version skew on
      * this class's isolate; retires the shared identity for the rebuild. */
     freshInstanceNonce?: string,
   ): Promise<
-    | { klass: T; ok: true; resolved: ResolvedWorkerSource }
+    | { loadClass: () => T; ok: true; resolved: ResolvedWorkerSource }
     | { failure: WorkerBuildFailure; ok: false }
   > {
-    const loaded = await this.#load(ref, "cached", buildBudgetMs, freshInstanceNonce);
-    if (!loaded.ok) return loaded;
+    const result = await resolveWorkerSource({
+      buildBudgetMs,
+      projectId: this.#projectId,
+      source: ref.source,
+    });
+    if (!result.ok) return result;
     return {
-      klass: this.#durableObjectClass<T>(ref, loaded.worker),
+      loadClass: () =>
+        tracing.enterSpan("dynamic_worker.stateful.load_class", () =>
+          this.#durableObjectClass<T>(
+            ref,
+            this.#loadResolved(result.source, "cached", freshInstanceNonce),
+          ),
+        ),
       ok: true,
-      resolved: loaded.resolved,
+      resolved: result.source,
     };
   }
 


### PR DESCRIPTION
Stateful app WebSocket reconnects can fail with HTTP 500 and `Durable Object reset because its code was updated.` The observed Preact app failure happened before its first RPC call, with unchanged source and no stored facet-version update: [production trace](https://dash.cloudflare.com/04b3b57291ef2626c6a8daa9d47065a7/observability/traces/6b4f8360320299704eba9513348961f4).

The host was loading a worker and obtaining its class before every `facets.get()`, including requests to an already running facet. Resolve the build/version on each request, but load the class inside the runtime's startup callback. This follows [Cloudflare's facet lifecycle example](https://developers.cloudflare.com/dynamic-workers/usage/durable-object-facets/), which avoids depending on Worker Loader cache identity for a live facet. Apply the same lifecycle to userspace stream processor facets. Unexpected SDK bootstrap errors now propagate instead of being swallowed and implicitly retried through the user request.

The deterministic regression is the unnecessary load: three HTTP/RPC calls to one running facet loaded three workers before this change and load one afterwards. The production reset is intermittent; fresh isolated apps also passed reconnect probes before this patch, so those green probes alone do not establish its cause.

### Validation

- Passed repository `pnpm install --frozen-lockfile`, `pnpm typecheck`, `pnpm lint`, `pnpm knip`, `pnpm format`, and `pnpm test` (OS: 300 test files; 3,132 passing tests, with existing expected-fail/skipped coverage unchanged).
- Unit regression covers warm HTTP/RPC calls, source-version changes, cold facet startup, and propagation of startup failures without an implicit retry.
- New real-worker Cap'n Web/SQLite test covers an existing open socket, reconnects, code updates, and durable data after a 30-second idle period. Socket assertions never retry.
- Real-worker regression passed locally (53 seconds) and on preview-3 (73.7 seconds), including SQLite writes, concurrent sockets, and a source update.
- Additional preview audit: four successful connections over 100 seconds, separated by 30-second idle periods. The runtime recycled app instances while preserving durable identity/version. The host's 38 telemetry records show one initial class load, four HTTP 101 results, and zero error-level logs. One native RPC invocation was canceled when the audit client disposed its session; this is an info-level terminal outcome after its result was returned.
- [Final reconnect trace](https://dash.cloudflare.com/376ef7ed81b0573f93524de763666c15/observability/traces/391c37c033dc14d8a653c20e9de469e2): 10 spans and 3 logs, HTTP 101, zero errors, no class load. The three semantic dispatch/resolve/fetch spans have their parents and are contained by them. Service `os-preview-3`, version `04517379-8afa-4abb-b94b-2455b6ec47f8`, 2026-09-11 19:10:37 UTC.
- Full preview suite passed: all five deployed apps green; OS real-worker suite has 214 passing tests, plus existing expected-fail/skipped coverage. CI unit/lint/typecheck checks, Iterate AI linter, and Cursor Bugbot are green, with no open review threads.

<details>
<summary>Reproduce the telemetry audit</summary>

POST `/accounts/376ef7ed81b0573f93524de763666c15/workers/observability/telemetry/query`:

```json
{
  "queryId": "pr2631-reconnect-audit",
  "view": "events",
  "timeframe": { "from": 1789153736248, "to": 1789153894740 },
  "limit": 500,
  "parameters": {
    "datasets": [],
    "needle": {
      "value": "e7af02fa4eb1b6d1651fe15b1e09ad35468ce98a9fd1ef8d07e4dbcbe330c057",
      "matchCase": true
    }
  }
}
```

This returned 32 spans and 6 invocation logs for the audit's host, below the result limit. To inspect the final reconnect with its parent spans, replace the needle with trace ID `391c37c033dc14d8a653c20e9de469e2` (10 spans, 3 logs). Native RPC/subrequest lifetimes are not used as method-duration evidence; the custom dispatch/resolve/fetch spans and returned responses establish the request outcome.

</details>

### Risk map

- Highest attention: `worker-runner.ts` separates source resolution from class loading. The startup callback captures the resolved immutable build; it must not resolve a different version after the host compares its durable marker.
- Review the two facet hosts next: genuine source changes still abort and recreate the same facet name; stream clone-version recovery still passes its replacement nonce to class loading. Bootstrap failures now surface immediately.
- On merge: no schema or storage-identity change, data migration, or added reconnect retry. OS deployment has its usual runtime restart effects. Existing SQLite data remains under the same facet identity.
- Review the unit lifecycle regression and then the real-worker WebSocket test. The Preact app's source and frontend changes are deliberately outside this PR.

<!-- loc-report -->
| Group | Lines | Significant |
| --- | ---: | ---: |
| Product | +40 -22 | +30 -16 🟩⬜⬜⬜⬜ |
| Tests | +303 -0 | +239 -0 🟩🟩🟩🟩🟩 |
| **Total** | **+343 -22** | **+269 -16** 🟩🟩🟩🟩🟩 |

<sub>Lines counts every changed line; Significant ignores blank lines, JS comments, and TypeScript lines with no runtime output. Between 2e6aa7a and 80eaa44, bucketed first-match-wins into the groups defined in `scripts/ci/loc-report.ts`.</sub>
<!-- /loc-report -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core stateful worker and stream facet hosting in `worker-runner` and two DO hosts; wrong ordering between version checks and `loadClass` could still reset live facets, but behavior is narrowed and heavily regression-tested.
> 
> **Overview**
> Fixes intermittent **“Durable Object reset because its code was updated”** on stateful apps by **deferring Worker Loader class materialization** until the runtime’s facet **startup** callback runs, instead of loading before every `ctx.facets.get()`.
> 
> **`DynamicWorkerRunner`** now exposes **`prepareStatefulClass`**: it still **resolves** the immutable build (and version marker) on each request, but returns a **`loadClass()`** thunk that actually loads the isolate only when the facet starts. **Stateful worker** and **stream processor facet** hosts pass that thunk into `facets.get(() => ({ class: loadClass() }))`, matching Cloudflare’s facet lifecycle so a warm facet is not replaced under live WebSockets/SQLite when source is unchanged.
> 
> **Bootstrap behavior:** unexpected errors from **`__stashSelfRef`** identity delivery **propagate** instead of being treated like “method missing.”
> 
> **Tests:** unit coverage for warm reuse vs source-change abort/restart and startup failure propagation; new **e2e** probe for Cap’n Web reconnect, open sockets during extra connects, deploy while connected, and SQLite counter after idle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80eaa44221901151da1d2e8ed5d98afb8eaf9274. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- CLOUDFLARE_PREVIEW -->
## Environment Config Lease

<!-- CLOUDFLARE_PREVIEW_STATE -->
<!--
{
  "apps": {
    "os": {
      "appDisplayName": "OS",
      "appSlug": "os",
      "status": "released",
      "updatedAt": "2026-09-14T10:49:10.889Z",
      "deployedAt": "2026-09-11T19:06:53.762Z",
      "headSha": "80eaa44221901151da1d2e8ed5d98afb8eaf9274",
      "message": "Preview app released.",
      "publicUrl": "https://os.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/416374791127132",
      "shortSha": "80eaa44",
      "cleanupDurationMs": 98057,
      "deployDurationMs": 102989,
      "deployConfigDurationMs": 2,
      "deployCommandDurationMs": 102900,
      "deployReadinessDurationMs": 86,
      "deployedWorkerName": "os-preview-3",
      "deployedWorkerVersion": "04517379-8afa-4abb-b94b-2455b6ec47f8",
      "testDurationMs": 263653,
      "testRetries": null,
      "workerSizeKib": 22071.96,
      "workerGzipKib": 5549.34,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": 5560.67
    },
    "docs": {
      "appDisplayName": "Docs",
      "appSlug": "docs",
      "status": "released",
      "updatedAt": "2026-09-14T10:47:36.447Z",
      "deployedAt": "2026-09-11T19:05:38.452Z",
      "headSha": "80eaa44221901151da1d2e8ed5d98afb8eaf9274",
      "message": "Preview app released.",
      "publicUrl": "https://docs-preview-3.iterate-dev-preview.workers.dev",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/416374791127132",
      "shortSha": "80eaa44",
      "cleanupDurationMs": 3612,
      "deployDurationMs": 28078,
      "deployConfigDurationMs": 3,
      "deployCommandDurationMs": 27588,
      "deployReadinessDurationMs": 486,
      "deployedWorkerName": "docs-preview-3",
      "deployedWorkerVersion": "d222ba53-5615-4df4-bedf-6e954afc50b9",
      "testDurationMs": 2937,
      "testRetries": null,
      "workerSizeKib": 4775.67,
      "workerGzipKib": 1121.44,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "auth": {
      "appDisplayName": "Auth",
      "appSlug": "auth",
      "status": "released",
      "updatedAt": "2026-09-14T10:47:37.929Z",
      "deployedAt": "2026-09-11T19:05:44.270Z",
      "headSha": "80eaa44221901151da1d2e8ed5d98afb8eaf9274",
      "message": "Preview app released.",
      "publicUrl": "https://auth.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/416374791127132",
      "shortSha": "80eaa44",
      "cleanupDurationMs": 5091,
      "deployDurationMs": 34128,
      "deployConfigDurationMs": 4,
      "deployCommandDurationMs": 33404,
      "deployReadinessDurationMs": 720,
      "deployedWorkerName": "auth-preview-3",
      "deployedWorkerVersion": "d08271f0-6101-464d-bd77-bf4e7cdf145a",
      "testDurationMs": 20841,
      "testRetries": null,
      "workerSizeKib": 4179,
      "workerGzipKib": 855.33,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "streams-example-app": {
      "appDisplayName": "Streams Example App",
      "appSlug": "streams-example-app",
      "status": "released",
      "updatedAt": "2026-09-14T10:47:37.514Z",
      "deployedAt": "2026-09-11T19:05:44.719Z",
      "headSha": "80eaa44221901151da1d2e8ed5d98afb8eaf9274",
      "message": "Preview app released.",
      "publicUrl": "https://streams.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/416374791127132",
      "shortSha": "80eaa44",
      "cleanupDurationMs": 4673,
      "deployDurationMs": 42466,
      "deployConfigDurationMs": 5,
      "deployCommandDurationMs": 33852,
      "deployReadinessDurationMs": 8609,
      "deployedWorkerName": "streams-example-app-preview-3",
      "deployedWorkerVersion": "5e4acfdf-d20b-432e-93fd-16916efbd129",
      "testDurationMs": 66321,
      "testRetries": null,
      "workerSizeKib": 5896.78,
      "workerGzipKib": 1663.87,
      "deployedFingerprint": null,
      "mainWorkerGzipKib": null
    },
    "dummy-petshop": {
      "appDisplayName": "Dummy Petshop",
      "appSlug": "dummy-petshop",
      "status": "released",
      "updatedAt": "2026-09-14T10:47:33.916Z",
      "deployedAt": "2026-09-11T19:05:17.441Z",
      "headSha": "80eaa44221901151da1d2e8ed5d98afb8eaf9274",
      "message": "Preview app released.",
      "publicUrl": "https://dummy-petshop.iterate-preview-3.com",
      "runUrl": "https://github.com/iterate/iterate/actions/runs/416374791127132",
      "shortSha": "80eaa44",
      "cleanupDurationMs": 1073,
      "deployDurationMs": 6779,
      "deployConfigDurationMs": 6,
      "deployCommandDurationMs": 6537,
      "deployReadinessDurationMs": 200,
      "deployedWorkerName": "dummy-petshop-preview-3",
      "deployedWorkerVersion": "f7caf2e1-5a4a-4705-8f3b-767107bdd139",
      "testDurationMs": 14213,
      "testRetries": null,
      "workerSizeKib": 1331.5,
      "workerGzipKib": 232.81,
      "deployedFingerprint": "c321865fd82cf1ce04086fcbe3c487f157babc45+c5abf1055de73f3b4ffbc5e5b742dff1f0b5ee52",
      "mainWorkerGzipKib": null
    }
  },
  "environmentConfigLease": null,
  "notice": null
}
-->
<!-- /CLOUDFLARE_PREVIEW_STATE -->

<details>
<summary>No preview slot recorded.</summary>

| app | status | commit | preview | size (gzip) | deploy duration | test duration | retries | cleanup duration | workflow run | updated | summary |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| Auth | released | `80eaa44` | [https://auth.iterate-preview-3.com](https://auth.iterate-preview-3.com) | 855.3 KiB | 34.1s | 20.8s |  | 5.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/416374791127132) | 2026-09-14T10:47:37.929Z | Preview app released. |
| Docs | released | `80eaa44` | [https://docs-preview-3.iterate-dev-preview.workers.dev](https://docs-preview-3.iterate-dev-preview.workers.dev) | 1.10 MiB | 28.1s | 2.9s |  | 3.6s | [Workflow run](https://github.com/iterate/iterate/actions/runs/416374791127132) | 2026-09-14T10:47:36.447Z | Preview app released. |
| Dummy Petshop | released | `80eaa44` | [https://dummy-petshop.iterate-preview-3.com](https://dummy-petshop.iterate-preview-3.com) | 232.8 KiB | 6.8s | 14.2s |  | 1.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/416374791127132) | 2026-09-14T10:47:33.916Z | Preview app released. |
| OS | released | `80eaa44` | [https://os.iterate-preview-3.com](https://os.iterate-preview-3.com) | 5.42 MiB (-11.3 KiB vs main) | 103.0s | 263.7s |  | 98.1s | [Workflow run](https://github.com/iterate/iterate/actions/runs/416374791127132) | 2026-09-14T10:49:10.889Z | Preview app released. |
| Streams Example App | released | `80eaa44` | [https://streams.iterate-preview-3.com](https://streams.iterate-preview-3.com) | 1.62 MiB | 42.5s | 66.3s |  | 4.7s | [Workflow run](https://github.com/iterate/iterate/actions/runs/416374791127132) | 2026-09-14T10:47:37.514Z | Preview app released. |

</details>
<!-- /CLOUDFLARE_PREVIEW -->